### PR TITLE
fix(serial): remove local echo to prevent double keystrokes (#106)

### DIFF
--- a/backend/session/serial_session.go
+++ b/backend/session/serial_session.go
@@ -121,11 +121,6 @@ func (s *SerialSession) Write(data []byte) error {
 		return fmt.Errorf("serial port not connected")
 	}
 	_, err := s.port.Write(data)
-	if err == nil && !s.IsZmodemMode() {
-		// Local echo: serial devices typically don't echo, so we
-		// echo input back to the terminal so the user can see typing.
-		s.emitData(data)
-	}
 	return err
 }
 


### PR DESCRIPTION
SerialSession.Write() was unconditionally echoing input back to the frontend, causing each character to appear twice when the connected serial device also provides echo (which is the default for most interactive consoles, UART shells, and network equipment CLIs).

This change removes the local echo so serial sessions behave consistently with SSH and Telnet sessions, which rely solely on remote echo.

Closes #106

---

SerialSession.Write() 无条件将输入回显到前端，当串口设备自身也回显时（大多数交互式控制台默认开启），每个字符会出现两次。去掉本地回显，与 SSH、Telnet 行为保持一致，全部依赖远程回显。

Closes #106