### PR TITLE
fix(ui): align macOS title bar controls

### DIFF
--- a/frontend/src/components/AppHeader.vue
+++ b/frontend/src/components/AppHeader.vue
@@ -1,6 +1,7 @@
 <template>
   <div
     class="app-header"
+    :class="`platform-${platform}`"
     @dblclick="onDblClick"
   >
     <!-- macOS: spacer for native traffic lights -->
@@ -165,6 +166,12 @@ onUnmounted(() => {
   --wails-draggable: drag;
 }
 
+.app-header.platform-darwin {
+  height: 52px;
+  padding: 0 10px;
+  gap: 8px;
+}
+
 .app-header::after {
   content: '';
   position: absolute;
@@ -188,6 +195,7 @@ onUnmounted(() => {
   min-width: 0;
   overflow: hidden;
   justify-content: flex-start;
+  align-items: center;
 }
 
 .header-tabs.tabs-centered {
@@ -198,6 +206,7 @@ onUnmounted(() => {
   display: flex;
   align-items: center;
   justify-content: center;
+  height: 28px;
   padding: 5px 8px;
   font-family: var(--font-ui);
   font-size: 12px;
@@ -254,11 +263,16 @@ onUnmounted(() => {
 
 .mac-traffic-light-spacer {
   width: 72px;
+  height: 1px;
   flex-shrink: 0;
 }
 
 .app-header :deep(.window-controls) {
   --wails-draggable: no-drag;
+}
+
+.app-header.platform-darwin :deep(.window-controls) {
+  align-self: center;
 }
 
 </style>

--- a/frontend/src/components/TabItem.vue
+++ b/frontend/src/components/TabItem.vue
@@ -286,7 +286,8 @@ onUnmounted(() => {
   display: flex;
   align-items: center;
   gap: 2px;
-  padding: 6px 12px;
+  height: 28px;
+  padding: 0 12px;
   margin: 0 1px;
   cursor: pointer;
   user-select: none;
@@ -360,10 +361,13 @@ onUnmounted(() => {
   border: none;
   color: var(--text-muted);
   cursor: pointer;
-  padding: 2px 4px;
+  width: 18px;
+  height: 18px;
+  padding: 0;
   border-radius: 3px;
   display: inline-flex;
   align-items: center;
+  justify-content: center;
 }
 .tab-ai-lock .ai-lock-icon {
   display: block;

--- a/frontend/src/components/TabsList.vue
+++ b/frontend/src/components/TabsList.vue
@@ -266,7 +266,7 @@ function onTabDrop(e: DragEvent, targetTabId: string, index: number) {
   flex: 1;
   overflow-x: auto;
   overflow-y: hidden;
-  align-items: stretch;
+  align-items: center;
   scrollbar-width: none;
   min-width: 0;
 }
@@ -279,6 +279,7 @@ function onTabDrop(e: DragEvent, targetTabId: string, index: number) {
   align-items: center;
   flex-shrink: 0;
   padding: 0 4px;
+  height: 28px;
 }
 .tab-more-btn {
   display: inline-flex;


### PR DESCRIPTION
## Summary

Increase the macOS title bar height and center the header controls so the sidebar button, tabs, AI button, settings button, and tab overflow button share the same vertical axis.

Previously the macOS title area used the same tight header height as other platforms while tab items were sized by padding. This made controls appear vertically uneven next to the native macOS traffic-light area.

## Changes

- Add a macOS-specific header class and increase the title bar height to `52px`
- Center the header tab container contents vertically
- Give header buttons, tab items, and the overflow button consistent fixed heights
- Center the tab AI-lock button within a fixed icon button box

Closes #73

## Validation

- `npm --prefix frontend run build`

---

## 摘要

提高 macOS 标题栏高度，并统一标题栏按钮、标签页、AI 按钮、设置按钮和标签页溢出按钮的垂直居中对齐。

之前 macOS 标题栏沿用了较紧的通用高度，标签页又主要由 padding 撑高，导致控件在原生红绿灯区域旁边看起来上下不齐。

## 验证

- `npm --prefix frontend run build`
