### PR TITLE
fix(terminal): keep background-tab output from truncating on buffer trim

### DIFF
--- a/frontend/src/components/BaseTerminal.vue
+++ b/frontend/src/components/BaseTerminal.vue
@@ -1065,8 +1065,9 @@ onActivated(() => {
   // setting isActive = true. The session:data handler gates on
   // isActive, so new data would race with the gap replay and
   // advance writtenChunks, making the gap undetectable.
-  // Uses chunk index (not byte offset) so sessionStore trimming
-  // doesn't invalidate the tracking position.
+  // Uses a monotonic sequence number (getChunkCount), not an array
+  // index, so front-trimming of the sessionStore buffer during a
+  // long background session doesn't invalidate the tracking position.
   if (props.sessionId) {
     const total = sessionStore.getChunkCount(props.sessionId)
     if (total > writtenChunks) {

--- a/frontend/src/stores/sessionStore.test.ts
+++ b/frontend/src/stores/sessionStore.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+
+// EventsOn is called at module load; stub it so importing the store is safe.
+import { vi } from 'vitest'
+vi.mock('../../wailsjs/runtime', () => ({
+  EventsOn: vi.fn(() => () => {}),
+}))
+
+import { useSessionStore } from './sessionStore'
+
+const MAX_CHUNKS = 2000
+const TRIM_TO = 1000
+
+describe('sessionStore replay tracking', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('getChunkCount is a monotonic sequence, not the buffer length', () => {
+    const store = useSessionStore()
+    const id = 'seq-monotonic'
+    store.initSession(id)
+
+    // Push more than MAX_CHUNKS so the buffer trims from the front.
+    const total = MAX_CHUNKS + 500
+    for (let i = 0; i < total; i++) store.appendData(id, `c${i}\n`)
+
+    // seq counts everything ever appended, even though data was trimmed.
+    expect(store.getChunkCount(id)).toBe(total)
+  })
+
+  it('replays the gap correctly after the buffer is trimmed', () => {
+    const store = useSessionStore()
+    const id = 'seq-gap'
+    store.initSession(id)
+
+    // Simulate: component recorded its position, then went to background
+    // while a long compile flooded the session past the trim threshold.
+    for (let i = 0; i < 500; i++) store.appendData(id, `pre${i}\n`)
+    const writtenChunks = store.getChunkCount(id) // = 500
+
+    // Flood well past MAX_CHUNKS so the first 500 chunks are trimmed away.
+    const flood = MAX_CHUNKS + 800
+    for (let i = 0; i < flood; i++) store.appendData(id, `post${i}\n`)
+
+    // Old behavior (array index): getChunkCount would have been <= writtenChunks
+    // after trimming, so `total > writtenChunks` was false and NOTHING replayed.
+    const total = store.getChunkCount(id)
+    expect(total).toBeGreaterThan(writtenChunks)
+
+    // The gap replay must return recent output, including the very last chunk,
+    // so the terminal never freezes mid-stream.
+    const tail = store.getDataFromChunk(id, writtenChunks)
+    expect(tail.length).toBeGreaterThan(0)
+    expect(tail.endsWith(`post${flood - 1}\n`)).toBe(true)
+  })
+
+  it('getDataFromChunk returns best-effort tail when position was trimmed away', () => {
+    const store = useSessionStore()
+    const id = 'seq-trimmed-pos'
+    store.initSession(id)
+
+    for (let i = 0; i < MAX_CHUNKS + 1000; i++) store.appendData(id, `x${i}\n`)
+
+    // Ask from sequence 0 (long since trimmed). Should not throw or return '',
+    // but the buffered remainder — bounded by TRIM_TO..MAX_CHUNKS chunks.
+    const tail = store.getDataFromChunk(id, 0)
+    expect(tail.length).toBeGreaterThan(0)
+    expect(tail.endsWith(`x${MAX_CHUNKS + 1000 - 1}\n`)).toBe(true)
+    const lines = tail.trimEnd().split('\n')
+    expect(lines.length).toBeLessThanOrEqual(MAX_CHUNKS)
+    expect(lines.length).toBeGreaterThanOrEqual(TRIM_TO - 1)
+  })
+
+  it('getDataFromChunk returns empty once fully consumed', () => {
+    const store = useSessionStore()
+    const id = 'seq-consumed'
+    store.initSession(id)
+    for (let i = 0; i < 10; i++) store.appendData(id, `y${i}\n`)
+    const total = store.getChunkCount(id)
+    expect(store.getDataFromChunk(id, total)).toBe('')
+  })
+})

--- a/frontend/src/stores/sessionStore.ts
+++ b/frontend/src/stores/sessionStore.ts
@@ -7,6 +7,25 @@ interface SessionData {
   id: string
   status: SessionStatus
   data: string[]
+  // Monotonically increasing count of chunks ever appended to this session.
+  // Unlike data.length, it is NOT reset when `data` is trimmed from the front,
+  // so it is a stable sequence number for tracking replay position across
+  // trims. See getDataFromChunk.
+  seq: number
+}
+
+// Keep at most MAX_CHUNKS buffered per session; once exceeded, drop the oldest
+// down to TRIM_TO. Trimming removes from the front, which is why consumers must
+// track position by `seq` (a stable sequence number), not by array index.
+const MAX_CHUNKS = 2000
+const TRIM_TO = 1000
+
+function pushChunk(s: SessionData, chunk: string) {
+  s.data.push(chunk)
+  s.seq++
+  if (s.data.length > MAX_CHUNKS) {
+    s.data.splice(0, s.data.length - TRIM_TO)
+  }
 }
 
 // Module-level reactive state (shared across all store instances)
@@ -20,7 +39,7 @@ const sessionState = reactive<{
 EventsOn('session:status', (payload: { id: string; status: SessionStatus }) => {
   let s = sessionState.sessions.get(payload.id)
   if (!s) {
-    s = { id: payload.id, status: 'connecting', data: [] }
+    s = { id: payload.id, status: 'connecting', data: [], seq: 0 }
     sessionState.sessions.set(payload.id, s)
   }
   s.status = payload.status
@@ -29,13 +48,10 @@ EventsOn('session:status', (payload: { id: string; status: SessionStatus }) => {
 EventsOn('session:data', (payload: { id: string; data: string }) => {
   let s = sessionState.sessions.get(payload.id)
   if (!s) {
-    s = { id: payload.id, status: 'connecting', data: [] }
+    s = { id: payload.id, status: 'connecting', data: [], seq: 0 }
     sessionState.sessions.set(payload.id, s)
   }
-  s.data.push(payload.data)
-  if (s.data.length > 2000) {
-    s.data.splice(0, s.data.length - 1000)
-  }
+  pushChunk(s, payload.data)
 })
 
 export const useSessionStore = defineStore('session', () => {
@@ -44,7 +60,7 @@ export const useSessionStore = defineStore('session', () => {
     if (existing) {
       existing.status = 'connecting'
     } else {
-      sessionState.sessions.set(id, { id, status: 'connecting', data: [] })
+      sessionState.sessions.set(id, { id, status: 'connecting', data: [], seq: 0 })
     }
   }
 
@@ -63,10 +79,7 @@ export const useSessionStore = defineStore('session', () => {
   function appendData(id: string, chunk: string) {
     const s = sessionState.sessions.get(id)
     if (s) {
-      s.data.push(chunk)
-      if (s.data.length > 2000) {
-        s.data.splice(0, s.data.length - 1000)
-      }
+      pushChunk(s, chunk)
     }
   }
 
@@ -89,15 +102,27 @@ export const useSessionStore = defineStore('session', () => {
     return raw
   }
 
+  // Total number of chunks ever received for this session. This is a stable,
+  // monotonically increasing sequence number — pass it to getDataFromChunk to
+  // resume from a remembered position even after the buffer has been trimmed.
   function getChunkCount(id: string): number {
     const s = sessionState.sessions.get(id)
-    return s ? s.data.length : 0
+    return s ? s.seq : 0
   }
 
-  function getDataFromChunk(id: string, startChunk: number): string {
+  // Return all chunks with sequence number >= startSeq, joined. `startSeq` is a
+  // value previously returned by getChunkCount. If the requested position has
+  // already been trimmed away, returns everything still buffered (best effort,
+  // so the most recent output — including the final prompt — is never dropped).
+  function getDataFromChunk(id: string, startSeq: number): string {
     const s = sessionState.sessions.get(id)
-    if (!s || startChunk >= s.data.length) return ''
-    return s.data.slice(startChunk).join('')
+    if (!s) return ''
+    // Number of chunks already dropped from the front of `data`.
+    const base = s.seq - s.data.length
+    let idx = startSeq - base
+    if (idx >= s.data.length) return ''
+    if (idx < 0) idx = 0
+    return s.data.slice(idx).join('')
   }
 
   function removeSession(id: string) {


### PR DESCRIPTION
## Summary

Fix long-running SSH command output freezing mid-stream for tabs that were in the background. A ~20-minute compile with heavy log output would stop at some point even though the command had finished and the shell was already back at the prompt; it showed up mainly when the tab had been switched to the background.

## Cause

`BaseTerminal` tracks how much session output it has written with `writtenChunks` and, on KeepAlive reactivation, replays the gap from `sessionStore`. The store buffer is capped at 2000 chunks and trimmed from the **front** down to 1000, but the tracking position was an **absolute array index**.

Heavy background output overflowed the cap, so after trimming `getChunkCount()` (the array length) became **smaller** than the remembered `writtenChunks`. The `total > writtenChunks` guard in `onActivated` was then false, so the gap was never replayed and the terminal appeared to stop mid-output. (The old code comment even claimed chunk-index tracking survived trimming — it did not, because front-trimming shifts every index.)

## Changes

- Track buffered output by a monotonic per-session sequence number (`seq`) that is **not** reset when the buffer is trimmed from the front
- `getChunkCount` now returns `seq`; `getDataFromChunk` translates a remembered `seq` to the current buffer offset, returning a best-effort tail when the exact position has already been trimmed away (so the most recent output — including the final prompt — is never dropped)
- Centralize buffering/trimming in a single `pushChunk` helper with named `MAX_CHUNKS` / `TRIM_TO` constants
- Correct the misleading comment in `BaseTerminal.vue`

## Validation

- `npm --prefix frontend test` — new `sessionStore` tests cover monotonic sequence, gap replay across a trim, best-effort tail, and fully-consumed cases
- `npm --prefix frontend run build`

Closes #88

---

## 摘要

修复后台标签页下长时间 SSH 命令输出中断的问题。一个约 20 分钟、日志量很大的编译，输出会在某处停住，即使命令其实已经执行完、shell 已回到提示符；该问题主要在标签页切到后台时出现。

## 原因

`BaseTerminal` 用 `writtenChunks` 记录已写入的输出量，KeepAlive 恢复时从 `sessionStore` 补齐缺口。但 store 缓冲区上限为 2000 个 chunk，超出后从**头部**裁剪到 1000，而记录的位置用的是**绝对数组下标**。

后台大量输出超过上限触发裁剪后，`getChunkCount()`（数组长度）会**小于**记录的 `writtenChunks`，于是 `onActivated` 里 `total > writtenChunks` 判断为假，缺口从未被补齐，终端看起来就"停住"了。（旧注释还声称按 chunk 下标追踪能不受裁剪影响——实际不能，因为头部裁剪会让所有下标偏移。）

## 改动

- 改用每会话单调递增的序号 `seq` 追踪输出位置，头部裁剪不会重置它
- `getChunkCount` 返回 `seq`；`getDataFromChunk` 把记录的 `seq` 换算为当前缓冲区偏移，位置已被裁剪时返回尽力而为的尾部（保证最新输出——含最后的提示符——不丢失）
- 用统一的 `pushChunk` 辅助函数集中缓冲/裁剪逻辑，并用命名常量 `MAX_CHUNKS` / `TRIM_TO`
- 修正 `BaseTerminal.vue` 中的误导性注释

## 验证

- `npm --prefix frontend test` —— 新增 `sessionStore` 测试覆盖：单调序号、跨裁剪补齐、尽力尾部、完全消费
- `npm --prefix frontend run build`
