### PR TITLE
feat: add notification dot on inactive tabs when terminal receives new output (#74)

### DIFF
--- a/frontend/src/components/BaseTerminal.vue
+++ b/frontend/src/components/BaseTerminal.vue
@@ -809,7 +809,30 @@ onMounted(() => {
 
   // Session data
   unsubscribe = EventsOn('session:data', (payload: { id: string; data: string }) => {
-    if (!isActive.value) return
+    if (!isActive.value) {
+      // Mark notification dot on the tab when inactive terminal receives output
+      // Only process events for this instance's session (events are global)
+      if (payload.id === props.sessionId && props.sessionId) {
+        // Find the panel by sessionId (panels Map is keyed by panelId)
+        let panelId: string | null = null
+        for (const [id, p] of panelStore.panels) {
+          if (p.sessionId === props.sessionId) {
+            panelId = id
+            break
+          }
+        }
+        if (panelId) {
+          const tab = tabStore.tabs.find(t =>
+            (t.type === 'terminal' && t.panelId === panelId) ||
+            (t.type === 'workspace' && t.panelIds.includes(panelId))
+          )
+          if (tab && tab.id !== tabStore.activeTabId) {
+            tabStore.markTabNotification(tab.id)
+          }
+        }
+      }
+      return
+    }
     if (payload.id !== props.sessionId || !terminal) return
 
     // 取消后 2 秒内吞掉所有数据，防止残余二进制乱码

--- a/frontend/src/components/TabItem.vue
+++ b/frontend/src/components/TabItem.vue
@@ -13,11 +13,16 @@
       class="tab-close"
       @click.stop="$emit('close', tab.id)"
     ><X /></button>
-    <component
+    <span
       v-else
-      :is="tabIcon"
-      class="tab-type-icon"
-    />
+      class="tab-icon-wrapper"
+    >
+      <component
+        :is="tabIcon"
+        class="tab-type-icon"
+      />
+      <span v-if="!isActive && hasNotification" class="tab-notification-dot" />
+    </span>
     <span v-if="!editing" class="tab-name" @dblclick.stop="startEdit">
       <ArrowDownUp v-if="hasActiveTransfers" class="transfer-indicator" :size="14" title="Transferring..." />
       {{ tab.name }}
@@ -85,6 +90,7 @@ import { SquareTerminal, Laptop, FolderUp, Monitor, MonitorCloud, Settings, Spar
 const props = defineProps<{
   tab: TerminalTab | SettingsTab | SFTPTab | RDPTab | VNCTab | SPICETab | DBTab | MonitorTab | WorkspaceTab
   isActive: boolean
+  hasNotification?: boolean
   showClose?: boolean
 }>()
 
@@ -327,6 +333,12 @@ onUnmounted(() => {
   margin-right: 4px;
   font-weight: 500;
 }
+.tab-icon-wrapper {
+  position: relative;
+  display: inline-flex;
+  flex-shrink: 0;
+  margin-right: 4px;
+}
 .tab-type-icon {
   flex-shrink: 0;
   display: flex;
@@ -334,8 +346,17 @@ onUnmounted(() => {
   justify-content: center;
   width: 14px;
   height: 14px;
-  margin-right: 4px;
   color: var(--text-muted);
+}
+.tab-notification-dot {
+  position: absolute;
+  top: -2px;
+  right: -4px;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 0 1px var(--bg-base);
 }
 .tab-item.active .tab-type-icon {
   color: var(--accent);

--- a/frontend/src/components/TabsList.vue
+++ b/frontend/src/components/TabsList.vue
@@ -9,6 +9,7 @@
       <TabItem
         :tab="tab"
         :is-active="tab.id === activeTabId"
+        :has-notification="tabStore.hasTabNotification(tab.id)"
         @activate="setActiveTab"
         @close="(id: string) => $emit('close-tab', id)"
         @toggle-ai-lock="(panelId: string) => $emit('toggle-ai-lock', panelId)"

--- a/frontend/src/stores/tabStore.ts
+++ b/frontend/src/stores/tabStore.ts
@@ -9,11 +9,13 @@ const tabState = reactive<{
   activeTabId: string | null
   aiLockedPanelId: string | null
   broadcastWorkspaceId: string | null
+  tabNotifications: Record<string, boolean>
 }>({
   tabs: [],
   activeTabId: null,
   aiLockedPanelId: null,
-  broadcastWorkspaceId: null
+  broadcastWorkspaceId: null,
+  tabNotifications: {}
 })
 
 let idCounter = 0
@@ -212,6 +214,22 @@ export const useTabStore = defineStore('tab', () => {
 
   function setActiveTab(id: string) {
     tabState.activeTabId = id
+    // Clear notification dot when user switches to this tab
+    tabState.tabNotifications[id] = false
+  }
+
+  // ── Notification dots ──
+
+  function markTabNotification(tabId: string) {
+    tabState.tabNotifications[tabId] = true
+  }
+
+  function clearTabNotification(tabId: string) {
+    tabState.tabNotifications[tabId] = false
+  }
+
+  function hasTabNotification(tabId: string): boolean {
+    return !!tabState.tabNotifications[tabId]
   }
 
   function nextTab() {
@@ -543,6 +561,9 @@ export const useTabStore = defineStore('tab', () => {
     broadcastWorkspaceId,
     toggleBroadcast,
     isBroadcasting,
+    markTabNotification,
+    clearTabNotification,
+    hasTabNotification,
     // Expose helpers for components
     collectPanelIds,
     insertPanelIntoLayout,


### PR DESCRIPTION
Add a notification dot indicator on inactive tab icons when the terminal receives new output, helping users identify which background tabs have activity without clicking through each one.

## Changes
- **tabStore**: add `tabNotifications` reactive state and `markTabNotification`/`clearTabNotification`/`hasTabNotification` methods
- **BaseTerminal**: when inactive and receiving `session:data`, mark the corresponding tab with a notification
- **TabItem**: render an accent-colored dot at the top-right of the tab icon when `!isActive && hasNotification`
- **TabsList**: pass `hasNotification` prop to each `TabItem`

## Behavior
- Notification dot appears on background tabs when their terminal produces new output
- Dot disappears automatically when switching to that tab
- Active (foreground) tab never shows the dot
- Works for both terminal tabs and workspace tabs

Closes #74

---

为非活跃标签页添加终端输出提醒功能。当后台标签的终端有新内容输出时，在标签图标右上角显示一个主题色提醒圆点，切换到该标签后自动消失。

## 修改内容
- **tabStore**: 新增 `tabNotifications` 响应式状态及相关方法
- **BaseTerminal**: 非活跃状态下收到 `session:data` 时标记对应标签
- **TabItem**: 标签图标右上角叠加主题色圆点
- **TabsList**: 向每个 TabItem 传递 `hasNotification` 属性

Closes #74