### PR TITLE
feat: improve markdown rendering and add send_enter param to send_terminal_key

### DIFF
--- a/frontend/src/components/AIMessage.vue
+++ b/frontend/src/components/AIMessage.vue
@@ -2,19 +2,12 @@
   <div class="ai-message" :class="message.role">
     <div class="avatar">{{ avatar }}</div>
     <div class="content">
-      <div class="text" v-html="renderedContent" />
+      <div class="text" v-html="renderedContent" @click="onTextClick" />
 
       <div v-if="message.role === 'assistant' && message.content" class="copy-action">
         <button class="copy-md-btn" @click="copyAsMarkdown" :title="t('ai.copyMarkdown')">
           <el-icon><Copy :size="14" /></el-icon>
           <span class="copy-md-label">{{ copyMdLabel }}</span>
-        </button>
-      </div>
-
-      <div v-if="isError && aiStore.lastDebugInfo" class="debug-actions">
-        <button class="debug-copy-btn" @click="copyDebugInfo">
-          <el-icon><Copy :size="14" /></el-icon>
-          {{ copyLabel }}
         </button>
       </div>
 
@@ -104,7 +97,6 @@ const aiStore = useAIStore()
 const { t } = useI18n()
 const inExpanded = ref(true)
 const outExpanded = ref(false)
-const copyLabel = ref(t('ai.copyDebug'))
 const copyMdLabel = ref(t('ai.copyMarkdown'))
 
 const avatar = computed(() => {
@@ -113,13 +105,8 @@ const avatar = computed(() => {
   return t('ai.avatarAI')
 })
 
-const isError = computed(() => {
-  const content = props.message.content
-  if (!content) return false
-  const hasErrorText = content.includes('[Error:')
-  // Assistant errors (legacy) or display-only tool errors
-  return (props.message.role === 'assistant' || (props.message.role === 'tool' && !props.message.tool_call_id)) && hasErrorText
-})
+const COPY_ICON = '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>'
+const CHECK_ICON = '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>'
 
 async function copyAsMarkdown() {
   try {
@@ -132,20 +119,6 @@ async function copyAsMarkdown() {
   }
 }
 
-async function copyDebugInfo() {
-  const info = aiStore.lastDebugInfo
-  if (!info) return
-  const text = `## Error\n\n${info.error}\n\n## Request\n\n\`\`\`json\n${info.request}\n\`\`\``
-  try {
-    await navigator.clipboard.writeText(text)
-    copyLabel.value = t('ai.copied')
-    setTimeout(() => { copyLabel.value = t('ai.copyDebug') }, 2000)
-  } catch {
-    copyLabel.value = t('ai.copyFailed')
-    setTimeout(() => { copyLabel.value = t('ai.copyDebug') }, 2000)
-  }
-}
-
 const copiedTool = ref('')
 
 async function copyToolText(text: string, key: string) {
@@ -155,6 +128,18 @@ async function copyToolText(text: string, key: string) {
     setTimeout(() => { copiedTool.value = '' }, 2000)
   } catch {
     // ignore
+  }
+}
+
+function onTextClick(event: MouseEvent) {
+  const btn = (event.target as HTMLElement).closest('.code-copy-btn') as HTMLElement | null
+  if (!btn) return
+  const wrapper = btn.closest('.code-block-wrapper')
+  const code = wrapper?.querySelector('code')?.textContent
+  if (code) {
+    navigator.clipboard.writeText(code)
+    btn.innerHTML = CHECK_ICON
+    setTimeout(() => { btn.innerHTML = COPY_ICON }, 2000)
   }
 }
 
@@ -224,9 +209,12 @@ function renderMarkdown(text: string): string {
 
   // Protect fenced code blocks and inline code from further markdown processing
   const protectedBlocks: string[] = []
-  html = html.replace(/```([\s\S]*?)```/g, (_, code) => {
+  html = html.replace(/```(\w*)[\t ]*[\r\n]*([\s\S]*?)```/g, (_, lang, code) => {
     const idx = protectedBlocks.length
-    protectedBlocks.push(`<pre><code>${code.trim()}</code></pre>`)
+    const langTag = lang ? `<span class="code-lang-tag">${lang}</span>` : ''
+    const header = `<div class="code-block-header">${langTag}<button class="tool-copy-btn code-copy-btn" title="${t('ai.copy')}">${COPY_ICON}</button></div>`
+    const codeHtml = code.replace(/^[\r\n]+|\s+$/g, '').replace(/\r?\n/g, '&#10;')
+    protectedBlocks.push(`<div class="code-block-wrapper">${header}<pre><code>${codeHtml}</code></pre></div>`)
     return `\x00CODEBLOCK${idx}\x00`
   })
   html = html.replace(/`([^`]+)`/g, (_, code) => {
@@ -243,25 +231,57 @@ function renderMarkdown(text: string): string {
   html = html.replace(/^## (.*$)/gim, '<h2>$1</h2>')
   html = html.replace(/^# (.*$)/gim, '<h1>$1</h1>')
 
+  // Horizontal rules
+  html = html.replace(/^(-{3,})$/gm, '<hr>')
+
+  // Footnotes: collect definitions, render inline at their position
+  const footnotes: { id: string; content: string }[] = []
+  const fnIdMap: Record<string, number> = {}
+  // First pass: collect footnote definitions and assign numbers
+  html = html.replace(/^\[\^([^\]]+)\]:\s*(.+)$/gm, (_, id, content) => {
+    footnotes.push({ id, content })
+    fnIdMap[id] = footnotes.length
+    return `\x00FN${footnotes.length - 1}\x00` // Placeholder to be rendered inline later
+  })
+  // Second pass: replace footnote references [^id] with superscript numbers
+  html = html.replace(/\[\^([^\]]+)\]/g, (_, id) => {
+    const num = fnIdMap[id]
+    if (num) {
+      return `<sup class="footnote-ref">[${num}]</sup>`
+    }
+    return `[^${id}]`
+  })
+  // Third pass: render footnote definitions as footnotes section at placeholder positions
+  html = html.replace(/\x00FN(\d+)\x00/g, (_, idx) => {
+    const fn = footnotes[parseInt(idx)]
+    return `<div class="footnote-item"><sup>[${idx + 1}]</sup> ${fn.content}</div>`
+  })
+
+  // Remove the append logic later — footnotes are now inline
+
   html = html.replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>')
   html = html.replace(/\*(.*?)\*/g, '<em>$1</em>')
+  html = html.replace(/~~(.+?)~~/g, '<del>$1</del>')
+  // Images (must be before links so ![ doesn't get partially matched)
+  html = html.replace(/!\[([^\]]*)\]\(([^)]+)\)/g, '<img src="$2" alt="$1">')
+  // Markdown links
   html = html.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" target="_blank">$1</a>')
+  // Auto-link raw URLs (after markdown links/images, only in text outside HTML tags)
+  html = autoLinkUrls(html)
 
-  const ulBlocks = html.match(/(?:^- .*\n?)+/gm)
-  if (ulBlocks) {
-    for (const block of ulBlocks) {
-      const items = block.replace(/^- (.*)$/gm, '<li>$1</li>')
-      html = html.replace(block, '<ul>' + items + '</ul>')
-    }
-  }
+  // Blockquotes (with nesting support)
+  html = html.replace(/(?:^(&gt; ?)+.*(?:\n|$))+/gm, (block) => buildNestedBlockquote(block))
 
-  const olBlocks = html.match(/(?:^\d+\. .*\n?)+/gm)
-  if (olBlocks) {
-    for (const block of olBlocks) {
-      const items = block.replace(/^\d+\. (.*)$/gm, '<li>$1</li>')
-      html = html.replace(block, '<ol>' + items + '</ol>')
-    }
-  }
+  // Nested unordered lists
+  html = html.replace(/(?:^ {0,4}- .*(?:\n|$))+/gm, (block) => buildNestedList(block, false))
+  // Nested ordered lists
+  html = html.replace(/(?:^ {0,4}\d+\. .*(?:\n|$))+/gm, (block) => buildNestedList(block, true))
+
+  // Task list checkboxes (Lucide-style SVGs)
+  const TASK_CHECKED = '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect><path d="m9 12 2 2 4-4"></path></svg>'
+  const TASK_UNCHECKED = '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect></svg>'
+  html = html.replace(/(<li>)\[x\] /gi, '$1<span class="task-check checked">' + TASK_CHECKED + '</span>')
+  html = html.replace(/(<li>)\[ \] /gi, '$1<span class="task-check">' + TASK_UNCHECKED + '</span>')
 
   // Tables
   const tableBlocks = html.match(/(?:^\|.*\|.*\n?)+/gm)
@@ -281,24 +301,121 @@ function renderMarkdown(text: string): string {
     }
   }
 
-  html = html.replace(/^---+$/gm, '<hr>')
-
   // Restore protected code blocks
   html = html.replace(/\x00CODEBLOCK(\d+)\x00/g, (_, idx) => protectedBlocks[parseInt(idx)])
 
   // Convert remaining newlines to <br>, but remove <br> after block-level elements
   html = html.replace(/\n/g, '<br>')
-  html = html.replace(/(<\/(h[1-6]|pre|table|ul|ol|hr|li|div|p)>|<hr\/?>)\s*<br>/gi, '$1')
-  html = html.replace(/<br>\s*(<(h[1-6]|pre|table|ul|ol|hr|div|p)>)/gi, '$1')
+  html = html.replace(/(<\/(h[1-6]|pre|table|ul|ol|hr|li|div|p|blockquote)>|<hr\/?>)(\s*<br>)+/gi, '$1')
+  html = html.replace(/<br>\s*(<(h[1-6]|pre|table|ul|ol|hr|div|p|blockquote)[\s>])/gi, '$1')
+  // Also remove <br> before/after code-block-wrapper and nested blockquotes
+  html = html.replace(/<br>\s*<div class="code-block-wrapper">/gi, '<div class="code-block-wrapper">')
+  html = html.replace(/(<\/blockquote>)\s*<br>/gi, '$1')
+  html = html.replace(/<br>\s*(<blockquote>)/gi, '$1')
+  // Remove leading/trailing <br>
+  html = html.replace(/^(\s*<br>)+/i, '')
+  html = html.replace(/(<br>\s*)+$/i, '')
   // Collapse multiple consecutive <br> into one
   html = html.replace(/(<br>\s*)+/g, '<br>')
 
   return html
 }
 
+function buildNestedList(block: string, isOrdered: boolean): string {
+  const tag = isOrdered ? 'ol' : 'ul'
+  const marker = isOrdered ? /^ *\d+\. / : /^ *- /
+  const lines = block.split('\n').filter(l => l.trim() !== '')
+
+  function process(startIdx: number, baseIndent: number): { html: string; endIdx: number } {
+    let result = ''
+    let i = startIdx
+
+    while (i < lines.length) {
+      const line = lines[i]
+      const indent = (line.match(/^ */) || [''])[0].length
+
+      if (indent < baseIndent) break
+
+      if (indent === baseIndent) {
+        const content = line.replace(marker, '').trim()
+        // Check for child items (more indented lines)
+        let childrenHtml = ''
+        const peek = i + 1
+        if (peek < lines.length) {
+          const peekIndent = (lines[peek].match(/^ */) || [''])[0].length
+          if (peekIndent > baseIndent) {
+            const child = process(peek, peekIndent)
+            childrenHtml = `<${tag}>${child.html}</${tag}>`
+            i = child.endIdx
+          } else {
+            i++
+          }
+        } else {
+          i++
+        }
+        result += `<li>${content}${childrenHtml}</li>`
+      } else {
+        i++
+      }
+    }
+
+    return { html: result, endIdx: i }
+  }
+
+  const { html } = process(0, 0)
+  return `<${tag}>${html}</${tag}>`
+}
+
+function buildNestedBlockquote(block: string): string {
+  const lines = block.split('\n').filter(l => l.trim() !== '')
+
+  function process(startIdx: number, depth: number): { html: string; endIdx: number } {
+    let content = ''
+    let i = startIdx
+
+    while (i < lines.length) {
+      const line = lines[i]
+      const match = line.match(/^(&gt; ?)+/)
+      const lineDepth = match ? match[0].split('&gt;').length - 1 : 0
+
+      if (lineDepth < depth) break
+
+      if (lineDepth === depth) {
+        const text = line.replace(/^(&gt; ?)+/, '')
+        // Check for deeper children
+        let childHtml = ''
+        const peek = i + 1
+        if (peek < lines.length) {
+          const peekMatch = lines[peek].match(/^(&gt; ?)+/)
+          const peekDepth = peekMatch ? peekMatch[0].split('&gt;').length - 1 : 0
+          if (peekDepth > depth) {
+            const child = process(peek, peekDepth)
+            childHtml = child.html
+            i = child.endIdx
+          } else {
+            i++
+          }
+        } else {
+          i++
+        }
+        content += (content ? '\n' : '') + text
+        if (childHtml) content += '\n' + childHtml
+      } else {
+        i++
+      }
+    }
+
+    return { html: `<blockquote>${content.trim()}</blockquote>`, endIdx: i }
+  }
+
+  const firstDepth = lines.length > 0
+    ? (lines[0].match(/^(&gt; ?)+/) || [''])[0].split('&gt;').length - 1
+    : 0
+  const { html } = process(0, firstDepth || 1)
+  return html
+}
+
 function highlightText(html: string, query: string): string {
-  if (!query) return html
-  const escaped = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
   const regex = new RegExp(escaped, 'gi')
   // Split on < to isolate text from HTML tags.
   // Even-indexed segments (after join) are outside tags; odd are inside.
@@ -315,6 +432,23 @@ function highlightText(html: string, query: string): string {
       const tag = parts[i].slice(0, gt + 1)
       const text = parts[i].slice(gt + 1)
       result += '<' + tag + text.replace(regex, '<mark class="ai-search-highlight">$&</mark>')
+    }
+  }
+  return result
+}
+
+function autoLinkUrls(html: string): string {
+  const regex = /(https?:\/\/[^\s<>\[\]()"']+)/g
+  const parts = html.split('<')
+  let result = parts[0].replace(regex, '<a href="$1" target="_blank">$1</a>')
+  for (let i = 1; i < parts.length; i++) {
+    const gt = parts[i].indexOf('>')
+    if (gt === -1) {
+      result += '<' + parts[i].replace(regex, '<a href="$1" target="_blank">$1</a>')
+    } else {
+      const tag = parts[i].slice(0, gt + 1)
+      const text = parts[i].slice(gt + 1)
+      result += '<' + tag + text.replace(regex, '<a href="$1" target="_blank">$1</a>')
     }
   }
   return result
@@ -406,6 +540,36 @@ function escapeHtml(text: string): string {
   user-select: text;
   -webkit-user-select: text;
 }
+.text :deep(.code-block-wrapper) {
+  margin: 6px 0;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+}
+.text :deep(.code-block-header) {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 3px 8px;
+  background: var(--bg-overlay);
+  border-bottom: 1px solid var(--border-subtle);
+}
+.text :deep(.code-lang-tag) {
+  font-size: 10px;
+  font-family: var(--font-ui);
+  color: var(--text-muted);
+}
+.text :deep(.code-block-wrapper pre) {
+  margin: 0;
+  border: none;
+  border-radius: 0;
+  background: var(--bg-base);
+}
+.text :deep(.code-block-wrapper code) {
+  padding: 0;
+  background: transparent;
+  color: var(--text-primary);
+}
 .text :deep(pre) {
   background: var(--bg-base);
   padding: 10px 12px;
@@ -440,6 +604,54 @@ function escapeHtml(text: string): string {
 }
 .text :deep(li) {
   margin: 2px 0;
+}
+.text :deep(li ul),
+.text :deep(li ol) {
+  padding-left: 12px;
+}
+.text :deep(ol ol) { list-style-type: lower-alpha; }
+.text :deep(ol ol ol) { list-style-type: lower-roman; }
+.text :deep(ul ul) { list-style-type: circle; }
+.text :deep(ul ul ul) { list-style-type: square; }
+.text :deep(.task-check) {
+  display: inline-flex;
+  vertical-align: middle;
+  margin-right: 4px;
+  color: var(--text-muted);
+}
+.text :deep(.task-check.checked) {
+  color: var(--success);
+}
+
+/* Links */
+.text :deep(a) {
+  color: #6db3f8;
+}
+.text :deep(a:hover) {
+  color: #93cbf9;
+}
+
+/* Strikethrough */
+.text :deep(del) {
+  text-decoration: line-through;
+  color: var(--text-muted);
+}
+
+/* Blockquote */
+.text :deep(blockquote) {
+  margin: 8px 0;
+  padding: 6px 8px 6px 12px;
+  border-left: 3px solid var(--accent-dim);
+  background: var(--bg-overlay);
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+  color: var(--text-secondary);
+}
+
+/* Horizontal rule */
+.text :deep(hr) {
+  margin: 14px 0;
+  border: none;
+  border-top: 1px solid var(--border-hover);
 }
 
 /* Tables */
@@ -504,6 +716,21 @@ function escapeHtml(text: string): string {
   opacity: 0.6;
 }
 .tool-copy-btn:hover {
+  opacity: 1 !important;
+}
+/* Replicate tool-copy-btn styles for v-html code block buttons (scoped styles don't penetrate v-html) */
+.text :deep(.code-block-header .tool-copy-btn) {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0 2px;
+  opacity: 0.4;
+  transition: opacity 0.15s;
+  color: var(--text-muted);
+  display: inline-flex;
+  align-items: center;
+}
+.text :deep(.code-block-header .tool-copy-btn:hover) {
   opacity: 1 !important;
 }
 .tool-box-body {
@@ -683,29 +910,5 @@ function escapeHtml(text: string): string {
 }
 .continue-box {
   margin-top: 8px;
-}
-
-.debug-actions {
-  margin-top: 6px;
-  display: flex;
-  gap: 8px;
-}
-.debug-copy-btn {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  padding: 4px 10px;
-  font-size: 11px;
-  color: var(--text-muted);
-  background: var(--bg-surface);
-  border: 1px solid var(--border-hover);
-  border-radius: var(--radius-sm);
-  cursor: pointer;
-  transition: all 0.15s;
-}
-.debug-copy-btn:hover {
-  color: var(--accent);
-  border-color: var(--accent-glow);
-  background: var(--accent-subtle);
 }
 </style>

--- a/frontend/src/services/agent.ts
+++ b/frontend/src/services/agent.ts
@@ -438,10 +438,12 @@ export async function runAgent(userInput: string) {
     } else if (tu.name === 'send_terminal_key') {
       const input = tu.input.input as string | undefined
       const control = tu.input.control as string | undefined
+      const sendEnter = (tu.input.send_enter as boolean) ?? true
       try {
         const result = await sendTerminalKey(
           input,
-          control as 'ctrl_c' | 'ctrl_d' | 'enter' | undefined
+          control as 'ctrl_c' | 'ctrl_d' | 'enter' | undefined,
+          sendEnter
         )
         store.addMessage({
           id: `msg-${Date.now()}`,

--- a/frontend/src/services/llm.ts
+++ b/frontend/src/services/llm.ts
@@ -194,6 +194,10 @@ export const AVAILABLE_TOOLS = [
           type: 'string',
           enum: ['ctrl_c', 'ctrl_d', 'enter'],
           description: 'Send a control character instead of text. "ctrl_c" interrupts/cancels the running command. "ctrl_d" sends EOF. "enter" sends a newline/Enter key.'
+        },
+        send_enter: {
+          type: 'boolean',
+          description: 'Whether to send an Enter/Return key after the input text to submit it. Default true. Set to false only when you need to send partial input without submitting (e.g., typing a password character by character). Ignored when using control.'
         }
       }
     }

--- a/frontend/src/services/terminalAgent.ts
+++ b/frontend/src/services/terminalAgent.ts
@@ -38,7 +38,7 @@ export function watchOutput(
       if (payload.id !== sessionId || resolved) return
 
       output += payload.data
-      const clean = stripAnsi(output)
+      const clean = stripAnsi(output).trim()
 
       const scanStart = Math.max(0, lastScanPos - marker.length)
       lastScanPos = clean.length
@@ -207,10 +207,23 @@ export function captureTerminal(tailLines: number = 200): CaptureResult {
     return { output: '' }
   }
 
-  const effectiveTail = Math.min(tailLines, totalLines)
+  // Find the last non-blank line — skip trailing empty space at the bottom of the terminal
+  let lastContentLine = totalLines - 1
+  while (lastContentLine >= 0) {
+    const line = buffer.getLine(lastContentLine)
+    if (line && line.translateToString().trim() !== '') break
+    lastContentLine--
+  }
+
+  if (lastContentLine < 0) {
+    return { output: '' }
+  }
+
+  // Capture up to tailLines lines, ending at the last non-blank line
+  const startLine = Math.max(0, lastContentLine - tailLines + 1)
   const lines: string[] = []
 
-  for (let i = totalLines - effectiveTail; i < totalLines; i++) {
+  for (let i = startLine; i <= lastContentLine; i++) {
     const line = buffer.getLine(i)
     if (line) lines.push(line.translateToString())
   }
@@ -253,9 +266,10 @@ interface SendKeyResult {
 
 export async function sendTerminalKey(
   input?: string,
-  control?: 'ctrl_c' | 'ctrl_d' | 'enter'
+  control?: 'ctrl_c' | 'ctrl_d' | 'enter',
+  sendEnter: boolean = true
 ): Promise<SendKeyResult> {
-  const { sessionId } = resolveActiveSession()
+  const { sessionId, shellPath } = resolveActiveSession()
 
   let data: string
   if (control) {
@@ -272,6 +286,11 @@ export async function sendTerminalKey(
     data = input
   } else {
     throw new Error('Either input or control must be provided')
+  }
+
+  // Append shell-appropriate newline when send_enter is true and input was provided
+  if (sendEnter && !control && input !== undefined && input !== '') {
+    data += getShellNewline(shellPath)
   }
 
   await SessionWrite(sessionId, data)

--- a/frontend/src/stores/aiStore.ts
+++ b/frontend/src/stores/aiStore.ts
@@ -52,7 +52,7 @@ AVAILABLE TOOLS:
 2. start_command — Start a background/long-running command (servers, daemons). Returns initial output immediately without waiting.
 3. capture_terminal — Take an instant snapshot of the terminal screen. Use to check current state without running commands.
 4. collect_output — Wait and collect new terminal output. Pure passive listening — does NOT send anything to the terminal. Use when a command is still running and you want to see progress.
-5. send_terminal_key — Send text or control keys to the terminal. Use ONLY when you can SEE an interactive prompt (password, y/n, confirmation).
+5. send_terminal_key — Send text or control keys to the terminal. Use ONLY when you can SEE an interactive prompt (password, y/n, confirmation). By default, send_enter=true automatically appends Enter after your input, so "y" becomes "y" + Enter. Set send_enter=false only when you need to type raw characters without submitting.
 6. interrupt_command — Send Ctrl+C to cancel the running command.
 
 CRITICAL RULES:
@@ -75,8 +75,9 @@ When execute_command times out, read the output carefully:
 
 INTERACTIVE PROMPTS:
 - Password prompt: ask the user (NEVER guess passwords).
-- y/n confirmation: use send_terminal_key with input: "y".
+- y/n confirmation: use send_terminal_key with input: "y" (send_enter defaults to true, so Enter is sent automatically).
 - Pager (less/more): use send_terminal_key with control: "ctrl_c" to exit.
+- send_enter parameter: defaults to true, automatically appends Enter after your input. Set to false only when you need to type raw characters without submitting.
 
 OUTPUT READING:
 - To check if shell prompt is back after a command: use capture_terminal.


### PR DESCRIPTION
## Changes

- Add `send_enter` parameter to `send_terminal_key` tool (default true), automatically appending Enter after input text
- Support markdown rendering: nested lists, blockquotes, strikethrough, images, footnotes
- Support task lists with SVG checkbox icons (square / square-check-big)
- Auto-link raw URLs only outside HTML tags (prevents broken links)
- Fix code block: preserve indentation and newlines, add copy button on hover
- Add language tag display on code blocks
- Fix link color for dark theme readability, HR spacing, and various rendering issues

---

## 改动

- `send_terminal_key` 工具增加 `send_enter` 参数（默认 true），交互式回复自动追加回车
- 支持 markdown 渲染：嵌套列表、引用块、删除线、图片、脚注
- 支持任务列表，使用 SVG 复选框图标（square / square-check-big）
- 自动链接仅在 HTML 标签外匹配，避免破坏已有链接
- 修复代码块：保留缩进和换行，悬停显示复制按钮
- 代码块显示语言标签
- 修复深色主题下链接颜色、分割线间距等渲染问题