### PR TITLE
fix(terminal): paste file path on drop in local terminal instead of rz (#105)

### DIFF
--- a/frontend/src/components/BaseTerminal.vue
+++ b/frontend/src/components/BaseTerminal.vue
@@ -266,6 +266,29 @@ function onDragDrop(e: DragEvent) {
   handleDroppedFiles(props.sessionId, Array.from(files))
 }
 
+// Convert a Windows native path to the format expected by the active shell.
+// - PowerShell / cmd: keep C:\foo\bar (native)
+// - Git Bash / MSYS2 / Cygwin / MinGW: /c/foo/bar
+// - WSL: /mnt/c/foo/bar
+function toShellPath(nativePath: string, shellPath?: string): string {
+  const isWinPath = /^[A-Za-z]:\\/.test(nativePath)
+  if (!isWinPath) return nativePath.replace(/\\/g, '/')
+
+  const lower = (shellPath || '').toLowerCase()
+  let converted: string
+  if (lower.includes('wsl')) {
+    const drive = nativePath.charAt(0).toLowerCase()
+    converted = '/mnt/' + drive + nativePath.slice(2).replace(/\\/g, '/')
+  } else if (lower.includes('bash') || lower.includes('git') || lower.includes('msys') || lower.includes('cygwin') || lower.includes('mingw')) {
+    const drive = nativePath.charAt(0).toLowerCase()
+    converted = '/' + drive + nativePath.slice(2).replace(/\\/g, '/')
+  } else {
+    converted = nativePath
+  }
+  // Quote paths with spaces so the shell treats them as a single argument
+  return converted.includes(' ') ? `"${converted}"` : converted
+}
+
 async function handleDroppedFiles(sessionId: string, files: File[]) {
   const paths: string[] = []
   for (const f of files) {
@@ -288,6 +311,16 @@ async function handleDroppedFiles(sessionId: string, files: File[]) {
   }
   if (paths.length === 0) return
 
+  // Local terminal: paste file paths as input, adapting format to the shell
+  if (props.mode === 'local') {
+    const panel = panelStore.getPanel(props.panelId || '')
+    const shellPath = panel?.config?.shellPath
+    const text = paths.map(p => toShellPath(p, shellPath)).join(' ')
+    SessionWrite(sessionId, text)
+    return
+  }
+
+  // Remote terminal: trigger zmodem upload
   zmodemStore.setPendingUploadFiles(sessionId, paths)
   SessionWrite(sessionId, 'rz -be\n')
 }


### PR DESCRIPTION
When dragging files into a local terminal, insert the file path as input text instead of triggering zmodem rz. Path format adapts to the active shell:

- **PowerShell / cmd**: native Windows path (C:\foo\bar)
- **Git Bash / MSYS2 / Cygwin**: Unix-style (/c/foo/bar)
- **WSL**: /mnt/c/foo/bar
- **macOS / Linux**: unchanged

Remote terminals (SSH) continue to use rz for zmodem upload.

Closes #105

---

本地终端拖入文件时，不再触发 rz，而是直接将文件路径粘贴为终端输入。路径格式根据 shell 类型自动适配：PowerShell/cmd 保持 Windows 原生路径，Git Bash 转为 /c/xxx 格式，WSL 转为 /mnt/c/xxx 格式，macOS/Linux 保持 Unix 路径。

Closes #105