### PR TITLE
fix(sftp): fallback to SFTP-level copy when remote cp command fails (#69)

### DIFF
--- a/backend/session/sftp_session.go
+++ b/backend/session/sftp_session.go
@@ -673,8 +673,9 @@ func shellEscape(str string) string {
 	return "'" + strings.ReplaceAll(str, "'", "'\\''") + "'"
 }
 
-// Copy copies a file or directory on the remote server using ssh exec cp.
-// Zero data transfer to local — the server handles the copy directly.
+// Copy copies a file or directory on the remote server.
+// Tries shell cp -r first (zero data transfer on Linux), falls back to
+// SFTP-level copy for servers without cp (Windows, etc.).
 func (s *SFTPSession) Copy(oldPath, newPath string) error {
 	if err := s.requireClient(); err != nil {
 		return err
@@ -687,12 +688,77 @@ func (s *SFTPSession) Copy(oldPath, newPath string) error {
 	if !path.IsAbs(n) {
 		n = path.Join(s.cwd, n)
 	}
+	// Try shell cp -r first (server-side copy, zero data transfer)
 	session, err := s.sshClient.NewSession()
 	if err != nil {
 		return err
 	}
-	defer session.Close()
-	return session.Run(fmt.Sprintf("cp -r -- %s %s", shellEscape(old), shellEscape(n)))
+	err = session.Run(fmt.Sprintf("cp -r -- %s %s", shellEscape(old), shellEscape(n)))
+	session.Close()
+	if err == nil {
+		return nil
+	}
+	// Fallback: SFTP-level copy (compatible with Windows and servers without cp)
+	return s.sftpCopy(old, n)
+}
+
+// sftpCopy copies a file or directory using SFTP operations only.
+// Works on any SFTP server regardless of the remote shell environment.
+func (s *SFTPSession) sftpCopy(oldPath, newPath string) error {
+	srcInfo, err := s.sftpClient.Stat(oldPath)
+	if err != nil {
+		return err
+	}
+	if srcInfo.IsDir() {
+		return s.sftpCopyDir(oldPath, newPath)
+	}
+	return s.sftpCopyFile(oldPath, newPath)
+}
+
+func (s *SFTPSession) sftpCopyFile(oldPath, newPath string) error {
+	src, err := s.sftpClient.Open(oldPath)
+	if err != nil {
+		return err
+	}
+	defer src.Close()
+
+	parentDir := path.Dir(newPath)
+	if err := s.sftpClient.MkdirAll(parentDir); err != nil {
+		return err
+	}
+
+	dst, err := s.sftpClient.Create(newPath)
+	if err != nil {
+		return err
+	}
+	defer dst.Close()
+
+	_, err = io.Copy(dst, src)
+	return err
+}
+
+func (s *SFTPSession) sftpCopyDir(oldPath, newPath string) error {
+	if err := s.sftpClient.MkdirAll(newPath); err != nil {
+		return err
+	}
+	entries, err := s.sftpClient.ReadDir(oldPath)
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		oldEntry := path.Join(oldPath, entry.Name())
+		newEntry := path.Join(newPath, entry.Name())
+		if entry.IsDir() {
+			if err := s.sftpCopyDir(oldEntry, newEntry); err != nil {
+				return err
+			}
+		} else {
+			if err := s.sftpCopyFile(oldEntry, newEntry); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 // Move moves a file or directory on the remote server.


### PR DESCRIPTION
## Summary

When copying files on a remote SFTP server, the `Copy` method relied exclusively on the shell `cp -r` command. This command does not exist on Windows SFTP servers (e.g., OpenSSH for Windows), causing copy-paste operations to fail with "Copied/Moved 0/1, 1 failed".

This PR adds an automatic fallback: if the shell `cp -r` fails, the copy is performed via SFTP protocol operations (file open/read/write), which works on any SFTP server regardless of the remote operating system.

- **Linux SFTP servers**: No behavior change — `cp -r` succeeds on first attempt (zero data transfer, server-side copy)
- **Windows SFTP servers**: `cp` fails → falls back to SFTP-level copy automatically

## Changes

| File | Change |
|---|---|
| `backend/session/sftp_session.go` | Rework `Copy()` with cp-first-then-SFTP-fallback; add `sftpCopy()`, `sftpCopyFile()`, `sftpCopyDir()` helpers |

---

## 概述

远程 SFTP 复制文件时，`Copy` 方法仅依赖 shell `cp -r` 命令。Windows SFTP 服务器（如 Windows 版 OpenSSH）没有 `cp` 命令，导致复制粘贴失败，报 "Copied/Moved 0/1, 1 failed"。

此 PR 增加自动回退：如果 shell `cp -r` 失败，则通过 SFTP 协议操作（文件打开/读取/写入）完成复制，适用于任何 SFTP 服务器，不依赖远程操作系统。

- **Linux SFTP 服务器**：行为不变 — `cp -r` 优先成功（零数据传输，服务端复制）
- **Windows SFTP 服务器**：`cp` 失败 → 自动回退到 SFTP 协议复制

Fixes #69