### PR TITLE
fix: fix ssh key authentication bug

### DIFF
--- a/backend/session/ssh_session.go
+++ b/backend/session/ssh_session.go
@@ -44,6 +44,13 @@ func NewSSHSession(id string) *SSHSession {
 	}
 }
 
+func shouldPromptForSSHPassword(config ConnectionConfig) bool {
+	if config.Password != "" {
+		return false
+	}
+	return config.AuthType == "" || config.AuthType == "password"
+}
+
 func (s *SSHSession) Connect(config ConnectionConfig) error {
 	s.setStatus(StatusConnecting)
 	s.title = fmt.Sprintf("%s@%s", config.User, config.Host)
@@ -59,10 +66,10 @@ func (s *SSHSession) Connect(config ConnectionConfig) error {
 		s.mu.Unlock()
 	}()
 
-	// If no password is stored, prompt the user in the terminal before the
-	// SSH handshake. This covers servers that do not advertise
+	// For password auth without a stored password, prompt in the terminal
+	// before the SSH handshake. This covers servers that do not advertise
 	// keyboard-interactive support (the kbCallback fallback below).
-	if config.Password == "" {
+	if shouldPromptForSSHPassword(config) {
 		s.emitData([]byte("\r\nPassword: "))
 		var answer string
 	promptLoop:


### PR DESCRIPTION
  Closes #52 
 
 ## Summary

  When connecting with SSH key-path authentication, the terminal no longer shows a pre-handshake Password: prompt. Password prompting is now limited to password authentication, while key authentication
  proceeds directly through the SSH connection flow.

  ### Changes

  - Added shouldPromptForSSHPassword to gate SSH password prompts by auth type
  - SSH key-path authentication no longer triggers Password: when no password is saved
  - Preserved existing password-auth behavior for empty-password connections
  - Added regression test for key-path auth without password prompt
  - Verified with go test ./... -count=1 and wails build

  ———

  Closes #52 

  ## 概要

  当使用 SSH 密钥路径认证连接时，终端不再在连接前显示 Password: 提示。现在密码提示仅用于密码认证，密钥认证会直接进入 SSH 连接流程。

  ### 改动

  - 新增 shouldPromptForSSHPassword，按认证方式控制 SSH 密码提示
  - SSH 密钥路径认证在未保存密码时不再触发 Password: 提示
  - 保留密码认证未填写密码时的原有提示行为
  - 新增回归测试，覆盖密钥路径认证不应显示密码提示的场景
  - 已通过 go test ./... -count=1 和 wails build 验证