### PR TITLE
fix(terminal): start local shell as a login shell on macOS

### DIFF
--- a/backend/session/local_session_unix.go
+++ b/backend/session/local_session_unix.go
@@ -50,7 +50,7 @@ func (s *LocalSession) Connect(config ConnectionConfig) error {
 
 	s.title = shellName(shell)
 
-	s.cmd = exec.Command(shell)
+	s.cmd = exec.Command(shell, loginShellArgs(shell)...)
 	s.cmd.Env = ensureTerminalEnv(os.Environ())
 
 	ptyFile, err := pty.Start(s.cmd)
@@ -181,6 +181,37 @@ func shellName(path string) string {
 		base = strings.TrimSuffix(base, ".exe")
 	}
 	return base
+}
+
+// loginShellArgs returns the arguments needed to start the shell as a login
+// shell on macOS.
+//
+// When the app is launched from the macOS Finder/Dock, the process inherits a
+// minimal PATH (roughly /usr/bin:/bin:/usr/sbin:/sbin). A plain interactive
+// shell does not restore it, so tools in /usr/local/bin, /opt/homebrew/bin,
+// etc. are "command not found". Terminal.app and iTerm avoid this by starting
+// login shells: on macOS the login shell sources /etc/zprofile (or
+// /etc/profile), which runs path_helper to rebuild PATH from /etc/paths and
+// /etc/paths.d, and then the user's ~/.zprofile / ~/.bash_profile.
+//
+// This is scoped to macOS. Linux terminal emulators conventionally launch
+// non-login interactive shells and the GUI session already exports a full
+// PATH, so we leave that behavior unchanged there.
+//
+// bash/zsh/sh accept -l; fish uses --login. csh/tcsh also accept -l. Unknown
+// shells get no argument to avoid passing a flag they might reject.
+func loginShellArgs(shellPath string) []string {
+	if runtime.GOOS != "darwin" {
+		return nil
+	}
+	switch shellName(shellPath) {
+	case "bash", "zsh", "sh", "dash", "ksh", "mksh", "csh", "tcsh":
+		return []string{"-l"}
+	case "fish":
+		return []string{"--login"}
+	default:
+		return nil
+	}
 }
 
 // ensureTerminalEnv guarantees the local shell starts with a usable terminal


### PR DESCRIPTION
## Summary

Fix local terminal commands in `/usr/local/bin` and `/opt/homebrew/bin` (docker, brew-installed tools, etc.) being reported as "command not found" on macOS.

Launched from the Finder/Dock, the app inherits only a minimal `PATH` (roughly `/usr/bin:/bin:/usr/sbin:/sbin`). The local PTY previously started a plain interactive shell, which does not restore the full `PATH`. Terminal.app and iTerm avoid this by starting a **login shell**: on macOS the login shell sources `/etc/zprofile` → `path_helper` (rebuilding `PATH` from `/etc/paths` and `/etc/paths.d`) and then the user's `~/.zprofile` / `~/.bash_profile`.

## Changes

- Start the local shell as a login shell by passing `-l` (or `--login` for fish) when launching the PTY
- Scope this to macOS only — Linux terminal emulators conventionally launch non-login interactive shells and the GUI session already exports a full `PATH`, so that behavior is unchanged
- Unknown shells receive no flag, to avoid passing an option they might reject

## Validation

- `go build ./backend/session`
- Verified on macOS that a login shell (`zsh -l`) restores `/opt/homebrew/bin`, `/opt/homebrew/sbin`, `/usr/local/bin` while a non-login shell does not
- Unit-tested `loginShellArgs` for bash/zsh/sh (`-l`), fish (`--login`), and unknown shells (none)

Closes #96

---

## 摘要

修复 macOS 上本地终端无法识别 `/usr/local/bin`、`/opt/homebrew/bin` 下命令（docker、brew 安装的工具等）报 "command not found" 的问题。

从 Finder/Dock 启动应用时，进程只继承到一个最小 `PATH`（大致 `/usr/bin:/bin:/usr/sbin:/sbin`）。此前本地 PTY 启动的是普通交互式 shell，不会重建完整 `PATH`。Terminal.app、iTerm 之所以正常，是因为它们启动的是**登录 shell**：在 macOS 上登录 shell 会加载 `/etc/zprofile` → `path_helper`（从 `/etc/paths` 和 `/etc/paths.d` 重建 `PATH`），再加载用户的 `~/.zprofile` / `~/.bash_profile`。

## 改动

- 启动本地 shell 时以登录 shell 方式运行：传入 `-l`（fish 用 `--login`）
- 仅限 macOS —— Linux 终端惯例启动非登录交互 shell，且图形会话本身已导出完整 `PATH`，行为保持不变
- 未知 shell 不传任何参数，避免传入其可能不支持的选项

## 验证

- `go build ./backend/session`
- 在 macOS 上验证登录 shell（`zsh -l`）能恢复 `/opt/homebrew/bin` 等路径，而非登录 shell 不能
- 对 `loginShellArgs` 做了单元测试：bash/zsh/sh → `-l`，fish → `--login`，未知 shell → 无
