### PR TITLE
feat: add serial port to connection form and fix custom baud rate input

### DIFF
--- a/app.go
+++ b/app.go
@@ -503,6 +503,49 @@ func (a *App) CreateSession(sessionType string, config session.ConnectionConfig)
 		ssh.SetEncoding(config.Encoding)
 	}
 
+	// Apply serial config and connect for serial sessions.
+	if serialSess, ok := s.(*session.SerialSession); ok {
+		var sb serial.StopBits
+		switch config.SerialStopBits {
+		case 1.5:
+			sb = serial.OnePointFiveStopBits
+		case 2:
+			sb = serial.TwoStopBits
+		default:
+			sb = serial.OneStopBit
+		}
+
+		parityMap := map[string]serial.Parity{
+			"none":  serial.NoParity,
+			"odd":   serial.OddParity,
+			"even":  serial.EvenParity,
+			"mark":  serial.MarkParity,
+			"space": serial.SpaceParity,
+		}
+		par, ok := parityMap[strings.ToLower(config.SerialParity)]
+		if !ok {
+			par = serial.NoParity
+		}
+
+		dataBits := config.SerialDataBits
+		if dataBits == 0 {
+			dataBits = 8
+		}
+
+		serialCfg := session.SerialConfig{
+			PortName: config.SerialPort,
+			BaudRate: config.SerialBaudRate,
+			DataBits: dataBits,
+			StopBits: sb,
+			Parity:   par,
+		}
+		serialSess.SetSerialConfig(serialCfg)
+		if err := serialSess.Connect(config); err != nil {
+			_ = a.sessionManager.Close(s.ID())
+			return nil, fmt.Errorf("serial connect %s: %w", config.SerialPort, err)
+		}
+	}
+
 	// ── SSH Tunnel ──────────────────────────────────────────────
 	if config.TunnelSSHConnID != "" && a.tunnelService != nil {
 		if a.connectionStore == nil {

--- a/backend/session/session.go
+++ b/backend/session/session.go
@@ -40,6 +40,12 @@ type ConnectionConfig struct {
 	RdpSmartSizing bool `json:"rdpSmartSizing"`
 	// Local terminal shell path
 	ShellPath string `json:"shellPath,omitempty"`
+	// Serial port configuration
+	SerialPort     string  `json:"serialPort,omitempty"`
+	SerialBaudRate int     `json:"serialBaudRate,omitempty"`
+	SerialDataBits int     `json:"serialDataBits,omitempty"`
+	SerialStopBits float64 `json:"serialStopBits,omitempty"`
+	SerialParity   string  `json:"serialParity,omitempty"`
 	// Database-specific fields
 	DBType string `json:"dbType,omitempty"` // "mysql", "postgres", "rqlite", "oracle"
 	DBName string `json:"dbName,omitempty"` // default database name

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -687,6 +687,8 @@ async function onConnect(config: ConnectionConfig) {
   const panel = panelStore.createPanel(config, config.type)
   const displayTitle = config.name || (config.type === 'local'
     ? getShellLabel(config.shellPath)
+    : config.type === 'serial'
+    ? `${config.serialPort || 'Serial'} (${config.serialBaudRate || 115200})`
     : config.type === 'telnet'
     ? `${config.host}:${config.port}`
     : `${config.user}@${config.host}`)

--- a/frontend/src/components/ConnectionForm.vue
+++ b/frontend/src/components/ConnectionForm.vue
@@ -37,6 +37,7 @@
             <el-radio-button label="telnet">Telnet</el-radio-button>
             <el-radio-button label="mosh">Mosh</el-radio-button>
             <el-radio-button label="local">{{ t('conn.localTerminal') }}</el-radio-button>
+            <el-radio-button label="serial">{{ t('serial.title') }}</el-radio-button>
           </el-radio-group>
         </template>
         <template v-if="category === 'filetransfer'">
@@ -63,13 +64,13 @@
           </el-radio-group>
         </template>
       </el-form-item>
-      <el-form-item :label="t('conn.host')" required v-if="form.type !== 'local'">
+      <el-form-item :label="t('conn.host')" required v-if="form.type !== 'local' && form.type !== 'serial'">
         <el-input v-model="form.host" :placeholder="t('conn.hostPlaceholder')" />
       </el-form-item>
-      <el-form-item :label="t('conn.port')" v-if="form.type !== 'local'">
+      <el-form-item :label="t('conn.port')" v-if="form.type !== 'local' && form.type !== 'serial'">
         <el-input-number v-model="form.port" :min="0" :max="65535" />
       </el-form-item>
-      <el-form-item v-if="form.type !== 'vnc' && form.type !== 'spice' && !(form.type === 'database' && form.dbType === 'rqlite') && form.type !== 'local'" :label="t('conn.user')">
+      <el-form-item v-if="form.type !== 'vnc' && form.type !== 'spice' && !(form.type === 'database' && form.dbType === 'rqlite') && form.type !== 'local' && form.type !== 'serial'" :label="t('conn.user')">
         <el-input v-model="form.user" :placeholder="t('conn.userPlaceholder')" />
       </el-form-item>
       <el-form-item v-if="form.type === 'ssh' || form.type === 'mosh'" :label="t('conn.authType')">
@@ -78,7 +79,7 @@
           <el-radio-button label="key">{{ t('conn.keyPath') }}</el-radio-button>
         </el-radio-group>
       </el-form-item>
-      <el-form-item v-if="form.type !== 'local' && (form.authType === 'password' || form.type === 'rdp' || form.type === 'vnc' || form.type === 'spice' || form.type === 'database' || form.type === 'mosh' || form.type === 'telnet' || form.type === 'ftp') && !(form.type === 'database' && form.dbType === 'rqlite')" :label="t('conn.password')">
+      <el-form-item v-if="form.type !== 'local' && form.type !== 'serial' && (form.authType === 'password' || form.type === 'rdp' || form.type === 'vnc' || form.type === 'spice' || form.type === 'database' || form.type === 'mosh' || form.type === 'telnet' || form.type === 'ftp') && !(form.type === 'database' && form.dbType === 'rqlite')" :label="t('conn.password')">
         <el-input v-model="form.password" type="password" show-password :key="passwordInputKey" />
       </el-form-item>
       <el-form-item v-if="form.authType === 'key' && (form.type === 'ssh' || form.type === 'mosh')" :label="t('conn.keyPath')">
@@ -105,7 +106,47 @@
           />
         </el-select>
       </el-form-item>
-      <div class="advanced-toggle" @click="showAdvanced = !showAdvanced">
+      <template v-if="form.type === 'serial'">
+        <el-form-item :label="t('serial.portLabel')" required>
+          <div style="display:flex;gap:8px;width:100%">
+            <el-select v-model="form.serialPort" :placeholder="portPlaceholder" :disabled="serialPorts.length === 0 || serialScanning" :loading="serialScanning" style="flex:1">
+              <el-option v-for="p in serialPorts" :key="p" :label="p" :value="p" />
+            </el-select>
+            <el-button :icon="RefreshCw" :loading="serialScanning" @click="scanSerialPorts">
+              {{ t('serial.scan') }}
+            </el-button>
+          </div>
+        </el-form-item>
+        <el-form-item :label="t('serial.baudRate')">
+          <el-autocomplete
+            v-model="serialBaudRateInput"
+            :fetch-suggestions="queryBaudRateSuggestions"
+            :placeholder="t('serial.baudRate')"
+            clearable
+            style="width:100%"
+          />
+        </el-form-item>
+        <el-form-item :label="t('serial.dataBits')">
+          <el-select v-model="serialDataBitsValue">
+            <el-option v-for="b in [5,6,7,8]" :key="b" :label="String(b)" :value="b" />
+          </el-select>
+        </el-form-item>
+        <el-form-item :label="t('serial.stopBits')">
+          <el-select v-model="serialStopBitsValue">
+            <el-option v-for="b in [1,1.5,2]" :key="b" :label="String(b)" :value="b" />
+          </el-select>
+        </el-form-item>
+        <el-form-item :label="t('serial.parity')">
+          <el-select v-model="serialParityValue">
+            <el-option :label="t('serial.parityNone')" value="none" />
+            <el-option :label="t('serial.parityOdd')" value="odd" />
+            <el-option :label="t('serial.parityEven')" value="even" />
+            <el-option :label="t('serial.parityMark')" value="mark" />
+            <el-option :label="t('serial.paritySpace')" value="space" />
+          </el-select>
+        </el-form-item>
+      </template>
+      <div v-if="form.type !== 'serial' && form.type !== 'spice'" class="advanced-toggle" @click="showAdvanced = !showAdvanced">
         <el-icon class="advanced-arrow" :class="{ expanded: showAdvanced }"><ChevronRight :size="14" /></el-icon>
         <span>{{ t('conn.advanced') }}</span>
       </div>
@@ -278,7 +319,8 @@ import { useSettingsStore } from '../stores/settingsStore'
 import { useI18n } from '../i18n'
 import type { ConnectionConfig, PostLoginExpectStep } from '../types/session'
 import { GetPlatform, OpenFileDialog } from '../../wailsjs/go/main/App'
-import { Plus, Trash2, ChevronRight, FolderOpen } from '@lucide/vue'
+import { Plus, Trash2, ChevronRight, FolderOpen, RefreshCw } from '@lucide/vue'
+import { ListSerialPorts } from '../../wailsjs/go/main/App'
 
 const { t } = useI18n()
 const connectionStore = useConnectionStore()
@@ -306,6 +348,40 @@ const isWindows = ref(true)
 const passwordInputKey = ref(0)
 const postLoginMode = ref<'script' | 'expect'>('script')
 const showAdvanced = ref(false)
+
+// Serial port config (separate refs so allow-create doesn't produce strings)
+const serialPorts = ref<string[]>([])
+const serialScanning = ref(false)
+const serialBaudRateInput = ref('')
+const serialDataBitsValue = ref(8)
+const serialStopBitsValue = ref(1)
+const serialParityValue = ref('none')
+
+const portPlaceholder = computed(() => {
+  if (serialScanning.value) return t('serial.scanning')
+  if (serialPorts.value.length === 0) return t('serial.noPorts')
+  return t('serial.portLabel')
+})
+
+async function scanSerialPorts() {
+  serialScanning.value = true
+  try {
+    serialPorts.value = await ListSerialPorts()
+  } catch {
+    serialPorts.value = []
+  } finally {
+    serialScanning.value = false
+  }
+}
+
+const baudRatePresets = [300, 1200, 2400, 4800, 9600, 14400, 19200, 38400, 57600, 115200, 230400, 460800, 921600]
+
+function queryBaudRateSuggestions(queryString: string, cb: (results: { value: string }[]) => void) {
+  const suggestions = baudRatePresets
+    .filter(r => String(r).includes(queryString))
+    .map(r => ({ value: String(r) }))
+  cb(suggestions)
+}
 
 onMounted(async () => {
   try { isWindows.value = (await GetPlatform()) === 'windows' } catch (_) {}
@@ -336,7 +412,7 @@ watch(visible, (val) => {
 
 const isEdit = computed(() => !!props.editConfig?.id)
 
-const TERMINAL_TYPES = ['ssh', 'telnet', 'mosh', 'local']
+const TERMINAL_TYPES = ['ssh', 'telnet', 'mosh', 'local', 'serial']
 const REMOTE_TYPES = ['rdp', 'vnc', 'spice']
 const FILETRANSFER_TYPES = ['ftp', 'ssh']
 
@@ -354,7 +430,7 @@ const sshConnections = computed(() =>
   )
 )
 
-const TUNNEL_UNSUPPORTED = ['spice', 'mosh', 'local']
+const TUNNEL_UNSUPPORTED = ['spice', 'mosh', 'local', 'serial']
 const showTunnel = computed(() =>
   !TUNNEL_UNSUPPORTED.includes(form.type)
 )
@@ -431,6 +507,12 @@ watch(() => props.editConfig, (config) => {
     Object.assign(form, { ...config, postLoginExpectSteps: cloneExpectSteps(config.postLoginExpectSteps || []) })
     postLoginMode.value = (config.postLoginExpectSteps?.length || 0) > 0 ? 'expect' : 'script'
     selectedGroupId.value = config.groupId || undefined
+    // Sync serial refs from config
+    if (config.serialBaudRate) serialBaudRateInput.value = String(config.serialBaudRate)
+    if (config.serialDataBits) serialDataBitsValue.value = config.serialDataBits
+    if (config.serialStopBits) serialStopBitsValue.value = config.serialStopBits
+    if (config.serialParity) serialParityValue.value = config.serialParity
+    if (config.type === 'serial') scanSerialPorts()
     // Sync resolution dropdown to the config's fixed size
     const match = rdpResolutions.find(r => r.w === config.rdpFixedWidth && r.h === config.rdpFixedHeight)
     if (match) rdpResolution.value = match.label
@@ -469,6 +551,9 @@ watch(() => form.type, (newType) => {
   }
   if (newType === 'local' && !form.shellPath && settingsStore.availableShells.length > 0) {
     form.shellPath = settingsStore.availableShells[0]
+  }
+  if (newType === 'serial') {
+    scanSerialPorts()
   }
 })
 
@@ -523,6 +608,12 @@ function resetForm() {
   form.ftpEncoding = 'utf-8'
   form.encoding = 'utf-8'
   form.shellPath = ''
+  form.serialPort = ''
+  form.serialBaudRate = 115200
+  form.serialDataBits = 8
+  form.serialStopBits = 1
+  form.serialParity = 'none'
+  serialBaudRateInput.value = ''
   form.tunnelSSHConnId = undefined
   rdpResolution.value = '1280 × 720 (HD)'
   selectedGroupId.value = undefined
@@ -579,6 +670,14 @@ function generateUniqueName(name: string): string {
 }
 
 function normalizeForm(): ConnectionConfig {
+  // Sync serial refs into form before normalization
+  if (form.type === 'serial') {
+    form.serialBaudRate = parseInt(serialBaudRateInput.value, 10) || 115200
+    serialBaudRateInput.value = String(form.serialBaudRate)
+    form.serialDataBits = serialDataBitsValue.value
+    form.serialStopBits = serialStopBitsValue.value
+    form.serialParity = serialParityValue.value
+  }
   const normalized = { ...form }
   normalized.postLoginExpectSteps = normalizeExpectSteps(form.postLoginExpectSteps || [])
   if (postLoginMode.value === 'script') {
@@ -586,11 +685,13 @@ function normalizeForm(): ConnectionConfig {
   } else {
     normalized.postLoginScript = ''
   }
-  if (normalized.type !== 'local' && !normalized.host.trim()) {
+  if (normalized.type !== 'local' && normalized.type !== 'serial' && !normalized.host.trim()) {
     throw new Error(t('conn.hostRequired'))
   }
   if (!normalized.name.trim()) {
-    normalized.name = generateUniqueName(normalized.host.trim())
+    normalized.name = generateUniqueName(
+      normalized.type === 'serial' ? (normalized.serialPort || 'Serial') : normalized.host.trim()
+    )
   }
   return normalized
 }

--- a/frontend/src/components/SerialConnectDialog.vue
+++ b/frontend/src/components/SerialConnectDialog.vue
@@ -17,19 +17,13 @@
         </el-select>
       </el-form-item>
       <el-form-item :label="t('serial.baudRate')">
-        <el-select
-          v-model="baudRate"
-          filterable
-          allow-create
-          default-first-option
-        >
-          <el-option
-            v-for="rate in baudRatePresets"
-            :key="rate"
-            :label="String(rate)"
-            :value="rate"
-          />
-        </el-select>
+        <el-autocomplete
+          v-model="baudRateInput"
+          :fetch-suggestions="queryBaudSuggestions"
+          :placeholder="t('serial.baudRate')"
+          clearable
+          style="width:100%"
+        />
       </el-form-item>
       <el-form-item :label="t('serial.dataBits')">
         <el-select v-model="dataBits">
@@ -102,7 +96,7 @@ const scanning = ref(false)
 
 // Form state
 const selectedPort = ref('')
-const baudRate = ref<number>(115200)
+const baudRateInput = ref('')
 const dataBits = ref<number>(8)
 const stopBits = ref<number>(1)
 const parity = ref<string>('none')
@@ -112,6 +106,13 @@ const connecting = ref(false)
 const baudRatePresets = [300, 1200, 2400, 4800, 9600, 14400, 19200, 38400, 57600, 115200, 230400, 460800, 921600]
 const dataBitsOptions = [5, 6, 7, 8]
 const stopBitsOptions = [1, 1.5, 2]
+
+function queryBaudSuggestions(queryString: string, cb: (results: { value: string }[]) => void) {
+  const suggestions = baudRatePresets
+    .filter(r => String(r).includes(queryString))
+    .map(r => ({ value: String(r) }))
+  cb(suggestions)
+}
 
 const portPlaceholder = computed(() => {
   if (scanning.value) return t('serial.scanning')
@@ -134,14 +135,15 @@ async function onConnect() {
   if (!selectedPort.value || connecting.value) return
   connecting.value = true
   try {
+    const baud = parseInt(baudRateInput.value, 10) || 115200
     const session = await ConnectSerial(
       selectedPort.value,
-      baudRate.value,
+      baud,
       dataBits.value,
       stopBits.value,
       parity.value
     )
-    emit('connect', session.id, selectedPort.value, baudRate.value)
+    emit('connect', session.id, selectedPort.value, baud)
     visible.value = false
   } catch {
     // Connection failed, keep dialog open so user can retry
@@ -154,7 +156,7 @@ async function onConnect() {
 watch(visible, (val) => {
   if (val) {
     selectedPort.value = ''
-    baudRate.value = 115200
+    baudRateInput.value = ''
     dataBits.value = 8
     stopBits.value = 1
     parity.value = 'none'

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -425,6 +425,7 @@
   "serial.parity": "Parität",
   "serial.connect": "Verbinden",
   "serial.noPorts": "Keine seriellen Ports gefunden",
+  "serial.scan": "Scannen",
   "serial.scanning": "Scannen...",
   "serial.parityNone": "Keine",
   "serial.parityOdd": "Ungerade",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -427,6 +427,7 @@
   "serial.parity": "Parity",
   "serial.connect": "Connect",
   "serial.noPorts": "No serial ports detected",
+  "serial.scan": "Scan",
   "serial.scanning": "Scanning...",
   "serial.parityNone": "None",
   "serial.parityOdd": "Odd",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -425,6 +425,7 @@
   "serial.parity": "Paridad",
   "serial.connect": "Conectar",
   "serial.noPorts": "No se detectaron puertos serie",
+  "serial.scan": "Escanear",
   "serial.scanning": "Escaneando...",
   "serial.parityNone": "Ninguna",
   "serial.parityOdd": "Impar",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -425,6 +425,7 @@
   "serial.parity": "Parité",
   "serial.connect": "Connecter",
   "serial.noPorts": "Aucun port série détecté",
+  "serial.scan": "Scanner",
   "serial.scanning": "Scan...",
   "serial.parityNone": "Aucune",
   "serial.parityOdd": "Impaire",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -425,6 +425,7 @@
   "serial.parity": "パリティ",
   "serial.connect": "接続",
   "serial.noPorts": "シリアルポートが見つかりません",
+  "serial.scan": "スキャン",
   "serial.scanning": "スキャン中...",
   "serial.parityNone": "なし",
   "serial.parityOdd": "奇数",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -425,6 +425,7 @@
   "serial.parity": "패리티",
   "serial.connect": "연결",
   "serial.noPorts": "시리얼 포트를 찾을 수 없습니다",
+  "serial.scan": "스캔",
   "serial.scanning": "스캔 중...",
   "serial.parityNone": "없음",
   "serial.parityOdd": "홀수",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -425,6 +425,7 @@
   "serial.parity": "Чётность",
   "serial.connect": "Подключиться",
   "serial.noPorts": "Последовательные порты не обнаружены",
+  "serial.scan": "Сканировать",
   "serial.scanning": "Сканирование...",
   "serial.parityNone": "Нет",
   "serial.parityOdd": "Нечёт",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -427,6 +427,7 @@
   "serial.parity": "校验位",
   "serial.connect": "连接",
   "serial.noPorts": "未检测到串口设备",
+  "serial.scan": "扫描",
   "serial.scanning": "扫描中...",
   "serial.parityNone": "无",
   "serial.parityOdd": "奇校验",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -425,6 +425,7 @@
   "serial.parity": "校驗位",
   "serial.connect": "連線",
   "serial.noPorts": "未偵測到序列埠裝置",
+  "serial.scan": "掃描",
   "serial.scanning": "掃描中...",
   "serial.parityNone": "無",
   "serial.parityOdd": "奇校驗",

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -439,6 +439,35 @@ body::before {
   background: var(--accent-subtle) !important;
 }
 
+/* Autocomplete suggestions - cover all Element Plus v2.x selectors */
+.el-autocomplete-suggestion,
+.el-autocomplete-suggestion__wrap,
+.el-autocomplete-suggestion__list {
+  overflow: hidden;
+  font-size: 12px !important;
+  background: var(--bg-surface) !important;
+}
+.el-autocomplete-suggestion__item,
+.el-autocomplete-suggestion__list .el-autocomplete-suggestion__item {
+  font-family: var(--font-ui);
+  font-size: 12px !important;
+  line-height: 1.4 !important;
+  padding: 6px 12px !important;
+  color: var(--text-secondary) !important;
+}
+.el-autocomplete-suggestion__item:hover,
+.el-autocomplete-suggestion__item.highlighted {
+  background: var(--bg-hover) !important;
+  color: var(--text-primary) !important;
+}
+.el-autocomplete__popper,
+.el-autocomplete-suggestion {
+  background: var(--bg-surface) !important;
+  border: 1px solid var(--border-subtle) !important;
+  border-radius: var(--radius-md) !important;
+  box-shadow: var(--shadow-md) !important;
+}
+
 .el-radio-button__original-radio:checked + .el-radio-button__inner {
   background-color: var(--accent-dim) !important;
   border-color: var(--accent-dim) !important;
@@ -622,4 +651,55 @@ body.drag-active .zone {
   flex: 1;
   height: 1px;
   background: var(--border-subtle);
+}
+
+/* ============================================================
+   Autocomplete suggestion dropdown
+   Target every possible selector so the item font matches
+   the rest of the UI (12px). The popper is teleported to body
+   so scoped styles cannot reach it.
+   ============================================================ */
+/* Container */
+.el-autocomplete-suggestion,
+.el-autocomplete__popper,
+.el-popper.is-pure:has(.el-autocomplete-suggestion) {
+  font-size: 12px !important;
+  background: var(--bg-surface) !important;
+  border: 1px solid var(--border-subtle) !important;
+  border-radius: var(--radius-md) !important;
+  box-shadow: var(--shadow-md) !important;
+}
+/* Force every child to 12px */
+.el-autocomplete-suggestion *,
+.el-autocomplete-suggestion__wrap,
+.el-autocomplete-suggestion__list,
+.el-autocomplete-suggestion__item {
+  font-size: 12px !important;
+}
+/* Ensure scrollbar wrap handles mouse wheel */
+.el-autocomplete-suggestion__wrap {
+  overflow: auto !important;
+  overflow-y: auto !important;
+  max-height: 280px;
+}
+/* Specific item styling */
+.el-autocomplete-suggestion__item {
+  font-family: var(--font-ui) !important;
+  line-height: 1.4 !important;
+  padding: 5px 12px !important;
+  color: var(--text-secondary) !important;
+  height: auto !important;
+  min-height: unset !important;
+}
+.el-autocomplete-suggestion__item:hover,
+.el-autocomplete-suggestion__item.highlighted,
+.el-autocomplete-suggestion__item.is-hovered,
+.el-autocomplete-suggestion li:hover,
+.el-autocomplete-suggestion li.is-hovered {
+  background: var(--bg-hover) !important;
+  color: var(--text-primary) !important;
+}
+/* Cover the case where autocomplete reuses select-dropdown */
+.el-autocomplete-suggestion .el-select-dropdown__item {
+  font-size: 12px !important;
 }

--- a/frontend/src/types/session.ts
+++ b/frontend/src/types/session.ts
@@ -15,7 +15,7 @@ export interface PostLoginExpectStep {
 export interface ConnectionConfig {
   id: string
   name: string
-  type: 'ssh' | 'telnet' | 'mosh' | 'rdp' | 'vnc' | 'spice' | 'database' | 'local' | 'sftp' | 'monitor' | 'ftp'
+  type: 'ssh' | 'telnet' | 'mosh' | 'rdp' | 'vnc' | 'spice' | 'database' | 'local' | 'sftp' | 'monitor' | 'ftp' | 'serial'
   host: string
   port: number
   user: string
@@ -29,6 +29,12 @@ export interface ConnectionConfig {
   rdpSmartSizing?: boolean
   // Local terminal shell path
   shellPath?: string
+  // Serial port
+  serialPort?: string
+  serialBaudRate?: number
+  serialDataBits?: number
+  serialStopBits?: number
+  serialParity?: string
   dbType?: string   // database type key
   dbName?: string   // default database name
   postLoginScript?: string

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -268,6 +268,11 @@ export namespace session {
 	    rdpFixedHeight?: number;
 	    rdpSmartSizing: boolean;
 	    shellPath?: string;
+	    serialPort?: string;
+	    serialBaudRate?: number;
+	    serialDataBits?: number;
+	    serialStopBits?: number;
+	    serialParity?: string;
 	    dbType?: string;
 	    dbName?: string;
 	    postLoginScript?: string;
@@ -301,6 +306,11 @@ export namespace session {
 	        this.rdpFixedHeight = source["rdpFixedHeight"];
 	        this.rdpSmartSizing = source["rdpSmartSizing"];
 	        this.shellPath = source["shellPath"];
+	        this.serialPort = source["serialPort"];
+	        this.serialBaudRate = source["serialBaudRate"];
+	        this.serialDataBits = source["serialDataBits"];
+	        this.serialStopBits = source["serialStopBits"];
+	        this.serialParity = source["serialParity"];
 	        this.dbType = source["dbType"];
 	        this.dbName = source["dbName"];
 	        this.postLoginScript = source["postLoginScript"];


### PR DESCRIPTION
## Summary

This PR adds serial port as a first-class connection type in the new connection form, fixes the custom baud rate input issue, and integrates serial session lifecycle into the standard CreateSession flow.

### Changes

- **Serial port in connection form**: Added serial port as a terminal category type alongside SSH/Telnet/Mosh/Local, with auto-scanning port list, baud rate (autocomplete with presets), data bits, stop bits, and parity fields
- **Custom baud rate fix**: Replaced `el-select` with `el-autocomplete` for baud rate input, allowing free-form entry while still offering preset suggestions (300–921600). Empty input defaults to 115200.
- **Backend integration**: Serial config (port, baud rate, data bits, stop bits, parity) now flows through `ConnectionConfig` and `CreateSession` automatically calls `SetSerialConfig` + `Connect`
- **UI polish**: Hide advanced section for serial and SPICE types (no applicable options). Fix autocomplete suggestion dropdown font size (12px) and scroll wheel support.
- **i18n**: Added `serial.scan` key for all 9 locales

Closes #78

---

## 概述

此 PR 将串口添加为新建连接表单中的正式连接类型，修复了自定义波特率输入问题，并将串口会话生命周期集成到标准 CreateSession 流程中。

### 变更内容

- **新建连接支持串口**：在终端类别下新增串口类型，支持自动扫描端口列表、波特率（autocomplete + 预设提示）、数据位、停止位、校验位配置
- **自定义波特率修复**：将波特率选择器替换为 `el-autocomplete`，支持自由输入任意值并保留预设提示（300–921600）。留空默认使用 115200
- **后端集成**：串口配置通过 `ConnectionConfig` 传递，`CreateSession` 自动调用 `SetSerialConfig` + `Connect`
- **UI 优化**：串口和 SPICE 类型隐藏高级配置折叠面板（无可用选项）。修复 autocomplete 下拉提示字体过大和滚动条鼠标滚轮失效问题
- **国际化**：为全部 9 种语言添加 `serial.scan` 翻译键

Closes #78