### PR TITLE
feat: add octal input to SFTP chmod dialog (#28)

### DIFF
--- a/frontend/src/components/SFTPTabContent.vue
+++ b/frontend/src/components/SFTPTabContent.vue
@@ -95,36 +95,32 @@
           <span class="chmod-filename">{{ dialogItem?.name }}</span>
           <span v-if="dialogItem?.owner || dialogItem?.group" class="chmod-ownergroup">{{ dialogItem?.owner || '-' }}:{{ dialogItem?.group || '-' }}</span>
         </div>
-        <table class="chmod-table">
-          <thead>
-            <tr>
-              <th></th>
-              <th>Read</th>
-              <th>Write</th>
-              <th>Execute</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td class="chmod-row-label">Owner</td>
-              <td><el-checkbox v-model="chmodOwnerR" /></td>
-              <td><el-checkbox v-model="chmodOwnerW" /></td>
-              <td><el-checkbox v-model="chmodOwnerX" /></td>
-            </tr>
-            <tr>
-              <td class="chmod-row-label">Group</td>
-              <td><el-checkbox v-model="chmodGroupR" /></td>
-              <td><el-checkbox v-model="chmodGroupW" /></td>
-              <td><el-checkbox v-model="chmodGroupX" /></td>
-            </tr>
-            <tr>
-              <td class="chmod-row-label">Other</td>
-              <td><el-checkbox v-model="chmodOtherR" /></td>
-              <td><el-checkbox v-model="chmodOtherW" /></td>
-              <td><el-checkbox v-model="chmodOtherX" /></td>
-            </tr>
-          </tbody>
-        </table>
+        <el-form class="chmod-form" label-width="80px">
+          <el-form-item label="Owner">
+            <el-checkbox v-model="chmodOwnerR">Read</el-checkbox>
+            <el-checkbox v-model="chmodOwnerW">Write</el-checkbox>
+            <el-checkbox v-model="chmodOwnerX">Execute</el-checkbox>
+          </el-form-item>
+          <el-form-item label="Group">
+            <el-checkbox v-model="chmodGroupR">Read</el-checkbox>
+            <el-checkbox v-model="chmodGroupW">Write</el-checkbox>
+            <el-checkbox v-model="chmodGroupX">Execute</el-checkbox>
+          </el-form-item>
+          <el-form-item label="Other">
+            <el-checkbox v-model="chmodOtherR">Read</el-checkbox>
+            <el-checkbox v-model="chmodOtherW">Write</el-checkbox>
+            <el-checkbox v-model="chmodOtherX">Execute</el-checkbox>
+          </el-form-item>
+          <el-form-item :label="t('sftp.dialog.chmodOctal')">
+            <el-input
+              v-model="chmodOctalInput"
+              class="chmod-octal-input"
+              maxlength="3"
+              :placeholder="'644'"
+              @input="onOctalInput"
+            />
+          </el-form-item>
+        </el-form>
       </template>
       <template v-else>
         <el-input v-model="dialogInput" :placeholder="dialogPlaceholder" @keyup.enter="onDialogConfirm" />
@@ -511,6 +507,26 @@ const chmodOctal = computed(() => {
   return String(o) + String(g) + String(t)
 })
 
+// Editable octal input (e.g. "644"); kept in sync with the checkbox grid both ways.
+const chmodOctalInput = ref('000')
+
+function applyOctal(digits: string) {
+  const nums = digits.split('').map(Number)
+  chmodOwnerR.value = !!(nums[0] & 4); chmodOwnerW.value = !!(nums[0] & 2); chmodOwnerX.value = !!(nums[0] & 1)
+  chmodGroupR.value = !!(nums[1] & 4); chmodGroupW.value = !!(nums[1] & 2); chmodGroupX.value = !!(nums[1] & 1)
+  chmodOtherR.value = !!(nums[2] & 4); chmodOtherW.value = !!(nums[2] & 2); chmodOtherX.value = !!(nums[2] & 1)
+}
+
+// User typing in the octal field: strip invalid chars, apply once 3 digits are present.
+function onOctalInput() {
+  chmodOctalInput.value = chmodOctalInput.value.replace(/[^0-7]/g, '').slice(0, 3)
+  if (chmodOctalInput.value.length === 3) applyOctal(chmodOctalInput.value)
+}
+
+// Checkbox grid -> octal field. No feedback loop: when applyOctal sets the grid,
+// the value written back equals what the user typed, so the field is unchanged.
+watch(chmodOctal, (v) => { chmodOctalInput.value = v })
+
 function parseMode(mode: string) {
   // mode example: "drwxr-xr-x" or "-rw-r--r--" — strip leading file type char
   const m = mode.length >= 10 ? mode.slice(1) : mode
@@ -523,6 +539,7 @@ function parseMode(mode: string) {
   chmodOtherR.value = m[6] === 'r'
   chmodOtherW.value = m[7] === 'w'
   chmodOtherX.value = m[8] === 'x' || m[8] === 't'
+  chmodOctalInput.value = chmodOctal.value
 }
 
 let unsubscribe: (() => void) | null = null
@@ -1748,40 +1765,18 @@ async function onDropRemote(e: DragEvent) {
   color: var(--text-disabled);
   margin-top: 2px;
 }
-.chmod-table {
-  width: 100%;
-  border-collapse: collapse;
+.chmod-form {
+  margin-top: 4px;
+}
+.chmod-form .el-form-item {
   margin-bottom: 12px;
 }
-.chmod-table th {
-  font-size: 11px;
-  color: var(--text-disabled);
-  font-weight: 500;
-  text-transform: uppercase;
-  padding: 4px 8px 8px;
-  text-align: center;
+.chmod-octal-input {
+  width: 120px;
 }
-.chmod-table th:first-child {
-  text-align: left;
-  padding-left: 0;
-}
-.chmod-table td {
-  padding: 6px 8px;
-  text-align: center;
-}
-.chmod-table td:first-child {
-  text-align: left;
-  padding-left: 0;
-}
-.chmod-row-label {
-  font-size: 12px;
-  color: var(--text-secondary);
-}
-.chmod-octal {
-  text-align: center;
-  font-size: 20px;
-  font-weight: 700;
+.chmod-octal-input :deep(.el-input__inner) {
   font-family: var(--font-mono, monospace);
-  color: var(--accent);
+  font-weight: 700;
+  letter-spacing: 2px;
 }
 </style>

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -162,6 +162,7 @@
   "sftp.dialog.mkdirPrompt": "Name des neuen Verzeichnisses:",
   "sftp.dialog.chmodTitle": "Berechtigung ändern",
   "sftp.dialog.chmodPrompt": "Berechtigung für \"{name}\" ändern (z. B. 755):",
+  "sftp.dialog.chmodOctal": "Oktal",
   "sftp.dialog.deleteTitle": "Löschen",
   "sftp.dialog.deleteConfirmMixed": "{count} Element(e) löschen?",
   "sftp.dialog.deleteConfirmDir": "{count} Verzeichnisse löschen?",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -164,6 +164,7 @@
   "sftp.dialog.mkdirPrompt": "New directory name:",
   "sftp.dialog.chmodTitle": "Change Permission",
   "sftp.dialog.chmodPrompt": "Change permission for \"{name}\" (e.g. 755):",
+  "sftp.dialog.chmodOctal": "Octal",
   "sftp.dialog.deleteTitle": "Delete",
   "sftp.dialog.deleteConfirmMixed": "Delete {count} item(s)?",
   "sftp.dialog.deleteConfirmDir": "Delete {count} directories?",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -162,6 +162,7 @@
   "sftp.dialog.mkdirPrompt": "Nombre de la nueva carpeta:",
   "sftp.dialog.chmodTitle": "Cambiar Permiso",
   "sftp.dialog.chmodPrompt": "Cambiar permiso de \"{name}\" (p. ej. 755):",
+  "sftp.dialog.chmodOctal": "Octal",
   "sftp.dialog.deleteTitle": "Eliminar",
   "sftp.dialog.deleteConfirmMixed": "¿Eliminar {count} elemento(s)?",
   "sftp.dialog.deleteConfirmDir": "¿Eliminar {count} carpetas?",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -162,6 +162,7 @@
   "sftp.dialog.mkdirPrompt": "Nom du nouveau dossier :",
   "sftp.dialog.chmodTitle": "Modifier la permission",
   "sftp.dialog.chmodPrompt": "Modifier la permission de \"{name}\" (ex. 755) :",
+  "sftp.dialog.chmodOctal": "Octal",
   "sftp.dialog.deleteTitle": "Supprimer",
   "sftp.dialog.deleteConfirmMixed": "Supprimer {count} élément(s) ?",
   "sftp.dialog.deleteConfirmDir": "Supprimer {count} dossier(s) ?",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -162,6 +162,7 @@
   "sftp.dialog.mkdirPrompt": "新しいディレクトリ名:",
   "sftp.dialog.chmodTitle": "権限を変更",
   "sftp.dialog.chmodPrompt": "「{name}」の権限を変更（例: 755）:",
+  "sftp.dialog.chmodOctal": "数値",
   "sftp.dialog.deleteTitle": "削除",
   "sftp.dialog.deleteConfirmMixed": "{count} 個の項目を削除しますか？",
   "sftp.dialog.deleteConfirmDir": "{count} 個のディレクトリを削除しますか？",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -162,6 +162,7 @@
   "sftp.dialog.mkdirPrompt": "새 폴터 이름:",
   "sftp.dialog.chmodTitle": "권한 변경",
   "sftp.dialog.chmodPrompt": "\"{name}\"의 권한 변경 (예: 755):",
+  "sftp.dialog.chmodOctal": "숫자",
   "sftp.dialog.deleteTitle": "삭제",
   "sftp.dialog.deleteConfirmMixed": "{count}개 항목을 삭제할까요?",
   "sftp.dialog.deleteConfirmDir": "{count}개 폴터를 삭제할까요?",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -162,6 +162,7 @@
   "sftp.dialog.mkdirPrompt": "Имя новой папки:",
   "sftp.dialog.chmodTitle": "Изменить права",
   "sftp.dialog.chmodPrompt": "Изменить права для \"{name}\" (например, 755):",
+  "sftp.dialog.chmodOctal": "Восьмеричный",
   "sftp.dialog.deleteTitle": "Удалить",
   "sftp.dialog.deleteConfirmMixed": "Удалить {count} элементов?",
   "sftp.dialog.deleteConfirmDir": "Удалить {count} папок?",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -164,6 +164,7 @@
   "sftp.dialog.mkdirPrompt": "新目录名称：",
   "sftp.dialog.chmodTitle": "修改权限",
   "sftp.dialog.chmodPrompt": "修改 \"{name}\" 的权限（如 755）：",
+  "sftp.dialog.chmodOctal": "数值",
   "sftp.dialog.deleteTitle": "删除",
   "sftp.dialog.deleteConfirmMixed": "确定要删除 {count} 个项目吗？",
   "sftp.dialog.deleteConfirmDir": "确定要删除 {count} 个目录吗？",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -162,6 +162,7 @@
   "sftp.dialog.mkdirPrompt": "新目錄名稱：",
   "sftp.dialog.chmodTitle": "修改權限",
   "sftp.dialog.chmodPrompt": "修改 \"{name}\" 的權限（如 755）：",
+  "sftp.dialog.chmodOctal": "數值",
   "sftp.dialog.deleteTitle": "刪除",
   "sftp.dialog.deleteConfirmMixed": "確定要刪除 {count} 個項目嗎？",
   "sftp.dialog.deleteConfirmDir": "確定要刪除 {count} 個目錄嗎？",


### PR DESCRIPTION
## Changes

Add an editable octal input (e.g. `644`) to the SFTP change-permission dialog so permissions can be set numerically as well as via checkboxes.

- The octal field and the read/write/execute checkbox grid stay in sync both ways: typing 3 octal digits updates the checkboxes, and toggling a checkbox updates the field.
- Invalid characters are stripped on input and the value is limited to 3 digits.
- The dialog is restyled as an `el-form` with `Owner` / `Group` / `Other` / octal rows, matching the connection form layout.
- Added the `chmodOctal` label to all locale files.

Closes #28

---

## 改动说明

在 SFTP 修改权限弹框中新增一个可编辑的八进制输入框（如 `644`），支持以数字方式设置权限，作为复选框之外的补充。

- 八进制输入框与读/写/执行复选框双向联动：输入 3 位八进制数字会同步勾选复选框，勾选复选框也会同步更新数字。
- 输入时自动过滤非法字符，并限制为 3 位。
- 弹框改为 `el-form` 布局，包含 `Owner` / `Group` / `Other` / 数值 各行，与新建连接表单样式保持一致。
- 为所有语言文件补充 `chmodOctal` 标签。

关联 #28
