### PR TITLE
feat: prompt for SSH password in terminal when not saved

### DIFF
--- a/backend/session/mosh_session.go
+++ b/backend/session/mosh_session.go
@@ -38,7 +38,7 @@ func (s *MoshSession) Connect(config ConnectionConfig) error {
 	s.title = fmt.Sprintf("%s@%s (mosh)", config.User, config.Host)
 
 	// Step 1: SSH to remote and start mosh-server to get key + UDP port.
-	authMethods := makeSSHAuthMethods(config)
+	authMethods := makeSSHAuthMethods(config, nil)
 	addr := fmt.Sprintf("%s:%d", config.Host, config.Port)
 	clientConfig := &ssh.ClientConfig{
 		User:            config.User,

--- a/backend/session/ssh_auth.go
+++ b/backend/session/ssh_auth.go
@@ -6,7 +6,7 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
-func makeSSHAuthMethods(config ConnectionConfig) []ssh.AuthMethod {
+func makeSSHAuthMethods(config ConnectionConfig, kbCallback ssh.KeyboardInteractiveChallenge) []ssh.AuthMethod {
 	var methods []ssh.AuthMethod
 
 	switch config.AuthType {
@@ -28,6 +28,12 @@ func makeSSHAuthMethods(config ConnectionConfig) []ssh.AuthMethod {
 		methods = append(methods, ssh.Password(config.Password))
 	default:
 		methods = append(methods, ssh.Password(config.Password))
+	}
+
+
+	// Keyboard-interactive as fallback for password-less or failed-password scenarios.
+	if kbCallback != nil {
+		methods = append(methods, ssh.KeyboardInteractive(kbCallback))
 	}
 
 	return methods

--- a/backend/session/ssh_session.go
+++ b/backend/session/ssh_session.go
@@ -28,6 +28,7 @@ type SSHSession struct {
 	quit         chan struct{}
 	quitOnce     sync.Once
 	lastReadTime atomic.Int64
+	authAnswerCh chan []byte
 }
 
 func NewSSHSession(id string) *SSHSession {
@@ -45,8 +46,97 @@ func (s *SSHSession) Connect(config ConnectionConfig) error {
 	s.setStatus(StatusConnecting)
 	s.title = fmt.Sprintf("%s@%s", config.User, config.Host)
 
-	authMethods := makeSSHAuthMethods(config)
+	// Set up keyboard-interactive auth input channel.
+	s.mu.Lock()
+	s.authAnswerCh = make(chan []byte, 256)
+	s.mu.Unlock()
+	defer func() {
+		s.mu.Lock()
+		s.authAnswerCh = nil
+		s.mu.Unlock()
+	}()
 
+	// If no password is stored, prompt the user in the terminal before the
+	// SSH handshake. This covers servers that do not advertise
+	// keyboard-interactive support (the kbCallback fallback below).
+	if config.Password == "" {
+		s.emitData([]byte("\r\nPassword: "))
+		var answer string
+	promptLoop:
+		for {
+			select {
+			case data := <-s.authAnswerCh:
+				for _, b := range data {
+					switch b {
+					case '\r', '\n':
+						break promptLoop
+					case '\x03': // Ctrl+C
+						s.emitData([]byte("^C\r\n"))
+						return fmt.Errorf("auth cancelled")
+					case 127, '\b': // Backspace
+						if len(answer) > 0 {
+							answer = answer[:len(answer)-1]
+						}
+					case '\x15': // Ctrl+U
+						answer = ""
+					default:
+						answer += string(b)
+					}
+				}
+			case <-time.After(120 * time.Second):
+				s.emitData([]byte("\r\nAuth timeout\r\n"))
+				return fmt.Errorf("auth timeout")
+			}
+		}
+		s.emitData([]byte("\r\n"))
+		config.Password = answer
+	}
+
+
+	kbCallback := func(user, instruction string, questions []string, echos []bool) ([]string, error) {
+		answers := make([]string, len(questions))
+		for i, q := range questions {
+			s.emitData([]byte("\r\n" + q + " "))
+			var answer string
+		loop:
+			for {
+				select {
+				case data := <-s.authAnswerCh:
+					for _, b := range data {
+						switch b {
+						case '\r', '\n':
+							break loop
+						case '\x03':
+							s.emitData([]byte("^C\r\n"))
+							return nil, fmt.Errorf("auth cancelled")
+						case 127, '\b':
+							if len(answer) > 0 {
+								answer = answer[:len(answer)-1]
+								if echos[i] {
+									s.emitData([]byte("\b \b"))
+								}
+							}
+						case '\x15': // Ctrl+U
+							answer = ""
+						default:
+							answer += string(b)
+							if echos[i] {
+								s.emitData([]byte{b})
+							}
+						}
+					}
+				case <-time.After(120 * time.Second):
+					s.emitData([]byte("\r\nAuth timeout\r\n"))
+					return nil, fmt.Errorf("auth timeout")
+				}
+			}
+			s.emitData([]byte("\r\n"))
+			answers[i] = answer
+		}
+		return answers, nil
+	}
+
+	authMethods := makeSSHAuthMethods(config, kbCallback)
 	addr := fmt.Sprintf("%s:%d", config.Host, config.Port)
 	clientConfig := &ssh.ClientConfig{
 		User:            config.User,
@@ -283,6 +373,14 @@ func (s *SSHSession) startKeepAlive() {
 }
 
 func (s *SSHSession) Write(data []byte) error {
+	// During keyboard-interactive auth, route input to the auth callback.
+	s.mu.RLock()
+	ch := s.authAnswerCh
+	s.mu.RUnlock()
+	if ch != nil {
+		ch <- data
+		return nil
+	}
 	if s.stdin == nil {
 		return fmt.Errorf("not connected")
 	}

--- a/backend/session/tunnel_service.go
+++ b/backend/session/tunnel_service.go
@@ -43,7 +43,7 @@ func (ts *TunnelService) Start(sessionID string, sshConfig ConnectionConfig, tar
 	}
 
 	// 1. Establish SSH connection
-	authMethods := makeSSHAuthMethods(sshConfig)
+	authMethods := makeSSHAuthMethods(sshConfig, nil)
 	addr := fmt.Sprintf("%s:%d", sshConfig.Host, sshConfig.Port)
 	clientConfig := &ssh.ClientConfig{
 		User:            sshConfig.User,

--- a/backend/store/connection_store.go
+++ b/backend/store/connection_store.go
@@ -57,7 +57,14 @@ func (s *ConnectionStore) Save(data session.ConnectionStoreData) error {
 	// Extract passwords to external store before writing JSON
 	for i := range connections {
 		conn := &connections[i]
-		if conn.AuthType != "password" || conn.Password == "" {
+		if conn.AuthType != "password" {
+			continue
+		}
+		if conn.Password == "" {
+			// Password was cleared - remove old entry from keychain.
+			if s.passwordStore != nil {
+				_ = s.passwordStore.DeletePassword(conn.ID)
+			}
 			continue
 		}
 		if s.passwordStore != nil {

--- a/frontend/src/components/BaseTerminal.vue
+++ b/frontend/src/components/BaseTerminal.vue
@@ -925,6 +925,8 @@ onMounted(() => {
           props.onSessionStatus(payload.status)
         }
       } else {
+        // Focus terminal on connecting so user can type password immediately.
+        focus()
         if (props.onSessionStatus) {
           props.onSessionStatus(payload.status)
         }


### PR DESCRIPTION
## Summary

When an SSH connection has no saved password, prompt the user for their password directly in the terminal before establishing the SSH connection. This works with all SSH servers (not just those supporting keyboard-interactive).

### Changes

- **Pre-handshake password prompt**: When password is empty, emit "Password:" to terminal and collect user input via a dedicated channel before the SSH handshake
- **Keyboard-interactive fallback**: Still available for servers that support it (OTP, 2FA, etc.)
- **Input handling**: Ctrl+U to clear password, Ctrl+C to cancel, backspace support, 120s timeout
- **Auto-focus**: Terminal automatically gains focus when session enters connecting state
- **Keychain fix**: Clearing a saved password now properly deletes the old entry from the keychain

### Files changed
- `backend/session/ssh_auth.go` — add kbCallback parameter + keyboard-interactive fallback
- `backend/session/ssh_session.go` — password prompt loop, kbCallback, Write() routing
- `backend/session/tunnel_service.go`, `mosh_session.go` — pass nil callback
- `backend/store/connection_store.go` — delete keychain password on clear
- `frontend/BaseTerminal.vue` — focus terminal on connecting

Closes #5

---

## 摘要

当 SSH 连接未保存密码时，在终端中提示用户输入密码（SSH 握手之前），适用于所有 SSH 服务器。

### 变更

- **握手前密码提示**: 密码为空时终端显示 "Password:"，通过专有 channel 收集用户输入
- **keyboard-interactive 回退**: 服务器支持时仍可用（OTP/2FA 场景）
- **输入处理**: Ctrl+U 清空、Ctrl+C 取消、退格键、120 秒超时
- **自动聚焦**: session 进入 connecting 状态时终端获得焦点
- **Keychain 修复**: 清空密码保存时正确删除旧条目

Closes #5