### PR TITLE
ci: mark GitHub Releases as prerelease by default

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -155,6 +155,7 @@ jobs:
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
+          prerelease: true
           files: |
             uniterm-*.zip
             uniterm-*.tar.gz


### PR DESCRIPTION
设置通过 tag 触发 GitHub Release 时，默认发布为 prerelease 状态。