### PR TITLE
feat: add connection-type icons to sidebar session list

### DIFF
--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -133,6 +133,7 @@
             @dblclick="onItemDblClick(conn)"
             @contextmenu.prevent="onContextMenu($event, conn)"
           >
+            <span class="conn-icon"><component :is="connIcon(conn)" :size="14" /></span>
             <div class="conn-details">
               <span class="name">{{ conn.name }}</span>
               <span class="conn-meta">
@@ -175,6 +176,7 @@
             @dblclick="onItemDblClick(conn)"
             @contextmenu.prevent="onContextMenu($event, conn)"
           >
+            <span class="conn-icon"><component :is="connIcon(conn)" :size="14" /></span>
             <div class="conn-details">
               <span class="name">{{ conn.name }}</span>
               <span class="conn-meta">
@@ -201,6 +203,7 @@
           @dblclick="onItemDblClick(conn)"
           @contextmenu.prevent="onContextMenu($event, conn)"
         >
+          <span class="conn-icon"><component :is="connIcon(conn)" :size="14" /></span>
           <div class="conn-details">
             <span class="name">{{ conn.name }}</span>
             <span class="conn-meta">
@@ -419,7 +422,7 @@
 
 <script setup lang="ts">
 import { ref, onMounted, onUnmounted, computed, watch, nextTick } from 'vue'
-import { X, ChevronRight, ChevronDown, Filter, Check, Network, Zap, Clock, Plus, Palette } from '@lucide/vue'
+import { X, ChevronRight, ChevronDown, Filter, Check, Network, Zap, Clock, Plus, Palette, SquareTerminal, FolderUp, Monitor, MonitorCloud, Database, Activity, Laptop, Cable } from '@lucide/vue'
 import { ElMessageBox } from 'element-plus'
 import { useConnectionStore } from '../stores/connectionStore'
 import { useSettingsStore } from '../stores/settingsStore'
@@ -1219,6 +1222,20 @@ function getShellLabel(path: string): string {
   return path.split(/[\\/]/).pop() || path
 }
 
+function connIcon(conn: ConnectionConfig) {
+  switch (conn.type) {
+    case 'sftp': return FolderUp
+    case 'rdp': return Monitor
+    case 'vnc': return MonitorCloud
+    case 'spice': return MonitorCloud
+    case 'database': return Database
+    case 'monitor': return Activity
+    case 'local': return Laptop
+    case 'serial': return Cable
+    default: return SquareTerminal // ssh, telnet, mosh, ftp
+  }
+}
+
 function onNewConnVisibleChange(visible: boolean) {
   if (!visible) return
   nextTick(() => {
@@ -1509,7 +1526,7 @@ defineExpose({ focusSearch })
 .connection-item {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 6px;
   padding: 8px 10px;
   border-radius: var(--radius-sm);
   cursor: pointer;
@@ -1519,7 +1536,7 @@ defineExpose({ focusSearch })
 }
 
 .connection-item.indented {
-  padding-left: 26px;
+  padding-left: 24px;
 }
 
 .connection-item:hover {
@@ -1535,6 +1552,14 @@ defineExpose({ focusSearch })
   color: var(--accent);
 }
 
+.conn-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  flex-shrink: 0;
+  color: var(--text-muted);
+}
 
 .conn-details {
   display: flex;


### PR DESCRIPTION
## Summary
- Add connection-type icons to each session item in the sidebar, matching the same icon set used in TabItem
- Icons provide clear visual distinction between group headers and session items, making it easier to scan groups when there are many sessions
- Adjust sidebar item spacing: reduce flex gap from 10px to 6px, indented padding-left from 26px to 24px

## Changes
- Single file: `frontend/src/components/Sidebar.vue` (+28/-3)
- Import 8 Lucide icons (`SquareTerminal`, `FolderUp`, `Monitor`, `MonitorCloud`, `Database`, `Activity`, `Laptop`, `Cable`)
- Add `connIcon()` function mapping connection types to icons
- Render icon `<span>` before `.conn-details` in all three connection-item template blocks
- Add `.conn-icon` CSS rule (`--text-muted`, 16px width, flex-shrink 0)

## Icon Mapping
| Connection type | Icon |
|---|---|
| ssh, telnet, mosh, ftp | SquareTerminal |
| sftp | FolderUp |
| rdp | Monitor |
| vnc, spice | MonitorCloud |
| database | Database |
| monitor | Activity |
| local | Laptop |
| serial | Cable |

---
## 摘要
- 在侧栏的每个会话条目左侧增加连接类型图标，与 TabItem 使用同一套图标
- 图标让 group 标题和 session 条目在视觉上明显区分，会话多时更容易定位 group
- 微调间距：flex gap 从 10px 减小到 6px，缩进 padding-left 从 26px 减小到 24px

## 修改
- 单文件：`frontend/src/components/Sidebar.vue` (+28/-3)
- 导入 8 个 Lucide 图标
- 新增 `connIcon()` 函数，按连接类型映射对应图标
- 在三处 connection-item 模板中添加图标 `<span>`
- 新增 `.conn-icon` CSS 样式

Closes #18