### PR TITLE
fix(sftp): show error message when SFTP connection fails

### DIFF
--- a/frontend/src/components/SFTPTabContent.vue
+++ b/frontend/src/components/SFTPTabContent.vue
@@ -549,14 +549,24 @@ let unsubscribeStatus: (() => void) | null = null
 
 onMounted(async () => {
   unsubscribeStatus = EventsOn('session:status', (payload: { id: string; status: string }) => {
-    if (payload.id === panel.value?.sessionId && payload.status === 'connected') {
-      onRefreshLocal()
-      onRefreshRemote()
+    if (payload.id === panel.value?.sessionId) {
+      if (payload.status === 'connected') {
+        onRefreshLocal()
+        onRefreshRemote()
+      } else if (payload.status === 'error') {
+        ElMessage.error(t('sftp.connectError'))
+      }
     }
   })
 
   unsubscribe = EventsOn('session:data', (payload: { id: string; data: string }) => {
     if (payload.id !== panel.value?.sessionId) return
+    // Connection failed messages from backend (SFTP/FTP async connect errors)
+    const connMatch = payload.data.match(/\[Connection failed: ([^\]]+)\]/)
+    if (connMatch) {
+      ElMessage.error(connMatch[1])
+      return
+    }
     const match = payload.data.match(/\x1b\]633;S([^\x07]*)\x07/)
     if (!match) return
     try {

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -189,6 +189,7 @@
   "sftp.cancelled": "Abgebrochen",
   "sftp.done": "Fertig",
   "sftp.error": "Fehler",
+  "sftp.connectError": "SFTP-Verbindung fehlgeschlagen",
   "sftp.dropHere": "Dateien hier ablegen",
   "sftp.upload": "Hochladen",
   "sftp.downloadTo": "Herunterladen nach...",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -191,6 +191,7 @@
   "sftp.cancelled": "Cancelled",
   "sftp.done": "Done",
   "sftp.error": "Error",
+  "sftp.connectError": "SFTP connection failed",
   "sftp.dropHere": "Drop files here",
   "sftp.upload": "Upload",
   "sftp.downloadTo": "Download to...",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -189,6 +189,7 @@
   "sftp.cancelled": "Cancelado",
   "sftp.done": "Completado",
   "sftp.error": "Error",
+  "sftp.connectError": "Error de conexión SFTP",
   "sftp.dropHere": "Suelte archivos aquí",
   "sftp.upload": "Subir",
   "sftp.downloadTo": "Descargar en...",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -189,6 +189,7 @@
   "sftp.cancelled": "Annulé",
   "sftp.done": "Terminé",
   "sftp.error": "Erreur",
+  "sftp.connectError": "Échec de la connexion SFTP",
   "sftp.dropHere": "Déposer les fichiers ici",
   "sftp.upload": "Téléverser",
   "sftp.downloadTo": "Télécharger vers...",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -189,6 +189,7 @@
   "sftp.cancelled": "キャンセルしました",
   "sftp.done": "完了",
   "sftp.error": "エラー",
+  "sftp.connectError": "SFTP 接続に失敗しました",
   "sftp.dropHere": "ここにファイルをドロップ",
   "sftp.upload": "アップロード",
   "sftp.downloadTo": "ダウンロード先...",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -189,6 +189,7 @@
   "sftp.cancelled": "취소됨",
   "sftp.done": "완료",
   "sftp.error": "오류",
+  "sftp.connectError": "SFTP 연결 실패",
   "sftp.dropHere": "여기에 파일을 놓으세요",
   "sftp.upload": "업로드",
   "sftp.downloadTo": "다운로드 위치...",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -189,6 +189,7 @@
   "sftp.cancelled": "Отменено",
   "sftp.done": "Готово",
   "sftp.error": "Ошибка",
+  "sftp.connectError": "Ошибка подключения SFTP",
   "sftp.dropHere": "Перетащите файлы сюда",
   "sftp.upload": "Загрузить",
   "sftp.downloadTo": "Скачать в...",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -191,6 +191,7 @@
   "sftp.cancelled": "已取消",
   "sftp.done": "完成",
   "sftp.error": "失败",
+  "sftp.connectError": "SFTP 连接失败",
   "sftp.dropHere": "拖动文件到此处",
   "sftp.upload": "上传",
   "sftp.downloadTo": "下载到...",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -189,6 +189,7 @@
   "sftp.cancelled": "已取消",
   "sftp.done": "完成",
   "sftp.error": "失敗",
+  "sftp.connectError": "SFTP 連線失敗",
   "sftp.dropHere": "拖曳檔案到此處",
   "sftp.upload": "上傳",
   "sftp.downloadTo": "下載到...",


### PR DESCRIPTION
## Summary

When an SFTP (or FTP) connection fails, the backend sends both a `session:status` event with status "error" and a `session:data` event containing `[Connection failed: ...]`. However, `SFTPTabContent.vue` only handled `status === 'connected'` and only parsed OSC 633 transfer events from `session:data`, so both error signals were silently discarded — the user saw no feedback at all.

## Changes

| File | Change |
|---|---|
| `frontend/src/components/SFTPTabContent.vue` | Handle `status === 'error'` in status listener with `ElMessage.error()`; detect `[Connection failed: ...]` pattern in data listener before the OSC 633 check |
| `frontend/src/i18n/locales/*.json` (9 files) | Add `sftp.connectError` translation key |

## Behavior

- Specific error (e.g. "ssh dial: connection refused") → extracted from `session:data` and shown via `ElMessage.error()`
- Generic fallback → shown via `ElMessage.error(t('sftp.connectError'))` when status is "error" but no data message matched

---

## 概述

SFTP/FTP 连接失败时，后端会发送 `session:status`（status="error"）和 `session:data`（包含 `[Connection failed: ...]`）。但 `SFTPTabContent.vue` 只处理了 `status === 'connected'`，`session:data` 也只看 OSC 633 传输事件，导致两个错误信号都被丢弃，用户完全看不到任何提示。

此 PR 让前端在收到连接失败事件时，通过 `ElMessage.error()` 弹出具体错误信息。