### PR TITLE
feat(ssh): add terminal character encoding support

### DIFF
--- a/app.go
+++ b/app.go
@@ -498,6 +498,10 @@ func (a *App) CreateSession(sessionType string, config session.ConnectionConfig)
 		return nil, err
 	}
 	log.Writef("[CreateSession] session created, id=%s", s.ID())
+	// Apply terminal character encoding (SSH only). No-op for utf-8/empty.
+	if ssh, ok := s.(*session.SSHSession); ok {
+		ssh.SetEncoding(config.Encoding)
+	}
 
 	// ── SSH Tunnel ──────────────────────────────────────────────
 	if config.TunnelSSHConnID != "" && a.tunnelService != nil {

--- a/backend/session/session.go
+++ b/backend/session/session.go
@@ -53,6 +53,9 @@ type ConnectionConfig struct {
 	FtpEncryption string `json:"ftpEncryption,omitempty"` // "none"(default) | "auto" | "required"
 	FtpPassive    bool   `json:"ftpPassive"`              // passive mode (default true)
 	FtpEncoding   string `json:"ftpEncoding,omitempty"`   // "utf-8" | "gbk" | "shift-jis" | "latin-1"
+	// Terminal character encoding for ssh/telnet:
+	// "" / "utf-8"(default) | "gbk" | "gb2312" | "gb18030" | "big5" | "shift-jis" | "euc-jp" | "euc-kr"
+	Encoding string `json:"encoding,omitempty"`
 }
 
 // ConnectionStoreData is the top-level structure persisted to connections.json.

--- a/backend/session/ssh_session.go
+++ b/backend/session/ssh_session.go
@@ -11,6 +11,12 @@ import (
 	"time"
 
 	"golang.org/x/crypto/ssh"
+	"golang.org/x/text/encoding"
+	"golang.org/x/text/encoding/japanese"
+	"golang.org/x/text/encoding/korean"
+	"golang.org/x/text/encoding/simplifiedchinese"
+	"golang.org/x/text/encoding/traditionalchinese"
+	"golang.org/x/text/transform"
 )
 
 const (
@@ -31,6 +37,10 @@ type SSHSession struct {
 	lastReadTime atomic.Int64
 	authAnswerCh chan []byte
 	expectOutput *postLoginOutputBuffer
+
+	enc            encoding.Encoding // input(write) codec; nil = utf-8 passthrough
+	decoder        *encoding.Decoder // persistent streaming decoder for output(read)
+	decodeLeftover []byte            // trailing partial multibyte bytes between reads
 }
 
 func NewSSHSession(id string) *SSHSession {
@@ -255,6 +265,9 @@ func (s *SSHSession) readStderr() {
 		n, err := s.stderr.Read(buf)
 		if n > 0 {
 			// Prefix stderr output so it can be distinguished in the UI
+			// stderr is emitted raw (not decoded): it is a separate byte stream and
+			// sharing the stdout decoder's leftover buffer could corrupt stdout. In
+			// normal PTY shell sessions stderr is merged into the PTY (stdout) anyway.
 			data := append([]byte("\r\n\x1b[31m[stderr] \x1b[0m"), buf[:n]...)
 			s.emitData(data)
 		}
@@ -278,7 +291,7 @@ func (s *SSHSession) readLoop() {
 				s.SetZmodemMode(true)
 				s.emitBinary(data)
 			} else {
-				s.emitData(data)
+				s.emitData(s.decodeOutput(data))
 			}
 		}
 		if err != nil {
@@ -343,7 +356,7 @@ func (s *SSHSession) runPostLoginExpect(config ConnectionConfig) {
 			if s.stdin == nil {
 				return fmt.Errorf("not connected")
 			}
-			_, err := s.stdin.Write(data)
+			_, err := s.stdin.Write(s.encodeInput(data))
 			return err
 		},
 		IsConnected:    func() bool { return s.Status() == StatusConnected },
@@ -372,7 +385,7 @@ func (s *SSHSession) runPostLoginScript(script string) {
 			return
 		}
 		if s.stdin != nil {
-			_, _ = s.stdin.Write([]byte(line + "\r"))
+			_, _ = s.stdin.Write(s.encodeInput([]byte(line + "\r")))
 		}
 		// Wait for command output to settle before sending the next line.
 		s.waitIdle(3*time.Second, 300*time.Millisecond)
@@ -455,7 +468,7 @@ func (s *SSHSession) Write(data []byte) error {
 	if s.stdin == nil {
 		return fmt.Errorf("not connected")
 	}
-	_, err := s.stdin.Write(data)
+	_, err := s.stdin.Write(s.encodeInput(data))
 	return err
 }
 
@@ -489,4 +502,85 @@ func (s *SSHSession) Resize(cols, rows int) error {
 
 func (s *SSHSession) IsConnected() bool {
 	return s.Status() == StatusConnected
+}
+
+// SetEncoding configures the character encoding for this session.
+// name: "" / "utf-8" (passthrough) | "gbk" | "gb2312" | "gb18030" |
+// "big5" | "shift-jis" | "euc-jp" | "euc-kr".
+func (s *SSHSession) SetEncoding(name string) {
+	enc := encodingByName(name)
+	s.mu.Lock()
+	s.enc = enc
+	if enc == nil {
+		s.decoder = nil
+	} else {
+		s.decoder = enc.NewDecoder()
+	}
+	s.decodeLeftover = nil
+	s.mu.Unlock()
+}
+
+// decodeOutput converts a chunk of remote bytes to UTF-8 using the configured
+// decoder. Partial trailing multibyte sequences are buffered until the next
+// call. Must only be called from the single readLoop goroutine.
+func (s *SSHSession) decodeOutput(data []byte) []byte {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.decoder == nil {
+		return data
+	}
+	src := make([]byte, 0, len(s.decodeLeftover)+len(data))
+	src = append(src, s.decodeLeftover...)
+	src = append(src, data...)
+
+	var out []byte
+	dst := make([]byte, 8192)
+	for {
+		nDst, nSrc, err := s.decoder.Transform(dst, src, false)
+		out = append(out, dst[:nDst]...)
+		src = src[nSrc:]
+		if err == transform.ErrShortDst {
+			continue // dst full but more src consumable; drain
+		}
+		break // nil or ErrShortSrc: remaining src is an incomplete trailing rune
+	}
+	s.decodeLeftover = append([]byte(nil), src...)
+	return out
+}
+
+// encodeInput converts user keystrokes (UTF-8) to the configured encoding
+// before writing to the remote. Each call handles a complete UTF-8 input.
+func (s *SSHSession) encodeInput(data []byte) []byte {
+	s.mu.RLock()
+	enc := s.enc
+	s.mu.RUnlock()
+	if enc == nil {
+		return data
+	}
+	out, err := enc.NewEncoder().Bytes(data)
+	if err != nil {
+		return data
+	}
+	return out
+}
+
+// encodingByName maps a connection's encoding setting to an x/text codec.
+// Returns nil for UTF-8 / empty (no conversion).
+func encodingByName(name string) encoding.Encoding {
+	switch name {
+	case "gbk", "gb2312": // GB2312 is a subset of GBK; decode with GBK
+		return simplifiedchinese.GBK
+	case "gb18030":
+		return simplifiedchinese.GB18030
+	case "big5":
+		return traditionalchinese.Big5
+	case "shift-jis":
+		return japanese.ShiftJIS
+	case "euc-jp":
+		return japanese.EUCJP
+	case "euc-kr":
+		return korean.EUCKR
+	default: // "", "utf-8"
+		return nil
+	}
 }

--- a/frontend/src/components/ConnectionForm.vue
+++ b/frontend/src/components/ConnectionForm.vue
@@ -177,6 +177,21 @@
           </div>
         </div>
       </el-form-item>
+      <el-form-item
+        v-if="form.type === 'ssh'"
+        :label="t('conn.encoding')"
+      >
+        <el-select v-model="form.encoding" placeholder="Unicode (UTF-8)">
+          <el-option label="Unicode (UTF-8)" value="utf-8" />
+          <el-option label="Simplified Chinese (GBK)" value="gbk" />
+          <el-option label="Simplified Chinese (GB2312)" value="gb2312" />
+          <el-option label="Simplified Chinese (GB18030)" value="gb18030" />
+          <el-option label="Traditional Chinese (Big5)" value="big5" />
+          <el-option label="Japanese (Shift-JIS)" value="shift-jis" />
+          <el-option label="Japanese (EUC-JP)" value="euc-jp" />
+          <el-option label="Korean (EUC-KR)" value="euc-kr" />
+        </el-select>
+      </el-form-item>
       <el-form-item v-if="form.type === 'ssh'" :label="t('conn.sftpMaxConcurrency')">
         <el-input-number v-model="form.sftpMaxConcurrency" :min="0" :max="20" />
       </el-form-item>
@@ -349,6 +364,7 @@ const form = reactive<ConnectionConfig>({
   ftpEncryption: 'none',
   ftpPassive: true,
   ftpEncoding: 'utf-8',
+  encoding: 'utf-8',
 })
 
 const rdpResolutions = [
@@ -464,6 +480,7 @@ function resetForm() {
   form.ftpEncryption = 'none'
   form.ftpPassive = true
   form.ftpEncoding = 'utf-8'
+  form.encoding = 'utf-8'
   form.tunnelSSHConnId = undefined
   rdpResolution.value = '1280 × 720 (HD)'
   selectedGroupId.value = undefined

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -617,6 +617,7 @@
   "conn.ftpEncryptionRequired": "Required",
   "conn.ftpPassive": "Passive Mode",
   "conn.ftpEncoding": "Encoding",
+  "conn.encoding": "Kodierung",
   "quickCommands.title": "Schnellbefehle",
   "quickCommands.connectionsTab": "Verbindungen",
   "quickCommands.quickCommandsTab": "Schnellbefehle",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -619,6 +619,7 @@
   "conn.ftpEncryptionRequired": "Required",
   "conn.ftpPassive": "Passive Mode",
   "conn.ftpEncoding": "Encoding",
+  "conn.encoding": "Encoding",
   "quickCommands.title": "Quick Commands",
   "quickCommands.connectionsTab": "Connections",
   "quickCommands.quickCommandsTab": "Quick Commands",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -617,6 +617,7 @@
   "conn.ftpEncryptionRequired": "Required",
   "conn.ftpPassive": "Passive Mode",
   "conn.ftpEncoding": "Encoding",
+  "conn.encoding": "Codificación",
   "quickCommands.title": "Comandos rápidos",
   "quickCommands.connectionsTab": "Conexiones",
   "quickCommands.quickCommandsTab": "Comandos rápidos",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -617,6 +617,7 @@
   "conn.ftpEncryptionRequired": "Required",
   "conn.ftpPassive": "Passive Mode",
   "conn.ftpEncoding": "Encoding",
+  "conn.encoding": "Encodage",
   "quickCommands.title": "Commandes rapides",
   "quickCommands.connectionsTab": "Connexions",
   "quickCommands.quickCommandsTab": "Commandes rapides",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -617,6 +617,7 @@
   "conn.ftpEncryptionRequired": "必須",
   "conn.ftpPassive": "パッシブモード",
   "conn.ftpEncoding": "文字エンコーディング",
+  "conn.encoding": "エンコーディング",
   "quickCommands.title": "クイックコマンド",
   "quickCommands.connectionsTab": "接続リスト",
   "quickCommands.quickCommandsTab": "クイックコマンド",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -617,6 +617,7 @@
   "conn.ftpEncryptionRequired": "Required",
   "conn.ftpPassive": "Passive Mode",
   "conn.ftpEncoding": "Encoding",
+  "conn.encoding": "인코딩",
   "quickCommands.title": "빠른 명령",
   "quickCommands.connectionsTab": "연결 목록",
   "quickCommands.quickCommandsTab": "빠른 명령",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -617,6 +617,7 @@
   "conn.ftpEncryptionRequired": "Required",
   "conn.ftpPassive": "Passive Mode",
   "conn.ftpEncoding": "Encoding",
+  "conn.encoding": "Кодировка",
   "quickCommands.title": "Быстрые команды",
   "quickCommands.connectionsTab": "Подключения",
   "quickCommands.quickCommandsTab": "Быстрые команды",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -619,6 +619,7 @@
   "conn.ftpEncryptionRequired": "必须加密",
   "conn.ftpPassive": "被动模式",
   "conn.ftpEncoding": "字符编码",
+  "conn.encoding": "终端编码",
   "quickCommands.title": "快捷命令",
   "quickCommands.connectionsTab": "连接列表",
   "quickCommands.quickCommandsTab": "快捷命令",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -617,6 +617,7 @@
   "conn.ftpEncryptionRequired": "必須加密",
   "conn.ftpPassive": "被動模式",
   "conn.ftpEncoding": "字元編碼",
+  "conn.encoding": "終端編碼",
   "quickCommands.title": "快捷命令",
   "quickCommands.connectionsTab": "連線列表",
   "quickCommands.quickCommandsTab": "快捷命令",

--- a/frontend/src/types/session.ts
+++ b/frontend/src/types/session.ts
@@ -43,6 +43,8 @@ export interface ConnectionConfig {
   ftpEncryption?: string  // "none" | "auto" | "required"
   ftpPassive?: boolean
   ftpEncoding?: string    // "utf-8" | "gbk" | "shift-jis" | "latin-1"
+  // Terminal encoding (SSH/Telnet)
+  encoding?: string // "utf-8" | "gbk" | "gb2312" | "gb18030" | "big5" | "shift-jis" | "euc-jp" | "euc-kr"
 }
 
 export interface SessionInfo {

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -302,7 +302,8 @@ export namespace session {
 	    ftpEncryption?: string;
 	    ftpPassive: boolean;
 	    ftpEncoding?: string;
-	
+	    encoding?: string;
+
 	    static createFrom(source: any = {}) {
 	        return new ConnectionConfig(source);
 	    }

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	go.bug.st/serial v1.7.1
 	golang.org/x/crypto v0.50.0
 	golang.org/x/sys v0.43.0
+	golang.org/x/text v0.36.0
 )
 
 require (
@@ -80,7 +81,6 @@ require (
 	golang.org/x/mod v0.34.0 // indirect
 	golang.org/x/net v0.53.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
-	golang.org/x/text v0.36.0 // indirect
 	golang.org/x/tools v0.43.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 )


### PR DESCRIPTION
## Summary

Adds a per-connection terminal character encoding setting for SSH sessions, so non-UTF-8 remote hosts (e.g. GBK) no longer display garbled text.

- Conversion happens entirely in the Go backend: remote bytes are decoded to UTF-8 on read; user input is encoded back to the target charset on write. Doing this in `string(data)`-land before the frontend would corrupt non-UTF-8 bytes.
- A persistent streaming decoder buffers partial multibyte sequences split across `Read()` boundaries.
- The zmodem binary path bypasses decoding; the SSH stderr stream is intentionally left raw (separate stream — sharing the stdout decoder buffer could corrupt stdout).
- Connection form gains an **Encoding** dropdown, shown for SSH only.

**Supported encodings:** UTF-8, GBK, GB2312, GB18030, Big5, Shift-JIS, EUC-JP, EUC-KR.

## Test plan

- `go build ./...` passes.
- Manual: connect to a GBK-locale host with Encoding = `Simplified Chinese (GBK)`; verify Chinese `ls` output renders correctly and Chinese command input is accepted.

Closes #36

---

## 概述

为 SSH 连接增加按连接配置的终端字符编码设置，解决非 UTF-8 远端（如 GBK）终端乱码问题。

- 转码全部在 Go 后端完成：读方向把远端字节解码为 UTF-8，写方向把用户输入编码回目标字符集。若沿用 `string(data)` 在到前端前转换会损坏非 UTF-8 字节。
- 持久流式 decoder 处理跨 `Read()` 边界被截断的半个多字节字符。
- zmodem 二进制流绕过转码；SSH stderr 故意保持原始字节（独立流，复用 stdout 解码缓冲会污染主输出）。
- 连接表单新增**终端编码**下拉，仅 SSH 显示。

**支持编码：** UTF-8、GBK、GB2312、GB18030、Big5、Shift-JIS、EUC-JP、EUC-KR。