### PR TITLE
feat: add padding around terminal content (#47)

### DIFF
--- a/frontend/src/components/BaseTerminal.vue
+++ b/frontend/src/components/BaseTerminal.vue
@@ -430,10 +430,10 @@ function resize() {
       return
     }
 
-    // Subtract scrollbar width so the canvas doesn't overlap the scrollbar.
+    const TERMINAL_PADDING = 4
     const scrollbarWidth = (terminal as any)._core?.viewport?.scrollBarWidth || 0
-    const cols = Math.floor((rect.width - scrollbarWidth) / cellWidth)
-    const rows = Math.floor(rect.height / cellHeight)
+    const cols = Math.floor((rect.width - TERMINAL_PADDING * 2 - scrollbarWidth) / cellWidth)
+    const rows = Math.floor((rect.height - TERMINAL_PADDING * 2) / cellHeight)
     const newCols = Math.max(2, cols)
     const newRows = Math.max(1, rows)
 
@@ -1380,6 +1380,8 @@ defineExpose({
   width: 100%;
   height: 100%;
   display: block;
+  box-sizing: border-box;
+  padding: 4px;
 }
 .terminal-area :deep(.xterm),
 .terminal-area :deep(.xterm-viewport) {


### PR DESCRIPTION
## Summary

Add a 4px breathing space between the terminal content and the panel edge, addressing the cramped look (especially a dark terminal theme on a light UI theme).

- Add `box-sizing: border-box; padding: 4px` to the `.xterm` element. Padding here insets the text layer but not the absolutely-positioned scrollbar, so the scrollbar stays full-height and flush with the edge.
- Subtract the padding in `resize()` cols/rows math so the text fits inside the padding box and never overlaps the scrollbar.

Closes #47

---

## 概述

在终端内容与面板边缘之间增加 4px 留白，解决内容直顶边缘、视觉局促的问题（亮色界面 + 暗色终端主题时尤为明显）。

- 给 `.xterm` 元素加 `box-sizing: border-box; padding: 4px`。padding 只内缩文本层，不影响绝对定位的滚动条，所以滚动条保持满高、贴边。
- 在 `resize()` 的列/行计算中扣除 padding，确保文本不溢出、也不会压住滚动条。