### PR TITLE
fix(terminal): use ANSI theme colors for keyword highlighting (#92)

### DIFF
--- a/frontend/src/composables/useHighlight.ts
+++ b/frontend/src/composables/useHighlight.ts
@@ -28,21 +28,24 @@ function segmentText(text: string): { text: string; isCSI: boolean }[] {
 }
 
 // ── Color palette ──
-// 256-color SGR codes: \x1b[38;5;{n}m for foreground
-// Add '4;' prefix for underline, e.g. \x1b[4;38;5;{n}m
-const FG = (n: number) => `\x1b[38;5;${n}m`
-const UNDERLINE_FG = (n: number) => `\x1b[4;38;5;${n}m`
+// Use ANSI standard SGR codes (30-37 / 90-97) instead of 256-color palette
+// indices so that highlight colors follow the terminal theme's ANSI color
+// definitions and always match the background.
+//
+// Standard: 30=black 31=red 32=green 33=yellow 34=blue 35=magenta 36=cyan 37=white
+// Bright:   90=brightBlack 91=brightRed 92=brightGreen 93=brightYellow
+//           94=brightBlue 95=brightMagenta 96=brightCyan 97=brightWhite
 const C = {
-  url:       UNDERLINE_FG(39),
-  ip:        FG(82),
-  path:      FG(177),
-  datetime:  FG(39),
-  string:    FG(215),
-  error:     FG(203),
-  warning:   FG(221),
-  info:      FG(75),
-  brace:     FG(223),
-  number:    FG(152),
+  url:       '\x1b[4;34m',   // blue + underline
+  ip:        '\x1b[32m',     // green
+  path:      '\x1b[35m',     // magenta
+  datetime:  '\x1b[94m',     // bright blue
+  string:    '\x1b[33m',     // yellow
+  error:     '\x1b[31m',     // red
+  warning:   '\x1b[93m',     // bright yellow
+  info:      '\x1b[36m',     // cyan
+  brace:     '\x1b[95m',     // bright magenta
+  number:    '\x1b[96m',     // bright cyan
 } as const
 
 // Patterns grouped by color type, ordered longest-first

--- a/frontend/src/composables/useTerminal.ts
+++ b/frontend/src/composables/useTerminal.ts
@@ -58,25 +58,25 @@ export function getXtermTheme(name: string): any {
     case 'uniterm-light':
       return {
         background: '#fafafa',
-        foreground: '#1f1f1f',
-        cursor: '#007acc',
-        selectionBackground: 'rgba(0, 122, 204, 0.2)',
+        foreground: '#2c2c2c',
+        cursor: '#1976d2',
+        selectionBackground: 'rgba(25, 118, 210, 0.15)',
         black: '#1e1e22',
         red: '#d32f2f',
         green: '#388e3c',
-        yellow: '#f9a825',
+        yellow: '#c68600',
         blue: '#1976d2',
         magenta: '#7b1fa2',
         cyan: '#00838f',
-        white: '#e0e0e0',
-        brightBlack: '#616161',
-        brightRed: '#e57373',
-        brightGreen: '#81c784',
-        brightYellow: '#fff176',
-        brightBlue: '#64b5f6',
-        brightMagenta: '#ba68c8',
-        brightCyan: '#4dd0e1',
-        brightWhite: '#ffffff'
+        white: '#9e9e9e',
+        brightBlack: '#555555',
+        brightRed: '#c62828',
+        brightGreen: '#2e7d32',
+        brightYellow: '#b87a00',
+        brightBlue: '#1565c0',
+        brightMagenta: '#6a1b9a',
+        brightCyan: '#006064',
+        brightWhite: '#424242'
       }
     case 'solarized-dark':
       return {


### PR DESCRIPTION
Replace hardcoded 256-color palette indices with ANSI standard SGR codes (30-37 / 90-97) so keyword highlight colors adapt to the active terminal theme instead of staying fixed.

### Changes

**useHighlight.ts** — Replace 256-color palette indices with ANSI standard SGR codes:

| Category | Before | After |
|----------|--------|-------|
| url | 256-color 39 | blue (34) + underline |
| ip | 256-color 82 | green (32) |
| path | 256-color 177 | magenta (35) |
| datetime | 256-color 39 | bright blue (94) |
| string | 256-color 215 | yellow (33) |
| error | 256-color 203 | red (31) |
| warning | 256-color 221 | bright yellow (93) |
| info | 256-color 75 | cyan (36) |
| brace | 256-color 223 | bright magenta (95) |
| number | 256-color 152 | bright cyan (96) |

**useTerminal.ts** — Redesign uniterm-light theme: bright colors changed from pastel/light to darker, more saturated tones for proper contrast on light background.

Closes #92

---

将关键字高亮的 256 色调色板索引替换为 ANSI 标准 SGR 码（30-37 / 90-97），使高亮颜色跟随终端主题自动适配。同时重新设计 uniterm-light 主题的 bright 配色，在浅色背景下获得更好的对比度。

Closes #92