### PR TITLE
feat: persist sidebar visibility to local state file

### DIFF
--- a/app.go
+++ b/app.go
@@ -37,6 +37,7 @@ type App struct {
 	connectionStore      *store.ConnectionStore
 	aiSessionStore       *store.AISessionStore
 	settingsStore        *store.SettingsStore
+	localStateStore      *store.LocalStateStore
 	quickCommandsStore   *store.QuickCommandsStore
 	terminalHistoryStore *store.TerminalHistoryStore
 	syncService          *sync.SyncService
@@ -104,6 +105,7 @@ func (a *App) startup(ctx context.Context) {
 	appDir := filepath.Join(configDir, "uniTerm")
 	a.terminalHistoryStore = store.NewTerminalHistoryStore(appDir)
 	a.quickCommandsStore = store.NewQuickCommandsStore(appDir)
+	a.localStateStore = store.NewLocalStateStore(appDir)
 
 	syncSvc, err := sync.NewSyncService()
 	if err != nil {
@@ -190,6 +192,22 @@ func (a *App) SaveAIConfig(config store.AIConfig) error {
 	}
 	a.triggerAutoSync()
 	return nil
+}
+
+// LocalStateStore methods — sidecar visibility that stays local, never synced.
+
+func (a *App) SaveLocalState(state store.LocalState) error {
+	if a.localStateStore == nil {
+		return fmt.Errorf("local state store not initialized")
+	}
+	return a.localStateStore.Save(state)
+}
+
+func (a *App) LoadLocalState() (store.LocalState, error) {
+	if a.localStateStore == nil {
+		return store.LocalState{SidebarVisible: true, AISidebarVisible: true}, nil
+	}
+	return a.localStateStore.Load()
 }
 
 // reloadStoresAfterSync reloads connections and settings from disk and emits

--- a/backend/store/local_state_store.go
+++ b/backend/store/local_state_store.go
@@ -1,0 +1,49 @@
+package store
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+)
+
+const localStateFileName = "local_state.json"
+
+type LocalState struct {
+	SidebarVisible   bool `json:"sidebarVisible"`
+	AISidebarVisible bool `json:"aiSidebarVisible"`
+}
+
+type LocalStateStore struct {
+	configDir string
+}
+
+func NewLocalStateStore(configDir string) *LocalStateStore {
+	return &LocalStateStore{configDir: configDir}
+}
+
+func (s *LocalStateStore) filePath() string {
+	return filepath.Join(s.configDir, localStateFileName)
+}
+
+func (s *LocalStateStore) Save(state LocalState) error {
+	bytes, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(s.filePath(), bytes, 0600)
+}
+
+func (s *LocalStateStore) Load() (LocalState, error) {
+	bytes, err := os.ReadFile(s.filePath())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return LocalState{SidebarVisible: true, AISidebarVisible: true}, nil
+		}
+		return LocalState{}, err
+	}
+	var state LocalState
+	if err := json.Unmarshal(bytes, &state); err != nil {
+		return LocalState{SidebarVisible: true, AISidebarVisible: true}, nil
+	}
+	return state, nil
+}

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -118,7 +118,7 @@ import { useUpdateCheck } from './composables/useUpdateCheck'
 import { loadKeybindings, installGlobalListener, uninstallGlobalListener } from './composables/useKeyboardShortcuts'
 import type { ShortcutAction } from '../types/settings'
 import { useI18n } from './i18n'
-import { CreateSession, CloseSession, RDPHide, RDPShow, RDPSetPosition, RDPSetFocus } from '../wailsjs/go/main/App'
+import { CreateSession, CloseSession, RDPHide, RDPShow, RDPSetPosition, RDPSetFocus, LoadLocalState, SaveLocalState } from '../wailsjs/go/main/App'
 import { EventsOn } from '../wailsjs/runtime'
 import { msg } from './services/message'
 import type { ConnectionConfig } from './types/session'
@@ -200,7 +200,7 @@ function RDPShowForOverlay() {
 
 const showConnectionForm = ref(false)
 const showSerialDialog = ref(false)
-const sidebarVisible = ref(localStorage.getItem('sidebarVisible') !== 'false')
+const sidebarVisible = ref(true)
 const sidebarRef = ref<any>(null)
 const aiSidebarRef = ref<any>(null)
 
@@ -284,10 +284,18 @@ function onWheel(e: WheelEvent) {
   }
 }
 
-onMounted(() => {
+onMounted(async () => {
   connectionStore.load()
   aiStore.init()
   updateCheck.initAutoCheck()
+
+  // Load sidebar visibility from local state
+  try {
+    const state = await LoadLocalState()
+    sidebarVisible.value = state.sidebarVisible ?? true
+  } catch {
+    // keep default
+  }
   // Pre-load quick commands so suggestions can read them immediately
   useQuickCommandStore().load()
   // Pre-load noVNC so VNC tab switches don't pay the dynamic import cost.
@@ -804,10 +812,16 @@ watch(showConnectionForm, (val) => {
   else RDPShowForOverlay()
 })
 
-watch(sidebarVisible, () => {
-  localStorage.setItem('sidebarVisible', String(sidebarVisible.value))
+watch(sidebarVisible, async () => {
   RDPHideForOverlay()
   nextTick(() => RDPShowForOverlay())
+  try {
+    const state = await LoadLocalState()
+    state.sidebarVisible = sidebarVisible.value
+    await SaveLocalState(state)
+  } catch {
+    // ignore save errors
+  }
 })
 
 watch(() => aiStore.visible, () => {

--- a/frontend/src/stores/aiStore.ts
+++ b/frontend/src/stores/aiStore.ts
@@ -1,7 +1,7 @@
 import { defineStore } from 'pinia'
-import { ref, computed, reactive } from 'vue'
+import { ref, computed, reactive, watch } from 'vue'
 import type { AIMessage, AIConfig, ExecutionMode, AISession } from '../types/ai'
-import { SaveAIConfig, LoadAIConfig, SaveAISessions, LoadAISessions } from '../../wailsjs/go/main/App'
+import { SaveAIConfig, LoadAIConfig, SaveAISessions, LoadAISessions, SaveLocalState, LoadLocalState } from '../../wailsjs/go/main/App'
 import { EventsOn } from '../../wailsjs/runtime'
 import { t } from '../i18n'
 
@@ -140,7 +140,7 @@ async function loadSessionsFromBackend(): Promise<{ sessions: AISession[], curre
 }
 
 export const useAIStore = defineStore('ai', () => {
-  const visible = ref(localStorage.getItem('aiSidebarVisible') !== 'false')
+  const visible = ref(true)
   const messages = ref<AIMessage[]>([])
   const mode = ref<ExecutionMode>('confirm_dangerous')
   const config = ref<AIConfig>({ ...DEFAULT_CONFIG })
@@ -162,6 +162,21 @@ export const useAIStore = defineStore('ai', () => {
   function setLastPanelContext(panelId: string, shellPath: string) {
     lastPanelContext.value = { panelId, shellPath }
   }
+
+  async function saveVisible() {
+    try {
+      const current = await LoadLocalState()
+      current.aiSidebarVisible = visible.value
+      await SaveLocalState(current)
+    } catch {
+      // ignore save errors
+    }
+  }
+
+  // Auto-persist AI sidebar visibility whenever it changes
+  watch(visible, () => {
+    saveVisible()
+  })
 
   function setDebugInfo(request: unknown, error: string) {
     try {
@@ -191,7 +206,6 @@ export const useAIStore = defineStore('ai', () => {
 
   function toggle() {
     visible.value = !visible.value
-    localStorage.setItem('aiSidebarVisible', String(visible.value))
   }
 
   function addMessage(msg: AIMessage): AIMessage {
@@ -233,6 +247,14 @@ export const useAIStore = defineStore('ai', () => {
     // Always start with a fresh session after restart
     currentSessionId.value = null
     initialized.value = true
+
+    // Load sidebar visibility from local state
+    try {
+      const state = await LoadLocalState()
+      visible.value = state.aiSidebarVisible ?? true
+    } catch {
+      // keep default
+    }
 
     // Restore current session or create a new one
     if (currentSessionId.value) {

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -89,6 +89,8 @@ export function LoadAISessions():Promise<store.AISessionData>;
 
 export function LoadConnections():Promise<session.ConnectionStoreData>;
 
+export function LoadLocalState():Promise<store.LocalState>;
+
 export function LoadQuickCommands():Promise<store.QuickCommandData>;
 
 export function LoadSettings():Promise<store.AppSettings>;
@@ -124,6 +126,8 @@ export function SaveAISessions(arg1:store.AISessionData):Promise<void>;
 export function SaveConnections(arg1:session.ConnectionStoreData):Promise<void>;
 
 export function SaveFileDialog(arg1:string):Promise<string>;
+
+export function SaveLocalState(arg1:store.LocalState):Promise<void>;
 
 export function SaveQuickCommands(arg1:store.QuickCommandData):Promise<void>;
 

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -166,6 +166,10 @@ export function LoadConnections() {
   return window['go']['main']['App']['LoadConnections']();
 }
 
+export function LoadLocalState() {
+  return window['go']['main']['App']['LoadLocalState']();
+}
+
 export function LoadQuickCommands() {
   return window['go']['main']['App']['LoadQuickCommands']();
 }
@@ -236,6 +240,10 @@ export function SaveConnections(arg1) {
 
 export function SaveFileDialog(arg1) {
   return window['go']['main']['App']['SaveFileDialog'](arg1);
+}
+
+export function SaveLocalState(arg1) {
+  return window['go']['main']['App']['SaveLocalState'](arg1);
 }
 
 export function SaveQuickCommands(arg1) {

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -797,6 +797,20 @@ export namespace store {
 	    }
 	}
 	
+	export class LocalState {
+	    sidebarVisible: boolean;
+	    aiSidebarVisible: boolean;
+	
+	    static createFrom(source: any = {}) {
+	        return new LocalState(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.sidebarVisible = source["sidebarVisible"];
+	        this.aiSidebarVisible = source["aiSidebarVisible"];
+	    }
+	}
 	export class QuickCommand {
 	    id: string;
 	    name?: string;


### PR DESCRIPTION
Replace localStorage with a Go-backed `local_state.json` file for both the connection sidebar and AI sidebar visibility state.

## Changes

- Add `LocalStateStore` (Go) writing to `local_state.json` in the app config directory
- Add `SaveLocalState` / `LoadLocalState` Wails bindings
- Migrate AI sidebar `visible` state from `localStorage` to backend store
- Migrate connection sidebar `sidebarVisible` state from `localStorage` to backend store
- Add `watch`-based auto-persistence on visibility changes (any entry point — button click, keyboard shortcut, context menu — all persist correctly)

The file is not included in the cloud sync file list, so local UI preferences stay local.

Closes #25

---

将连接侧栏和 AI 侧栏的可见性状态从 `localStorage` 迁移到 Go 后端的 `local_state.json` 文件。

## 改动

- 新增 `LocalStateStore`（Go），写入应用配置目录下的 `local_state.json`
- 新增 `SaveLocalState` / `LoadLocalState` Wails 绑定
- AI 侧栏 `visible` 状态改为从后端存储读写
- 连接侧栏 `sidebarVisible` 状态改为从后端存储读写
- 通过 `watch` 实现任意入口修改后自动持久化（按钮、快捷键、右键菜单均生效）

该文件不在云同步文件列表中，本地 UI 偏好不会上传到云端。

Closes #25