### PR TITLE
fix: guard against empty role in AI API messages

### DIFF
--- a/docs/superpowers/plans/2026-06-22-keyboard-shortcuts-plan.md
+++ b/docs/superpowers/plans/2026-06-22-keyboard-shortcuts-plan.md
@@ -1,0 +1,437 @@
+# Keyboard Shortcuts Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add 11 global keyboard shortcuts to uniTerm via a centralized composable, avoiding conflicts with terminal shell input.
+
+**Architecture:** Single `useKeyboardShortcuts.ts` composable registers a `document.addEventListener('keydown')` listener in App.vue. All shortcuts use Ctrl+Shift or Alt modifiers. The listener does not intercept when focus is in input/textarea/select elements (except AI lock toggle).
+
+**Tech Stack:** Vue 3 Composition API, Pinia stores, TypeScript
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `frontend/src/composables/useKeyboardShortcuts.ts` | **CREATE** | Shortcut registry, key normalization, global keydown handler |
+| `frontend/src/App.vue` | MODIFY | Integrate composable, expose handlers |
+| `frontend/src/stores/tabStore.ts` | MODIFY | Add `nextTab()`, `prevTab()` helpers |
+| `frontend/src/components/Sidebar.vue` | MODIFY | Add template ref to search input, expose `focusSearch()` |
+| `frontend/src/components/AISidebar.vue` | MODIFY | Add template ref to textarea, expose `focusInput()` |
+
+---
+
+### Task 1: Add `nextTab()` and `prevTab()` to tabStore
+
+**Files:**
+- Modify: `frontend/src/stores/tabStore.ts`
+
+- [ ] **Step 1: Add nextTab()**
+
+After `setActiveTab` (around line 213), add:
+
+```typescript
+function nextTab() {
+  const idx = tabState.tabs.findIndex(t => t.id === tabState.activeTabId)
+  if (idx < 0) return
+  const next = tabState.tabs[(idx + 1) % tabState.tabs.length]
+  tabState.activeTabId = next.id
+}
+
+function prevTab() {
+  const idx = tabState.tabs.findIndex(t => t.id === tabState.activeTabId)
+  if (idx < 0) return
+  const prev = tabState.tabs[(idx - 1 + tabState.tabs.length) % tabState.tabs.length]
+  tabState.activeTabId = prev.id
+}
+```
+
+- [ ] **Step 2: Export nextTab and prevTab**
+
+In the return object (around line 505), add:
+
+```typescript
+nextTab,
+prevTab,
+```
+
+- [ ] **Step 3: Verify build**
+
+```bash
+cd c:/Users/Admin/Documents/Workspaces/uniTerm/frontend && npx vue-tsc --noEmit --project tsconfig.json 2>&1 | head -20
+```
+
+---
+
+### Task 2: Add `focusSearch()` ref to Sidebar.vue
+
+**Files:**
+- Modify: `frontend/src/components/Sidebar.vue`
+
+- [ ] **Step 1: Add template ref to search input**
+
+Find the `<el-input>` for search (around line 18, has `v-model="searchQuery"`). Add a ref:
+
+```html
+<el-input
+  ref="searchInputRef"
+  v-model="searchQuery"
+```
+
+- [ ] **Step 2: Add ref variable and expose**
+
+In the `<script setup>` section, near the other refs (around line 410), add:
+
+```typescript
+const searchInputRef = ref<InstanceType<typeof ElInput>>()
+```
+
+At the end of `<script setup>`, add defineExpose before the closing `</script>` tag (before `<style>`):
+
+```typescript
+defineExpose({ focusSearch })
+```
+
+- [ ] **Step 3: Add focusSearch function**
+
+After the searchInputRef declaration, add:
+
+```typescript
+function focusSearch() {
+  nextTick(() => {
+    const el = searchInputRef.value?.$el?.querySelector('input')
+    if (el instanceof HTMLInputElement) {
+      el.focus()
+      el.select()
+    }
+  })
+}
+```
+
+Make sure `nextTick` is imported from `vue` (check existing import at top of `<script setup>`).
+
+- [ ] **Step 4: Verify build**
+
+```bash
+cd c:/Users/Admin/Documents/Workspaces/uniTerm/frontend && npx vue-tsc --noEmit --project tsconfig.json 2>&1 | grep -i "sidebar" | head -10
+```
+
+---
+
+### Task 3: Add `focusInput()` ref to AISidebar.vue
+
+**Files:**
+- Modify: `frontend/src/components/AISidebar.vue`
+
+- [ ] **Step 1: Add template ref to chat textarea**
+
+Find the `<el-input type="textarea">` (around line 89, has `v-model="input"`). Add a ref:
+
+```html
+<el-input
+  ref="chatInputRef"
+  v-model="input"
+  type="textarea"
+```
+
+- [ ] **Step 2: Add ref variable and expose**
+
+In `<script setup>`, find the ref declarations and add:
+
+```typescript
+const chatInputRef = ref<InstanceType<typeof ElInput>>()
+```
+
+At the end of `<script setup>`, add:
+
+```typescript
+defineExpose({ focusInput })
+```
+
+- [ ] **Step 3: Add focusInput function**
+
+After chatInputRef:
+
+```typescript
+function focusInput() {
+  nextTick(() => {
+    const el = chatInputRef.value?.$el?.querySelector('textarea')
+    if (el instanceof HTMLTextAreaElement) {
+      el.focus()
+    }
+  })
+}
+```
+
+Verify `nextTick` is in the import from `vue`.
+
+- [ ] **Step 4: Verify build**
+
+```bash
+cd c:/Users/Admin/Documents/Workspaces/uniTerm/frontend && npx vue-tsc --noEmit --project tsconfig.json 2>&1 | grep -i "aisidebar" | head -10
+```
+
+---
+
+### Task 4: Create `useKeyboardShortcuts.ts` composable
+
+**Files:**
+- Create: `frontend/src/composables/useKeyboardShortcuts.ts`
+
+- [ ] **Step 1: Write the composable**
+
+```typescript
+interface ShortcutDef {
+  ctrl: boolean
+  shift: boolean
+  alt: boolean
+  key: string
+  handler: () => void
+}
+
+function normalize(e: KeyboardEvent): string {
+  const parts: string[] = []
+  if (e.ctrlKey || e.metaKey) parts.push('ctrl')
+  if (e.shiftKey) parts.push('shift')
+  if (e.altKey) parts.push('alt')
+  parts.push(e.key.toLowerCase())
+  return parts.join('+')
+}
+
+function buildKey(s: ShortcutDef): string {
+  let k = ''
+  if (s.ctrl) k += 'ctrl+'
+  if (s.shift) k += 'shift+'
+  if (s.alt) k += 'alt+'
+  k += s.key.toLowerCase()
+  return k
+}
+
+export function useKeyboardShortcuts(shortcuts: ShortcutDef[]) {
+  const map = new Map<string, () => void>()
+  for (const s of shortcuts) {
+    map.set(buildKey(s), s.handler)
+  }
+
+  function onKeydown(e: KeyboardEvent) {
+    const tag = (e.target as HTMLElement)?.tagName
+    const isEditing = tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT'
+      || (e.target as HTMLElement)?.isContentEditable
+
+    const normalized = normalize(e)
+    const handler = map.get(normalized)
+    if (!handler) return
+
+    // Ctrl+Shift+L (lock AI) works even when focus is in AI textarea
+    if (isEditing && normalized !== 'ctrl+shift+l') return
+
+    e.preventDefault()
+    e.stopPropagation()
+    handler()
+  }
+
+  function register() {
+    document.addEventListener('keydown', onKeydown)
+  }
+
+  function unregister() {
+    document.removeEventListener('keydown', onKeydown)
+  }
+
+  return { register, unregister }
+}
+```
+
+- [ ] **Step 2: Verify build**
+
+```bash
+cd c:/Users/Admin/Documents/Workspaces/uniTerm/frontend && npx vue-tsc --noEmit --project tsconfig.json 2>&1 | grep "useKeyboardShortcuts" | head -5
+```
+
+---
+
+### Task 5: Wire shortcuts in App.vue
+
+**Files:**
+- Modify: `frontend/src/App.vue`
+
+- [ ] **Step 1: Add imports and refs**
+
+Add import (near other composable imports, around line 116):
+
+```typescript
+import { useKeyboardShortcuts } from './composables/useKeyboardShortcuts'
+```
+
+Add template refs for sidebar and AI sidebar (near other refs, around line 198):
+
+```typescript
+const sidebarRef = ref<InstanceType<typeof Sidebar>>()
+const aiSidebarRef = ref<InstanceType<typeof AISidebar>>()
+```
+
+Import the component types for InstanceType — these should be inferred from existing imports.
+
+- [ ] **Step 2: Add ref binding in template**
+
+Bind `sidebarRef` to Sidebar (line 12):
+
+```html
+<Sidebar ref="sidebarRef" :visible="sidebarVisible" @toggle="sidebarVisible = !sidebarVisible" ... />
+```
+
+Bind `aiSidebarRef` to AISidebar (line 71):
+
+```html
+<AISidebar ref="aiSidebarRef" />
+```
+
+- [ ] **Step 3: Build shortcuts array and register**
+
+In `onMounted` (around line 282), add after the existing code:
+
+```typescript
+const shortcuts = [
+  // Tab navigation
+  { ctrl: true, shift: false, alt: false, key: 'tab', handler: () => tabStore.nextTab() },
+  { ctrl: true, shift: true, alt: false, key: 'tab', handler: () => tabStore.prevTab() },
+  { ctrl: true, shift: true, alt: false, key: 'w', handler: () => {
+    const t = tabStore.activeTab
+    if (t) closeTab(t.id)
+  }},
+  // Connection
+  { ctrl: true, shift: true, alt: false, key: 'n', handler: () => { showConnectionForm.value = true }},
+  // Sidebar
+  { ctrl: true, shift: true, alt: false, key: 'b', handler: () => {
+    sidebarVisible.value = true
+    nextTick(() => sidebarRef.value?.focusSearch())
+  }},
+  // AI
+  { ctrl: true, shift: true, alt: false, key: 'j', handler: () => {
+    aiStore.visible = true
+    nextTick(() => aiSidebarRef.value?.focusInput())
+  }},
+  { ctrl: true, shift: true, alt: false, key: 'k', handler: () => {
+    // Focus back to active terminal
+    const t = tabStore.activeTab
+    if (!t) return
+    if (t.type === 'workspace') {
+      const panelId = t.activePanelId || t.panelIds[0]
+      if (panelId) focusPanelTerminal(panelId)
+    } else if (t.type === 'terminal') {
+      focusPanelTerminal(t.panelId)
+    }
+  }},
+  { ctrl: true, shift: true, alt: false, key: 'l', handler: () => {
+    const t = tabStore.activeTab
+    if (!t) return
+    let panelId: string | null = null
+    if (t.type === 'workspace') {
+      panelId = t.activePanelId || t.panelIds[0] || null
+    } else if (t.type === 'terminal') {
+      panelId = t.panelId
+    }
+    if (panelId) onToggleAiLock(panelId)
+  }},
+  // Panel
+  { ctrl: true, shift: true, alt: false, key: 'q', handler: () => {
+    const t = tabStore.activeTab
+    if (!t) return
+    if (t.type === 'workspace' && t.panelIds.length > 1) {
+      const panelId = t.activePanelId || t.panelIds[t.panelIds.length - 1]
+      tabStore.removePanelFromWorkspaceTab(t.id, panelId)
+    } else if (t.type === 'workspace' && t.panelIds.length === 1) {
+      const panelId = t.panelIds[0]
+      tabStore.removePanelFromWorkspaceTab(t.id, panelId)
+    } else {
+      closeTab(t.id)
+    }
+  }},
+  // Panel navigation
+  { ctrl: false, shift: false, alt: true, key: 'arrowleft', handler: () => navigatePanel('left') },
+  { ctrl: false, shift: false, alt: true, key: 'arrowright', handler: () => navigatePanel('right') },
+  { ctrl: false, shift: false, alt: true, key: 'arrowup', handler: () => navigatePanel('up') },
+  { ctrl: false, shift: false, alt: true, key: 'arrowdown', handler: () => navigatePanel('down') },
+  // Settings
+  { ctrl: true, shift: true, alt: false, key: ',', handler: () => openSettings() },
+]
+
+const { register, unregister } = useKeyboardShortcuts(shortcuts)
+register()
+```
+
+- [ ] **Step 5: Unregister in onUnmounted**
+
+In the `onUnmounted` callback (around line 324), add at the end:
+
+```typescript
+unregister()
+```
+
+Add after the shortcuts definition (before the closing of onMounted):
+
+```typescript
+function focusPanelTerminal(panelId: string) {
+  nextTick(() => {
+    const el = document.querySelector(`[data-panel-id="${panelId}"] .xterm-helper-textarea`)
+    if (el instanceof HTMLTextAreaElement) {
+      el.focus()
+    }
+  })
+}
+
+function navigatePanel(direction: 'left' | 'right' | 'up' | 'down') {
+  const t = tabStore.activeTab
+  if (!t || t.type !== 'workspace') return
+  const panels = t.panelIds
+  if (panels.length <= 1) return
+  const current = t.activePanelId || panels[0]
+  const idx = panels.indexOf(current)
+  if (idx < 0) return
+
+  // Simple linear navigation: left/up = prev, right/down = next
+  let nextIdx: number
+  if (direction === 'left' || direction === 'up') {
+    nextIdx = (idx - 1 + panels.length) % panels.length
+  } else {
+    nextIdx = (idx + 1) % panels.length
+  }
+  tabStore.setActivePanel(t.id, panels[nextIdx])
+}
+```
+
+---
+
+### Task 6: Full build and smoke test
+
+- [ ] **Step 1: Build frontend + Wails**
+
+```bash
+cd c:/Users/Admin/Documents/Workspaces/uniTerm/frontend && rm -rf dist node_modules/.vite && npm run build && cd .. && wails build -platform windows/amd64
+```
+
+- [ ] **Step 2: Manual smoke test checklist**
+
+Launch `build/bin/uniTerm.exe` and verify each shortcut:
+
+| Shortcut | Expected |
+|----------|----------|
+| Ctrl+Tab | Switch to next tab |
+| Ctrl+Shift+Tab | Switch to previous tab |
+| Ctrl+Shift+W | Close current tab |
+| Ctrl+Shift+N | Open connection dialog |
+| Ctrl+Shift+B | Open sidebar + focus search |
+| Ctrl+Shift+J | Open AI sidebar + focus input |
+| Ctrl+Shift+K | Focus back to active terminal |
+| Ctrl+Shift+L | Lock/unlock AI panel |
+| Ctrl+Shift+Q | Close current panel (workspace) or tab |
+| Alt+←→ | Navigate workspace panels |
+| Ctrl+Shift+, | Open settings tab |
+
+Also verify:
+- Typing Ctrl+C in terminal still works (sends SIGINT)
+- Typing Ctrl+W in bash/zsh still deletes word
+- Ctrl+F in terminal still opens search bar
+- Typing in input fields (connection form, etc.) does not trigger shortcuts
+- Ctrl+Shift+L in AI textarea still toggles lock

--- a/docs/superpowers/specs/2026-06-22-keyboard-shortcuts-design.md
+++ b/docs/superpowers/specs/2026-06-22-keyboard-shortcuts-design.md
@@ -1,0 +1,100 @@
+# Keyboard Shortcuts Design
+
+## Overview
+
+为 uniTerm 增加全局快捷键系统。采用集中式 composable 方案，所有快捷键在 `useKeyboardShortcuts.ts` 中统一注册，不依赖用户配置，使用固定预设。
+
+## Design Principles
+
+1. **不冲突终端**：快捷键不与 shell 常用按键冲突。全部使用 Ctrl+Shift 或 Alt 组合
+2. **集中管理**：所有快捷键在单一 composable 中注册，App.vue 挂载时绑定 `document.addEventListener('keydown')`
+3. **固定预设**：不需要用户配置界面，快捷键硬编码在 composable 中
+
+## Shortcuts
+
+| 操作 | 快捷键 | 实现 |
+|------|--------|------|
+| 下一个 tab | `Ctrl+Tab` | `tabStore.nextTab()` |
+| 上一个 tab | `Ctrl+Shift+Tab` | `tabStore.prevTab()` |
+| 关闭当前 tab | `Ctrl+Shift+W` | `tabStore.closeTab(activeTab.id)` |
+| 新建会话对话框 | `Ctrl+Shift+N` | `showConnectionForm = true` |
+| 打开侧边栏并聚焦搜索 | `Ctrl+Shift+B` | `sidebarVisible = true` + focus search input |
+| 焦点回到终端 | `Ctrl+Shift+K` | `tabStore.getActivePanelId()` + focus terminal |
+| 锁定/解锁 AI 窗口 | `Ctrl+Shift+L` | `tabStore.setAILockedPanel()` toggle |
+| 打开/聚焦 AI 输入框 | `Ctrl+Shift+J` | `aiStore.visible = true` + focus textarea |
+| 关闭当前面板 | `Ctrl+Shift+Q` | workspace 中分离面板，只剩一个时转为独立 tab；非 workspace 直接关闭 tab |
+| 面板间导航 | `Alt+↑↓←→` | workspace 内切换焦点面板 |
+| 打开设置 | `Ctrl+Shift+,` | `tabStore.createSettingsTab()` or switch to existing settings tab |
+
+## Architecture
+
+### New File: `frontend/src/composables/useKeyboardShortcuts.ts`
+
+```typescript
+// Key: normalized key string (e.g. "ctrl+shift+b")
+// Value: handler function or action identifier
+interface Shortcut {
+  ctrl: boolean
+  shift: boolean
+  alt: boolean
+  key: string
+  handler: () => void
+}
+
+function normalize(e: KeyboardEvent): string
+  // e.g. Ctrl+Shift+B → normalized "ctrl+shift+b"
+  // Ignore case, sort modifiers alphabetically
+
+function register(shortcuts: Shortcut[]): void
+  // Called from App.vue onMounted
+
+function unregister(): void
+  // Called from App.vue onUnmounted
+```
+
+### Modified Files
+
+| File | Change |
+|------|--------|
+| `frontend/src/composables/useKeyboardShortcuts.ts` | **NEW** — shortcut registry and handler |
+| `frontend/src/App.vue` | Add `onMounted` keydown listener, expose shortcut targets (sidebar ref, AI textarea ref) |
+| `frontend/src/stores/tabStore.ts` | Add `nextTab()` / `prevTab()` methods if missing |
+| `frontend/src/stores/aiStore.ts` | Add `toggleLock()` method if missing |
+| `frontend/src/components/Sidebar.vue` | Expose `focusSearch()` method via expose or reactive flag |
+| `frontend/src/components/AISidebar.vue` | Expose `focusInput()` method via expose or reactive flag |
+
+### Intercept Strategy
+
+**Don't intercept when:**
+- User is typing in an `input`, `textarea`, `select`, or `[contenteditable]` element
+- Exception: AI textarea allows `Ctrl+Shift+L` (lock toggle) even when focused
+
+**Block browser defaults:**
+- `Ctrl+Tab` → prevent browser from trying to switch tabs
+- `Ctrl+Shift+T` → prevent browser from reopening closed tab
+- `Ctrl+Shift+W` → prevent browser from closing the WebView2
+- `Ctrl+Shift+B` → prevent browser from showing bookmarks bar
+- `Ctrl+Shift+N` → prevent browser from opening incognito
+- All registered shortcuts call `e.preventDefault()` and `e.stopPropagation()`
+
+### Error Handling
+
+- All handlers wrapped in try/catch, log to console
+- If a store method is unavailable (not yet initialized), shortcut silently ignored
+- Shortcut registration is idempotent; calling `register()` twice unregisters first
+
+## Testing
+
+- Manual: Start app, press each shortcut, verify behavior
+- Unit: Test key normalization in `useKeyboardShortcuts.ts`
+- Regression: Verify existing shortcuts (Ctrl+F search, Ctrl+Enter in DB editor, Ctrl+Shift+V in VNC/SPICE) still work and are not intercepted
+
+## Scope Boundaries
+
+**In scope:** The 13 shortcuts listed above with fixed keybindings, centralized composable, App.vue integration
+
+**Out of scope:**
+- User-configurable keybindings or settings UI
+- Global OS-level hotkeys (registering system-wide shortcuts)
+- Backend-only shortcuts
+- Adding new store methods beyond what's needed for the listed shortcuts

--- a/frontend/src/services/llm.ts
+++ b/frontend/src/services/llm.ts
@@ -75,7 +75,7 @@ export async function chat(options: ChatOptions): Promise<void> {
 
   // Store raw message for history preservation
   ;(options as any)._rawApiMsg = {
-    role: json.role,
+    role: json.role || 'assistant',
     content: rawContent
   }
 

--- a/frontend/src/stores/aiStore.ts
+++ b/frontend/src/stores/aiStore.ts
@@ -442,9 +442,9 @@ export const useAIStore = defineStore('ai', () => {
             return true
           })
           if (filtered.length === 0 && !m.content && !(m.pendingTools?.length || pendingCommand.value?.messageId === m.id)) continue
-          result.push({ ...raw, content: filtered })
+          result.push({ ...raw, role: (raw.role as string) || 'assistant', content: filtered })
         } else {
-          result.push({ ...raw })
+          result.push({ ...raw, role: (raw.role as string) || 'assistant' })
         }
         continue
       }
@@ -475,7 +475,7 @@ export const useAIStore = defineStore('ai', () => {
       if (m.role === 'user' && m._contextHeader) {
         result.push({ role: m.role, content: m._contextHeader + '\n\n' + m.content })
       } else {
-        result.push({ role: m.role, content: m.content })
+        result.push({ role: m.role || 'user', content: m.content })
       }
     }
 


### PR DESCRIPTION
修复 AI 助手 API 调用时因空 role 导致的 400 错误。

## 问题
消息数组中 role 字段为空字符串，导致 API 返回：
```
Error: API Error: 400 - Input should be 'user' or 'assistant'
```

## 修复
三层防御，确保 role 字段始终有效：
- llm.ts: 存储 `_rawApiMsg` 时兜底 `'assistant'`
- aiStore.ts: 展开 `_rawApiMsg` 时兜底 `'assistant'`
- aiStore.ts: 兜底路径中 `m.role || 'user'`

Closes #4