### PR TITLE
fix(settings): add min-width and horizontal scrollbar to prevent column squeezing (#98)

### DIFF
--- a/frontend/src/components/SettingsTab.vue
+++ b/frontend/src/components/SettingsTab.vue
@@ -789,6 +789,7 @@ function getShellLabel(path: string): string {
 .settings-tab {
   display: flex;
   width: 100%;
+  min-width: 680px;
   max-width: 960px;
   height: 100%;
   margin: 0 auto;

--- a/frontend/src/components/SettingsTabContent.vue
+++ b/frontend/src/components/SettingsTabContent.vue
@@ -13,7 +13,7 @@ import SettingsTab from './SettingsTab.vue'
   flex: 1;
   display: flex;
   flex-direction: column;
-  overflow: hidden;
+  overflow: auto;
   background: var(--bg-base);
 }
 </style>


### PR DESCRIPTION
Settings page columns were being squeezed at narrow window widths, causing labels, controls, and the sidebar to overlap or get clipped.

### Changes

- **SettingsTab.vue**: Add  to  to ensure sidebar (180px), panel padding (64px), controls (210px), and text labels all have enough room
- **SettingsTabContent.vue**: Change  to  so a horizontal scrollbar appears when the container is narrower than the settings content

Note: The dialog modals constrained within the app window is a Wails v2 framework limitation and will be revisited when Wails v3 is stable.

Closes #98

---

设置页面在窗口较窄时列布局被挤压，标签、控件和侧边栏重叠或被裁切。

- **SettingsTab.vue**: 给  添加 ，确保侧边栏(180px)、面板padding(64px)、控件(210px)和文字标签都有足够空间
- **SettingsTabContent.vue**:  改为 ，容器窄于内容时显示横向滚动条

弹窗限制在窗口内的问题是 Wails v2 框架限制，等 v3 稳定后再处理。

Closes #98