### PR TITLE
feat(ai): detect command completion via prompt reappearance

### DIFF
--- a/frontend/src/services/terminalAgent.test.ts
+++ b/frontend/src/services/terminalAgent.test.ts
@@ -15,6 +15,25 @@ vi.mock('../../wailsjs/go/main/App', () => ({
   SessionWrite: mockSessionWrite,
 }))
 
+// ---- mock terminal manager (prompt-line capture) ----
+const PROMPT = '[root@node140 ~]#'
+const mockGetManagedTerminal = vi.fn(() => ({
+  terminal: {
+    buffer: {
+      active: {
+        baseY: 0,
+        cursorY: 0,
+        getLine: (_n: number) => ({
+          translateToString: (_trim?: boolean) => PROMPT,
+        }),
+      },
+    },
+  },
+}))
+vi.mock('../services/terminalManager', () => ({
+  getManagedTerminal: (...args: any[]) => mockGetManagedTerminal(...(args as [])),
+}))
+
 // ---- mock pinia stores ----
 const mockPanel = {
   sessionId: 'test-session-id',
@@ -49,9 +68,6 @@ import { EventsOn } from '../../wailsjs/runtime'
 
 // ---- helpers ----
 const MOCK_TIMESTAMP = 1700000000000
-// Math.random = 0 => toString(36) = "0" => slice(2,8) = "" => ""
-// Marker = __AI_DONE_ + timestamp + _ + random + __ = __AI_DONE_1700000000000___
-const MOCK_MARKER = `__AI_DONE_${MOCK_TIMESTAMP}_${''}__`
 
 function fakeData(sessionId: string, data: string) {
   return { id: sessionId, data }
@@ -152,30 +168,65 @@ describe('watchOutput', () => {
   })
 
   it('returns promise and cleanup', () => {
-    const result = watchOutput('session-1', '__MARK__', 1000)
+    const result = watchOutput('session-1', PROMPT, 1000)
     expect(result.promise).toBeInstanceOf(Promise)
     expect(typeof result.cleanup).toBe('function')
   })
 
-  it('emits with events and resolves on second marker', async () => {
+  it('resolves when the prompt line reappears after the command', async () => {
     let capturedCallback: ((payload: { id: string; data: string }) => void) | null = null
     vi.mocked(EventsOn).mockImplementation((_eventName, callback) => {
       capturedCallback = callback
       return () => { }
     })
 
-    const { promise } = watchOutput('s1', '__M__', 5000)
+    const { promise } = watchOutput('s1', PROMPT, 5000)
 
-    // first marker
-    capturedCallback!(fakeData('s1', 'some output\n__M__'))
-
-    // Wait a tick, then send second marker
-    await new Promise(r => setTimeout(r, 10))
-    capturedCallback!(fakeData('s1', 'more output\n__M__'))
+    // Echoed command line, then output, then the prompt returns.
+    capturedCallback!(fakeData('s1', `${PROMPT} echo hi\nhi\n${PROMPT} `))
 
     const result: WatchResult = await promise
     expect(result.timedOut).toBe(false)
-    expect(result.output).toContain('some output')
+    expect(result.output).toContain('hi')
+  })
+
+  it('does not resolve on the initial prompt alone', async () => {
+    vi.useFakeTimers()
+    let capturedCallback: ((payload: { id: string; data: string }) => void) | null = null
+    vi.mocked(EventsOn).mockImplementation((_eventName, callback) => {
+      capturedCallback = callback
+      return () => { }
+    })
+
+    const { promise } = watchOutput('s1', PROMPT, 1000)
+
+    // Only the prompt so far (no echoed command line before it) → keep waiting.
+    capturedCallback!(fakeData('s1', `${PROMPT} `))
+    vi.advanceTimersByTime(1000)
+
+    const result: WatchResult = await promise
+    expect(result.timedOut).toBe(true)
+    vi.useRealTimers()
+  })
+
+  it('never resolves early when promptLine is empty (timeout only)', async () => {
+    vi.useFakeTimers()
+    let capturedCallback: ((payload: { id: string; data: string }) => void) | null = null
+    vi.mocked(EventsOn).mockImplementation((_eventName, callback) => {
+      capturedCallback = callback
+      return () => { }
+    })
+
+    const { promise } = watchOutput('s1', '', 1000)
+
+    // Even output that looks like a prompt must not trigger detection.
+    capturedCallback!(fakeData('s1', `${PROMPT} echo hi\nhi\n${PROMPT} `))
+    vi.advanceTimersByTime(1000)
+
+    const result: WatchResult = await promise
+    expect(result.timedOut).toBe(true)
+    expect(result.output).toContain('hi')
+    vi.useRealTimers()
   })
 
   it('times out after timeoutMs', async () => {
@@ -186,7 +237,7 @@ describe('watchOutput', () => {
       return () => { }
     })
 
-    const { promise } = watchOutput('s1', '__M__', 1000)
+    const { promise } = watchOutput('s1', PROMPT, 1000)
 
     capturedCallback!(fakeData('s1', 'partial output'))
     vi.advanceTimersByTime(1000)
@@ -205,7 +256,7 @@ describe('watchOutput', () => {
       return () => { }
     })
 
-    const { promise } = watchOutput('s1', '__M__', 1000)
+    const { promise } = watchOutput('s1', PROMPT, 1000)
 
     capturedCallback!(fakeData('s2', 'wrong session data'))
     vi.advanceTimersByTime(1000)
@@ -221,7 +272,7 @@ describe('watchOutput', () => {
       return () => { }
     })
 
-    const { promise, cleanup } = watchOutput('s1', '__M__', 1000)
+    const { promise, cleanup } = watchOutput('s1', PROMPT, 1000)
     cleanup()
 
     // Should not resolve/resolve with undefined after cleanup
@@ -253,7 +304,7 @@ describe('executeCommand', () => {
     await expect(executeCommand('ls')).rejects.toThrow('No active terminal session')
   })
 
-  it('writes command with marker to session', async () => {
+  it('sends the command with no injected marker', async () => {
     const restore = withMockedTime()
 
     let capturedCallback: ((payload: { id: string; data: string }) => void) | null = null
@@ -264,18 +315,19 @@ describe('executeCommand', () => {
 
     const cmdPromise = executeCommand('echo hello')
 
-    // Should have written to session
+    // Should have written to session — command only, no marker echo appended.
     expect(mockSessionWrite).toHaveBeenCalledOnce()
     const writtenArg = mockSessionWrite.mock.calls[0][1]
     expect(writtenArg).toContain('echo hello')
-    expect(writtenArg).toContain('echo "')
+    expect(writtenArg).not.toContain('__AI_DONE_')
+    expect(writtenArg).not.toContain('echo "')
 
     // Wait for async EventsOn to fire (inside Promise constructor = microtask)
     await Promise.resolve()
     expect(capturedCallback).not.toBeNull()
 
-    // Send output containing the marker twice (first seen = markerSeen=true, second = resolve)
-    capturedCallback!(fakeData('test-session-id', `output before\n${MOCK_MARKER}\nmore output\n${MOCK_MARKER}`))
+    // Prompt reappears after the echoed command + output → completion.
+    capturedCallback!(fakeData('test-session-id', `${PROMPT} echo hello\nhello\n${PROMPT} `))
 
     const result = await cmdPromise
     expect(result.exitCode).toBe(0)
@@ -326,14 +378,15 @@ describe('executeCommand', () => {
     const lines = Array.from({ length: 10 }, (_, i) => `line${i + 1}`)
     const output = lines.join('\n')
 
-    const cmdPromise = executeCommand('some-cmd', 5000, 2, 3)
+    // headLines=3 so the head keeps the echoed command line + line1 + line2.
+    const cmdPromise = executeCommand('some-cmd', 5000, 3, 3)
 
     // Wait for async EventsOn to capture the callback
     await Promise.resolve()
     expect(capturedCallback).not.toBeNull()
 
-    // Send output with two markers to trigger resolution
-    capturedCallback!(fakeData('test-session-id', output + '\n' + MOCK_MARKER + '\n' + output + '\n' + MOCK_MARKER))
+    // Echoed command + long output + returning prompt triggers completion.
+    capturedCallback!(fakeData('test-session-id', `${PROMPT} some-cmd\n` + output + `\n${PROMPT} `))
 
     const result: ExecuteResult = await cmdPromise
     expect(result.exitCode).toBe(0)

--- a/frontend/src/services/terminalAgent.ts
+++ b/frontend/src/services/terminalAgent.ts
@@ -15,17 +15,37 @@ export interface WatchResult {
   timedOut: boolean
 }
 
+// Split terminal output into display lines. Splits on newlines and, within a
+// line, keeps only the text after the last carriage return so progress-bar
+// style redraws (which overwrite the line with bare \r) collapse to their
+// final state — the same way the text appears on screen.
+function toDisplayLines(clean: string): string[] {
+  return clean.split(/\r?\n/).map((line) => {
+    const cr = line.lastIndexOf('\r')
+    return cr >= 0 ? line.slice(cr + 1) : line
+  })
+}
+
+// Watch session output and resolve when the command finishes.
+//
+// Completion is detected by the shell prompt reappearing: `promptLine` is the
+// prompt captured immediately before the command was sent, and once that exact
+// line shows up again at the bottom of the output the shell is back at the
+// prompt and the command is done. No marker is injected into the shell, so the
+// terminal shows nothing extra.
+//
+// When `promptLine` is empty (prompt could not be captured, or the prompt is
+// dynamic and never reappears verbatim) detection is skipped entirely and the
+// call resolves on timeout — the command already carries its own timeout.
 export function watchOutput(
   sessionId: string,
-  marker: string,
+  promptLine: string,
   timeoutMs: number
 ): { promise: Promise<WatchResult>; cleanup: () => void } {
   let timeoutId: ReturnType<typeof setTimeout>
   let unsubscribe: (() => void) | null = null
   let resolved = false
   let output = ''
-  let lastScanPos = 0
-  let markerSeen = false
 
   const cleanup = () => {
     clearTimeout(timeoutId)
@@ -38,21 +58,20 @@ export function watchOutput(
       if (payload.id !== sessionId || resolved) return
 
       output += payload.data
-      const clean = stripAnsi(output).trim()
+      if (!promptLine) return
 
-      const scanStart = Math.max(0, lastScanPos - marker.length)
-      lastScanPos = clean.length
-      let searchIdx = scanStart
-      while ((searchIdx = clean.indexOf(marker, searchIdx)) !== -1) {
-        searchIdx += marker.length
-        if (!markerSeen) {
-          markerSeen = true
-          continue
-        }
+      const lines = toDisplayLines(stripAnsi(output))
+      // Locate the last non-blank display line.
+      let last = lines.length - 1
+      while (last >= 0 && lines[last].trimEnd() === '') last--
+      // Require at least the echoed command line before the prompt, so the
+      // reappearing prompt — not the initial state — is what triggers.
+      if (last < 1) return
+
+      if (lines[last].trimEnd() === promptLine) {
         cleanup()
-        const result = clean.slice(0, searchIdx - marker.length).trim()
+        const result = lines.slice(0, last).join('\n').trim()
         resolve({ output: result, timedOut: false })
-        return
       }
     })
 
@@ -120,6 +139,20 @@ function getShellNewline(shellPath?: string): string {
   }
 }
 
+// Read the current prompt line from the terminal buffer. Called right before a
+// command is sent, when the cursor sits on the (freshly drawn) prompt with no
+// input yet, so the cursor line's text is exactly the prompt string. Returns ''
+// when unavailable, which disables prompt detection for that command.
+function capturePromptLine(sessionId: string): string {
+  const managed = getManagedTerminal(sessionId)
+  const terminal = managed?.terminal
+  if (!terminal) return ''
+  const buffer = terminal.buffer.active
+  const line = buffer.getLine(buffer.baseY + buffer.cursorY)
+  if (!line) return ''
+  return line.translateToString(true).trimEnd()
+}
+
 export async function executeCommand(
   command: string,
   timeoutMs: number = 60000,
@@ -127,13 +160,13 @@ export async function executeCommand(
   tailLines: number = 300
 ): Promise<ExecuteResult> {
   const { sessionId, shellPath } = resolveActiveSession()
-  const marker = `__AI_DONE_${Date.now()}_${Math.random().toString(36).slice(2, 8)}__`
-  const fullCommand = buildCommand(command, marker, shellPath)
+  const promptLine = capturePromptLine(sessionId)
+  const fullCommand = buildCommand(command, shellPath)
   const newline = getShellNewline(shellPath)
 
   await SessionWrite(sessionId, fullCommand + newline)
 
-  const { promise } = watchOutput(sessionId, marker, timeoutMs)
+  const { promise } = watchOutput(sessionId, promptLine, timeoutMs)
   const result = await promise
 
   if (result.timedOut) {
@@ -314,18 +347,18 @@ export async function sendTerminalKey(
   return { output: '(input sent)' }
 }
 
-function buildCommand(command: string, marker: string, shellPath?: string): string {
+// Build the string sent to the shell. No completion marker is appended — the
+// AI executor detects completion by watching for the shell prompt to reappear
+// (see watchOutput). This keeps the terminal clean and, for POSIX shells,
+// avoids corrupting multi-line input such as here-documents. A single leading
+// space keeps the command out of shell history (HISTCONTROL=ignorespace).
+function buildCommand(command: string, shellPath?: string): string {
   const lower = (shellPath || '').toLowerCase()
-  if (lower.includes('powershell') || lower.includes('pwsh')) {
-    // PowerShell syntax — use newline to keep here-string terminators ("@ / '@) intact
-    return `${command}\nWrite-Output "${marker}"`
+  if (lower.includes('powershell') || lower.includes('pwsh') || lower.includes('cmd')) {
+    return command
   }
-  if (lower.includes('cmd')) {
-    // CMD syntax
-    return `${command}&echo ${marker}`
-  }
-  // Default: bash / sh / zsh / fish — leading spaces keep both out of shell history
-  return ` ${command}\n echo "${marker}"`
+  // bash / sh / zsh / fish
+  return ` ${command}`
 }
 
 // Simple ANSI stripper for extracting readable text from terminal output


### PR DESCRIPTION
## Summary

Remove the injected `__AI_DONE__` completion marker from AI command execution. Previously the executor appended `echo "__AI_DONE_<id>"` (or `Write-Output`/`echo` for PowerShell/cmd) after every command and watched for that marker to detect completion. The marker line was visible in the terminal, and on POSIX shells the extra `\n echo ...` corrupted multi-line input such as here-documents.

Completion is now detected by capturing the shell prompt line from the terminal buffer immediately before sending the command, then resolving once that exact line reappears at the bottom of the output — the shell is back at the prompt. Nothing extra is injected, so the terminal stays clean and here-docs stay intact.

## Changes

- Capture the current prompt line from the xterm buffer right before sending a command (`capturePromptLine`)
- Rewrite `watchOutput` to resolve when the captured prompt reappears as the last non-blank display line, collapsing `\r` redraws to their final state
- Send the command with no appended marker; a single leading space still keeps it out of shell history for POSIX shells
- Fall back to the command's existing timeout when the prompt can't be captured or is dynamic and never reappears verbatim

## Validation

- `npm --prefix frontend test`
- `npm --prefix frontend run build`

Closes #99

---

## 摘要

去掉 AI 执行命令时注入的 `__AI_DONE__` 完成标记。此前执行器会在每条命令后追加 `echo "__AI_DONE_<id>"`（PowerShell/cmd 为 `Write-Output`/`echo`）来判断命令结束，导致：标记行在终端可见，污染输出；POSIX shell 下追加的 `\n echo ...` 会破坏 here-document 等多行输入。

现改为：发送命令前从终端缓冲区读取当前提示符行，之后监听输出，当该提示符行重新出现在输出末尾（shell 回到提示符）时判定完成。不再注入任何内容，终端保持干净，heredoc 也不再被破坏。若提示符无法读取或为动态提示符（不会原样重现），则退化为命令原有的超时机制。

## 验证

- `npm --prefix frontend test`
- `npm --prefix frontend run build`
