### PR TITLE
fix(ux): improve login retry flow and credential dialog auto-focus (#70)

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -104,7 +104,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch, nextTick, onMounted, onUnmounted } from 'vue'
+import { ref, computed, watch, nextTick, onMounted, onUnmounted, provide } from 'vue'
 import AppHeader from './components/AppHeader.vue'
 import Sidebar from './components/Sidebar.vue'
 import TerminalTabContent from './components/TerminalTabContent.vue'
@@ -252,6 +252,8 @@ function showCredentialDialog(
     credentialVisible.value = true
   })
 }
+
+provide('showCredentialDialog', showCredentialDialog)
 
 function onCredentialResolve(result: CredentialResult | null) {
   credentialVisible.value = false

--- a/frontend/src/components/CredentialPrompt.vue
+++ b/frontend/src/components/CredentialPrompt.vue
@@ -5,6 +5,7 @@
     :title="title"
     width="400px"
     :close-on-click-modal="false"
+    @opened="onDialogOpened"
   >
     <p v-if="subtitle" class="credential-subtitle">{{ subtitle }}</p>
     <div class="credential-fields">
@@ -20,6 +21,7 @@
       <div v-if="fields.includes('password')" class="credential-field">
         <label class="credential-label">{{ t('conn.password') }}</label>
         <el-input
+          ref="passwordInputRef"
           v-model="inputPassword"
           type="password"
           show-password
@@ -37,8 +39,9 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watch, nextTick } from 'vue'
+import { ref, watch } from 'vue'
 import { useI18n } from '../i18n'
+import type { InputInstance } from 'element-plus'
 
 export interface CredentialResult {
   action: 'connect' | 'save_and_connect'
@@ -64,18 +67,28 @@ const { t } = useI18n()
 
 const inputUser = ref('')
 const inputPassword = ref('')
-const userInputRef = ref<InstanceType<typeof import('element-plus').ElInput> | null>(null)
+const userInputRef = ref<InputInstance | null>(null)
+const passwordInputRef = ref<InputInstance | null>(null)
 
-watch(() => props.visible, async (v) => {
+watch(() => props.visible, (v) => {
   if (v) {
     inputUser.value = props.initialUser || ''
     inputPassword.value = props.initialPassword || ''
-    await nextTick()
-    if (props.fields.includes('user')) {
-      userInputRef.value?.focus()
-    }
   }
 })
+
+function onDialogOpened() {
+  // Focus the first empty field, or username if both are filled
+  if (props.fields.includes('password') && !inputPassword.value) {
+    passwordInputRef.value?.focus()
+  } else if (props.fields.includes('user') && !inputUser.value) {
+    userInputRef.value?.focus()
+  } else if (props.fields.includes('user')) {
+    userInputRef.value?.focus()
+  } else if (props.fields.includes('password')) {
+    passwordInputRef.value?.focus()
+  }
+}
 
 function onCancel() {
   emit('resolve', null)

--- a/frontend/src/components/Panel.vue
+++ b/frontend/src/components/Panel.vue
@@ -69,7 +69,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watch, computed, nextTick, onMounted, onUnmounted } from 'vue'
+import { ref, watch, computed, nextTick, onMounted, onUnmounted, inject } from 'vue'
 import { Radio, Sparkles, MoreHorizontal, X } from '@lucide/vue'
 import BaseTerminal from './BaseTerminal.vue'
 import { useTabStore } from '../stores/tabStore'
@@ -80,6 +80,7 @@ import { CreateSession } from '../../wailsjs/go/main/App'
 import { useI18n } from '../i18n'
 import type { Panel } from '../types/workspace'
 import type { ConnectionConfig } from '../types/session'
+import type { CredentialResult } from './CredentialPrompt.vue'
 
 const { t } = useI18n()
 
@@ -105,6 +106,8 @@ const tabStore = useTabStore()
 const panelStore = usePanelStore()
 const sessionStore = useSessionStore()
 const settingsStore = useSettingsStore()
+
+const showCredentialDialog = inject<(title: string, subtitle: string, fields: ('user' | 'password')[], initialUser?: string, initialPassword?: string) => Promise<CredentialResult | null>>('showCredentialDialog', () => Promise.resolve(null))
 
 const isAILocked = computed(() =>
   tabStore.aiLockedPanelId === props.panel.id
@@ -163,13 +166,18 @@ function cancelEdit() {
   editing.value = false
 }
 
+let retryAttempt = 0
+
 function onSessionStatus(status: string) {
   if (status === 'retry') {
     retryConnection()
+  } else if (status === 'connected') {
+    retryAttempt = 0
   }
 }
 
 async function retryConnection() {
+  retryAttempt++
   if (props.panel.type === 'local') {
     // Local terminal: reconnect with the same shell used when created
     baseTerminalRef.value?.write('\r\n\x1b[33mRestarting local shell...\x1b[0m\r\n')
@@ -179,6 +187,7 @@ async function retryConnection() {
       const info = await CreateSession('local', config)
       panelStore.bindSession(props.panel.id, info.id)
       sessionStore.initSession(info.id)
+      retryAttempt = 0
     } catch (e: any) {
       baseTerminalRef.value?.write(`\r\n\x1b[31mFailed to start local shell: ${e}\x1b[0m\r\n`)
       baseTerminalRef.value?.setRetryOnEnter(true)
@@ -186,6 +195,26 @@ async function retryConnection() {
     return
   }
   if (!props.panel.config) return
+
+  // On first retry, try with existing credentials; on subsequent retries, re-prompt
+  const credTypes = ['ssh', 'mosh', 'sftp', 'ftp', 'telnet']
+  if (credTypes.includes(props.panel.type) && props.panel.config.authType !== 'key' && retryAttempt > 1) {
+    const result = await showCredentialDialog(
+      t('credential.title'),
+      props.panel.config.user || props.panel.config.host ? `${props.panel.config.user}@${props.panel.config.host}` : '',
+      ['user', 'password'],
+      props.panel.config.user,
+      props.panel.config.password || ''
+    )
+    if (!result) {
+      baseTerminalRef.value?.write('\r\n\x1b[33mRetry cancelled.\x1b[0m\r\n')
+      baseTerminalRef.value?.setRetryOnEnter(true)
+      return
+    }
+    props.panel.config.user = result.user || props.panel.config.user
+    props.panel.config.password = result.password
+  }
+
   baseTerminalRef.value?.write('\r\n\x1b[33mReconnecting...\x1b[0m\r\n')
   try {
     const info = await CreateSession(props.panel.config.type, props.panel.config)


### PR DESCRIPTION
## Summary

Two login UX improvements from issue #70.

### 1. Re-prompt credentials on auth failure

When a connection fails, pressing Enter now follows a two-step flow:

1. **First retry** — silent reconnect with existing credentials (handles transient network issues)
2. **Second retry** — credential dialog pops up with last-entered username/password pre-filled

Previously the dialog appeared immediately on every retry, which was annoying for network-related disconnects.

### 2. Auto-focus credential dialog input

Fixed auto-focus by using `el-dialog`'s `@opened` event instead of `watch` + `nextTick`. The `nextTick` approach fired before the dialog's CSS animation completed, so the input element wasn't focusable yet.

Focus priority: first empty field → username → password.

### Changes

| File | Change |
|---|---|
| `frontend/src/App.vue` | `provide('showCredentialDialog', ...)` to expose dialog from Panel |
| `frontend/src/components/Panel.vue` | `inject` dialog function, add `retryAttempt` counter, re-prompt on second retry |
| `frontend/src/components/CredentialPrompt.vue` | Use `@opened` + `InputInstance` for reliable auto-focus |

---

## 概述

来自 #70 的两项登录体验改进。

### 1. 密码错误时回车重新弹出凭据框

两步流程：第一次按 Enter 静默重连（可能是网络抖动），第二次才弹出凭据对话框并回填用户名和密码。

### 2. 凭据对话框自动聚焦

改用 `el-dialog` 的 `@opened` 事件触发聚焦，解决 `nextTick` 在动画完成前触发的问题。优先聚焦空白字段。