### PR TITLE
fix: Linux 多屏环境下窗口最大化使用错误屏幕尺寸

### DIFF
--- a/frontend/src/components/AppHeader.vue
+++ b/frontend/src/components/AppHeader.vue
@@ -52,8 +52,12 @@ import {
   Environment,
   WindowMinimise,
   WindowToggleMaximise,
+  WindowMaximise,
+  WindowUnmaximise,
   WindowIsMaximised,
+  WindowSetMaxSize,
   Quit,
+  ScreenGetAll,
 } from '../../wailsjs/runtime'
 
 const { t } = useI18n()
@@ -83,8 +87,35 @@ function onMinimise() {
 }
 
 async function onMaximise() {
-  WindowToggleMaximise()
+  if (platform.value === 'linux') {
+    await linuxMaximise()
+  } else {
+    WindowToggleMaximise()
+  }
   setTimeout(updateMaximisedState, 100)
+}
+
+async function linuxMaximise() {
+  const maximised = await WindowIsMaximised()
+  if (maximised) {
+    // Restore: use native unmaximise, then clear max size constraint
+    WindowUnmaximise()
+    WindowSetMaxSize(0, 0)
+  } else {
+    // Before native maximise, set max size to current screen dimensions
+    // to prevent GTK from clamping to the wrong monitor's size.
+    try {
+      const screens = await ScreenGetAll()
+      const current = screens.find((s: { isCurrent: boolean }) => s.isCurrent) || screens[0]
+      if (current) {
+        WindowSetMaxSize(current.width, current.height)
+      }
+    } catch {
+      // Fallback: set large max size to disable any constraint
+      WindowSetMaxSize(9999, 9999)
+    }
+    WindowMaximise()
+  }
 }
 
 function onClose() {

--- a/main.go
+++ b/main.go
@@ -42,10 +42,21 @@ func main() {
 
 	app := NewApp(webviewDataPath)
 
+	// Linux multi-monitor maximize workaround:
+	// Wails sets default max size to primary display, which can clamp
+	// maximize on secondary monitors. Set to large values to disable.
+	// See: https://github.com/wailsapp/wails/issues/2431
+	maxW, maxH := 0, 0
+	if runtime.GOOS == "linux" {
+		maxW, maxH = 9999, 9999
+	}
+
 	err := wails.Run(&options.App{
 		Title:  "uniTerm",
 		Width:  1200,
 		Height:    800,
+		MaxWidth:  maxW,
+		MaxHeight: maxH,
 		Frameless: runtime.GOOS != "darwin",
 		AssetServer: &assetserver.Options{
 			Assets: assets,


### PR DESCRIPTION
## Problem

Closes #9

On Linux (deepin) with multiple screens (one portrait, one landscape), maximizing the window on the landscape screen results in the window width being set to the portrait screen's width.

## Root Cause

Wails v2 uses the WebKitGTK backend on Linux. At startup, it sets the window's max size to the primary display's resolution. In a multi-monitor setup with different resolutions/orientations, GTK's maximize is clamped to the wrong monitor's max size, preventing the window from correctly filling the current screen.

Related upstream issue: https://github.com/wailsapp/wails/issues/2431

## Fix

Two layers of protection:

1. **main.go** — Set `MaxWidth`/`MaxHeight` to `9999` on Linux to prevent GTK from clamping the window to the primary monitor's dimensions.
2. **AppHeader.vue** — On Linux, before maximizing, use `ScreenGetAll()` to find the current screen and dynamically set the correct max size, then call native maximize.

Behavior on non-Linux platforms is unchanged.

---

## 问题

Closes #9

Linux (deepin) 多屏环境下，竖屏+横屏时，窗口在横屏上最大化，宽度为竖屏的宽度。

## 根因

Wails v2 在 Linux 上使用 WebKitGTK 后端，启动时将窗口 max size 设为主显示器分辨率。在多屏不同分辨率/方向时，GTK 的 maximize 会被错误的 max size 钳制，导致窗口无法正确填充当前屏幕。

相关上游 issue: https://github.com/wailsapp/wails/issues/2431

## 修复

两层防护：

1. **main.go** — Linux 下将 `MaxWidth`/`MaxHeight` 设为 `9999`，防止启动时用主显示器分辨率限制窗口
2. **AppHeader.vue** — Linux 下点击最大化按钮时，先通过 `ScreenGetAll()` 找到当前屏幕，动态设置正确的 max size，再调用原生最大化

非 Linux 平台行为不变。