### PR TITLE
feat: add local terminal support in connection form

### DIFF
--- a/backend/session/local_session_unix.go
+++ b/backend/session/local_session_unix.go
@@ -4,6 +4,7 @@
 package session
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -71,6 +72,7 @@ func (s *LocalSession) Connect(config ConnectionConfig) error {
 	}
 
 	go s.readLoop()
+	go s.runPostLoginScript(config.PostLoginScript)
 
 	return nil
 }
@@ -86,6 +88,7 @@ func (s *LocalSession) readLoop() {
 
 		n, err := s.pty.Read(buf)
 		if n > 0 {
+			s.RecordReadActivity()
 			s.emitData(append([]byte(nil), buf[:n]...))
 		}
 		if err != nil {
@@ -130,6 +133,25 @@ func (s *LocalSession) Resize(cols, rows int) error {
 
 func (s *LocalSession) IsConnected() bool {
 	return s.Status() == StatusConnected
+}
+
+func (s *LocalSession) runPostLoginScript(script string) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		select {
+		case <-s.quit:
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+
+	send := func(data []byte) {
+		if s.pty != nil {
+			s.pty.Write(data)
+		}
+	}
+	s.baseSession.RunPostLoginScript(ctx, script, send, s.IsConnected)
 }
 
 func defaultShell() string {

--- a/backend/session/local_session_windows.go
+++ b/backend/session/local_session_windows.go
@@ -97,6 +97,7 @@ func (s *LocalSession) Connect(config ConnectionConfig) error {
 			}()
 			s.setStatus(StatusConnected)
 			go s.readLoop()
+			go s.runPostLoginScript(config.PostLoginScript)
 			return nil
 		}
 		// Fall through to pipe mode if ConPTY fails.
@@ -131,6 +132,7 @@ func (s *LocalSession) Connect(config ConnectionConfig) error {
 
 	s.setStatus(StatusConnected)
 	go s.readLoop()
+	go s.runPostLoginScript(config.PostLoginScript)
 	return nil
 }
 
@@ -195,6 +197,7 @@ func (s *LocalSession) readLoop() {
 		}
 
 		if n > 0 {
+			s.RecordReadActivity()
 			s.emitData(append([]byte(nil), buf[:n]...))
 		}
 		if err != nil {
@@ -251,6 +254,27 @@ func (s *LocalSession) Resize(cols, rows int) error {
 
 func (s *LocalSession) IsConnected() bool {
 	return s.Status() == StatusConnected
+}
+
+func (s *LocalSession) runPostLoginScript(script string) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		select {
+		case <-s.quit:
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+
+	send := func(data []byte) {
+		if s.cpty != nil {
+			s.cpty.Write(data)
+		} else if s.stdin != nil {
+			s.stdin.Write(data)
+		}
+	}
+	s.baseSession.RunPostLoginScript(ctx, script, send, s.IsConnected)
 }
 
 func defaultShell() string {

--- a/backend/session/mosh_session.go
+++ b/backend/session/mosh_session.go
@@ -99,6 +99,14 @@ func (s *MoshSession) Connect(config ConnectionConfig) error {
 	return nil
 }
 
+func (s *MoshSession) runPostLoginScript(ctx context.Context, script string) {
+	s.baseSession.RunPostLoginScript(ctx, script, func(data []byte) {
+		if s.moshClient != nil {
+			s.moshClient.Send(data)
+		}
+	}, s.IsConnected)
+}
+
 func startMoshServer(client *ssh.Client) (key string, udpPort int, err error) {
 	session, err := client.NewSession()
 	if err != nil {
@@ -169,35 +177,13 @@ func (s *MoshSession) readLoop(ctx context.Context) {
 
 		data := s.moshClient.Recv(100 * time.Millisecond)
 		if len(data) > 0 {
+			s.RecordReadActivity()
 			s.emitData(append([]byte(nil), data...))
 		}
 
 		if s.moshClient == nil {
 			return
 		}
-	}
-}
-
-func (s *MoshSession) runPostLoginScript(ctx context.Context, script string) {
-	if strings.TrimSpace(script) == "" {
-		return
-	}
-	time.Sleep(2 * time.Second)
-	lines := strings.Split(script, "\n")
-	for _, line := range lines {
-		line = strings.TrimSpace(line)
-		if line == "" {
-			continue
-		}
-		select {
-		case <-ctx.Done():
-			return
-		default:
-		}
-		if s.moshClient != nil {
-			s.moshClient.Send([]byte(line + "\r"))
-		}
-		time.Sleep(500 * time.Millisecond)
 	}
 }
 

--- a/backend/session/session.go
+++ b/backend/session/session.go
@@ -1,6 +1,12 @@
 package session
 
-import "sync"
+import (
+	"context"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+)
 
 type SessionStatus string
 
@@ -102,6 +108,7 @@ type baseSession struct {
 	pendingCols      int
 	pendingRows      int
 	zmodemMode       bool
+	lastReadTime     atomic.Int64
 }
 
 func (s *baseSession) ID() string            { return s.id }
@@ -221,4 +228,57 @@ func looksLikeZmodemHeader(data []byte) bool {
 
 func isHexDigit(c byte) bool {
 	return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')
+}
+
+// RecordReadActivity updates the last-read timestamp for idle detection.
+// Each session's readLoop should call this whenever data is received.
+func (s *baseSession) RecordReadActivity() {
+	s.lastReadTime.Store(time.Now().UnixNano())
+}
+
+// waitIdle blocks until no read activity has occurred for the given idle
+// duration, or the overall timeout expires. It returns true on idle detection.
+func (s *baseSession) waitIdle(timeout, idle time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		last := time.Unix(0, s.lastReadTime.Load())
+		if !last.IsZero() && time.Since(last) >= idle {
+			return true
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	return false
+}
+
+// RunPostLoginScript sends each non-empty line of script after the terminal
+// output goes idle, and waits for idle between commands. Stops early if ctx
+// is cancelled or isConnected returns false.
+func (s *baseSession) RunPostLoginScript(ctx context.Context, script string, send func([]byte), isConnected func() bool) {
+	if strings.TrimSpace(script) == "" {
+		return
+	}
+	// Wait for shell to finish initialization.
+	if !s.waitIdle(5*time.Second, 300*time.Millisecond) {
+		return
+	}
+	lines := strings.Split(script, "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+		if !isConnected() {
+			return
+		}
+		send([]byte(line + "\r"))
+		// Wait for command output to settle.
+		if !s.waitIdle(3*time.Second, 300*time.Millisecond) {
+			return
+		}
+	}
 }

--- a/backend/session/ssh_session.go
+++ b/backend/session/ssh_session.go
@@ -5,9 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"golang.org/x/crypto/ssh"
@@ -34,7 +32,6 @@ type SSHSession struct {
 	stderr       io.Reader
 	quit         chan struct{}
 	quitOnce     sync.Once
-	lastReadTime atomic.Int64
 	authAnswerCh chan []byte
 	expectOutput *postLoginOutputBuffer
 
@@ -282,7 +279,7 @@ func (s *SSHSession) readLoop() {
 	for {
 		n, err := s.stdout.Read(buf)
 		if n > 0 {
-			s.lastReadTime.Store(time.Now().UnixNano())
+			s.RecordReadActivity()
 			data := append([]byte(nil), buf[:n]...)
 			s.offerExpectOutput(data)
 			if s.IsZmodemMode() {
@@ -368,42 +365,11 @@ func (s *SSHSession) runPostLoginExpect(config ConnectionConfig) {
 }
 
 func (s *SSHSession) runPostLoginScript(script string) {
-	if strings.TrimSpace(script) == "" {
-		return
-	}
-	// Wait for shell to finish initialization (first idle period).
-	if !s.waitIdle(5*time.Second, 300*time.Millisecond) {
-		return
-	}
-	lines := strings.Split(script, "\n")
-	for _, line := range lines {
-		line = strings.TrimSpace(line)
-		if line == "" {
-			continue
-		}
-		if s.Status() != StatusConnected {
-			return
-		}
+	s.baseSession.RunPostLoginScript(context.Background(), script, func(data []byte) {
 		if s.stdin != nil {
-			_, _ = s.stdin.Write(s.encodeInput([]byte(line + "\r")))
+			s.stdin.Write(s.encodeInput(data))
 		}
-		// Wait for command output to settle before sending the next line.
-		s.waitIdle(3*time.Second, 300*time.Millisecond)
-	}
-}
-
-// waitIdle blocks until stdout has been idle for the given duration,
-// or until the overall timeout expires. It returns true on idle detection.
-func (s *SSHSession) waitIdle(timeout, idle time.Duration) bool {
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
-		last := time.Unix(0, s.lastReadTime.Load())
-		if !last.IsZero() && time.Since(last) >= idle {
-			return true
-		}
-		time.Sleep(50 * time.Millisecond)
-	}
-	return false
+	}, s.IsConnected)
 }
 
 func (s *SSHSession) startKeepAlive() {

--- a/backend/session/telnet_session.go
+++ b/backend/session/telnet_session.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"strings"
 	"sync"
 	"time"
 )
@@ -102,6 +101,7 @@ func (s *TelnetSession) readLoop(ctx context.Context) {
 
 		n, err := s.conn.Read(buf)
 		if n > 0 {
+			s.RecordReadActivity()
 			filtered := s.filterIAC(buf[:n])
 			if len(filtered) > 0 {
 				s.emitData(filtered)
@@ -253,26 +253,11 @@ func (s *TelnetSession) sendAutoLogin(ctx context.Context, user, password string
 }
 
 func (s *TelnetSession) runPostLoginScript(ctx context.Context, script string) {
-	if strings.TrimSpace(script) == "" {
-		return
-	}
-	time.Sleep(1 * time.Second)
-	lines := strings.Split(script, "\n")
-	for _, line := range lines {
-		line = strings.TrimSpace(line)
-		if line == "" {
-			continue
-		}
-		select {
-		case <-ctx.Done():
-			return
-		default:
-		}
+	s.baseSession.RunPostLoginScript(ctx, script, func(data []byte) {
 		if s.conn != nil {
-			s.conn.Write([]byte(line + "\r\n"))
+			s.conn.Write(data)
 		}
-		time.Sleep(500 * time.Millisecond)
-	}
+	}, s.IsConnected)
 }
 
 func (s *TelnetSession) Write(data []byte) error {

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -685,7 +685,9 @@ async function onConnect(config: ConnectionConfig) {
   }
 
   const panel = panelStore.createPanel(config, config.type)
-  const displayTitle = config.name || (config.type === 'telnet'
+  const displayTitle = config.name || (config.type === 'local'
+    ? getShellLabel(config.shellPath)
+    : config.type === 'telnet'
     ? `${config.host}:${config.port}`
     : `${config.user}@${config.host}`)
   panel.title = displayTitle

--- a/frontend/src/components/ConnectionForm.vue
+++ b/frontend/src/components/ConnectionForm.vue
@@ -36,6 +36,7 @@
             <el-radio-button label="ssh">SSH (SFTP)</el-radio-button>
             <el-radio-button label="telnet">Telnet</el-radio-button>
             <el-radio-button label="mosh">Mosh</el-radio-button>
+            <el-radio-button label="local">{{ t('conn.localTerminal') }}</el-radio-button>
           </el-radio-group>
         </template>
         <template v-if="category === 'filetransfer'">
@@ -62,13 +63,13 @@
           </el-radio-group>
         </template>
       </el-form-item>
-      <el-form-item :label="t('conn.host')" required>
+      <el-form-item :label="t('conn.host')" required v-if="form.type !== 'local'">
         <el-input v-model="form.host" :placeholder="t('conn.hostPlaceholder')" />
       </el-form-item>
-      <el-form-item :label="t('conn.port')">
+      <el-form-item :label="t('conn.port')" v-if="form.type !== 'local'">
         <el-input-number v-model="form.port" :min="0" :max="65535" />
       </el-form-item>
-      <el-form-item v-if="form.type !== 'vnc' && form.type !== 'spice' && !(form.type === 'database' && form.dbType === 'rqlite')" :label="t('conn.user')">
+      <el-form-item v-if="form.type !== 'vnc' && form.type !== 'spice' && !(form.type === 'database' && form.dbType === 'rqlite') && form.type !== 'local'" :label="t('conn.user')">
         <el-input v-model="form.user" :placeholder="t('conn.userPlaceholder')" />
       </el-form-item>
       <el-form-item v-if="form.type === 'ssh' || form.type === 'mosh'" :label="t('conn.authType')">
@@ -77,7 +78,7 @@
           <el-radio-button label="key">{{ t('conn.keyPath') }}</el-radio-button>
         </el-radio-group>
       </el-form-item>
-      <el-form-item v-if="(form.authType === 'password' || form.type === 'rdp' || form.type === 'vnc' || form.type === 'spice' || form.type === 'database' || form.type === 'mosh' || form.type === 'telnet' || form.type === 'ftp') && !(form.type === 'database' && form.dbType === 'rqlite')" :label="t('conn.password')">
+      <el-form-item v-if="form.type !== 'local' && (form.authType === 'password' || form.type === 'rdp' || form.type === 'vnc' || form.type === 'spice' || form.type === 'database' || form.type === 'mosh' || form.type === 'telnet' || form.type === 'ftp') && !(form.type === 'database' && form.dbType === 'rqlite')" :label="t('conn.password')">
         <el-input v-model="form.password" type="password" show-password :key="passwordInputKey" />
       </el-form-item>
       <el-form-item v-if="form.authType === 'key' && (form.type === 'ssh' || form.type === 'mosh')" :label="t('conn.keyPath')">
@@ -93,6 +94,16 @@
       </el-form-item>
       <el-form-item v-if="form.type === 'database' && form.dbType !== 'rqlite' && form.dbType !== 'redis'" :label="t('db.databases')">
         <el-input v-model="form.dbName" :placeholder="t('db.databases')" />
+      </el-form-item>
+      <el-form-item v-if="form.type === 'local'" :label="t('conn.shell')">
+        <el-select v-model="form.shellPath" filterable>
+          <el-option
+            v-for="sh in shellOptions"
+            :key="sh.value"
+            :label="sh.label"
+            :value="sh.value"
+          />
+        </el-select>
       </el-form-item>
       <div class="advanced-toggle" @click="showAdvanced = !showAdvanced">
         <el-icon class="advanced-arrow" :class="{ expanded: showAdvanced }"><ChevronRight :size="14" /></el-icon>
@@ -114,7 +125,7 @@
           <el-switch v-model="form.rdpSmartSizing" />
         </el-form-item>
       </template>
-      <el-form-item v-if="form.type === 'ssh' || form.type === 'telnet' || form.type === 'mosh'" :label="t('conn.postLoginScript')">
+      <el-form-item v-if="form.type === 'ssh' || form.type === 'telnet' || form.type === 'mosh' || form.type === 'local'" :label="t('conn.postLoginScript')">
         <div class="post-login-config">
           <el-radio-group v-model="postLoginMode" size="small">
             <el-radio-button label="script">{{ t('conn.postLoginModeScript') }}</el-radio-button>
@@ -263,6 +274,7 @@
 <script setup lang="ts">
 import { reactive, computed, watch, ref, onMounted } from 'vue'
 import { useConnectionStore } from '../stores/connectionStore'
+import { useSettingsStore } from '../stores/settingsStore'
 import { useI18n } from '../i18n'
 import type { ConnectionConfig, PostLoginExpectStep } from '../types/session'
 import { GetPlatform, OpenFileDialog } from '../../wailsjs/go/main/App'
@@ -270,6 +282,25 @@ import { Plus, Trash2, ChevronRight, FolderOpen } from '@lucide/vue'
 
 const { t } = useI18n()
 const connectionStore = useConnectionStore()
+const settingsStore = useSettingsStore()
+
+function getShellLabel(path: string): string {
+  if (!path) return ''
+  const lower = path.toLowerCase()
+  if (lower.startsWith('wsl://')) {
+    const distro = path.slice(6)
+    return distro ? `WSL - ${distro}` : 'WSL'
+  }
+  if (lower.includes('pwsh')) return 'PowerShell'
+  if (lower.includes('powershell')) return 'Windows PowerShell'
+  if (lower.includes('bash')) return 'Git Bash'
+  if (lower.includes('cmd')) return 'Command Prompt'
+  return path.split(/[\\/]/).pop() || path
+}
+
+const shellOptions = computed(() =>
+  settingsStore.availableShells.map(sh => ({ label: getShellLabel(sh), value: sh }))
+)
 
 const isWindows = ref(true)
 const passwordInputKey = ref(0)
@@ -305,7 +336,7 @@ watch(visible, (val) => {
 
 const isEdit = computed(() => !!props.editConfig?.id)
 
-const TERMINAL_TYPES = ['ssh', 'telnet', 'mosh']
+const TERMINAL_TYPES = ['ssh', 'telnet', 'mosh', 'local']
 const REMOTE_TYPES = ['rdp', 'vnc', 'spice']
 const FILETRANSFER_TYPES = ['ftp', 'ssh']
 
@@ -368,6 +399,7 @@ const form = reactive<ConnectionConfig>({
   ftpPassive: true,
   ftpEncoding: 'utf-8',
   encoding: 'utf-8',
+  shellPath: '',
 })
 
 const rdpResolutions = [
@@ -435,6 +467,9 @@ watch(() => form.type, (newType) => {
   if (REMOTE_TYPES.includes(newType) || newType === 'database') {
     form.authType = 'password'
   }
+  if (newType === 'local' && !form.shellPath && settingsStore.availableShells.length > 0) {
+    form.shellPath = settingsStore.availableShells[0]
+  }
 })
 
 watch(postLoginMode, (mode) => {
@@ -487,6 +522,7 @@ function resetForm() {
   form.ftpPassive = true
   form.ftpEncoding = 'utf-8'
   form.encoding = 'utf-8'
+  form.shellPath = ''
   form.tunnelSSHConnId = undefined
   rdpResolution.value = '1280 × 720 (HD)'
   selectedGroupId.value = undefined
@@ -550,7 +586,7 @@ function normalizeForm(): ConnectionConfig {
   } else {
     normalized.postLoginScript = ''
   }
-  if (!normalized.host.trim()) {
+  if (normalized.type !== 'local' && !normalized.host.trim()) {
     throw new Error(t('conn.hostRequired'))
   }
   if (!normalized.name.trim()) {

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -73,7 +73,7 @@
                 @mouseleave="showShellSubmenu = false"
               >
                 <el-dropdown-item class="submenu-trigger">
-                  {{ t('header.newLocalTerminal') }} <ChevronRight :size="12" />
+                  {{ t('conn.localTerminal') }} <ChevronRight :size="12" />
                 </el-dropdown-item>
               </div>
               <el-dropdown-item command="new-serial">{{ t('sidebar.connectSerial') }}</el-dropdown-item>
@@ -137,7 +137,7 @@
             <div class="conn-details">
               <span class="name">{{ conn.name }}</span>
               <span class="conn-meta">
-                <span class="host">{{ conn.type === 'database' ? (conn.dbType || conn.type) : conn.type }} {{ conn.user ? `${conn.user}@${conn.host}:${conn.port}` : `${conn.host}:${conn.port}` }}</span>
+                <span class="host">{{ conn.type === 'database' ? (conn.dbType || conn.type) : conn.type }} {{ conn.type === 'local' ? getShellLabel(conn.shellPath) : conn.user ? `${conn.user}@${conn.host}:${conn.port}` : `${conn.host}:${conn.port}` }}</span>
               </span>
             </div>
           </div>
@@ -180,7 +180,7 @@
             <div class="conn-details">
               <span class="name">{{ conn.name }}</span>
               <span class="conn-meta">
-                <span class="host">{{ conn.type === 'database' ? (conn.dbType || conn.type) : conn.type }} {{ conn.user ? `${conn.user}@${conn.host}:${conn.port}` : `${conn.host}:${conn.port}` }}</span>
+                <span class="host">{{ conn.type === 'database' ? (conn.dbType || conn.type) : conn.type }} {{ conn.type === 'local' ? getShellLabel(conn.shellPath) : conn.user ? `${conn.user}@${conn.host}:${conn.port}` : `${conn.host}:${conn.port}` }}</span>
               </span>
             </div>
           </div>
@@ -207,7 +207,7 @@
           <div class="conn-details">
             <span class="name">{{ conn.name }}</span>
             <span class="conn-meta">
-              <span class="host">{{ conn.type === 'database' ? (conn.dbType || conn.type) : conn.type }} {{ conn.user ? `${conn.user}@${conn.host}:${conn.port}` : `${conn.host}:${conn.port}` }}</span>
+              <span class="host">{{ conn.type === 'database' ? (conn.dbType || conn.type) : conn.type }} {{ conn.type === 'local' ? getShellLabel(conn.shellPath) : conn.user ? `${conn.user}@${conn.host}:${conn.port}` : `${conn.host}:${conn.port}` }}</span>
             </span>
           </div>
         </div>
@@ -1236,6 +1236,7 @@ function onShellSelect(sh: string) {
 }
 
 function getShellLabel(path: string): string {
+  if (!path) return 'Local'
   const lower = path.toLowerCase()
   if (lower.startsWith('wsl://')) {
     const distro = path.slice(6)

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -1,7 +1,6 @@
 {
   "header.connections": "Verbindungen",
   "header.newConnection": "Neue Verbindung",
-  "header.newLocalTerminal": "Lokales Terminal",
   "header.settings": "Einstellungen",
   "header.ai": "KI",
   "sidebar.title": "Verbindungen",
@@ -45,6 +44,8 @@
   "conn.hostRequired": "Host ist erforderlich",
   "conn.advanced": "Erweitert",
   "conn.postLoginScript": "Post-Login-Skript",
+  "conn.localTerminal": "Lokales Terminal",
+  "conn.shell": "Shell-Typ",
   "conn.postLoginScriptPlaceholder": "Ein Befehl pro Zeile, werden nach dem Login nacheinander ausgeführt",
   "conn.postLoginModeScript": "Skript",
   "conn.postLoginModeExpect": "Expect/Send",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1,7 +1,6 @@
 {
   "header.connections": "Connections",
   "header.newConnection": "New Connection",
-  "header.newLocalTerminal": "Local Terminal",
   "header.settings": "Settings",
   "header.ai": "AI",
   "sidebar.title": "Connections",
@@ -46,6 +45,8 @@
   "conn.hostRequired": "Host is required",
   "conn.advanced": "Advanced",
   "conn.postLoginScript": "Post-login Script",
+  "conn.localTerminal": "Local Terminal",
+  "conn.shell": "Terminal Type",
   "conn.postLoginScriptPlaceholder": "One command per line, executed sequentially after login",
   "conn.postLoginModeScript": "Script",
   "conn.postLoginModeExpect": "Expect/Send",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -1,7 +1,6 @@
 {
   "header.connections": "Conexiones",
   "header.newConnection": "Nueva Conexión",
-  "header.newLocalTerminal": "Terminal Local",
   "header.settings": "Configuración",
   "header.ai": "IA",
   "sidebar.title": "Conexiones",
@@ -45,6 +44,8 @@
   "conn.hostRequired": "El host es obligatorio",
   "conn.advanced": "Avanzado",
   "conn.postLoginScript": "Script Posterior al Inicio de Sesión",
+  "conn.localTerminal": "Terminal local",
+  "conn.shell": "Tipo de terminal",
   "conn.postLoginScriptPlaceholder": "Un comando por línea, ejecutados secuencialmente después del inicio de sesión",
   "conn.postLoginModeScript": "Script",
   "conn.postLoginModeExpect": "Expect/Send",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -1,7 +1,6 @@
 {
   "header.connections": "Connexions",
   "header.newConnection": "Nouvelle connexion",
-  "header.newLocalTerminal": "Terminal local",
   "header.settings": "Paramètres",
   "header.ai": "IA",
   "sidebar.title": "Connexions",
@@ -45,6 +44,8 @@
   "conn.hostRequired": "L'hôte est requis",
   "conn.advanced": "Avancé",
   "conn.postLoginScript": "Script post-connexion",
+  "conn.localTerminal": "Terminal local",
+  "conn.shell": "Type de terminal",
   "conn.postLoginScriptPlaceholder": "Une commande par ligne, exécutées séquentiellement après la connexion",
   "conn.postLoginModeScript": "Script",
   "conn.postLoginModeExpect": "Expect/Send",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -1,7 +1,6 @@
 {
   "header.connections": "接続",
   "header.newConnection": "新規接続",
-  "header.newLocalTerminal": "ローカルターミナル",
   "header.settings": "設定",
   "header.ai": "AI",
   "sidebar.title": "接続",
@@ -45,6 +44,8 @@
   "conn.hostRequired": "ホストは必須です",
   "conn.advanced": "詳細設定",
   "conn.postLoginScript": "ログイン後スクリプト",
+  "conn.localTerminal": "ローカル端末",
+  "conn.shell": "端末タイプ",
   "conn.postLoginScriptPlaceholder": "1行に1コマンド、ログイン後に順次実行されます",
   "conn.postLoginModeScript": "スクリプト",
   "conn.postLoginModeExpect": "Expect/Send",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -1,7 +1,6 @@
 {
   "header.connections": "연결",
   "header.newConnection": "새 연결",
-  "header.newLocalTerminal": "로컬 터미널",
   "header.settings": "설정",
   "header.ai": "AI",
   "sidebar.title": "연결",
@@ -45,6 +44,8 @@
   "conn.hostRequired": "호스트를 입력해 주세요",
   "conn.advanced": "고급 설정",
   "conn.postLoginScript": "로그인 후 스크립트",
+  "conn.localTerminal": "로컬 터미널",
+  "conn.shell": "터미널 유형",
   "conn.postLoginScriptPlaceholder": "한 줄에 하나의 명령어를 입력하면 로그인 후 순차적으로 실행됩니다",
   "conn.postLoginModeScript": "스크립트",
   "conn.postLoginModeExpect": "Expect/Send",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -1,7 +1,6 @@
 {
   "header.connections": "Подключения",
   "header.newConnection": "Новое подключение",
-  "header.newLocalTerminal": "Локальный терминал",
   "header.settings": "Настройки",
   "header.ai": "ИИ",
   "sidebar.title": "Подключения",
@@ -45,6 +44,8 @@
   "conn.hostRequired": "Укажите хост",
   "conn.advanced": "Дополнительно",
   "conn.postLoginScript": "Скрипт после входа",
+  "conn.localTerminal": "Локальный терминал",
+  "conn.shell": "Тип терминала",
   "conn.postLoginScriptPlaceholder": "По одной команде на строку, выполняются последовательно после входа",
   "conn.postLoginModeScript": "Скрипт",
   "conn.postLoginModeExpect": "Expect/Send",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -1,7 +1,6 @@
 {
   "header.connections": "连接列表",
   "header.newConnection": "新建连接",
-  "header.newLocalTerminal": "本地终端",
   "header.settings": "设置",
   "header.ai": "AI",
   "sidebar.title": "连接",
@@ -46,6 +45,8 @@
   "conn.hostRequired": "主机地址不能为空",
   "conn.advanced": "高级配置",
   "conn.postLoginScript": "登录后执行",
+  "conn.localTerminal": "本地终端",
+  "conn.shell": "终端类型",
   "conn.postLoginScriptPlaceholder": "每行一条命令，连接成功后依次执行",
   "conn.postLoginModeScript": "脚本",
   "conn.postLoginModeExpect": "Expect/Send",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -1,7 +1,6 @@
 {
   "header.connections": "連線列表",
   "header.newConnection": "新增連線",
-  "header.newLocalTerminal": "本機終端機",
   "header.settings": "設定",
   "header.ai": "AI",
   "sidebar.title": "連線",
@@ -45,6 +44,8 @@
   "conn.hostRequired": "主機位址不能為空",
   "conn.advanced": "進階設定",
   "conn.postLoginScript": "登入後執行",
+  "conn.localTerminal": "本地終端",
+  "conn.shell": "終端類型",
   "conn.postLoginScriptPlaceholder": "每行一條命令，連線成功後依序執行",
   "conn.postLoginModeScript": "腳本",
   "conn.postLoginModeExpect": "Expect/Send",


### PR DESCRIPTION
## Summary

Add local terminal as a first-class connection type in the new connection form, with shell selection and post-login script support. Previously local terminals could only be created via a separate submenu.

### Backend
- Move `lastReadTime` and `waitIdle()` to `baseSession` for shared idle detection across all session types
- Extract `RunPostLoginScript()` as a `baseSession` method using idle detection instead of fixed delays
- Add `RecordReadActivity()` to all session read loops (SSH, Mosh, Telnet, Local)
- Add post-login script execution to local sessions (Windows ConPTY/pipe, Unix PTY)
- Remove duplicated `runPostLoginScript` / `waitIdle` code from SSH, Mosh, Telnet

### Frontend
- Add "Local Terminal" radio option in the terminal category of ConnectionForm
- Show shell selector with friendly aliases (PowerShell, Git Bash, etc.) when local is selected
- Auto-select first available shell as default
- Hide irrelevant fields (host, port, user, password, auth) for local connections
- Support post-login script in advanced options for local terminals
- Display shell alias instead of empty host:port in sidebar connection list
- Merge duplicate i18n key `header.newLocalTerminal` into `conn.localTerminal`

Closes #50

---

## 概要

在新建连接对话框中新增本地终端类型，支持选择 Shell 和登录后执行脚本。之前本地终端只能通过独立的二级菜单创建。

### 后端
- 将 `lastReadTime` 和 `waitIdle()` 提升到 `baseSession`，统一所有会话类型的空闲检测
- `RunPostLoginScript()` 改为 `baseSession` 方法，用空闲检测替代固定延迟
- 所有会话 readLoop 添加 `RecordReadActivity()` 调用
- 本地会话（Windows/Unix）支持登录后脚本执行
- 清理 SSH/Mosh/Telnet 中重复的代码

### 前端
- 连接表单终端分类新增"本地终端"选项
- 选择本地终端时显示 Shell 下拉框（含友好别名）
- 默认选中第一个可用 Shell
- 隐藏本地终端无关字段（主机、端口、用户名、密码、认证）
- 高级选项中支持登录后脚本
- 侧边栏连接列表对本地终端显示 Shell 别名而非空 host:port
- 合并重复的 i18n key

Closes #50