### PR TITLE
fix(terminal): set locale and TERM for local PTY on macOS

### DIFF
--- a/backend/session/local_session_unix.go
+++ b/backend/session/local_session_unix.go
@@ -51,7 +51,7 @@ func (s *LocalSession) Connect(config ConnectionConfig) error {
 	s.title = shellName(shell)
 
 	s.cmd = exec.Command(shell)
-	s.cmd.Env = os.Environ()
+	s.cmd.Env = ensureTerminalEnv(os.Environ())
 
 	ptyFile, err := pty.Start(s.cmd)
 	if err != nil {
@@ -181,4 +181,97 @@ func shellName(path string) string {
 		base = strings.TrimSuffix(base, ".exe")
 	}
 	return base
+}
+
+// ensureTerminalEnv guarantees the local shell starts with a usable terminal
+// environment: a UTF-8 locale and a valid TERM.
+//
+// When the app is launched from the macOS Finder/Dock (rather than a terminal),
+// it inherits no LANG/LC_* and no TERM. The PTY shell then runs in the C/POSIX
+// locale with an unknown terminal, which breaks zsh in two ways:
+//   - C locale: zsh's line editor binds every 0x80-0xFF byte to self-insert and
+//     cannot compose multibyte UTF-8 — garbled CJK/IME input.
+//   - missing TERM: zsh's ZLE has no terminfo to redraw the line, so backspace
+//     and other editing keys leave the display out of sync and appear broken.
+// bash/sh tolerate both; zsh's ZLE does not. We inject each variable only when
+// it is not already set so we never override the user's explicit configuration.
+func ensureTerminalEnv(env []string) []string {
+	cleaned := make([]string, 0, len(env)+3)
+	hasLocale := false
+	hasTerm := false
+	for _, kv := range env {
+		isLocaleKey := strings.HasPrefix(kv, "LC_ALL=") ||
+			strings.HasPrefix(kv, "LC_CTYPE=") ||
+			strings.HasPrefix(kv, "LANG=")
+		if isLocaleKey {
+			idx := strings.IndexByte(kv, '=')
+			if idx >= 0 && kv[idx+1:] != "" {
+				hasLocale = true
+			} else {
+				// Drop empty locale entries so they can't shadow the value
+				// we inject below (libc may honor the first duplicate key).
+				continue
+			}
+		}
+		if strings.HasPrefix(kv, "TERM=") {
+			if kv != "TERM=" {
+				hasTerm = true
+			} else {
+				continue
+			}
+		}
+		cleaned = append(cleaned, kv)
+	}
+	if !hasLocale {
+		locale := preferredUTF8Locale()
+		cleaned = append(cleaned, "LANG="+locale, "LC_CTYPE="+locale)
+	}
+	if !hasTerm {
+		cleaned = append(cleaned, "TERM=xterm-256color")
+	}
+	return cleaned
+}
+
+// preferredUTF8Locale returns a UTF-8 locale to use for the local shell,
+// preferring the user's system language when a matching UTF-8 locale exists and
+// falling back to the universally available en_US.UTF-8.
+func preferredUTF8Locale() string {
+	const fallback = "en_US.UTF-8"
+	if runtime.GOOS != "darwin" {
+		return fallback
+	}
+	out, err := exec.Command("defaults", "read", "-g", "AppleLocale").Output()
+	if err != nil {
+		return fallback
+	}
+	region := strings.TrimSpace(string(out))
+	// AppleLocale may carry a script subtag (e.g. zh_Hans_CN); reduce to
+	// language_region which is what UTF-8 locales are named after.
+	parts := strings.Split(region, "_")
+	if len(parts) >= 3 {
+		region = parts[0] + "_" + parts[len(parts)-1]
+	}
+	if region == "" {
+		return fallback
+	}
+	candidate := region + ".UTF-8"
+	if localeAvailable(candidate) {
+		return candidate
+	}
+	return fallback
+}
+
+// localeAvailable reports whether `locale -a` lists the given locale.
+func localeAvailable(name string) bool {
+	out, err := exec.Command("locale", "-a").Output()
+	if err != nil {
+		return false
+	}
+	target := strings.ToLower(strings.ReplaceAll(name, "-", ""))
+	for _, line := range strings.Split(string(out), "\n") {
+		if strings.ToLower(strings.ReplaceAll(strings.TrimSpace(line), "-", "")) == target {
+			return true
+		}
+	}
+	return false
 }

--- a/frontend/src/components/BaseTerminal.vue
+++ b/frontend/src/components/BaseTerminal.vue
@@ -508,6 +508,75 @@ function filterTerminalInput(input: string, inAlternateScreen: boolean): string 
   return filtered
 }
 
+function writeTerminalInput(data: string, inAlternateScreen: boolean) {
+  const sid = props.sessionId
+  const filtered = filterTerminalInput(data, inAlternateScreen)
+  if (!sid || !filtered) return
+
+  if (props.broadcastActive && props.workspaceId) {
+    const tab = tabStore.tabs.find(t => t.id === props.workspaceId)
+    if (tab && tab.type === 'workspace') {
+      for (const pid of tab.panelIds) {
+        const p = panelStore.getPanel(pid)
+        if (p?.sessionId && (p.type === 'ssh' || p.type === 'local')) {
+          SessionWrite(p.sessionId, filtered)
+        }
+      }
+      return
+    }
+  }
+
+  SessionWrite(sid, filtered)
+}
+
+function handleTerminalKey(e: KeyboardEvent): boolean {
+  // Check global shortcuts first (Ctrl+Shift+/Alt+ combos)
+  if (e.type === 'keydown' && !onTerminalKey(e)) return false
+
+  if (e.ctrlKey && e.key === 'f' && e.type === 'keydown') {
+    openSearch()
+    return false
+  }
+
+  // Suggestion navigation (only on keydown, ignore keyup)
+  if (suggestions.isVisible() && e.type === 'keydown') {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      suggestions.selectNext()
+      return false
+    }
+    if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      suggestions.selectPrev()
+      return false
+    }
+    if (e.key === 'Tab') {
+      const selected = suggestions.getSelectedItem()
+      if (selected) {
+        e.preventDefault()
+        applySuggestion(selected)
+        return false
+      }
+    }
+    if (e.key === 'Enter') {
+      // Only apply suggestion if user explicitly selected one with arrow keys
+      const selected = suggestions.getSelectedItem()
+      if (selected) {
+        e.preventDefault()
+        applySuggestion(selected)
+        return false
+      }
+      // No selection: let xterm handle Enter normally (terminal command execution)
+    }
+    if (e.key === 'Escape') {
+      suggestions.close()
+      return false
+    }
+  }
+
+  return true
+}
+
 let bindListeners: (() => void) | null = null
 
 onMounted(() => {
@@ -636,6 +705,8 @@ onMounted(() => {
     const sidNow = props.sessionId
     const gen = sidNow ? bumpOnDataGeneration(sidNow) : 0
 
+    keyHandlerDispose = terminal.attachCustomKeyEventHandler(handleTerminalKey)
+
     // Input handling
     onDataDispose = terminal.onData((data) => {
       // ── Stale callback guard (terminal-shared) ──
@@ -736,19 +807,7 @@ onMounted(() => {
       const sid = props.sessionId
       const inAlt = terminalInput?.isInAlternateScreen() ?? false
       if (sid) {
-        if (props.broadcastActive && props.workspaceId) {
-          const tab = tabStore.tabs.find(t => t.id === props.workspaceId)
-          if (tab && tab.type === 'workspace') {
-            for (const pid of tab.panelIds) {
-              const p = panelStore.getPanel(pid)
-              if (p?.sessionId && (p.type === 'ssh' || p.type === 'local')) {
-                SessionWrite(p.sessionId, filterTerminalInput(data, inAlt))
-              }
-            }
-            return
-          }
-        }
-        SessionWrite(sid, filterTerminalInput(data, inAlt))
+        writeTerminalInput(data, inAlt)
       }
     } else {
       // SFTP line buffering
@@ -975,55 +1034,6 @@ onMounted(() => {
     }
   }
   window.addEventListener('terminal:send-rz', onSendRz)
-
-  // Ctrl+F to open search
-  keyHandlerDispose = terminal.attachCustomKeyEventHandler((e) => {
-    // Check global shortcuts first (Ctrl+Shift+/Alt+ combos)
-    if (e.type === 'keydown' && !onTerminalKey(e)) return false
-
-    if (e.ctrlKey && e.key === 'f' && e.type === 'keydown') {
-      openSearch()
-      return false
-    }
-
-    // Suggestion navigation (only on keydown, ignore keyup)
-    if (suggestions.isVisible() && e.type === 'keydown') {
-      if (e.key === 'ArrowDown') {
-        e.preventDefault()
-        suggestions.selectNext()
-        return false
-      }
-      if (e.key === 'ArrowUp') {
-        e.preventDefault()
-        suggestions.selectPrev()
-        return false
-      }
-      if (e.key === 'Tab') {
-        const selected = suggestions.getSelectedItem()
-        if (selected) {
-          e.preventDefault()
-          applySuggestion(selected)
-          return false
-        }
-      }
-      if (e.key === 'Enter') {
-        // Only apply suggestion if user explicitly selected one with arrow keys
-        const selected = suggestions.getSelectedItem()
-        if (selected) {
-          e.preventDefault()
-          applySuggestion(selected)
-          return false
-        }
-        // No selection: let xterm handle Enter normally (terminal command execution)
-      }
-      if (e.key === 'Escape') {
-        suggestions.close()
-        return false
-      }
-    }
-
-    return true
-  })
 
   bindListeners()
 


### PR DESCRIPTION
## Summary

Fix garbled CJK/IME input and broken Backspace in the local macOS zsh terminal.

When the app is launched from the Finder/Dock it inherits no `LANG`/`LC_*` or `TERM`, so the local PTY shell runs in the C/POSIX locale with an unknown terminal. This breaks zsh specifically:

- **C locale** — zsh's line editor (ZLE) binds every `0x80`–`0xFF` byte to `self-insert` and cannot compose multibyte UTF-8, producing garbled Chinese/IME input.
- **Missing `TERM`** — ZLE has no terminfo to redraw the line, so Backspace and other editing keys leave the display out of sync and appear broken.

`bash`/`sh` tolerate both, which is why the issue only reproduces under zsh. SSH, Windows-local, telnet and mosh sessions already set these variables; the Unix local session did not.

## Changes

- Inject a UTF-8 locale into the local PTY env when none is set, preferring the system language (e.g. `zh_CN.UTF-8`) and falling back to `en_US.UTF-8`
- Inject `TERM=xterm-256color` when `TERM` is unset, matching the SSH/Windows-local paths
- Never override locale/`TERM` already provided by the user, and drop empty entries so they cannot shadow the injected values
- Remove the explicit Backspace interception; local input now flows through xterm like SSH

## Validation

- `go build ./...`
- `npm --prefix frontend run build`
- Built `.app` launched from Finder: `echo $LANG` → `zh_CN.UTF-8`, `echo $TERM` → `xterm-256color`, CJK input and Backspace work in local zsh

Closes #84

---

## 摘要

修复 macOS 本地 zsh 终端中文/输入法输入乱码、以及退格键无法删除的问题。

从 Finder/Dock 启动应用时，进程不会继承 `LANG`/`LC_*` 和 `TERM`，导致本地 PTY 里的 shell 运行在 C/POSIX locale 且终端类型未知。这会专门影响 zsh：

- **C locale** —— zsh 行编辑器（ZLE）把每个 `0x80`–`0xFF` 字节都绑定为 `self-insert`，无法组合多字节 UTF-8，导致中文/输入法输入乱码。
- **缺少 `TERM`** —— ZLE 没有 terminfo 无法重绘行，退格等编辑键导致画面错乱、看似失效。

`bash`/`sh` 对两者都能容忍，所以问题只在 zsh 下复现。SSH、Windows 本地、telnet、mosh 会话本就设置了这些变量，唯独 Unix 本地会话没有。

## 验证

- `go build ./...`
- `npm --prefix frontend run build`
- 从 Finder 启动打包后的 `.app`：`echo $LANG` → `zh_CN.UTF-8`，`echo $TERM` → `xterm-256color`，本地 zsh 下中文输入与退格均正常
