### PR TITLE
feat: expand terminal themes to 27 and add sidebar personalization panel

### DIFF
--- a/backend/store/settings_store.go
+++ b/backend/store/settings_store.go
@@ -154,7 +154,7 @@ func defaultSettings() AppSettings {
 		Theme:    "dark",
 		Language: "system",
 		Terminal: TerminalSettings{
-			Theme:            "dark",
+			Theme:            "uniterm-dark",
 			FontFamily:       "Consolas, \"Courier New\", monospace",
 			FontSize:         14,
 			SelectionAction:  "none",

--- a/frontend/src/components/AIMessage.vue
+++ b/frontend/src/components/AIMessage.vue
@@ -19,7 +19,7 @@
       </div>
 
       <div v-if="message.needsContinue" class="continue-box">
-        <el-button type="primary" size="small" @click="$emit('continue')">
+        <el-button type="primary" @click="$emit('continue')">
           {{ t('ai.continue') }}
         </el-button>
       </div>
@@ -64,8 +64,8 @@
           </div>
           <code class="tool-args">{{ pendingCmd.command }}</code>
           <div class="tool-actions">
-            <el-button size="small" type="primary" @click="handleApprove">{{ t('ai.run') }}</el-button>
-            <el-button size="small" @click="handleReject">{{ t('ai.skip') }}</el-button>
+            <el-button type="primary" @click="handleApprove">{{ t('ai.run') }}</el-button>
+            <el-button @click="handleReject">{{ t('ai.skip') }}</el-button>
           </div>
         </div>
       </div>

--- a/frontend/src/components/AISidebar.vue
+++ b/frontend/src/components/AISidebar.vue
@@ -95,8 +95,8 @@
           @keydown.enter="onKeydownEnter"
         />
         <div class="input-actions">
-          <el-dropdown trigger="click" @command="onModelChange" size="small" v-if="settingsStore.settings.ai.models.length > 0">
-            <el-button size="small" class="model-btn">
+          <el-dropdown trigger="click" @command="onModelChange" v-if="settingsStore.settings.ai.models.length > 0">
+            <el-button class="model-btn">
               <span class="model-btn-name">{{ currentModelName }}</span>
               <el-icon class="dropdown-icon"><ChevronDown /></el-icon>
             </el-button>
@@ -113,8 +113,8 @@
               </el-dropdown-menu>
             </template>
           </el-dropdown>
-          <el-dropdown trigger="click" @command="onModeChange" size="small">
-            <el-button :type="modeButtonType" size="small" class="mode-btn">
+          <el-dropdown trigger="click" @command="onModeChange">
+            <el-button :type="modeButtonType" class="mode-btn">
               {{ modeLabel }}<el-icon class="dropdown-icon"><ChevronDown /></el-icon>
             </el-button>
             <template #dropdown>
@@ -134,10 +134,10 @@
               </el-dropdown-menu>
             </template>
           </el-dropdown>
-          <el-button v-if="!aiStore.isRunning && !aiStore.pendingCommand" type="primary" size="small" :disabled="!input.trim()" @click="onSend">
+          <el-button v-if="!aiStore.isRunning && !aiStore.pendingCommand" type="primary" :disabled="!input.trim()" @click="onSend">
             {{ t('ai.send') }}
           </el-button>
-          <el-button v-else type="danger" size="small" @click="onStop">{{ t('ai.stop') }}</el-button>
+          <el-button v-else type="danger" @click="onStop">{{ t('ai.stop') }}</el-button>
         </div>
       </div>
     </div>

--- a/frontend/src/components/DBQueryEditor.vue
+++ b/frontend/src/components/DBQueryEditor.vue
@@ -31,7 +31,7 @@
         <el-table
           :data="queryResult.rows"
           border
-          size="small"
+         
           style="width:100%"
           :empty-text="t('db.noData')"
           @cell-dblclick="onCellDblClick"

--- a/frontend/src/components/DBTableStructure.vue
+++ b/frontend/src/components/DBTableStructure.vue
@@ -14,7 +14,7 @@
           <div class="section-title">{{ t('db.columns') }}</div>
           <button class="exec-btn" @click="startAddColumn">{{ t('db.addColumn') }}</button>
         </div>
-        <el-table :data="schema?.columns || []" border size="small" style="width:100%">
+        <el-table :data="schema?.columns || []" border style="width:100%">
           <el-table-column prop="name" :label="t('db.colName')" />
           <el-table-column prop="type" :label="t('db.colType')" />
           <el-table-column :label="t('db.colNullable')" width="80">
@@ -47,7 +47,7 @@
           <div class="section-title">{{ t('db.indexes') }}</div>
           <button class="exec-btn" @click="startAddIndex">{{ t('db.addIndex') }}</button>
         </div>
-        <el-table :data="schema?.indexes || []" border size="small" style="width:100%">
+        <el-table :data="schema?.indexes || []" border style="width:100%">
           <el-table-column prop="name" :label="t('db.idxName')" />
           <el-table-column :label="t('db.idxColumns')">
             <template #default="{ row }">

--- a/frontend/src/components/HistoryPanel.vue
+++ b/frontend/src/components/HistoryPanel.vue
@@ -5,7 +5,7 @@
         v-model="searchQuery"
         :placeholder="t('settings.historySearchPlaceholder')"
         clearable
-        size="small"
+       
         class="qc-search-input"
         @keydown="onListKeydown"
       />

--- a/frontend/src/components/MonitorTabContent.vue
+++ b/frontend/src/components/MonitorTabContent.vue
@@ -66,13 +66,13 @@
           </div>
         </div>
         <div class="process-actions">
-          <el-button :type="paused ? 'primary' : 'default'" size="small" @click="togglePause">
+          <el-button :type="paused ? 'primary' : 'default'" @click="togglePause">
             {{ paused ? t('monitor.resume') : t('monitor.pause') }}
           </el-button>
         </div>
       </div>
       <el-input v-model="processSearch" :placeholder="t('monitor.searchProcess')" clearable class="process-search" />
-      <el-table :data="filteredProcesses" height="calc(100% - 40px)" size="small" class="process-table" @row-click="onProcessRowClick">
+      <el-table :data="filteredProcesses" height="calc(100% - 40px)" class="process-table" @row-click="onProcessRowClick">
         <el-table-column prop="pid" label="PID" sortable width="80" />
         <el-table-column prop="name" :label="t('monitor.processName')" sortable />
         <el-table-column prop="user" :label="t('monitor.user')" sortable width="100" />
@@ -92,11 +92,11 @@
     <div v-show="activeTab === 'ports'" class="tab-pane ports-pane" @contextmenu.prevent="showContextMenu($event)">
       <div class="od-toolbar">
         <el-input v-model="portSearch" :placeholder="t('monitor.searchPort')" clearable class="od-search" />
-        <el-button size="small" :icon="RefreshRight" :loading="loadingPorts" @click="fetchPorts">
+        <el-button :icon="RefreshRight" :loading="loadingPorts" @click="fetchPorts">
           {{ t('monitor.refresh') }}
         </el-button>
       </div>
-      <el-table :data="filteredPorts" v-loading="loadingPorts" height="calc(100% - 36px)" size="small" class="od-table">
+      <el-table :data="filteredPorts" v-loading="loadingPorts" height="calc(100% - 36px)" class="od-table">
         <el-table-column prop="protocol" :label="t('monitor.port.protocol')" sortable width="90" />
         <el-table-column prop="localAddr" :label="t('monitor.port.localAddr')" sortable width="160" />
         <el-table-column prop="process" :label="t('monitor.port.process')" sortable />
@@ -107,11 +107,11 @@
     <div v-show="activeTab === 'disks'" class="tab-pane disks-pane" @contextmenu.prevent="showContextMenu($event)">
       <div class="od-toolbar">
         <el-input v-model="diskSearch" :placeholder="t('monitor.searchDisk')" clearable class="od-search" />
-        <el-button size="small" :icon="RefreshRight" :loading="loadingDisks" @click="fetchDisks">
+        <el-button :icon="RefreshRight" :loading="loadingDisks" @click="fetchDisks">
           {{ t('monitor.refresh') }}
         </el-button>
       </div>
-      <el-table :data="filteredDisks" v-loading="loadingDisks" height="calc(100% - 36px)" size="small" class="od-table">
+      <el-table :data="filteredDisks" v-loading="loadingDisks" height="calc(100% - 36px)" class="od-table">
         <el-table-column prop="name" :label="t('monitor.disk.name')" sortable>
           <template #default="{ row }">
             <span :style="{ paddingLeft: (row.name.match(/^ +/)?.[0].length || 0) * 6 + 'px' }">{{ row.name.trim() }}</span>
@@ -136,11 +136,11 @@
     <div v-show="activeTab === 'network'" class="tab-pane network-pane" @contextmenu.prevent="showContextMenu($event)">
       <div class="od-toolbar">
         <el-input v-model="netSearch" :placeholder="t('monitor.searchNetwork')" clearable class="od-search" />
-        <el-button size="small" :icon="RefreshRight" :loading="loadingNetCards" @click="fetchNetCards">
+        <el-button :icon="RefreshRight" :loading="loadingNetCards" @click="fetchNetCards">
           {{ t('monitor.refresh') }}
         </el-button>
       </div>
-      <el-table :data="filteredNetCards" v-loading="loadingNetCards" height="calc(100% - 36px)" size="small" class="od-table">
+      <el-table :data="filteredNetCards" v-loading="loadingNetCards" height="calc(100% - 36px)" class="od-table">
         <el-table-column prop="name" :label="t('monitor.net.name')" sortable width="120" />
         <el-table-column prop="state" :label="t('monitor.net.state')" sortable width="90" />
         <el-table-column prop="mac" :label="t('monitor.net.mac')" sortable width="160" />
@@ -174,7 +174,7 @@
     <div class="detail-drawer" :class="{ open: detailDrawerVisible }">
       <div class="detail-drawer-header">
         <span class="detail-drawer-title">{{ t('monitor.processDetail') }}</span>
-        <el-button link size="small" @click="detailDrawerVisible = false">
+        <el-button link @click="detailDrawerVisible = false">
           <el-icon><Close /></el-icon>
         </el-button>
       </div>
@@ -258,9 +258,9 @@
           </div>
         </div>
         <div class="detail-actions">
-          <el-button size="small" @click="detailDrawerVisible = false">{{ t('common.cancel') }}</el-button>
-          <el-dropdown size="small" trigger="click" @command="(cmd: string) => onDetailAction(cmd)">
-            <el-button size="small" type="primary">
+          <el-button @click="detailDrawerVisible = false">{{ t('common.cancel') }}</el-button>
+          <el-dropdown trigger="click" @command="(cmd: string) => onDetailAction(cmd)">
+            <el-button type="primary">
               {{ t('monitor.sendSignal') }}<el-icon class="dropdown-icon"><ArrowDown /></el-icon>
             </el-button>
             <template #dropdown>
@@ -281,8 +281,8 @@
     <el-dialog v-model="killDialogVisible" :title="killType === 'kill' ? t('monitor.forceKill') : t('monitor.kill')" width="360px" align-center>
       <p>{{ killMessage }}</p>
       <template #footer>
-        <el-button size="small" @click="killDialogVisible = false">{{ t('common.cancel') }}</el-button>
-        <el-button size="small" type="danger" @click="confirmKill">{{ t('common.confirm') }}</el-button>
+        <el-button @click="killDialogVisible = false">{{ t('common.cancel') }}</el-button>
+        <el-button type="danger" @click="confirmKill">{{ t('common.confirm') }}</el-button>
       </template>
     </el-dialog>
 

--- a/frontend/src/components/QuickCommandsPanel.vue
+++ b/frontend/src/components/QuickCommandsPanel.vue
@@ -6,7 +6,7 @@
         v-model="searchQuery"
         :placeholder="t('quickCommands.searchPlaceholder')"
         clearable
-        size="small"
+       
         class="qc-search-input"
         @keydown="onListKeydown"
       />

--- a/frontend/src/components/SFTPFileList.vue
+++ b/frontend/src/components/SFTPFileList.vue
@@ -4,37 +4,37 @@
       <el-input
         v-model="filterText"
         :placeholder="t('sftp.filterByName')"
-        size="small"
+       
         clearable
       />
-      <el-button size="small" @click="emit('refresh')" :title="t('sftp.refresh')">
+      <el-button @click="emit('refresh')" :title="t('sftp.refresh')">
         <el-icon><RefreshCw :size="14" /></el-icon>
       </el-button>
-      <el-button size="small" @click="showHidden = !showHidden" :type="showHidden ? 'primary' : undefined" :title="showHidden ? t('sftp.hideHidden') : t('sftp.showHidden')">
+      <el-button @click="showHidden = !showHidden" :type="showHidden ? 'primary' : undefined" :title="showHidden ? t('sftp.hideHidden') : t('sftp.showHidden')">
         <el-icon><Eye :size="14" /></el-icon>
       </el-button>
-      <el-button v-if="mode === 'remote'" size="small" type="primary" @click="emit('upload')" :title="t('sftp.upload')">
+      <el-button v-if="mode === 'remote'" type="primary" @click="emit('upload')" :title="t('sftp.upload')">
         <el-icon><Upload :size="14" /></el-icon>
       </el-button>
     </div>
     <div v-if="clipboardCount" class="clipboard-bar">
       <span class="clipboard-info">{{ clipboardMode === 'cut' ? t('sftp.cut') : t('sftp.copy') }} ({{ clipboardCount }})</span>
-      <el-button size="small" type="primary" @click="emit('paste')">{{ t('sftp.paste') }}</el-button>
-      <el-button size="small" @click="emit('clearClipboard')">{{ t('sftp.dialog.cancel') }}</el-button>
+      <el-button type="primary" @click="emit('paste')">{{ t('sftp.paste') }}</el-button>
+      <el-button @click="emit('clearClipboard')">{{ t('sftp.dialog.cancel') }}</el-button>
     </div>
     <div class="table-wrapper" @contextmenu.prevent="onEmptyAreaContextMenu">
       <div v-if="loading || pasteLoading" class="loading-overlay">
         <div class="loading-content">
           <div class="loading-spinner"></div>
           <span class="loading-text">{{ pasteLoading ? t('sftp.pasting') : t('sftp.loading') }}</span>
-          <el-button size="small" @click="pasteLoading ? emit('cancelPaste') : emit('cancelLoad')">{{ t('sftp.cancel') }}</el-button>
+          <el-button @click="pasteLoading ? emit('cancelPaste') : emit('cancelLoad')">{{ t('sftp.cancel') }}</el-button>
         </div>
       </div>
       <el-table
         ref="tableRef"
         :key="locale"
         :data="filteredFiles"
-        size="small"
+       
         :row-class-name="getRowClassName"
         @row-click="onRowClick"
         @row-dblclick="onRowDblClick"

--- a/frontend/src/components/SFTPPathBreadcrumb.vue
+++ b/frontend/src/components/SFTPPathBreadcrumb.vue
@@ -9,7 +9,7 @@
       <el-input
         ref="inputRef"
         v-model="pathInput"
-        size="small"
+       
         class="path-input"
         @keyup.enter="commitEdit"
         @blur="commitEdit"

--- a/frontend/src/components/SFTPTabContent.vue
+++ b/frontend/src/components/SFTPTabContent.vue
@@ -159,14 +159,14 @@
       <template #footer>
         <div class="editor-footer">
           <div class="editor-footer-left">
-            <el-checkbox v-model="editorWrapEnabled" size="small">{{ t('sftp.edit.wrap') }}</el-checkbox>
-            <el-select v-model="editorEncoding" size="small" style="width: 100px">
+            <el-checkbox v-model="editorWrapEnabled">{{ t('sftp.edit.wrap') }}</el-checkbox>
+            <el-select v-model="editorEncoding" style="width: 100px">
               <el-option label="UTF-8" value="utf-8" />
               <el-option label="UTF-16 LE" value="utf-16le" />
               <el-option label="UTF-16 BE" value="utf-16be" />
               <el-option label="GBK" value="gbk" />
             </el-select>
-            <el-select v-model="editorLineEnding" size="small" style="width: 140px">
+            <el-select v-model="editorLineEnding" style="width: 140px">
               <el-option label="LF (Linux/macOS)" value="lf" />
               <el-option label="CRLF (Windows)" value="crlf" />
               <el-option label="CR (old Mac)" value="cr" />

--- a/frontend/src/components/SFTPTransferProgress.vue
+++ b/frontend/src/components/SFTPTransferProgress.vue
@@ -13,7 +13,7 @@
       />
       <el-button
         v-if="task.status === 'running'"
-        size="small"
+       
         :icon="Pause"
         circle
         @click="emit('pause', task.id)"
@@ -21,7 +21,7 @@
       />
       <el-button
         v-else-if="task.status === 'paused'"
-        size="small"
+       
         type="success"
         :icon="Play"
         circle
@@ -30,7 +30,7 @@
       />
       <el-button
         v-if="task.status === 'running' || task.status === 'paused'"
-        size="small"
+       
         type="danger"
         :icon="X"
         circle

--- a/frontend/src/components/SPICETabContent.vue
+++ b/frontend/src/components/SPICETabContent.vue
@@ -37,7 +37,7 @@
       <span class="spice-scale-label">{{ t('spice.scale') }}</span>
       <el-switch
         v-model="scaleViewport"
-        size="small"
+       
         style="--el-switch-on-color: #67c23a; --el-switch-off-color: #606266"
       />
     </div>

--- a/frontend/src/components/SettingsTab.vue
+++ b/frontend/src/components/SettingsTab.vue
@@ -25,7 +25,7 @@
               <div class="setting-desc">{{ t('settings.themeDesc') }}</div>
             </div>
             <div class="setting-control">
-              <el-select v-model="settingsStore.settings.theme" size="small" @change="settingsStore.save()">
+              <el-select v-model="settingsStore.settings.theme" @change="settingsStore.save()">
                 <el-option :label="t('settings.themeDark')" value="dark" />
                 <el-option :label="t('settings.themeDeepBlue')" value="deep-blue" />
                 <el-option :label="t('settings.themeLight')" value="light" />
@@ -40,7 +40,7 @@
               <div class="setting-desc">{{ t('settings.languageDesc') }}</div>
             </div>
             <div class="setting-control">
-              <el-select :model-value="settingsStore.settings.language" size="small" @change="settingsStore.updateLanguage">
+              <el-select :model-value="settingsStore.settings.language" @change="settingsStore.updateLanguage">
                 <el-option
                   v-for="lang in LANGUAGE_OPTIONS"
                   :key="lang.value"
@@ -65,13 +65,19 @@
               <div class="setting-desc">{{ t('settings.colorSchemeDesc') }}</div>
             </div>
             <div class="setting-control">
-              <el-select v-model="settingsStore.settings.terminal.theme" size="small" @change="settingsStore.save()">
-                <el-option
-                  v-for="th in TERMINAL_THEMES"
-                  :key="th.value"
-                  :label="th.label"
-                  :value="th.value"
-                />
+              <el-select v-model="settingsStore.settings.terminal.theme" @change="settingsStore.save()" popper-class="theme-select-popper">
+                <el-option-group
+                  v-for="group in terminalThemeGroups"
+                  :key="group.label"
+                  :label="group.label"
+                >
+                  <el-option
+                    v-for="th in group.options"
+                    :key="th.value"
+                    :label="th.label"
+                    :value="th.value"
+                  />
+                </el-option-group>
               </el-select>
             </div>
           </div>
@@ -82,7 +88,7 @@
               <div class="setting-desc">{{ t('settings.fontDesc') }}</div>
             </div>
             <div class="setting-control">
-              <el-select v-model="settingsStore.settings.terminal.fontFamily" size="small" filterable @change="settingsStore.save()">
+              <el-select v-model="settingsStore.settings.terminal.fontFamily" @change="settingsStore.save()">
                 <el-option
                   v-for="f in fontOptions"
                   :key="f.value"
@@ -104,7 +110,7 @@
                 v-model="settingsStore.settings.terminal.fontSize"
                 :min="8"
                 :max="32"
-                size="small"
+               
                 @change="settingsStore.save()"
               />
             </div>
@@ -116,7 +122,7 @@
               <div class="setting-desc">{{ t('settings.selectionActionDesc') }}</div>
             </div>
             <div class="setting-control">
-              <el-select v-model="settingsStore.settings.terminal.selectionAction" size="small" @change="settingsStore.save()">
+              <el-select v-model="settingsStore.settings.terminal.selectionAction" @change="settingsStore.save()">
                 <el-option :label="t('settings.selectionNone')" value="none" />
                 <el-option :label="t('settings.selectionCopy')" value="copy" />
               </el-select>
@@ -129,7 +135,7 @@
               <div class="setting-desc">{{ t('settings.rightClickDesc') }}</div>
             </div>
             <div class="setting-control">
-              <el-select v-model="settingsStore.settings.terminal.rightClickAction" size="small" @change="settingsStore.save()">
+              <el-select v-model="settingsStore.settings.terminal.rightClickAction" @change="settingsStore.save()">
                 <el-option :label="t('settings.rightClickMenu')" value="menu" />
                 <el-option :label="t('settings.rightClickPaste')" value="paste" />
               </el-select>
@@ -147,7 +153,7 @@
                 :min="100"
                 :max="50000"
                 :step="100"
-                size="small"
+               
                 @change="settingsStore.save()"
               />
             </div>
@@ -198,7 +204,7 @@
           <div class="sync-card">
             <div class="sync-card-header">
               <span>{{ t('settings.syncRepoCard') }}</span>
-              <el-button size="small" text @click="openEditRepo">{{ t('settings.syncEdit') }}</el-button>
+              <el-button text @click="openEditRepo">{{ t('settings.syncEdit') }}</el-button>
             </div>
             <div class="sync-card-body">
               <div class="repo-info">
@@ -212,8 +218,8 @@
                 </div>
               </div>
               <div class="repo-actions">
-                <el-button size="small" @click="syncStore.showChangePassword = true">{{ t('settings.syncChangePassword') }}</el-button>
-                <el-button size="small" @click="syncStore.showDeleteRepo = true">{{ t('settings.syncDeleteRepo') }}</el-button>
+                <el-button @click="syncStore.showChangePassword = true">{{ t('settings.syncChangePassword') }}</el-button>
+                <el-button @click="syncStore.showDeleteRepo = true">{{ t('settings.syncDeleteRepo') }}</el-button>
               </div>
             </div>
           </div>
@@ -274,7 +280,7 @@
           </div>
           <div class="about-update-actions">
             <el-button
-              size="small"
+             
               :loading="updateCheck.checking"
               @click="handleCheckUpdate"
             >
@@ -311,7 +317,7 @@
               <td><kbd class="kb-key">{{ bindingDisplay(action) }}</kbd></td>
               <td class="kb-actions">
                 <el-button
-                  size="small"
+                 
                   :type="rebindingAction === action ? 'warning' : 'default'"
                   @click="startRebind(action)"
                 >
@@ -319,14 +325,14 @@
                 </el-button>
                 <el-button
                   v-if="rebindingAction === action"
-                  size="small"
+                 
                   @click="stopRebind()"
                 >
                   {{ t('shortcut.cancel') }}
                 </el-button>
                 <el-button
                   v-if="rebindingAction === action"
-                  size="small"
+                 
                   type="danger"
                   @click="clearBinding(action)"
                 >
@@ -334,7 +340,7 @@
                 </el-button>
                 <el-button
                   v-if="!isDefaultBinding(action) && rebindingAction !== action"
-                  size="small"
+                 
                   type="danger"
                   @click="resetBinding(action)"
                 >
@@ -357,7 +363,7 @@
               <div class="setting-desc">{{ t('settings.modelListDesc') }}</div>
             </div>
             <div class="setting-control">
-              <el-button size="small" @click="showModelForm = true">+ {{ t('settings.addModel') }}</el-button>
+              <el-button @click="showModelForm = true">+ {{ t('settings.addModel') }}</el-button>
             </div>
           </div>
 
@@ -378,10 +384,10 @@
               <span class="model-detail">{{ model.model }} @ {{ model.baseURL }}</span>
             </div>
             <div class="model-actions">
-              <el-button link size="small" @click="editModel(model)">
+              <el-button link @click="editModel(model)">
                 <el-icon><Pencil :size="14" /></el-icon>
               </el-button>
-              <el-button link size="small" type="danger" @click="settingsStore.removeModel(model.id)">
+              <el-button link type="danger" @click="settingsStore.removeModel(model.id)">
                 <el-icon><Trash2 :size="14" /></el-icon>
               </el-button>
             </div>
@@ -425,13 +431,13 @@
               :fetch-suggestions="(qs, cb) => cb(qs ? modelSuggestions.filter(s => s.value.toLowerCase().includes(qs.toLowerCase())) : modelSuggestions)"
               class="model-autocomplete"
             />
-            <el-button size="small" :loading="modelFetching" @click="fetchModelList">
+            <el-button :loading="modelFetching" @click="fetchModelList">
               {{ t('settings.fetchModels') }}
             </el-button>
           </div>
         </el-form-item>
         <el-form-item>
-          <el-button size="small" :loading="testingConnection" @click="testConnection">
+          <el-button :loading="testingConnection" @click="testConnection">
             {{ t('settings.testConnection') }}
           </el-button>
           <span v-if="testResult != null" :class="testResult ? 'test-ok' : 'test-fail'" style="margin-left: 8px; font-size: 13px;">
@@ -465,7 +471,7 @@ import { useUpdateCheck } from '../composables/useUpdateCheck'
 import { useI18n } from '../i18n'
 import { BrowserOpenURL } from '../../wailsjs/runtime'
 import { TERMINAL_THEMES, FONT_OPTIONS, LANGUAGE_OPTIONS, DEFAULT_KEYBOARD, SHORTCUT_LABELS, USER_AGENT_PRESETS } from '../types/settings'
-import type { AIModelConfig, ShortcutAction, KeyBinding, KeyboardSettings } from '../types/settings'
+import type { AIModelConfig, ShortcutAction, KeyBinding, KeyboardSettings, TerminalTheme } from '../types/settings'
 import { uninstallGlobalListener, installGlobalListener } from '../composables/useKeyboardShortcuts'
 import AddRepoDialog from './AddRepoDialog.vue'
 import EditRepoDialog from './EditRepoDialog.vue'
@@ -515,6 +521,11 @@ const fontOptions = computed(() => {
   }
   return FONT_OPTIONS
 })
+
+const terminalThemeGroups = computed(() => [
+  { label: 'Dark', options: TERMINAL_THEMES.filter(t => t.type === 'dark') },
+  { label: 'Light', options: TERMINAL_THEMES.filter(t => t.type === 'light') }
+])
 
 onMounted(async () => {
   try {

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -10,6 +10,7 @@
       <button class="sidebar-tab" :class="{ active: activeView === 'connections' }" @click="activeView = 'connections'" :title="t('header.connections')"><el-icon><Network :size="14" /></el-icon></button>
       <button class="sidebar-tab" :class="{ active: activeView === 'quickCommands' }" @click="activeView = 'quickCommands'" :title="t('quickCommands.quickCommandsTab')"><el-icon><Zap :size="14" /></el-icon></button>
       <button class="sidebar-tab" :class="{ active: activeView === 'history' }" @click="activeView = 'history'" :title="t('quickCommands.historyTab')"><el-icon><Clock :size="14" /></el-icon></button>
+      <button class="sidebar-tab" :class="{ active: activeView === 'personalization' }" @click="activeView = 'personalization'" :title="t('sidebar.personalization')"><el-icon><Palette :size="14" /></el-icon></button>
       <button class="icon-btn" @click="emit('toggle')" :title="t('sidebar.collapse')"><el-icon><X :size="14" /></el-icon></button>
     </div>
 
@@ -236,6 +237,40 @@
 
     <HistoryPanel v-if="activeView === 'history'" />
 
+    <template v-if="activeView === 'personalization'">
+      <div class="personalization-panel">
+        <div class="persist-section">
+          <div class="persist-label">{{ t('settings.colorScheme') }}</div>
+          <el-select v-model="settingsStore.settings.terminal.theme" @change="settingsStore.save()" popper-class="theme-select-popper">
+            <el-option-group v-for="group in terminalThemeGroups" :key="group.label" :label="group.label">
+              <el-option v-for="th in group.options" :key="th.value" :label="th.label" :value="th.value" />
+            </el-option-group>
+          </el-select>
+        </div>
+        <div class="persist-section">
+          <div class="persist-label">{{ t('settings.font') }}</div>
+          <el-select v-model="settingsStore.settings.terminal.fontFamily" @change="settingsStore.save()">
+            <el-option
+              v-for="f in personalizationFontOptions"
+              :key="f.value"
+              :label="f.label"
+              :value="f.value"
+              :style="{ fontFamily: f.value }"
+            />
+          </el-select>
+        </div>
+        <div class="persist-section">
+          <div class="persist-label">{{ t('settings.fontSize') }}</div>
+          <el-input-number
+            v-model="settingsStore.settings.terminal.fontSize"
+            :min="8"
+            :max="32"
+            @change="settingsStore.save()"
+          />
+        </div>
+      </div>
+    </template>
+
     <ConnectionForm v-model="showForm" :edit-config="editConfig" :default-group-id="newConnGroupId" @save="onSave" @connect="onConnectFromForm" />
 
     <!-- Connection context menu (kept inside sidebar to avoid native RDP occlusion) -->
@@ -384,7 +419,7 @@
 
 <script setup lang="ts">
 import { ref, onMounted, onUnmounted, computed, watch, nextTick } from 'vue'
-import { X, ChevronRight, ChevronDown, Filter, Check, Network, Zap, Clock, Plus } from '@lucide/vue'
+import { X, ChevronRight, ChevronDown, Filter, Check, Network, Zap, Clock, Plus, Palette } from '@lucide/vue'
 import { ElMessageBox } from 'element-plus'
 import { useConnectionStore } from '../stores/connectionStore'
 import { useSettingsStore } from '../stores/settingsStore'
@@ -393,6 +428,9 @@ import ConnectionForm from './ConnectionForm.vue'
 import QuickCommandsPanel from './QuickCommandsPanel.vue'
 import HistoryPanel from './HistoryPanel.vue'
 import type { ConnectionConfig, ConnectionGroup } from '../types/session'
+import { FONT_OPTIONS, TERMINAL_THEMES } from '../types/settings'
+import type { TerminalTheme } from '../types/settings'
+import { GetSystemFonts } from '../../wailsjs/go/main/App'
 
 defineProps<{
   visible: boolean
@@ -403,7 +441,21 @@ const settingsStore = useSettingsStore()
 const { t } = useI18n()
 const showForm = ref(false)
 const editConfig = ref<ConnectionConfig | undefined>(undefined)
-const activeView = ref<'connections' | 'quickCommands' | 'history'>('connections')
+const activeView = ref<'connections' | 'quickCommands' | 'history' | 'personalization'>('connections')
+
+// ── Personalization panel ──
+const systemFonts = ref<{ label: string; value: string }[]>([])
+const personalizationFontOptions = computed(() => {
+  if (systemFonts.value.length > 0) {
+    return systemFonts.value
+  }
+  return FONT_OPTIONS
+})
+
+const terminalThemeGroups = computed(() => [
+  { label: 'Dark', options: TERMINAL_THEMES.filter(t => t.type === 'dark') },
+  { label: 'Light', options: TERMINAL_THEMES.filter(t => t.type === 'light') }
+])
 
 // Notify App.vue to hide native RDP window when edit dialog opens
 watch(showForm, (val) => {
@@ -1226,7 +1278,7 @@ function onConnectFromForm(config: ConnectionConfig) {
 }
 
 // ── Lifecycle ──
-onMounted(() => {
+onMounted(async () => {
   window.addEventListener('global:close-context-menus', () => {
     closeMenu()
     closeGroupMenu()
@@ -1237,6 +1289,15 @@ onMounted(() => {
     closeGroupMenu()
     closeEmptyAreaMenu()
   })
+  // Load system fonts for personalization panel
+  try {
+    const fonts = await GetSystemFonts()
+    if (fonts && fonts.length > 0) {
+      systemFonts.value = fonts.map(f => ({ label: f, value: f }))
+    }
+  } catch {
+    // Fall back to FONT_OPTIONS
+  }
 })
 
 onUnmounted(() => {
@@ -1544,6 +1605,32 @@ defineExpose({ focusSearch })
   color: var(--accent);
   background: var(--accent-subtle);
 }
+
+/* ── Personalization panel ── */
+.personalization-panel {
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.persist-section {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.persist-label {
+  font-size: 11px;
+  font-family: var(--font-ui);
+  color: var(--text-muted);
+  padding-left: 2px;
+}
+
+.persist-section .el-select,
+.persist-section .el-input-number {
+  width: 100%;
+}
 </style>
 
 <style>
@@ -1650,5 +1737,22 @@ defineExpose({ focusSearch })
 .new-conn-popper {
   margin-top: -8px !important;
   margin-left: 4px !important;
+}
+
+.theme-select-popper .el-select-group__title {
+  font-size: 10px;
+  color: var(--text-disabled);
+  text-align: center;
+  padding: 6px 12px 2px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.theme-select-popper .el-select-group__title::before,
+.theme-select-popper .el-select-group__title::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: var(--border-subtle);
 }
 </style>

--- a/frontend/src/composables/useTerminal.ts
+++ b/frontend/src/composables/useTerminal.ts
@@ -53,7 +53,9 @@ export function getXtermTheme(name: string): any {
     brightWhite: '#d0d0d8'
   }
   switch (name) {
-    case 'light':
+    case 'uniterm-dark':
+      return base
+    case 'uniterm-light':
       return {
         background: '#fafafa',
         foreground: '#1f1f1f',
@@ -145,6 +147,140 @@ export function getXtermTheme(name: string): any {
         brightCyan: '#a1efe4',
         brightWhite: '#f9f8f5'
       }
+    case 'dracula':
+      return {
+        background: '#282a36',
+        foreground: '#f8f8f2',
+        cursor: '#f8f8f0',
+        selectionBackground: 'rgba(248, 248, 242, 0.2)',
+        black: '#21222c', red: '#ff5555', green: '#50fa7b', yellow: '#f1fa8c',
+        blue: '#bd93f9', magenta: '#ff79c6', cyan: '#8be9fd', white: '#f8f8f2',
+        brightBlack: '#6272a4', brightRed: '#ff6e6e', brightGreen: '#69ff94',
+        brightYellow: '#ffffa5', brightBlue: '#d6acff', brightMagenta: '#ff92df',
+        brightCyan: '#a4ffff', brightWhite: '#ffffff'
+      }
+    case 'molokai':
+      return {
+        background: '#1b1d1e',
+        foreground: '#f8f8f2',
+        cursor: '#bbbbbb',
+        selectionBackground: 'rgba(248, 248, 242, 0.2)',
+        black: '#1b1d1e', red: '#f92672', green: '#a6e22e', yellow: '#e6db74',
+        blue: '#66d9ef', magenta: '#ae81ff', cyan: '#a1efe4', white: '#f8f8f2',
+        brightBlack: '#465457', brightRed: '#ff5995', brightGreen: '#b6e354',
+        brightYellow: '#feed6c', brightBlue: '#8cedff', brightMagenta: '#9e6ffe',
+        brightCyan: '#899ca1', brightWhite: '#ffffff'
+      }
+    case 'tomorrow-night':
+      return {
+        background: '#1d1f21',
+        foreground: '#c5c8c6',
+        cursor: '#c5c8c6',
+        selectionBackground: 'rgba(197, 200, 198, 0.2)',
+        black: '#1d1f21', red: '#cc6666', green: '#b5bd68', yellow: '#f0c674',
+        blue: '#81a2be', magenta: '#b294bb', cyan: '#8abeb7', white: '#c5c8c6',
+        brightBlack: '#969896', brightRed: '#cc6666', brightGreen: '#b5bd68',
+        brightYellow: '#f0c674', brightBlue: '#81a2be', brightMagenta: '#b294bb',
+        brightCyan: '#8abeb7', brightWhite: '#ffffff'
+      }
+    case 'tomorrow':
+      return { background: '#ffffff', foreground: '#4d4d4c', cursor: '#4d4d4c', selectionBackground: 'rgba(77,77,76,0.2)', black: '#1d1f21', red: '#c82829', green: '#718c00', yellow: '#eab700', blue: '#4271ae', magenta: '#8959a8', cyan: '#3e999f', white: '#8e908c', brightBlack: '#969896', brightRed: '#c82829', brightGreen: '#718c00', brightYellow: '#eab700', brightBlue: '#4271ae', brightMagenta: '#8959a8', brightCyan: '#3e999f', brightWhite: '#4d4d4c' }
+    case 'tomorrow-night-bright':
+      return {
+        background: '#000000',
+        foreground: '#eaeaea',
+        cursor: '#eaeaea',
+        selectionBackground: 'rgba(234, 234, 234, 0.2)',
+        black: '#000000', red: '#d54e53', green: '#b9ca4a', yellow: '#e7c547',
+        blue: '#7aa6da', magenta: '#c397d8', cyan: '#70c0b1', white: '#eaeaea',
+        brightBlack: '#666666', brightRed: '#ff3334', brightGreen: '#9ec400',
+        brightYellow: '#e7c547', brightBlue: '#7aa6da', brightMagenta: '#b77ee0',
+        brightCyan: '#54ced6', brightWhite: '#ffffff'
+      }
+    case 'one-dark':
+      return {
+        background: '#282c34',
+        foreground: '#abb2bf',
+        cursor: '#528bff',
+        selectionBackground: 'rgba(171, 178, 191, 0.2)',
+        black: '#282c34', red: '#e06c75', green: '#98c379', yellow: '#e5c07b',
+        blue: '#61afef', magenta: '#c678dd', cyan: '#56b6c2', white: '#abb2bf',
+        brightBlack: '#545862', brightRed: '#e06c75', brightGreen: '#98c379',
+        brightYellow: '#e5c07b', brightBlue: '#61afef', brightMagenta: '#c678dd',
+        brightCyan: '#56b6c2', brightWhite: '#c8ccd4'
+      }
+    case 'one-light':
+      return {
+        background: '#fafafa',
+        foreground: '#383a42',
+        cursor: '#526fff',
+        selectionBackground: 'rgba(56, 58, 66, 0.2)',
+        black: '#383a42', red: '#e45649', green: '#50a14f', yellow: '#c18401',
+        blue: '#4078f2', magenta: '#a626a4', cyan: '#0184bc', white: '#fafafa',
+        brightBlack: '#4f525e', brightRed: '#e06c75', brightGreen: '#98c379',
+        brightYellow: '#e5c07b', brightBlue: '#61afef', brightMagenta: '#c678dd',
+        brightCyan: '#56b6c2', brightWhite: '#ffffff'
+      }
+    case 'github-dark':
+      return {
+        background: '#0d1117',
+        foreground: '#c9d1d9',
+        cursor: '#c9d1d9',
+        selectionBackground: 'rgba(201, 209, 217, 0.2)',
+        black: '#0d1117', red: '#ff7b72', green: '#3fb950', yellow: '#d29922',
+        blue: '#58a6ff', magenta: '#bc8cff', cyan: '#39c5cf', white: '#b1bac4',
+        brightBlack: '#484f58', brightRed: '#ffa198', brightGreen: '#56d364',
+        brightYellow: '#e3b341', brightBlue: '#79c0ff', brightMagenta: '#d2a8ff',
+        brightCyan: '#56d4dd', brightWhite: '#f0f6fc'
+      }
+    case 'gotham':
+      return {
+        background: '#0a0f14',
+        foreground: '#98d1ce',
+        cursor: '#d3ebe9',
+        selectionBackground: 'rgba(152, 209, 206, 0.2)',
+        black: '#0a0f14', red: '#c33027', green: '#26a98b', yellow: '#edb54b',
+        blue: '#195465', magenta: '#4e5165', cyan: '#33859e', white: '#98d1ce',
+        brightBlack: '#10151b', brightRed: '#d26939', brightGreen: '#2a9b72',
+        brightYellow: '#f1c83e', brightBlue: '#25525e', brightMagenta: '#696d87',
+        brightCyan: '#4d97b1', brightWhite: '#d3ebe9'
+      }
+    case 'hybrid':
+      return {
+        background: '#1d1f21',
+        foreground: '#c5c8c6',
+        cursor: '#c5c8c6',
+        selectionBackground: 'rgba(197, 200, 198, 0.2)',
+        black: '#282a2e', red: '#a54242', green: '#8c9440', yellow: '#de935f',
+        blue: '#5f819d', magenta: '#85678f', cyan: '#5e8d87', white: '#707880',
+        brightBlack: '#373b41', brightRed: '#cc6666', brightGreen: '#b5bd68',
+        brightYellow: '#f0c674', brightBlue: '#81a2be', brightMagenta: '#b294bb',
+        brightCyan: '#8abeb7', brightWhite: '#c5c8c6'
+      }
+    case 'nord':
+      return { background: '#2e3440', foreground: '#d8dee9', cursor: '#d8dee9', selectionBackground: 'rgba(216,222,233,0.2)', black: '#3b4252', red: '#bf616a', green: '#a3be8c', yellow: '#ebcb8b', blue: '#81a1c1', magenta: '#b48ead', cyan: '#88c0d0', white: '#e5e9f0', brightBlack: '#4c566a', brightRed: '#bf616a', brightGreen: '#a3be8c', brightYellow: '#ebcb8b', brightBlue: '#81a1c1', brightMagenta: '#b48ead', brightCyan: '#8fbcbb', brightWhite: '#eceff4' }
+    case 'gruvbox-dark':
+      return { background: '#282828', foreground: '#ebdbb2', cursor: '#ebdbb2', selectionBackground: 'rgba(235,219,178,0.2)', black: '#282828', red: '#cc241d', green: '#98971a', yellow: '#d79921', blue: '#458588', magenta: '#b16286', cyan: '#689d6a', white: '#a89984', brightBlack: '#928374', brightRed: '#fb4934', brightGreen: '#b8bb26', brightYellow: '#fabd2f', brightBlue: '#83a598', brightMagenta: '#d3869b', brightCyan: '#8ec07c', brightWhite: '#ebdbb2' }
+    case 'gruvbox-light':
+      return { background: '#fbf1c7', foreground: '#3c3836', cursor: '#3c3836', selectionBackground: 'rgba(60,56,54,0.2)', black: '#fbf1c7', red: '#cc241d', green: '#98971a', yellow: '#d79921', blue: '#458588', magenta: '#b16286', cyan: '#689d6a', white: '#7c6f64', brightBlack: '#928374', brightRed: '#9d0006', brightGreen: '#79740e', brightYellow: '#b57614', brightBlue: '#076678', brightMagenta: '#8f3f71', brightCyan: '#427b58', brightWhite: '#3c3836' }
+    case 'catppuccin-mocha':
+      return { background: '#1e1e2e', foreground: '#cdd6f4', cursor: '#f5e0dc', selectionBackground: 'rgba(205,214,244,0.2)', black: '#45475a', red: '#f38ba8', green: '#a6e3a1', yellow: '#f9e2af', blue: '#89b4fa', magenta: '#f5c2e7', cyan: '#94e2d5', white: '#bac2de', brightBlack: '#585b70', brightRed: '#f38ba8', brightGreen: '#a6e3a1', brightYellow: '#f9e2af', brightBlue: '#89b4fa', brightMagenta: '#f5c2e7', brightCyan: '#94e2d5', brightWhite: '#a6adc8' }
+    case 'catppuccin-latte':
+      return { background: '#eff1f5', foreground: '#4c4f69', cursor: '#dc8a78', selectionBackground: 'rgba(76,79,105,0.2)', black: '#5c5f77', red: '#d20f39', green: '#40a02b', yellow: '#df8e1d', blue: '#1e66f5', magenta: '#ea76cb', cyan: '#179299', white: '#acb0be', brightBlack: '#6c6f85', brightRed: '#d20f39', brightGreen: '#40a02b', brightYellow: '#df8e1d', brightBlue: '#1e66f5', brightMagenta: '#ea76cb', brightCyan: '#179299', brightWhite: '#bcc0cc' }
+    case 'tokyo-night':
+      return { background: '#1a1b26', foreground: '#c0caf5', cursor: '#c0caf5', selectionBackground: 'rgba(192,202,245,0.2)', black: '#15161e', red: '#f7768e', green: '#9ece6a', yellow: '#e0af68', blue: '#7aa2f7', magenta: '#bb9af7', cyan: '#7dcfff', white: '#a9b1d6', brightBlack: '#414868', brightRed: '#f7768e', brightGreen: '#9ece6a', brightYellow: '#e0af68', brightBlue: '#7aa2f7', brightMagenta: '#bb9af7', brightCyan: '#7dcfff', brightWhite: '#c0caf5' }
+    case 'tokyo-day':
+      return { background: '#f8fafc', foreground: '#334155', cursor: '#334155', selectionBackground: 'rgba(51,65,85,0.2)', black: '#e2e8f0', red: '#ef4444', green: '#22c55e', yellow: '#eab308', blue: '#3b82f6', magenta: '#8b5cf6', cyan: '#06b6d4', white: '#64748b', brightBlack: '#94a3b8', brightRed: '#ef4444', brightGreen: '#22c55e', brightYellow: '#eab308', brightBlue: '#3b82f6', brightMagenta: '#8b5cf6', brightCyan: '#06b6d4', brightWhite: '#1e293b' }
+    case 'rose-pine':
+      return { background: '#191724', foreground: '#e0def4', cursor: '#e0def4', selectionBackground: 'rgba(224,222,244,0.2)', black: '#26233a', red: '#eb6f92', green: '#31748f', yellow: '#f6c177', blue: '#9ccfd8', magenta: '#c4a7e7', cyan: '#ebbcba', white: '#e0def4', brightBlack: '#6e6a86', brightRed: '#eb6f92', brightGreen: '#31748f', brightYellow: '#f6c177', brightBlue: '#9ccfd8', brightMagenta: '#c4a7e7', brightCyan: '#ebbcba', brightWhite: '#e0def4' }
+    case 'rose-pine-dawn':
+      return { background: '#faf4ed', foreground: '#575279', cursor: '#575279', selectionBackground: 'rgba(87,82,121,0.2)', black: '#f2e9e1', red: '#b4637a', green: '#286983', yellow: '#ea9d34', blue: '#56949f', magenta: '#907aa9', cyan: '#d7827e', white: '#575279', brightBlack: '#9893a5', brightRed: '#b4637a', brightGreen: '#286983', brightYellow: '#ea9d34', brightBlue: '#56949f', brightMagenta: '#907aa9', brightCyan: '#d7827e', brightWhite: '#575279' }
+    case 'github-light':
+      return { background: '#ffffff', foreground: '#24292f', cursor: '#24292f', selectionBackground: 'rgba(36,41,47,0.2)', black: '#ffffff', red: '#cf222e', green: '#1a7f37', yellow: '#9a6700', blue: '#0969da', magenta: '#8250df', cyan: '#1b7c83', white: '#6e7781', brightBlack: '#57606a', brightRed: '#a40e26', brightGreen: '#116329', brightYellow: '#633d01', brightBlue: '#0550ae', brightMagenta: '#7339ac', brightCyan: '#126061', brightWhite: '#24292f' }
+    case 'everforest-dark':
+      return { background: '#2d353b', foreground: '#d3c6aa', cursor: '#d3c6aa', selectionBackground: 'rgba(211,198,170,0.2)', black: '#475258', red: '#e67e80', green: '#a7c080', yellow: '#dbbc7f', blue: '#7fbbb3', magenta: '#d699b6', cyan: '#83c092', white: '#d3c6aa', brightBlack: '#475258', brightRed: '#e67e80', brightGreen: '#a7c080', brightYellow: '#dbbc7f', brightBlue: '#7fbbb3', brightMagenta: '#d699b6', brightCyan: '#83c092', brightWhite: '#d3c6aa' }
+    case 'everforest-light':
+      return { background: '#fdf6e3', foreground: '#5c6a72', cursor: '#5c6a72', selectionBackground: 'rgba(92,106,114,0.2)', black: '#fdf6e3', red: '#f85552', green: '#8da101', yellow: '#dfa000', blue: '#3a94c5', magenta: '#df69ba', cyan: '#35a77c', white: '#5c6a72', brightBlack: '#a6b0a0', brightRed: '#f85552', brightGreen: '#8da101', brightYellow: '#dfa000', brightBlue: '#3a94c5', brightMagenta: '#df69ba', brightCyan: '#35a77c', brightWhite: '#5c6a72' }
     default:
       return base
   }
@@ -176,7 +312,7 @@ export function useTerminal(
 
   function getTerminalOptions() {
     const ts = settingsStore.settings.terminal
-    const themeName = ts.theme || 'dark'
+    const themeName = ts.theme || 'uniterm-dark'
     return {
       fontSize: ts.fontSize || 13,
       fontFamily: ts.fontFamily || 'Consolas, "Courier New", monospace',

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -7,6 +7,7 @@
   "sidebar.title": "Connections",
   "sidebar.newConnection": "New Connection",
   "sidebar.collapse": "Collapse",
+  "sidebar.personalization": "Personalization",
   "sidebar.noConnections": "No connections yet",
   "sidebar.noSearchResults": "No matches",
   "sidebar.searchPlaceholder": "Search or quick connect...",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -7,6 +7,7 @@
   "sidebar.title": "连接",
   "sidebar.newConnection": "新建连接",
   "sidebar.collapse": "收起",
+  "sidebar.personalization": "个性化",
   "sidebar.noConnections": "暂无连接",
   "sidebar.noSearchResults": "无匹配结果",
   "sidebar.searchPlaceholder": "搜索或快捷连接...",

--- a/frontend/src/stores/settingsStore.ts
+++ b/frontend/src/stores/settingsStore.ts
@@ -159,7 +159,10 @@ function mergeSettings(loaded: AppSettings): AppSettings {
     language: loaded.language || DEFAULT_SETTINGS.language,
     terminal: {
       ...DEFAULT_SETTINGS.terminal,
-      ...loaded.terminal
+      ...loaded.terminal,
+      theme: (loaded.terminal?.theme as string) === 'dark' || (loaded.terminal?.theme as string) === 'light'
+        ? DEFAULT_SETTINGS.terminal.theme
+        : loaded.terminal?.theme || DEFAULT_SETTINGS.terminal.theme
     },
     ai: {
       models: loaded.ai?.models?.length ? loaded.ai.models : DEFAULT_SETTINGS.ai.models,

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -293,13 +293,10 @@ body::before {
    Unified control sizing — all input/button/select controls = 28px
    ============================================================ */
 
-/* --- height: 28px group --- */
+/* --- input wrapper base --- */
 .el-input__wrapper,
 .el-select .el-input__wrapper,
 .el-input-number .el-input__wrapper {
-  height: 28px !important;
-  min-height: 28px !important;
-  padding: 1px 8px !important;
   box-sizing: border-box !important;
   background-color: var(--bg-base) !important;
 }
@@ -604,4 +601,23 @@ body.drag-active .zone {
   box-shadow: var(--shadow-md);
   pointer-events: none;
   white-space: nowrap;
+}
+
+/* --- Theme select group labels --- */
+.theme-select-popper .el-select-group__title {
+  font-size: 10px;
+  line-height: 1.2;
+  color: var(--text-disabled);
+  text-align: center;
+  padding: 2px 12px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.theme-select-popper .el-select-group__title::before,
+.theme-select-popper .el-select-group__title::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: var(--border-subtle);
 }

--- a/frontend/src/types/settings.ts
+++ b/frontend/src/types/settings.ts
@@ -5,7 +5,7 @@ export const SUPPORTED_LOCALES = [
 export type Locale = typeof SUPPORTED_LOCALES[number]
 export type Language = Locale | 'system'
 export type Theme = 'dark' | 'deep-blue' | 'light' | 'system'
-export type TerminalTheme = 'dark' | 'light' | 'solarized-dark' | 'solarized-light' | 'monokai'
+export type TerminalTheme = 'uniterm-dark' | 'uniterm-light' | 'solarized-dark' | 'solarized-light' | 'monokai' | 'dracula' | 'molokai' | 'tomorrow-night' | 'tomorrow-night-bright' | 'tomorrow' | 'one-dark' | 'one-light' | 'github-dark' | 'github-light' | 'gotham' | 'hybrid' | 'nord' | 'gruvbox-dark' | 'gruvbox-light' | 'catppuccin-mocha' | 'catppuccin-latte' | 'tokyo-night' | 'tokyo-day' | 'rose-pine' | 'rose-pine-dawn' | 'everforest-dark' | 'everforest-light'
 
 export interface TerminalSettings {
   theme: TerminalTheme
@@ -103,7 +103,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   theme: 'dark',
   language: 'system',
   terminal: {
-    theme: 'dark',
+    theme: 'uniterm-dark',
     fontFamily: 'Consolas, "Courier New", monospace',
     fontSize: 14,
     selectionAction: 'none',
@@ -129,12 +129,35 @@ export const DEFAULT_SETTINGS: AppSettings = {
   autoCheckUpdate: true
 }
 
-export const TERMINAL_THEMES: { label: string; value: TerminalTheme }[] = [
-  { label: 'Dark', value: 'dark' },
-  { label: 'Light', value: 'light' },
-  { label: 'Solarized Dark', value: 'solarized-dark' },
-  { label: 'Solarized Light', value: 'solarized-light' },
-  { label: 'Monokai', value: 'monokai' }
+export interface TerminalThemeEntry { label: string; value: TerminalTheme; type: 'dark' | 'light' }
+export const TERMINAL_THEMES: TerminalThemeEntry[] = [
+  { label: 'uniTerm Dark', value: 'uniterm-dark', type: 'dark' },
+  { label: 'uniTerm Light', value: 'uniterm-light', type: 'light' },
+  { label: 'Solarized Dark', value: 'solarized-dark', type: 'dark' },
+  { label: 'Solarized Light', value: 'solarized-light', type: 'light' },
+  { label: 'Monokai', value: 'monokai', type: 'dark' },
+  { label: 'Dracula', value: 'dracula', type: 'dark' },
+  { label: 'Molokai', value: 'molokai', type: 'dark' },
+  { label: 'Tomorrow Night', value: 'tomorrow-night', type: 'dark' },
+  { label: 'Tomorrow Night Bright', value: 'tomorrow-night-bright', type: 'dark' },
+  { label: 'Tomorrow', value: 'tomorrow', type: 'light' },
+  { label: 'One Dark', value: 'one-dark', type: 'dark' },
+  { label: 'One Light', value: 'one-light', type: 'light' },
+  { label: 'GitHub Dark', value: 'github-dark', type: 'dark' },
+  { label: 'GitHub Light', value: 'github-light', type: 'light' },
+  { label: 'Gotham', value: 'gotham', type: 'dark' },
+  { label: 'Hybrid', value: 'hybrid', type: 'dark' },
+  { label: 'Nord', value: 'nord', type: 'dark' },
+  { label: 'Gruvbox Dark', value: 'gruvbox-dark', type: 'dark' },
+  { label: 'Gruvbox Light', value: 'gruvbox-light', type: 'light' },
+  { label: 'Catppuccin Mocha', value: 'catppuccin-mocha', type: 'dark' },
+  { label: 'Catppuccin Latte', value: 'catppuccin-latte', type: 'light' },
+  { label: 'Tokyo Night', value: 'tokyo-night', type: 'dark' },
+  { label: 'Tokyo Day', value: 'tokyo-day', type: 'light' },
+  { label: 'Rosé Pine', value: 'rose-pine', type: 'dark' },
+  { label: 'Rosé Pine Dawn', value: 'rose-pine-dawn', type: 'light' },
+  { label: 'Everforest Dark', value: 'everforest-dark', type: 'dark' },
+  { label: 'Everforest Light', value: 'everforest-light', type: 'light' }
 ]
 
 export const FONT_OPTIONS: { label: string; value: string }[] = [


### PR DESCRIPTION
## Summary

- Expand terminal themes from 5 to 27 (17 Dark + 10 Light) with popular schemes: Nord, Gruvbox, Catppuccin, Tokyo Night/Day, Rosé Pine, Dracula, Everforest, etc.
- Add Dark/Light grouping with type field in TERMINAL_THEMES (single source of truth)
- Add sidebar personalization tab with quick access to terminal theme, font, and font size
- Remove global size="small" from all components, restore Element Plus default sizing
- Remove global input height 28px override in style.css
- Add theme group label styling (centered text with divider lines)

Closes #14

---

## 概要

- 终端主题从 5 个扩展到 27 个（17 Dark + 10 Light），包含 Nord、Gruvbox、Catppuccin、Tokyo Night/Day、Rosé Pine、Dracula、Everforest 等主流配色
- 添加 Dark/Light 分组，在 TERMINAL_THEMES 中增加 type 字段作为唯一数据源
- 侧边栏新增个性化面板，快捷切换终端主题、字体、字号
- 全局移除 size="small"，恢复 Element Plus 默认尺寸
- 移除 style.css 中全局 input 高度 28px 覆盖
- 主题分组标签样式：居中文本 + 左右分割线

Closes #14