### PR TITLE
fix: prevent SFTP breadcrumb freeze on overflow boundary

### DIFF
--- a/frontend/src/components/SFTPPathBreadcrumb.vue
+++ b/frontend/src/components/SFTPPathBreadcrumb.vue
@@ -121,12 +121,12 @@ function recalcOverflow() {
     const el = breadcrumbRef.value
     if (!el) return
     const maxCollapse = Math.max(0, pathParts.value.length - 2)
-    if (el.scrollWidth > el.clientWidth) {
-      if (collapsedCount.value < maxCollapse) {
-        collapsedCount.value++
-      }
-    } else if (collapsedCount.value > 0) {
-      collapsedCount.value--
+    // Only ever collapse more within a layout pass. Expanding is handled by
+    // resetting collapsedCount to 0 on path/size change. Mixing increment and
+    // decrement here causes an infinite flip-flop when a path sits exactly at
+    // the overflow boundary (e.g. a single very long segment), freezing the UI.
+    if (el.scrollWidth > el.clientWidth && collapsedCount.value < maxCollapse) {
+      collapsedCount.value++
     }
   })
 }
@@ -137,6 +137,8 @@ watch(() => props.path, () => {
 })
 
 watch(containerWidth, () => {
+  // Recompute from scratch so a wider container can re-expand collapsed parts.
+  collapsedCount.value = 0
   recalcOverflow()
 })
 


### PR DESCRIPTION
## Summary

When navigating into a deep SFTP directory whose name is very long (e.g. `project.artifactId_IS_UNDEFINED`), the whole UI froze.

**Root cause:** the breadcrumb overflow-collapse logic in `SFTPPathBreadcrumb.vue` incremented `collapsedCount` when the breadcrumb overflowed and decremented it when it fit, while `watch(collapsedCount, recalcOverflow)` re-ran the check on every change. For a path sitting exactly at the overflow boundary (a single very long segment), this caused an infinite collapse → fits → expand → overflows → collapse flip-flop, each step scheduling another `nextTick`, locking up the UI.

**Fix:** make collapsing monotonic.
- `recalcOverflow()` now only ever increments `collapsedCount` (capped at `maxCollapse`), so the watcher converges and stops re-triggering.
- Re-expansion is handled by resetting `collapsedCount = 0` on path change and container-width change, then re-collapsing from scratch — so a wider window still re-expands parts.

Closes #61

---

## 概述

进入名字很长的深层 SFTP 目录（如 `project.artifactId_IS_UNDEFINED`）时整个界面卡死。

**原因：** `SFTPPathBreadcrumb.vue` 的面包屑折叠逻辑——溢出时 `collapsedCount++`、放得下时 `collapsedCount--`，同时 `watch(collapsedCount)` 每次变化都重算。当路径正好卡在临界宽度时，就在"折叠→放得下→展开→放不下→折叠"之间无限抖动，每轮都排一个 `nextTick`，导致界面卡死。

**修复：** 将折叠改为单向。
- `recalcOverflow()` 只做 `collapsedCount++`（到 `maxCollapse` 上限即停），watcher 收敛后不再触发。
- 展开改为在路径变化、容器宽度变化时把 `collapsedCount` 重置为 0 再重新折叠，窗口变宽时仍能正常展开。

Closes #61