### PR TITLE
feat: Added a file-picker button to the key path input

### DIFF
--- a/frontend/src/components/ConnectionForm.vue
+++ b/frontend/src/components/ConnectionForm.vue
@@ -78,7 +78,15 @@
         <el-input v-model="form.password" type="password" show-password :key="passwordInputKey" />
       </el-form-item>
       <el-form-item v-if="form.authType === 'key' && (form.type === 'ssh' || form.type === 'mosh')" :label="t('conn.keyPath')">
-        <el-input v-model="form.keyPath" :placeholder="t('conn.keyPathPlaceholder')" />
+        <el-input v-model="form.keyPath" :placeholder="t('conn.keyPathPlaceholder')">
+          <template #append>
+            <el-tooltip :content="t('conn.selectKeyFile')" placement="top">
+              <el-button :aria-label="t('conn.selectKeyFile')" @click="selectKeyFile">
+                <el-icon><FolderOpen :size="16" /></el-icon>
+              </el-button>
+            </el-tooltip>
+          </template>
+        </el-input>
       </el-form-item>
       <el-form-item v-if="form.type === 'database' && form.dbType !== 'rqlite'" :label="t('db.databases')">
         <el-input v-model="form.dbName" :placeholder="t('db.databases')" />
@@ -229,8 +237,9 @@ import { reactive, computed, watch, ref, onMounted } from 'vue'
 import { useConnectionStore } from '../stores/connectionStore'
 import { useI18n } from '../i18n'
 import type { ConnectionConfig, PostLoginExpectStep } from '../types/session'
-import { GetPlatform } from '../../wailsjs/go/main/App'
-import { Plus, Trash2, ChevronRight } from '@lucide/vue'
+import { selectKeyPath } from '../services/keyPathPicker'
+import { GetPlatform, OpenFileDialog } from '../../wailsjs/go/main/App'
+import { Plus, Trash2, ChevronRight, FolderOpen } from '@lucide/vue'
 
 const { t } = useI18n()
 const connectionStore = useConnectionStore()
@@ -479,6 +488,14 @@ async function confirmNewGroup() {
   form.groupId = group.id
   selectedGroupId.value = group.id
   showNewGroupDialog.value = false
+}
+
+async function selectKeyFile() {
+  try {
+    form.keyPath = await selectKeyPath(OpenFileDialog, form.keyPath || '')
+  } catch (e) {
+    console.error('select key file:', e)
+  }
 }
 
 function generateUniqueName(name: string): string {

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -37,6 +37,7 @@
   "conn.password": "Passwort",
   "conn.keyPath": "Schlüsselpfad",
   "conn.keyPathPlaceholder": "z. B. ~/.ssh/id_rsa",
+  "conn.selectKeyFile": "Schlüsseldatei auswählen",
   "conn.cancel": "Abbrechen",
   "conn.saveConnect": "Speichern & Verbinden",
   "conn.save": "Speichern",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -38,6 +38,7 @@
   "conn.password": "Password",
   "conn.keyPath": "Key Path",
   "conn.keyPathPlaceholder": "e.g. ~/.ssh/id_rsa",
+  "conn.selectKeyFile": "Select key file",
   "conn.cancel": "Cancel",
   "conn.saveConnect": "Save & Connect",
   "conn.save": "Save",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -37,6 +37,7 @@
   "conn.password": "Contraseña",
   "conn.keyPath": "Ruta de la Clave",
   "conn.keyPathPlaceholder": "p. ej. ~/.ssh/id_rsa",
+  "conn.selectKeyFile": "Seleccionar archivo de clave",
   "conn.cancel": "Cancelar",
   "conn.saveConnect": "Guardar y Conectar",
   "conn.save": "Guardar",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -37,6 +37,7 @@
   "conn.password": "Mot de passe",
   "conn.keyPath": "Chemin de la clé",
   "conn.keyPathPlaceholder": "ex. ~/.ssh/id_rsa",
+  "conn.selectKeyFile": "Sélectionner le fichier de clé",
   "conn.cancel": "Annuler",
   "conn.saveConnect": "Enregistrer et connecter",
   "conn.save": "Enregistrer",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -37,6 +37,7 @@
   "conn.password": "パスワード",
   "conn.keyPath": "鍵のパス",
   "conn.keyPathPlaceholder": "例: ~/.ssh/id_rsa",
+  "conn.selectKeyFile": "鍵ファイルを選択",
   "conn.cancel": "キャンセル",
   "conn.saveConnect": "保存して接続",
   "conn.save": "保存",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -37,6 +37,7 @@
   "conn.password": "비밀번호",
   "conn.keyPath": "키 경로",
   "conn.keyPathPlaceholder": "예: ~/.ssh/id_rsa",
+  "conn.selectKeyFile": "키 파일 선택",
   "conn.cancel": "취소",
   "conn.saveConnect": "저장 후 연결",
   "conn.save": "저장",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -37,6 +37,7 @@
   "conn.password": "Пароль",
   "conn.keyPath": "Путь к ключу",
   "conn.keyPathPlaceholder": "например, ~/.ssh/id_rsa",
+  "conn.selectKeyFile": "Выбрать файл ключа",
   "conn.cancel": "Отмена",
   "conn.saveConnect": "Сохранить и подключиться",
   "conn.save": "Сохранить",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -38,6 +38,7 @@
   "conn.password": "密码",
   "conn.keyPath": "密钥路径",
   "conn.keyPathPlaceholder": "例如 ~/.ssh/id_rsa",
+  "conn.selectKeyFile": "选择密钥文件",
   "conn.cancel": "取消",
   "conn.saveConnect": "保存并连接",
   "conn.save": "保存",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -37,6 +37,7 @@
   "conn.password": "密碼",
   "conn.keyPath": "金鑰路徑",
   "conn.keyPathPlaceholder": "例如 ~/.ssh/id_rsa",
+  "conn.selectKeyFile": "選擇金鑰檔案",
   "conn.cancel": "取消",
   "conn.saveConnect": "儲存並連線",
   "conn.save": "儲存",


### PR DESCRIPTION
 Closes #54 

  ## Summary

  When configuring SSH or Mosh key-path authentication, users can now choose a private key file from the system file picker instead of typing the path manually. The selected file path is filled into the key
  path field, while cancelling the dialog preserves the existing value.

  ### Changes

  - Added a file-picker button to the key path input in ConnectionForm.vue
  - Reused the existing Wails OpenFileDialog() binding
  - Added selectKeyPath helper to preserve the current path when file selection is cancelled
  - Added Vitest coverage for selected-file and cancelled-dialog behavior
  - i18n: all 9 locale files include the new “Select key file” tooltip text

  ———

  Closes #54 

  ## 概要

  配置 SSH 或 Mosh 的密钥路径认证时，现在可以通过系统文件选择器选择私钥文件，不需要手动输入路径。选择文件后会自动填入密钥路径；如果取消选择，则保留原有路径不变。

  ### 改动

  - 在 ConnectionForm.vue 的密钥路径输入框右侧新增文件选择按钮
  - 复用现有 Wails OpenFileDialog() 绑定
  - 新增 selectKeyPath 辅助函数，取消文件选择时保留当前路径
  - 新增 Vitest 测试，覆盖选择文件和取消选择两种行为
  - 国际化：全部 9 个语言文件新增“选择密钥文件”提示文案