### PR TITLE
fix: Fix Out of Memory issue when processing large files in sz/rz

### DIFF
--- a/app.go
+++ b/app.go
@@ -727,12 +727,92 @@ func (a *App) ReadFileBase64(path string) (string, error) {
 	return base64.StdEncoding.EncodeToString(data), nil
 }
 
+func (a *App) FileSize(path string) (int64, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return 0, fmt.Errorf("stat file: %w", err)
+	}
+	if info.IsDir() {
+		return 0, fmt.Errorf("path is a directory: %s", path)
+	}
+	return info.Size(), nil
+}
+
+func (a *App) ReadFileChunkBase64(path string, offset int64, length int64) (string, error) {
+	if offset < 0 {
+		return "", fmt.Errorf("offset must be non-negative")
+	}
+	if length <= 0 {
+		return "", fmt.Errorf("length must be positive")
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return "", fmt.Errorf("open file: %w", err)
+	}
+	defer f.Close()
+
+	info, err := f.Stat()
+	if err != nil {
+		return "", fmt.Errorf("stat file: %w", err)
+	}
+	if info.IsDir() {
+		return "", fmt.Errorf("path is a directory: %s", path)
+	}
+	if offset >= info.Size() {
+		return "", nil
+	}
+	if remaining := info.Size() - offset; length > remaining {
+		length = remaining
+	}
+
+	buf := make([]byte, length)
+	n, err := f.ReadAt(buf, offset)
+	if err != nil && err != io.EOF {
+		return "", fmt.Errorf("read file chunk: %w", err)
+	}
+	return base64.StdEncoding.EncodeToString(buf[:n]), nil
+}
+
 func (a *App) WriteFileBase64(path string, base64Data string) error {
 	data, err := base64.StdEncoding.DecodeString(base64Data)
 	if err != nil {
 		return fmt.Errorf("decode base64: %w", err)
 	}
 	return os.WriteFile(path, data, 0644)
+}
+
+func (a *App) AppendFileBase64(path string, base64Data string, offset int64) error {
+	data, err := base64.StdEncoding.DecodeString(base64Data)
+	if err != nil {
+		return fmt.Errorf("decode base64: %w", err)
+	}
+
+	flag := os.O_CREATE | os.O_WRONLY
+	if offset == 0 {
+		flag |= os.O_TRUNC
+	} else {
+		flag |= os.O_APPEND
+	}
+
+	f, err := os.OpenFile(path, flag, 0644)
+	if err != nil {
+		return fmt.Errorf("open file: %w", err)
+	}
+	defer f.Close()
+
+	info, err := f.Stat()
+	if err != nil {
+		return fmt.Errorf("stat file: %w", err)
+	}
+	if info.Size() != offset {
+		return fmt.Errorf("append offset mismatch: expected %d, got %d", offset, info.Size())
+	}
+
+	if _, err := f.Write(data); err != nil {
+		return fmt.Errorf("write file: %w", err)
+	}
+	return nil
 }
 
 func (a *App) RDPSetPosition(sessionID string, x, y, w, h int) error {

--- a/frontend/src/services/zmodemService.ts
+++ b/frontend/src/services/zmodemService.ts
@@ -3,8 +3,9 @@ import {
   SessionEndZmodem,
   SessionWriteBinary,
   SessionWrite,
-  ReadFileBase64,
-  WriteFileBase64,
+  AppendFileBase64,
+  FileSize,
+  ReadFileChunkBase64,
   OpenDirectoryDialog,
   OpenMultipleFilesDialog,
 } from '../../wailsjs/go/main/App'
@@ -44,7 +45,7 @@ export function startZmodemService(options: ZmodemServiceOptions) {
 
   function sender(octets: number[]) {
     const base64 = arrayBufferToBase64(new Uint8Array(octets))
-    const p = SessionWriteBinary(sessionId, base64).catch((err) => {
+    const p = SessionWriteBinary(sessionId, base64).catch(() => {
       // noop
     })
     pendingWrites.push(p)
@@ -165,25 +166,24 @@ async function handleSend(
 ) {
   const store = useZmodemStore()
   const files: string[] = []
-  const rejected: string[] = []
 
   try {
     for (let i = 0; i < paths.length; i++) {
       const path = paths[i]
       const filename = path.split(/[\\/]/).pop() || 'unknown'
       const transferId = `${sessionId}-up-${i}`
-      const fileData = base64ToUint8Array(await ReadFileBase64(path))
+      const fileSize = await FileSize(path)
 
       store.addTransfer(sessionId, {
         id: transferId, sessionId, filename,
-        size: fileData.length, transferred: 0,
+        size: fileSize, transferred: 0,
         direction: 'upload', status: 'transferring', speed: 0,
       })
 
       const xfer: any = await (zsession as any).send_offer({
-        name: filename, size: fileData.length,
+        name: filename, size: fileSize,
         mode: 0o644, mtime: new Date(),
-        files_remaining: 1, bytes_remaining: fileData.length,
+        files_remaining: 1, bytes_remaining: fileSize,
       })
       if (!xfer) {
         store.updateTransfer(sessionId, transferId, {
@@ -194,14 +194,14 @@ async function handleSend(
         return
       }
 
-      // Race sendChunks against abort so cancel during rz can interrupt
+      // Race file sending against abort so cancel during rz can interrupt
       let done = false
       const abortPromise = new Promise<Error>((_, reject) => {
         abortCtl.reject = () => { if (!done) reject(new Error('aborted')) }
       })
       try {
         await Promise.race([
-          sendChunks(xfer, fileData, CHUNK, sessionId, transferId, drainWrites, isAborted),
+          sendFileChunks(xfer, path, fileSize, CHUNK, sessionId, transferId, drainWrites, isAborted),
           abortPromise,
         ])
       } catch (e: any) {
@@ -212,7 +212,7 @@ async function handleSend(
       }
       if (isAborted()) break
 
-      store.updateTransfer(sessionId, transferId, { status: 'completed', transferred: fileData.length })
+      store.updateTransfer(sessionId, transferId, { status: 'completed', transferred: fileSize })
       files.push(filename)
     }
 
@@ -232,30 +232,35 @@ async function handleSend(
 }
 
 const CHUNK = 8192
+const READ_CHUNK = CHUNK * 16
 
-async function sendChunks(
-  xfer: any, data: Uint8Array, chunkSize: number,
+async function sendFileChunks(
+  xfer: any, path: string, size: number, chunkSize: number,
   sessionId: string, transferId: string,
   drainWrites: () => Promise<void>,
   isAborted: () => boolean,
 ) {
   const store = useZmodemStore()
   let offset = 0
-  while (offset < data.length) {
+  while (offset < size) {
     if (isAborted()) throw new Error('aborted')
-    const end = Math.min(offset + chunkSize, data.length)
-    const chunk = Array.from(data.slice(offset, end)) as number[]
-    if (end >= data.length) {
-      xfer.send(chunk); await drainWrites()
-      await xfer.end([]); await drainWrites()
-    } else {
-      xfer.send(chunk); await drainWrites()
-    }
-    offset = end
-    store.updateTransfer(sessionId, transferId, { transferred: offset })
-  }
-}
+    const length = Math.min(READ_CHUNK, size - offset)
+    const data = base64ToUint8Array(await ReadFileChunkBase64(path, offset, length))
+    if (data.length === 0) throw new Error(`Read empty chunk at offset ${offset}`)
 
+    let chunkOffset = 0
+    while (chunkOffset < data.length) {
+      if (isAborted()) throw new Error('aborted')
+      const end = Math.min(chunkOffset + chunkSize, data.length)
+      const chunk = Array.from(data.slice(chunkOffset, end)) as number[]
+      xfer.send(chunk); await drainWrites()
+      chunkOffset = end
+      offset += chunk.length
+      store.updateTransfer(sessionId, transferId, { transferred: offset })
+    }
+  }
+  await xfer.end([]); await drainWrites()
+}
 // ── Download (sz) ────────────────────────────────────────────────────
 
 async function handleReceive(
@@ -298,20 +303,27 @@ async function handleReceive(
         savePath: finalSavePath,
       })
       let received = 0
-      offer.on('input', (payload: number[]) => {
-        received += payload.length
+      let writeChain = Promise.resolve()
+      let writeError: unknown = null
+      const onInput = (payload: number[]) => {
+        const offset = received
+        const chunk = Uint8Array.from(payload)
+        received += chunk.length
         resetIdle()
         store.updateTransfer(sessionId, transferId, { transferred: received })
-      })
+        writeChain = writeChain.then(async () => {
+          if (writeError) return
+          await AppendFileBase64(finalSavePath, arrayBufferToBase64(chunk), offset)
+        }).catch((err) => {
+          writeError = err
+        })
+      }
       try {
-        const chunks: Uint8Array[] = await offer.accept()
-        const totalLen = chunks.reduce((s, c) => s + c.length, 0)
-        const fileData = new Uint8Array(totalLen)
-        let pos = 0
-        for (const c of chunks) { fileData.set(c, pos); pos += c.length }
-        await WriteFileBase64(finalSavePath, arrayBufferToBase64(fileData))
+        await offer.accept({ on_input: onInput })
+        await writeChain
+        if (writeError) throw writeError
         store.updateTransfer(sessionId, transferId, {
-          status: 'completed', transferred: totalLen,
+          status: 'completed', transferred: received,
         })
         files.push(finalSavePath)
       } catch (e: any) {

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -11,6 +11,8 @@ export function AddColumn(arg1:string,arg2:string,arg3:string,arg4:database.Colu
 
 export function AddIndex(arg1:string,arg2:string,arg3:string,arg4:database.IndexDef):Promise<void>;
 
+export function AppendFileBase64(arg1:string,arg2:string,arg3:number):Promise<void>;
+
 export function CancelChatStream():Promise<void>;
 
 export function ChatCompletion(arg1:string,arg2:string,arg3:string,arg4:string,arg5:string,arg6:string):Promise<string>;
@@ -44,6 +46,8 @@ export function ExecuteQuery(arg1:string,arg2:string,arg3:string):Promise<databa
 export function ExecuteStatement(arg1:string,arg2:string,arg3:string):Promise<database.ExecResult>;
 
 export function FetchModels(arg1:string,arg2:string):Promise<Array<main.ModelInfo>>;
+
+export function FileSize(arg1:string):Promise<number>;
 
 export function FrontendLog(arg1:string,arg2:string):Promise<void>;
 
@@ -116,6 +120,8 @@ export function RDPSetPosition(arg1:string,arg2:number,arg3:number,arg4:number,a
 export function RDPShow(arg1:string):Promise<void>;
 
 export function ReadFileBase64(arg1:string):Promise<string>;
+
+export function ReadFileChunkBase64(arg1:string,arg2:number,arg3:number):Promise<string>;
 
 export function RemoveTempFile(arg1:string):Promise<void>;
 

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -10,6 +10,10 @@ export function AddIndex(arg1, arg2, arg3, arg4) {
   return window['go']['main']['App']['AddIndex'](arg1, arg2, arg3, arg4);
 }
 
+export function AppendFileBase64(arg1, arg2, arg3) {
+  return window['go']['main']['App']['AppendFileBase64'](arg1, arg2, arg3);
+}
+
 export function CancelChatStream() {
   return window['go']['main']['App']['CancelChatStream']();
 }
@@ -76,6 +80,10 @@ export function ExecuteStatement(arg1, arg2, arg3) {
 
 export function FetchModels(arg1, arg2) {
   return window['go']['main']['App']['FetchModels'](arg1, arg2);
+}
+
+export function FileSize(arg1) {
+  return window['go']['main']['App']['FileSize'](arg1);
 }
 
 export function FrontendLog(arg1, arg2) {
@@ -220,6 +228,10 @@ export function RDPShow(arg1) {
 
 export function ReadFileBase64(arg1) {
   return window['go']['main']['App']['ReadFileBase64'](arg1);
+}
+
+export function ReadFileChunkBase64(arg1, arg2, arg3) {
+  return window['go']['main']['App']['ReadFileChunkBase64'](arg1, arg2, arg3);
 }
 
 export function RemoveTempFile(arg1) {


### PR DESCRIPTION
## Summary
  Fixed an Out of Memory issue in sz/rz transfers where large files were loaded and buffered entirely in memory.

## Root Cause
  Upload read the whole file via ReadFileBase64(), decoded it into a full Uint8Array, then sent chunks from that in-memory buffer. Download collected all received chunks from offer.accept(), concatenated them
  into one large buffer, then wrote the whole file via WriteFileBase64(). Large files caused memory spikes from full-file buffers plus base64 copies.

## Fix
  Added backend chunk APIs and changed zmodem transfer handling to stream data in bounded chunks. Upload now reads file chunks with ReadFileChunkBase64() and sends them incrementally. Download now handles
  incoming payloads with on_input and appends each chunk to disk through AppendFileBase64() with offset validation.

## Changes
  app.go: +80 lines (FileSize, ReadFileChunkBase64, AppendFileBase64)
  frontend/src/services/zmodemService.ts: +45/-33 lines (streaming upload/download flow)
  frontend/wailsjs/go/main/App.d.ts: +6 lines (new Wails declarations)
  frontend/wailsjs/go/main/App.js: +12 lines (new Wails bindings)

  Closes #43 
---
## Summary
  修复了 sz/rz 传输大文件时的内存溢出问题，避免一次性把整个文件读入和缓存在内存中。

## Root Cause
  上传时通过 ReadFileBase64() 一次性读取整个文件，再解码成完整的 Uint8Array 后分块发送。下载时通过 offer.accept() 收集所有接收块，拼接成一个完整文件缓冲区，再通过 WriteFileBase64() 一次性写入。大文件会同时产生
  完整文件缓冲区和 base64 副本，导致内存占用暴涨并触发 OOM。

## Fix
  新增后端分块文件接口，并将 zmodem 传输改为流式处理。上传时先获取文件大小，再通过 ReadFileChunkBase64() 分块读取并增量发送。下载时使用 on_input 逐块接收数据，并通过 AppendFileBase64() 按 offset 校验后追加写入
  磁盘，避免在内存中累计整个文件。

## Changes
  app.go: +80 行（新增 FileSize、ReadFileChunkBase64、AppendFileBase64）
  frontend/src/services/zmodemService.ts: +45/-33 行（上传/下载改为流式传输）
  frontend/wailsjs/go/main/App.d.ts: +6 行（新增 Wails TS 声明）
  frontend/wailsjs/go/main/App.js: +12 行（新增 Wails JS 绑定）

  Closes #43 