### PR TITLE
fix(terminal): extend prompt detection to support zsh/oh-my-zsh glyphs

### DIFF
--- a/frontend/src/composables/useTerminalInput.ts
+++ b/frontend/src/composables/useTerminalInput.ts
@@ -43,7 +43,8 @@ export function useTerminalInput(terminal: Terminal | null, options: UseTerminal
     try {
       const buffer = (terminal as any).buffer?.active
       if (!buffer) return null
-      const PROMPT_RE = /(.+?[$#>\]])(?:\s+|$)(.*)/
+      // Prompt endings: $ # > ] plus common zsh/oh-my-zsh/powerline glyphs
+      const PROMPT_RE = /(.+?[$#>\]❯➜→»λ])(?:\s+|$)(.*)/
       // Scan entire visible area from bottom to top to find the prompt
       const rows = (terminal as any).rows || 24
       for (let dy = 0; dy < rows; dy++) {
@@ -57,8 +58,13 @@ export function useTerminalInput(terminal: Terminal | null, options: UseTerminal
         const match = cleanText.match(PROMPT_RE)
         if (!match) continue
         const promptPart = match[1]
+        // Accept: user@host patterns, tilde-path patterns, bare $/#, or
+        // lines ending with a Unicode prompt glyph (❯➜→»λ) which are
+        // rare in normal output so false positives are minimal.
+        const lastChar = promptPart.charAt(promptPart.length - 1)
+        const isUnicodePrompt = /[❯➜→»λ]/.test(lastChar)
         if (!promptPart.includes('@') && !promptPart.includes('~') &&
-            promptPart !== '$' && promptPart !== '#') continue
+            promptPart !== '$' && promptPart !== '#' && !isUnicodePrompt) continue
         const command = match[2].trim()
         if (command && !command.includes('__AI_DONE_') && command.length <= MAX_COMMAND_LENGTH) {
           return command


### PR DESCRIPTION
## Summary

Extend the prompt detection regex in `useTerminalInput.ts` to recognize common zsh, oh-my-zsh, and powerline prompt characters (`❯` `➜` `→` `»` `λ`), so command history recording works for users with custom zsh themes.

Previously only lines ending with `$`, `#`, `>`, `]` were matched as prompts. Zsh themes like pure, powerlevel10k, and oh-my-zsh default use Unicode glyphs that were completely unrecognized.

## Changes

- Extended `PROMPT_RE` character class from `[$#>\]]` to `[$#>\]❯➜→»λ]`
- Added validation check: if the prompt ends with one of these Unicode glyphs, accept it as a valid prompt (these characters are extremely rare in normal terminal output, so false positives are minimal)
- `>` and `]` retain existing `@`/`~` validation to avoid false matching against log output, SQL prompts, etc.

Closes #51

---

## 摘要

扩展 `useTerminalInput.ts` 中的提示符检测正则，识别常见的 zsh/oh-my-zsh/powerline 提示符字符（`❯` `➜` `→` `»` `λ`），使自定义 zsh 主题的用户也能正常记录命令历史。

之前仅匹配以 `$`、`#`、`>`、`]` 结尾的行作为提示符。pure、powerlevel10k、oh-my-zsh 默认主题等使用的 Unicode 字符完全无法识别。

Closes #51