### PR TITLE
fix: add file keyPathPicker.ts

### DIFF
--- a/frontend/src/components/ConnectionForm.vue
+++ b/frontend/src/components/ConnectionForm.vue
@@ -78,7 +78,15 @@
         <el-input v-model="form.password" type="password" show-password :key="passwordInputKey" />
       </el-form-item>
       <el-form-item v-if="form.authType === 'key' && (form.type === 'ssh' || form.type === 'mosh')" :label="t('conn.keyPath')">
-        <el-input v-model="form.keyPath" :placeholder="t('conn.keyPathPlaceholder')" />
+        <el-input v-model="form.keyPath" :placeholder="t('conn.keyPathPlaceholder')">
+          <template #append>
+            <el-tooltip :content="t('conn.selectKeyFile')" placement="top">
+              <el-button :aria-label="t('conn.selectKeyFile')" @click="selectKeyFile">
+                <el-icon><FolderOpen :size="16" /></el-icon>
+              </el-button>
+            </el-tooltip>
+          </template>
+        </el-input>
       </el-form-item>
       <el-form-item v-if="form.type === 'database' && form.dbType !== 'rqlite'" :label="t('db.databases')">
         <el-input v-model="form.dbName" :placeholder="t('db.databases')" />
@@ -229,8 +237,9 @@ import { reactive, computed, watch, ref, onMounted } from 'vue'
 import { useConnectionStore } from '../stores/connectionStore'
 import { useI18n } from '../i18n'
 import type { ConnectionConfig, PostLoginExpectStep } from '../types/session'
-import { GetPlatform } from '../../wailsjs/go/main/App'
-import { Plus, Trash2, ChevronRight } from '@lucide/vue'
+import { selectKeyPath } from '../services/keyPathPicker'
+import { GetPlatform, OpenFileDialog } from '../../wailsjs/go/main/App'
+import { Plus, Trash2, ChevronRight, FolderOpen } from '@lucide/vue'
 
 const { t } = useI18n()
 const connectionStore = useConnectionStore()
@@ -479,6 +488,14 @@ async function confirmNewGroup() {
   form.groupId = group.id
   selectedGroupId.value = group.id
   showNewGroupDialog.value = false
+}
+
+async function selectKeyFile() {
+  try {
+    form.keyPath = await selectKeyPath(OpenFileDialog, form.keyPath || '')
+  } catch (e) {
+    console.error('select key file:', e)
+  }
 }
 
 function generateUniqueName(name: string): string {

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -37,6 +37,7 @@
   "conn.password": "Passwort",
   "conn.keyPath": "Schlüsselpfad",
   "conn.keyPathPlaceholder": "z. B. ~/.ssh/id_rsa",
+  "conn.selectKeyFile": "Schlüsseldatei auswählen",
   "conn.cancel": "Abbrechen",
   "conn.saveConnect": "Speichern & Verbinden",
   "conn.save": "Speichern",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -38,6 +38,7 @@
   "conn.password": "Password",
   "conn.keyPath": "Key Path",
   "conn.keyPathPlaceholder": "e.g. ~/.ssh/id_rsa",
+  "conn.selectKeyFile": "Select key file",
   "conn.cancel": "Cancel",
   "conn.saveConnect": "Save & Connect",
   "conn.save": "Save",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -37,6 +37,7 @@
   "conn.password": "Contraseña",
   "conn.keyPath": "Ruta de la Clave",
   "conn.keyPathPlaceholder": "p. ej. ~/.ssh/id_rsa",
+  "conn.selectKeyFile": "Seleccionar archivo de clave",
   "conn.cancel": "Cancelar",
   "conn.saveConnect": "Guardar y Conectar",
   "conn.save": "Guardar",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -37,6 +37,7 @@
   "conn.password": "Mot de passe",
   "conn.keyPath": "Chemin de la clé",
   "conn.keyPathPlaceholder": "ex. ~/.ssh/id_rsa",
+  "conn.selectKeyFile": "Sélectionner le fichier de clé",
   "conn.cancel": "Annuler",
   "conn.saveConnect": "Enregistrer et connecter",
   "conn.save": "Enregistrer",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -37,6 +37,7 @@
   "conn.password": "パスワード",
   "conn.keyPath": "鍵のパス",
   "conn.keyPathPlaceholder": "例: ~/.ssh/id_rsa",
+  "conn.selectKeyFile": "鍵ファイルを選択",
   "conn.cancel": "キャンセル",
   "conn.saveConnect": "保存して接続",
   "conn.save": "保存",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -37,6 +37,7 @@
   "conn.password": "비밀번호",
   "conn.keyPath": "키 경로",
   "conn.keyPathPlaceholder": "예: ~/.ssh/id_rsa",
+  "conn.selectKeyFile": "키 파일 선택",
   "conn.cancel": "취소",
   "conn.saveConnect": "저장 후 연결",
   "conn.save": "저장",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -37,6 +37,7 @@
   "conn.password": "Пароль",
   "conn.keyPath": "Путь к ключу",
   "conn.keyPathPlaceholder": "например, ~/.ssh/id_rsa",
+  "conn.selectKeyFile": "Выбрать файл ключа",
   "conn.cancel": "Отмена",
   "conn.saveConnect": "Сохранить и подключиться",
   "conn.save": "Сохранить",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -38,6 +38,7 @@
   "conn.password": "密码",
   "conn.keyPath": "密钥路径",
   "conn.keyPathPlaceholder": "例如 ~/.ssh/id_rsa",
+  "conn.selectKeyFile": "选择密钥文件",
   "conn.cancel": "取消",
   "conn.saveConnect": "保存并连接",
   "conn.save": "保存",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -37,6 +37,7 @@
   "conn.password": "密碼",
   "conn.keyPath": "金鑰路徑",
   "conn.keyPathPlaceholder": "例如 ~/.ssh/id_rsa",
+  "conn.selectKeyFile": "選擇金鑰檔案",
   "conn.cancel": "取消",
   "conn.saveConnect": "儲存並連線",
   "conn.save": "儲存",

--- a/frontend/src/services/keyPathPicker.ts
+++ b/frontend/src/services/keyPathPicker.ts
@@ -1,0 +1,6 @@
+export type OpenFileDialog = () => Promise<string>
+
+export async function selectKeyPath(openFileDialog: OpenFileDialog, currentKeyPath: string): Promise<string> {
+  const selected = await openFileDialog()
+  return selected || currentKeyPath
+}


### PR DESCRIPTION
Closes #54 

  ## Summary

  Adds the missing keyPathPicker.ts service file for SSH key path selection. The helper opens a file dialog and keeps the existing key path when the user cancels or no file is selected.

  ### Changes

  - New frontend/src/services/keyPathPicker.ts service file
  - Added OpenFileDialog type for injected file dialog behavior
  - Added selectKeyPath helper to return the selected key path
  - Falls back to the current key path when the dialog returns an empty value

  ———

  Closes #54 

  ## 概要

  新增缺失的 keyPathPicker.ts 服务文件，用于 SSH 密钥路径选择。该工具方法会打开文件选择对话框，并在用户取消或未选择文件时保留原有密钥路径。

  ### 改动

  - 新增 frontend/src/services/keyPathPicker.ts 服务文件
  - 添加 OpenFileDialog 类型，用于注入文件选择对话框行为
  - 添加 selectKeyPath 工具方法，返回用户选择的密钥路径
  - 当未选择文件或取消选择时，自动回退为当前已有的密钥路径