### PR TITLE
fix: enable macOS header double-click maximize

### DIFF
--- a/frontend/src/components/AppHeader.vue
+++ b/frontend/src/components/AppHeader.vue
@@ -123,9 +123,8 @@ function onClose() {
 }
 
 function onDblClick(e: MouseEvent) {
-  if (platform.value === 'darwin') return
   const target = e.target as HTMLElement
-  if (target.closest('button') || target.closest('.window-controls')) return
+  if (target.closest('button, input, textarea, select, a, [role="button"], .tab-item, .tab-more, .window-controls')) return
   onMaximise()
 }
 


### PR DESCRIPTION
## Summary

Enable double-clicking the app header empty area on macOS to toggle window maximize/restore, matching the behavior already available on Windows/Linux.

### Root Cause

`AppHeader.vue` returned early when the detected platform was `darwin`, so the header double-click handler never called the existing maximize toggle logic on macOS.

### Fix

Removed the macOS early return and tightened the interactive-target guard so buttons, inputs, tabs, the more menu, and window controls do not accidentally trigger maximize/restore.

### Changes

- `frontend/src/components/AppHeader.vue`: allow macOS header double-click maximize/restore and expand the ignored interactive target selector.

Closes #48

---

## 概要

支持在 macOS 下双击应用 header 空白区域切换窗口最大化/还原，与 Windows/Linux 上已有行为保持一致。

### 根因

`AppHeader.vue` 在检测到平台为 `darwin` 时直接返回，导致 macOS 下 header 双击事件不会调用已有的最大化切换逻辑。

### 修复

移除 macOS 的提前返回，并收紧交互元素过滤，避免按钮、输入框、标签页、更多菜单和窗口控制区域误触发最大化/还原。

### 改动

- `frontend/src/components/AppHeader.vue`：允许 macOS header 双击切换最大化，并扩展需要忽略的交互目标选择器。

关联 #48
