### PR TITLE
fix: SFTP drive dropdown unresponsive on Windows (#40)

### DIFF
--- a/frontend/src/components/SFTPPathBreadcrumb.vue
+++ b/frontend/src/components/SFTPPathBreadcrumb.vue
@@ -50,6 +50,7 @@
         class="drive-dropdown"
         :style="driveMenuStyle"
         @click.stop
+        @mousedown.stop
       >
         <div
           v-for="drive in drives"


### PR DESCRIPTION
## Summary

Fixed an event race condition in `SFTPPathBreadcrumb.vue` where clicking drive letters (C:, D:, etc.) in the dropdown menu had no response.

### Root Cause

When the drive dropdown opened, `toggleDriveMenu()` registered a `mousedown` listener on `document` to auto-close the menu on outside clicks. However, when clicking a drive item inside the dropdown, the `mousedown` event fired first, bubbled to `document`, triggered `closeDriveMenu()`, and set `driveMenuVisible = false`. Vue's `v-show` then hid the dropdown before the `click` event could fire on the `.drive-item` element, so `onDriveSelect()` was never called.

### Fix

Added `@mousedown.stop` on the dropdown container `<div>` to prevent `mousedown` events inside the dropdown from propagating to `document`, allowing the subsequent `click` event to fire normally.

### Changes

- `frontend/src/components/SFTPPathBreadcrumb.vue`: +1 line (`@mousedown.stop` on dropdown container)

Closes #40

---

## 摘要

修复了 `SFTPPathBreadcrumb.vue` 中的事件竞争问题：点击盘符下拉菜单中的盘符（C:\、D:\ 等）无反应。

### 根因

盘符下拉菜单打开时，`toggleDriveMenu()` 在 `document` 上注册了 `mousedown` 监听器以支持点击外部关闭。但点击菜单内的盘符项时，`mousedown` 事件先触发并冒泡到 `document`，调用 `closeDriveMenu()` 将 `driveMenuVisible` 设为 `false`。Vue 的 `v-show` 随之隐藏下拉菜单，导致后续的 `click` 事件无法到达 `.drive-item` 元素，`onDriveSelect()` 永远不会被调用。

### 修复

在下拉菜单容器 `<div>` 上添加 `@mousedown.stop`，阻止菜单内部的 `mousedown` 冒泡到 `document`，确保 `click` 事件正常触发。

### 变更

- `frontend/src/components/SFTPPathBreadcrumb.vue`: +1 行（在下拉容器上增加 `@mousedown.stop`）

Closes #40