### PR TITLE
refactor(theme): unify color system and button styles across components

### DIFF
--- a/frontend/src/components/AIMessage.vue
+++ b/frontend/src/components/AIMessage.vue
@@ -509,7 +509,7 @@ function escapeHtml(text: string): string {
   height: 26px;
   border-radius: 50%;
   background: linear-gradient(135deg, var(--accent-dim), var(--accent));
-  color: #fff;
+  color: var(--on-accent);
   font-size: 9px;
   font-family: var(--font-ui);
   font-weight: 600;
@@ -625,10 +625,10 @@ function escapeHtml(text: string): string {
 
 /* Links */
 .text :deep(a) {
-  color: #6db3f8;
+  color: var(--info);
 }
 .text :deep(a:hover) {
-  color: #93cbf9;
+  color: var(--info);
 }
 
 /* Strikethrough */
@@ -739,11 +739,11 @@ function escapeHtml(text: string): string {
 
 /* IN box - success themed */
 .in-box {
-  background: rgba(52, 211, 153, 0.04);
-  border: 1px solid rgba(52, 211, 153, 0.15);
+  background: var(--success-subtle);
+  border: 1px solid var(--success-glow);
 }
 .in-box .tool-box-header {
-  background: rgba(52, 211, 153, 0.08);
+  background: var(--success-subtle);
 }
 .in-box .tool-box-label {
   background: var(--success);
@@ -795,7 +795,7 @@ function escapeHtml(text: string): string {
 }
 .out-box .tool-box-label {
   background: var(--accent-dim);
-  color: #fff;
+  color: var(--on-accent);
 }
 .tool-pairs {
   display: flex;
@@ -831,7 +831,7 @@ function escapeHtml(text: string): string {
 }
 .pending-tool.dangerous {
   border-color: var(--error);
-  background: rgba(248, 113, 113, 0.04);
+  background: var(--error-subtle);
 }
 .danger-badge {
   margin-left: 8px;
@@ -840,7 +840,7 @@ function escapeHtml(text: string): string {
   padding: 1px 6px;
   border-radius: 3px;
   background: var(--error);
-  color: #fff;
+  color: var(--on-accent);
   text-transform: uppercase;
 }
 .pending-tool {

--- a/frontend/src/components/AISidebar.vue
+++ b/frontend/src/components/AISidebar.vue
@@ -699,7 +699,7 @@ defineExpose({ focusInput })
   opacity: 1;
 }
 :deep(.el-dropdown-menu__item.active) {
-  background: rgba(52, 211, 153, 0.08);
+  background: var(--success-subtle);
   color: var(--success);
 }
 
@@ -783,7 +783,7 @@ defineExpose({ focusInput })
   height: 26px;
   border-radius: 50%;
   background: linear-gradient(135deg, var(--accent-dim), var(--accent));
-  color: #fff;
+  color: var(--on-accent);
   font-size: 9px;
   font-family: var(--font-ui);
   font-weight: 600;

--- a/frontend/src/components/AppHeader.vue
+++ b/frontend/src/components/AppHeader.vue
@@ -229,7 +229,7 @@ onUnmounted(() => {
 
 .header-btn.accent {
   background: linear-gradient(135deg, var(--accent-dim), var(--accent));
-  color: #fff;
+  color: var(--on-accent);
   box-shadow: 0 0 0 1px var(--accent-glow), 0 2px 8px var(--accent-glow);
 }
 

--- a/frontend/src/components/ConnectionForm.vue
+++ b/frontend/src/components/ConnectionForm.vue
@@ -763,15 +763,15 @@ function onConnect() {
   margin-bottom: 4px;
   cursor: pointer;
   user-select: none;
-  color: var(--text-secondary, #909399);
+  color: var(--text-secondary);
   font-size: 13px;
   font-weight: 500;
-  border-bottom: 1px solid var(--border-subtle, #e4e7ed);
+  border-bottom: 1px solid var(--border-subtle);
   transition: color 0.15s;
 }
 
 .advanced-toggle:hover {
-  color: var(--accent, #409eff);
+  color: var(--accent);
 }
 
 .advanced-arrow {

--- a/frontend/src/components/DBObjectList.vue
+++ b/frontend/src/components/DBObjectList.vue
@@ -6,7 +6,7 @@
         class="object-search"
         :placeholder="t('db.searchTables')"
       />
-      <button class="exec-btn" @click="openNewTable">{{ t('db.newTable') }}</button>
+      <button class="btn btn-primary" @click="openNewTable">{{ t('db.newTable') }}</button>
     </div>
     <el-table
       :data="filtered"
@@ -32,17 +32,17 @@
         <template #default="{ row }">
           <button
             v-if="row.type === 'view'"
-            class="action-icon-btn danger"
+            class="btn btn-ghost btn-icon btn-sm danger"
             :title="t('db.dropView')"
             @click.stop="askDropView(row)"
           >
             <Trash2 :size="14" />
           </button>
           <template v-else>
-            <button class="action-icon-btn" :title="t('db.truncateTable')" @click.stop="askTruncate(row)">
+            <button class="btn btn-ghost btn-icon btn-sm" :title="t('db.truncateTable')" @click.stop="askTruncate(row)">
               <Eraser :size="14" />
             </button>
-            <button class="action-icon-btn danger" :title="t('db.dropTable')" @click.stop="askDrop(row)">
+            <button class="btn btn-ghost btn-icon btn-sm danger" :title="t('db.dropTable')" @click.stop="askDrop(row)">
               <Trash2 :size="14" />
             </button>
           </template>
@@ -251,21 +251,7 @@ async function onCreateTable() {
 .object-search::placeholder {
   color: var(--text-muted);
 }
-.exec-btn {
-  padding: 4px 16px;
-  background: var(--accent);
-  color: #fff;
-  border: none;
-  border-radius: var(--radius-sm);
-  cursor: pointer;
-  font-family: var(--font-ui);
-  font-size: 13px;
-  transition: all 0.15s ease;
-}
-.exec-btn:hover {
-  background: var(--accent-dim);
-  box-shadow: 0 0 12px var(--accent-glow);
-}
+
 .object-table {
   flex: 1;
   min-height: 0;
@@ -283,22 +269,6 @@ async function onCreateTable() {
 .object-icon {
   color: var(--text-muted);
   flex-shrink: 0;
-}
-.action-icon-btn {
-  border: none;
-  background: none;
-  color: var(--text-secondary);
-  cursor: pointer;
-  padding: 2px 4px;
-  border-radius: var(--radius-sm);
-  transition: color 0.15s ease, background 0.15s ease;
-}
-.action-icon-btn:hover {
-  color: var(--text-primary);
-  background: var(--bg-hover);
-}
-.action-icon-btn.danger:hover {
-  color: var(--error);
 }
 .confirm-body {
   display: flex;

--- a/frontend/src/components/DBQueryEditor.vue
+++ b/frontend/src/components/DBQueryEditor.vue
@@ -4,7 +4,7 @@
       <div class="loading-box">
         <div class="spinner" />
         <span class="loading-text">{{ t('db.loading') }}</span>
-        <button class="cancel-btn" @click="onCancelQuery">{{ t('common.cancel') }}</button>
+        <button class="btn btn-default" @click="onCancelQuery">{{ t('common.cancel') }}</button>
       </div>
     </div>
     <div class="editor-top" :style="{ height: topHeight + 'px' }">
@@ -16,7 +16,7 @@
           @keydown="onKeydown"
         />
         <div class="exec-btn-wrapper">
-          <button class="exec-btn exec-btn-overlay" @click="onExecute">{{ t('db.execute') }}</button>
+          <button class="btn btn-primary exec-btn-overlay" @click="onExecute">{{ t('db.execute') }}</button>
           <span class="shortcut-hint">Ctrl+Enter</span>
         </div>
       </div>
@@ -43,8 +43,8 @@
             fixed="right"
           >
             <template #default="{ $index }">
-              <button class="action-icon-btn" title="Edit" @click="startEditRow($index)"><Pencil :size="14" /></button>
-              <button class="action-icon-btn danger" title="Delete" @click="onDeleteRow($index)"><Trash2 :size="14" /></button>
+              <button class="btn btn-ghost btn-icon btn-sm" title="Edit" @click="startEditRow($index)"><Pencil :size="14" /></button>
+              <button class="btn btn-ghost btn-icon btn-sm danger" title="Delete" @click="onDeleteRow($index)"><Trash2 :size="14" /></button>
             </template>
           </el-table-column>
           <el-table-column
@@ -78,7 +78,7 @@
       </div>
 
       <div v-if="queryResult && tableName && !isView" class="insert-row-bar">
-        <button class="exec-btn" @click="startInsertRow">{{ t('db.insertRow') }}</button>
+        <button class="btn btn-primary" @click="startInsertRow">{{ t('db.insertRow') }}</button>
       </div>
 
       <div v-if="insertingRow" class="insert-row-form">
@@ -93,8 +93,8 @@
           </div>
         </div>
         <div class="insert-actions">
-          <button class="exec-btn" @click="onInsertConfirm">{{ t('common.confirm') }}</button>
-          <button class="cancel-btn" @click="onInsertCancel">{{ t('common.cancel') }}</button>
+          <button class="btn btn-primary" @click="onInsertConfirm">{{ t('common.confirm') }}</button>
+          <button class="btn btn-default" @click="onInsertCancel">{{ t('common.cancel') }}</button>
         </div>
       </div>
 
@@ -109,8 +109,8 @@
           </div>
         </div>
         <div class="insert-actions">
-          <button class="exec-btn" @click="onEditRowConfirm">{{ t('common.save') }}</button>
-          <button class="cancel-btn" @click="onEditRowCancel">{{ t('common.cancel') }}</button>
+          <button class="btn btn-primary" @click="onEditRowConfirm">{{ t('common.save') }}</button>
+          <button class="btn btn-default" @click="onEditRowCancel">{{ t('common.cancel') }}</button>
         </div>
       </div>
     </div>
@@ -548,21 +548,6 @@ function onEditRowCancel() {
   font-size: 13px;
   color: var(--text-secondary);
 }
-.cancel-btn {
-  padding: 4px 16px;
-  background: var(--bg-elevated);
-  color: var(--text-primary);
-  border: 1px solid var(--border-subtle);
-  border-radius: var(--radius-sm);
-  cursor: pointer;
-  font-family: var(--font-ui);
-  font-size: 13px;
-  transition: all 0.15s ease;
-}
-.cancel-btn:hover {
-  background: var(--bg-hover);
-  border-color: var(--border-hover);
-}
 .editor-top {
   flex-shrink: 0;
   display: flex;
@@ -630,25 +615,10 @@ function onEditRowCancel() {
   flex-direction: column;
   min-height: 0;
 }
-.exec-btn {
-  padding: 4px 16px;
-  background: var(--accent);
-  color: #fff;
-  border: none;
-  border-radius: var(--radius-sm);
-  cursor: pointer;
-  font-family: var(--font-ui);
-  font-size: 13px;
-  transition: all 0.15s ease;
-}
-.exec-btn:hover {
-  background: var(--accent-dim);
-  box-shadow: 0 0 12px var(--accent-glow);
-}
 .error-msg {
   color: var(--error);
   padding: 8px;
-  background: rgba(248, 113, 113, 0.1);
+  background: var(--error-subtle);
   border-radius: var(--radius-sm);
   margin-bottom: 8px;
   user-select: text;
@@ -687,20 +657,6 @@ function onEditRowCancel() {
   font-size: 13px;
   outline: none;
 }
-.action-icon-btn {
-  border: none;
-  background: none;
-  color: var(--text-secondary);
-  padding: 2px 4px;
-  border-radius: var(--radius-sm);
-  cursor: pointer;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  transition: all 0.12s ease;
-}
-.action-icon-btn:hover { color: var(--text-primary); background: var(--bg-hover); }
-.action-icon-btn.danger:hover { color: var(--error); }
 .insert-row-bar { padding: 4px 0; }
 .insert-row-form {
   border: 1px solid var(--accent);

--- a/frontend/src/components/DBTableStructure.vue
+++ b/frontend/src/components/DBTableStructure.vue
@@ -6,13 +6,13 @@
         <div class="loading-box">
           <div class="spinner" />
           <span class="loading-text">{{ t('db.loading') }}</span>
-          <button class="cancel-btn" @click="onCancelLoad">{{ t('common.cancel') }}</button>
+          <button class="btn btn-default" @click="onCancelLoad">{{ t('common.cancel') }}</button>
         </div>
       </div>
       <div class="section">
         <div class="section-header">
           <div class="section-title">{{ t('db.columns') }}</div>
-          <button class="exec-btn" @click="startAddColumn">{{ t('db.addColumn') }}</button>
+          <button class="btn btn-primary" @click="startAddColumn">{{ t('db.addColumn') }}</button>
         </div>
         <el-table :data="schema?.columns || []" border size="small" style="width:100%">
           <el-table-column prop="name" :label="t('db.colName')" />
@@ -35,8 +35,8 @@
           </el-table-column>
           <el-table-column :label="t('db.actions')" width="80">
             <template #default="{ row }">
-              <button v-if="caps?.['supportsModifyColumn']" class="action-icon-btn" title="Edit" @click="startEditColumn(row)"><Pencil :size="14" /></button>
-              <button class="action-icon-btn danger" title="Delete" @click="onDropColumn(row.name)"><Trash2 :size="14" /></button>
+              <button v-if="caps?.['supportsModifyColumn']" class="btn btn-ghost btn-icon btn-sm" title="Edit" @click="startEditColumn(row)"><Pencil :size="14" /></button>
+              <button class="btn btn-ghost btn-icon btn-sm danger" title="Delete" @click="onDropColumn(row.name)"><Trash2 :size="14" /></button>
             </template>
           </el-table-column>
         </el-table>
@@ -45,7 +45,7 @@
       <div class="section">
         <div class="section-header">
           <div class="section-title">{{ t('db.indexes') }}</div>
-          <button class="exec-btn" @click="startAddIndex">{{ t('db.addIndex') }}</button>
+          <button class="btn btn-primary" @click="startAddIndex">{{ t('db.addIndex') }}</button>
         </div>
         <el-table :data="schema?.indexes || []" border size="small" style="width:100%">
           <el-table-column prop="name" :label="t('db.idxName')" />
@@ -63,7 +63,7 @@
           </el-table-column>
           <el-table-column :label="t('db.actions')" width="80">
             <template #default="{ row }">
-              <button class="action-icon-btn danger" title="Delete" @click="onDropIndex(row)"><Trash2 :size="14" /></button>
+              <button class="btn btn-ghost btn-icon btn-sm danger" title="Delete" @click="onDropIndex(row)"><Trash2 :size="14" /></button>
             </template>
           </el-table-column>
         </el-table>
@@ -565,21 +565,6 @@ async function onAddIndex() {
   font-size: 13px;
   color: var(--text-secondary);
 }
-.cancel-btn {
-  padding: 4px 16px;
-  background: var(--bg-elevated);
-  color: var(--text-primary);
-  border: 1px solid var(--border-subtle);
-  border-radius: var(--radius-sm);
-  cursor: pointer;
-  font-family: var(--font-ui);
-  font-size: 13px;
-  transition: all 0.15s ease;
-}
-.cancel-btn:hover {
-  background: var(--bg-hover);
-  border-color: var(--border-hover);
-}
 .section {
   margin-bottom: 16px;
 }
@@ -624,43 +609,14 @@ async function onAddIndex() {
 }
 .toggle-btn.active {
   background: var(--accent);
-  color: #fff;
+  color: var(--on-accent);
   border-color: var(--accent);
 }
 .toggle-btn:disabled {
   opacity: 0.4;
   cursor: not-allowed;
 }
-.action-icon-btn {
-  border: none;
-  background: none;
-  color: var(--text-secondary);
-  padding: 2px 4px;
-  border-radius: var(--radius-sm);
-  cursor: pointer;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  transition: all 0.12s ease;
-}
-.action-icon-btn:hover { color: var(--text-primary); background: var(--bg-hover); }
-.action-icon-btn.danger:hover { color: var(--error); }
-.exec-btn {
-  padding: 4px 16px;
-  background: var(--accent);
-  color: #fff;
-  border: none;
-  border-radius: var(--radius-sm);
-  cursor: pointer;
-  font-family: var(--font-ui);
-  font-size: 13px;
-  margin-top: 4px;
-  transition: all 0.15s ease;
-}
-.exec-btn:hover {
-  background: var(--accent-dim);
-  box-shadow: 0 0 12px var(--accent-glow);
-}
+.exec-btn { margin-top: 4px; }
 .idx-type {
   font-size: 11px;
   font-weight: 600;
@@ -668,7 +624,7 @@ async function onAddIndex() {
   border-radius: var(--radius-sm);
 }
 .idx-type-pk { color: var(--accent); }
-.idx-type-uq { color: var(--info, #409eff); }
+.idx-type-uq { color: var(--info); }
 .idx-type-idx { color: var(--text-secondary); }
 </style>
 

--- a/frontend/src/components/HistoryPanel.vue
+++ b/frontend/src/components/HistoryPanel.vue
@@ -301,7 +301,7 @@ watch(searchQuery, () => {
   flex: 1;
   font-family: var(--font-mono, 'Consolas', 'Courier New', monospace);
   font-size: 12px;
-  color: var(--text-muted);
+  color: var(--text-secondary);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/frontend/src/components/HistoryPanel.vue
+++ b/frontend/src/components/HistoryPanel.vue
@@ -25,10 +25,10 @@
       >
         <span class="history-command">{{ entry.command }}</span>
         <div v-if="selectedIds.size <= 1 && (selectedIds.has(entry.id) || hoveredId === entry.id)" class="qc-item-actions">
-          <button class="qc-action-btn run" @click.stop="runCommand(entry)" :title="t('quickCommands.run')">
+          <button class="btn btn-ghost btn-icon btn-sm run" @click.stop="runCommand(entry)" :title="t('quickCommands.run')">
             <Play :size="14" />
           </button>
-          <button class="qc-action-btn paste" @click.stop="pasteCommand(entry)" :title="t('quickCommands.paste')">
+          <button class="btn btn-ghost btn-icon btn-sm paste" @click.stop="pasteCommand(entry)" :title="t('quickCommands.paste')">
             <Clipboard :size="14" />
           </button>
         </div>
@@ -288,7 +288,7 @@ watch(searchQuery, () => {
   font-size: 12px;
   color: var(--text-primary);
   background: var(--bg-overlay);
-  border: 1px solid var(--border-color);
+  border: 1px solid var(--border-subtle);
   border-radius: 4px;
   box-shadow: var(--shadow-md);
   pointer-events: none;
@@ -351,23 +351,6 @@ watch(searchQuery, () => {
   flex-shrink: 0;
 }
 
-.qc-action-btn {
-  width: 24px;
-  height: 24px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
-  color: var(--text-muted);
-  background: transparent;
-}
-
-.qc-action-btn:hover { color: var(--text-primary); background: var(--bg-hover); }
-.qc-action-btn.run:hover { color: var(--success-color, #22c55e); }
-.qc-action-btn.paste:hover { color: var(--accent-color, #22d3ee); }
-
 .qc-empty {
   padding: 24px 12px;
   text-align: center;
@@ -379,7 +362,7 @@ watch(searchQuery, () => {
   position: fixed;
   z-index: 9999;
   background: var(--bg-surface);
-  border: 1px solid var(--border-color);
+  border: 1px solid var(--border-subtle);
   border-radius: 6px;
   box-shadow: var(--shadow-lg);
   padding: 4px;
@@ -395,12 +378,12 @@ watch(searchQuery, () => {
 }
 
 .qc-context-menu .menu-item:hover { background: var(--bg-hover); }
-.qc-context-menu .menu-item.danger { color: var(--danger-color, #f56c6c); }
+.qc-context-menu .menu-item.danger { color: var(--error); }
 .qc-context-menu .menu-item.disabled { color: var(--text-disabled); pointer-events: none; }
 
 .qc-context-menu .menu-divider {
   height: 1px;
-  background: var(--border-color);
+  background: var(--border-subtle);
   margin: 4px 6px;
 }
 </style>

--- a/frontend/src/components/MonitorTabContent.vue
+++ b/frontend/src/components/MonitorTabContent.vue
@@ -377,28 +377,28 @@ const perfItems = computed(() => [
     label: t('monitor.cpu'),
     value: currentCpu.value.usage + '%',
     percent: Math.min(currentCpu.value.usage, 100),
-    color: '#4ade80'
+    color: 'var(--chart-1)'
   },
   {
     key: 'memory',
     label: t('monitor.memory'),
     value: currentMem.value.usage + '%',
     percent: Math.min(currentMem.value.usage, 100),
-    color: '#60a5fa'
+    color: 'var(--chart-2)'
   },
   {
     key: 'disk',
     label: t('monitor.disk'),
     value: currentDisk.value.usage + '%',
     percent: Math.min(currentDisk.value.usage, 100),
-    color: '#fbbf24'
+    color: 'var(--chart-3)'
   },
   {
     key: 'network',
     label: t('monitor.network'),
     value: formatBytes(currentNet.value.rx + currentNet.value.tx) + '/s',
     percent: Math.min((currentNet.value.rx + currentNet.value.tx) / 1048576 * 100, 100),
-    color: '#a78bfa'
+    color: 'var(--chart-4)'
   }
 ])
 
@@ -407,7 +407,7 @@ const currentPerf = computed(() => {
     case 'cpu':
       return {
         bigValue: currentCpu.value.usage + '%',
-        color: '#4ade80',
+        color: 'var(--chart-1)',
         history: cpuHistory.value,
         yMin: 0,
         yMax: 100,
@@ -423,7 +423,7 @@ const currentPerf = computed(() => {
     case 'memory':
       return {
         bigValue: currentMem.value.usage + '%',
-        color: '#60a5fa',
+        color: 'var(--chart-2)',
         history: memHistory.value,
         yMin: 0,
         yMax: 100,
@@ -438,7 +438,7 @@ const currentPerf = computed(() => {
     case 'disk':
       return {
         bigValue: currentDisk.value.usage + '%',
-        color: '#fbbf24',
+        color: 'var(--chart-3)',
         history: diskHistory.value,
         yMin: 0,
         yMax: 100,
@@ -450,8 +450,8 @@ const currentPerf = computed(() => {
     case 'network':
       return {
         bigValue: formatBytes(currentNet.value.rx + currentNet.value.tx) + '/s',
-        color: '#a78bfa',
-        color2: '#c4b5fd',
+        color: 'var(--chart-4)',
+        color2: 'var(--chart-4-alt)',
         history: netRxHistory.value,
         history2: netTxHistory.value,
         yMin: 0,
@@ -461,7 +461,7 @@ const currentPerf = computed(() => {
         ]
       }
     default:
-      return { bigValue: '', color: '#fff', history: [] as number[], details: [] }
+      return { bigValue: '', color: 'var(--text-primary)', history: [] as number[], details: [] }
   }
 })
 
@@ -1105,7 +1105,7 @@ watch(activeTab, (tab) => {
   align-items: baseline;
   padding: 8px 0;
   gap: 40px;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.03);
+  border-bottom: 1px solid var(--border-subtle);
 }
 
 .system-row:last-child {
@@ -1222,7 +1222,7 @@ watch(activeTab, (tab) => {
   background: var(--bg-elevated);
   border: 1px solid var(--border-subtle);
   border-radius: var(--radius-sm);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  box-shadow: var(--shadow-md);
   padding: 4px 0;
   min-width: 100px;
 }

--- a/frontend/src/components/Panel.vue
+++ b/frontend/src/components/Panel.vue
@@ -277,8 +277,8 @@ watch(() => props.isActive, (active) => {
   border-bottom-color: var(--accent-dim);
 }
 .panel-header.ai-locked {
-  border-left: 3px solid var(--warning, #f59e0b);
-  box-shadow: inset 0 0 12px rgba(245, 158, 11, 0.12);
+  border-left: 3px solid var(--warning);
+  box-shadow: inset 0 0 12px var(--warning-subtle);
 }
 .panel-title {
   font-size: 12px;
@@ -322,7 +322,7 @@ watch(() => props.isActive, (active) => {
   background: var(--bg-hover);
 }
 .panel-broadcast.active {
-  color: var(--accent, #22d3ee);
+  color: var(--accent);
   background: var(--accent-subtle);
 }
 .broadcast-icon {
@@ -347,7 +347,7 @@ watch(() => props.isActive, (active) => {
   background: var(--bg-hover);
 }
 .panel-ai-lock.locked {
-  color: var(--warning, #f59e0b);
+  color: var(--warning);
 }
 .panel-duplicate {
   background: none;

--- a/frontend/src/components/QuickCommandEditDialog.vue
+++ b/frontend/src/components/QuickCommandEditDialog.vue
@@ -147,7 +147,7 @@ function resetForm() {
   font-family: var(--font-mono, 'Consolas', 'Courier New', monospace);
 }
 .form-error {
-  color: var(--danger-color, #f56c6c);
+  color: var(--error);
   font-size: 12px;
   margin-top: -8px;
   margin-bottom: 8px;

--- a/frontend/src/components/QuickCommandsPanel.vue
+++ b/frontend/src/components/QuickCommandsPanel.vue
@@ -666,7 +666,7 @@ watch(searchQuery, (q) => {
 
 .qc-item-cmd {
   font-size: 12px;
-  color: var(--text-muted);
+  color: var(--text-secondary);
   font-family: var(--font-mono, 'Consolas', 'Courier New', monospace);
   white-space: nowrap;
   overflow: hidden;

--- a/frontend/src/components/QuickCommandsPanel.vue
+++ b/frontend/src/components/QuickCommandsPanel.vue
@@ -62,10 +62,10 @@
               <div class="qc-item-cmd" :class="{ 'qc-item-cmd-only': !cmd.name }">{{ cmd.command }}</div>
             </div>
             <div v-if="selectedId === cmd.id || hoveredId === cmd.id" class="qc-item-actions">
-              <button class="qc-action-btn run" @click.stop="runCommand(cmd)" :title="t('quickCommands.run')">
+              <button class="btn btn-ghost btn-icon btn-sm run" @click.stop="runCommand(cmd)" :title="t('quickCommands.run')">
                 <Play :size="14" />
               </button>
-              <button class="qc-action-btn paste" @click.stop="pasteCommand(cmd)" :title="t('quickCommands.paste')">
+              <button class="btn btn-ghost btn-icon btn-sm paste" @click.stop="pasteCommand(cmd)" :title="t('quickCommands.paste')">
                 <Clipboard :size="14" />
               </button>
             </div>
@@ -93,10 +93,10 @@
             <div class="qc-item-cmd" :class="{ 'qc-item-cmd-only': !cmd.name }">{{ cmd.command }}</div>
           </div>
           <div v-if="selectedId === cmd.id || hoveredId === cmd.id" class="qc-item-actions">
-            <button class="qc-action-btn run" @click.stop="runCommand(cmd)" :title="t('quickCommands.run')">
+            <button class="btn btn-ghost btn-icon btn-sm run" @click.stop="runCommand(cmd)" :title="t('quickCommands.run')">
               <Play :size="14" />
             </button>
-            <button class="qc-action-btn paste" @click.stop="pasteCommand(cmd)" :title="t('quickCommands.paste')">
+            <button class="btn btn-ghost btn-icon btn-sm paste" @click.stop="pasteCommand(cmd)" :title="t('quickCommands.paste')">
               <Clipboard :size="14" />
             </button>
           </div>
@@ -138,10 +138,10 @@
               <div class="qc-item-cmd" :class="{ 'qc-item-cmd-only': !cmd.name }">{{ cmd.command }}</div>
             </div>
             <div v-if="selectedId === cmd.id || hoveredId === cmd.id" class="qc-item-actions">
-              <button class="qc-action-btn run" @click.stop="runCommand(cmd)" :title="t('quickCommands.run')">
+              <button class="btn btn-ghost btn-icon btn-sm run" @click.stop="runCommand(cmd)" :title="t('quickCommands.run')">
                 <Play :size="14" />
               </button>
-              <button class="qc-action-btn paste" @click.stop="pasteCommand(cmd)" :title="t('quickCommands.paste')">
+              <button class="btn btn-ghost btn-icon btn-sm paste" @click.stop="pasteCommand(cmd)" :title="t('quickCommands.paste')">
                 <Clipboard :size="14" />
               </button>
             </div>
@@ -551,7 +551,7 @@ watch(searchQuery, (q) => {
   gap: 4px;
   padding: 0 10px 6px;
   flex-shrink: 0;
-  border-bottom: 1px solid var(--border-color);
+  border-bottom: 1px solid var(--border-subtle);
 }
 
 .qc-search-input {
@@ -683,32 +683,6 @@ watch(searchQuery, (q) => {
   flex-shrink: 0;
 }
 
-.qc-action-btn {
-  width: 24px;
-  height: 24px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
-  color: var(--text-muted);
-  background: transparent;
-}
-
-.qc-action-btn:hover {
-  color: var(--text-primary);
-  background: var(--bg-hover);
-}
-
-.qc-action-btn.run:hover {
-  color: var(--success-color, #22c55e);
-}
-
-.qc-action-btn.paste:hover {
-  color: var(--accent-color, #22d3ee);
-}
-
 .qc-empty {
   padding: 24px 12px;
   text-align: center;
@@ -720,7 +694,7 @@ watch(searchQuery, (q) => {
   position: fixed;
   z-index: 9999;
   background: var(--bg-surface);
-  border: 1px solid var(--border-color);
+  border: 1px solid var(--border-subtle);
   border-radius: 6px;
   box-shadow: var(--shadow-lg);
   padding: 4px;
@@ -740,12 +714,12 @@ watch(searchQuery, (q) => {
 }
 
 .qc-context-menu .menu-item.danger {
-  color: var(--danger-color, #f56c6c);
+  color: var(--error);
 }
 
 .qc-context-menu .menu-divider {
   height: 1px;
-  background: var(--border-color);
+  background: var(--border-subtle);
   margin: 4px 6px;
 }
 

--- a/frontend/src/components/RDPTabContent.vue
+++ b/frontend/src/components/RDPTabContent.vue
@@ -156,24 +156,24 @@ watch(() => props.sessionId, (newId) => {
   align-items: center;
   justify-content: center;
   gap: 12px;
-  color: #999;
+  color: var(--text-muted);
   z-index: 10;
 }
-.rdp-error-text { color: #f56c6c; }
+.rdp-error-text { color: var(--error); }
 .rdp-statusbar {
   display: flex;
   align-items: center;
   gap: 8px;
   padding: 4px 12px;
-  background: #1e1e1e;
-  color: #999;
+  background: var(--bg-elevated);
+  color: var(--text-muted);
   font-size: 12px;
   flex-shrink: 0;
 }
 .rdp-status-dot {
   width: 8px; height: 8px;
   border-radius: 50%;
-  background: #67c23a;
+  background: var(--success);
 }
-.rdp-status-sep { color: #444; }
+.rdp-status-sep { color: var(--text-disabled); }
 </style>

--- a/frontend/src/components/RedisTabContent.vue
+++ b/frontend/src/components/RedisTabContent.vue
@@ -9,8 +9,8 @@
             <el-option v-for="n in 16" :key="n-1" :label="`${n-1} (${dbSizes[n-1] ?? '?'})`" :value="n-1" />
           </el-select>
           <el-input v-model="scanPattern" size="small" placeholder="*" style="flex: 1; min-width: 80px" @keyup.enter="onScan" />
-          <button class="action-icon-btn" title="Refresh" @click="onScan" style="flex-shrink: 0"><RefreshCw :size="14" /></button>
-          <button class="action-icon-btn" :title="t('redis.newKey')" @click="onShowNewKeyDialog" style="flex-shrink: 0"><Plus :size="14" /></button>
+          <button class="btn btn-ghost btn-icon btn-sm" title="Refresh" @click="onScan" style="flex-shrink: 0"><RefreshCw :size="14" /></button>
+          <button class="btn btn-ghost btn-icon btn-sm" :title="t('redis.newKey')" @click="onShowNewKeyDialog" style="flex-shrink: 0"><Plus :size="14" /></button>
         </div>
 
         <!-- Key list -->
@@ -81,7 +81,7 @@
                 </el-table-column>
                 <el-table-column width="50">
                   <template #default="{ $index }">
-                    <button class="action-icon-btn danger" title="Delete" @click="hashEntries.splice($index, 1)"><Trash2 :size="14" /></button>
+                    <button class="btn btn-ghost btn-icon btn-sm danger" title="Delete" @click="hashEntries.splice($index, 1)"><Trash2 :size="14" /></button>
                   </template>
                 </el-table-column>
               </el-table>
@@ -104,7 +104,7 @@
                 </el-table-column>
                 <el-table-column width="50">
                   <template #default="{ $index }">
-                    <button class="action-icon-btn danger" title="Delete" @click="listEntries.splice($index, 1)"><Trash2 :size="14" /></button>
+                    <button class="btn btn-ghost btn-icon btn-sm danger" title="Delete" @click="listEntries.splice($index, 1)"><Trash2 :size="14" /></button>
                   </template>
                 </el-table-column>
               </el-table>
@@ -122,7 +122,7 @@
                 </el-table-column>
                 <el-table-column width="50">
                   <template #default="{ $index }">
-                    <button class="action-icon-btn danger" title="Delete" @click="setEntries.splice($index, 1)"><Trash2 :size="14" /></button>
+                    <button class="btn btn-ghost btn-icon btn-sm danger" title="Delete" @click="setEntries.splice($index, 1)"><Trash2 :size="14" /></button>
                   </template>
                 </el-table-column>
               </el-table>
@@ -145,7 +145,7 @@
                 </el-table-column>
                 <el-table-column width="50">
                   <template #default="{ $index }">
-                    <button class="action-icon-btn danger" title="Delete" @click="zsetEntries.splice($index, 1)"><Trash2 :size="14" /></button>
+                    <button class="btn btn-ghost btn-icon btn-sm danger" title="Delete" @click="zsetEntries.splice($index, 1)"><Trash2 :size="14" /></button>
                   </template>
                 </el-table-column>
               </el-table>
@@ -198,7 +198,7 @@
                 <template #default="{ $index }"><el-input v-model="newHashEntries[$index].value" size="small" type="textarea" :rows="1" autosize /></template>
               </el-table-column>
               <el-table-column width="50">
-                <template #default="{ $index }"><button class="action-icon-btn danger" title="Delete" @click="newHashEntries.splice($index, 1)"><Trash2 :size="14" /></button></template>
+                <template #default="{ $index }"><button class="btn btn-ghost btn-icon btn-sm danger" title="Delete" @click="newHashEntries.splice($index, 1)"><Trash2 :size="14" /></button></template>
               </el-table-column>
             </el-table>
             <el-button size="small" style="margin-top: 4px" @click="newHashEntries.push({ field: '', value: '' })"><Plus :size="14" /></el-button>
@@ -218,7 +218,7 @@
                 <template #default="{ $index }"><el-input v-model="newListEntries[$index]" size="small" type="textarea" :rows="1" autosize /></template>
               </el-table-column>
               <el-table-column width="50">
-                <template #default="{ $index }"><button class="action-icon-btn danger" title="Delete" @click="newListEntries.splice($index, 1)"><Trash2 :size="14" /></button></template>
+                <template #default="{ $index }"><button class="btn btn-ghost btn-icon btn-sm danger" title="Delete" @click="newListEntries.splice($index, 1)"><Trash2 :size="14" /></button></template>
               </el-table-column>
             </el-table>
             <el-button size="small" style="margin-top: 4px" @click="newListEntries.push('')"><Plus :size="14" /></el-button>
@@ -233,7 +233,7 @@
                 <template #default="{ $index }"><el-input v-model="newSetEntries[$index]" size="small" type="textarea" :rows="1" autosize /></template>
               </el-table-column>
               <el-table-column width="50">
-                <template #default="{ $index }"><button class="action-icon-btn danger" title="Delete" @click="newSetEntries.splice($index, 1)"><Trash2 :size="14" /></button></template>
+                <template #default="{ $index }"><button class="btn btn-ghost btn-icon btn-sm danger" title="Delete" @click="newSetEntries.splice($index, 1)"><Trash2 :size="14" /></button></template>
               </el-table-column>
             </el-table>
             <el-button size="small" style="margin-top: 4px" @click="newSetEntries.push('')"><Plus :size="14" /></el-button>
@@ -250,7 +250,7 @@
                 <template #default="{ $index }"><el-input-number v-model="newZSetEntries[$index].score" size="small" controls-position="right" style="width: 100%" /></template>
               </el-table-column>
               <el-table-column width="50">
-                <template #default="{ $index }"><button class="action-icon-btn danger" title="Delete" @click="newZSetEntries.splice($index, 1)"><Trash2 :size="14" /></button></template>
+                <template #default="{ $index }"><button class="btn btn-ghost btn-icon btn-sm danger" title="Delete" @click="newZSetEntries.splice($index, 1)"><Trash2 :size="14" /></button></template>
               </el-table-column>
             </el-table>
             <el-button size="small" style="margin-top: 4px" @click="newZSetEntries.push({ member: '', score: 0 })"><Plus :size="14" /></el-button>
@@ -767,24 +767,12 @@ watch(() => props.sessionId, async (newId) => {
   align-items: center;
   justify-content: center;
 }
-.action-icon-btn {
-  border: none;
-  background: none;
-  color: var(--text-secondary);
-  cursor: pointer;
-  padding: 2px 4px;
-  border-radius: var(--radius-sm);
-  font-size: 14px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  transition: all 0.15s ease;
-}
-.action-icon-btn:hover { color: var(--text-primary); background: var(--bg-hover); }
-.action-icon-btn:disabled { opacity: 0.3; cursor: default; }
-.action-icon-btn:disabled:hover { color: var(--text-secondary); background: none; }
-.action-icon-btn.danger:hover { color: var(--error); }
-:deep(.el-table .action-icon-btn) { background: none; }
+/* .btn.btn-ghost.btn-icon(.danger) now supplies the base look; keep only
+   Redis-specific overrides here (font-size for icon glyphs, table-cell reset). */
+.btn-icon.is-disabled,
+.btn-icon:disabled { opacity: 0.3; cursor: default; }
+.btn-icon:disabled:hover { color: var(--text-secondary); background: none; }
+:deep(.el-table .btn-icon) { background: none; }
 .drag-handle {
   cursor: grab;
   color: var(--text-muted);

--- a/frontend/src/components/RenderNode.vue
+++ b/frontend/src/components/RenderNode.vue
@@ -231,11 +231,11 @@ function onDrop(e: DragEvent, panelId: string) {
 }
 .dz {
   position: absolute;
-  background: rgba(34, 211, 238, 0.06);
+  background: var(--accent-subtle);
   transition: background 0.12s;
 }
 .dz.active {
-  background: rgba(34, 211, 238, 0.18);
+  background: var(--accent-glow);
 }
 .dz-left { left: 0; top: 0; width: 50%; height: 100%; }
 .dz-right { right: 0; top: 0; width: 50%; height: 100%; }

--- a/frontend/src/components/SFTPFileList.vue
+++ b/frontend/src/components/SFTPFileList.vue
@@ -562,7 +562,7 @@ function onDragStart(event: DragEvent, row: FileItem) {
   background: var(--bg-surface) !important;
 }
 .el-message--error .el-message__content {
-  color: #f56c6c !important;
+  color: var(--error) !important;
 }
 .el-table tr.cut-item-row {
   opacity: 0.4;

--- a/frontend/src/components/SFTPTabContent.vue
+++ b/frontend/src/components/SFTPTabContent.vue
@@ -1675,7 +1675,7 @@ async function onDropRemote(e: DragEvent) {
 }
 .drop-overlay span {
   font-size: 14px;
-  color: #fff;
+  color: var(--on-accent);
   padding: 12px 24px;
   border: 2px dashed rgba(255, 255, 255, 0.6);
   border-radius: var(--radius-md);

--- a/frontend/src/components/SFTPTransferProgress.vue
+++ b/frontend/src/components/SFTPTransferProgress.vue
@@ -122,6 +122,6 @@ const { t } = useI18n()
   color: var(--accent);
 }
 .status-text.error {
-  color: var(--danger, #f56c6c);
+  color: var(--error);
 }
 </style>

--- a/frontend/src/components/SPICETabContent.vue
+++ b/frontend/src/components/SPICETabContent.vue
@@ -38,7 +38,7 @@
       <el-switch
         v-model="scaleViewport"
        
-        style="--el-switch-on-color: #67c23a; --el-switch-off-color: #606266"
+        style="--el-switch-on-color: var(--success); --el-switch-off-color: var(--text-disabled)"
       />
     </div>
   </div>
@@ -309,10 +309,10 @@ watch(() => props.sessionId, (newId) => {
   align-items: center;
   justify-content: center;
   gap: 12px;
-  color: #999;
+  color: var(--text-muted);
   z-index: 10;
 }
-.spice-error-text { color: #f56c6c; }
+.spice-error-text { color: var(--error); }
 .spice-statusbar {
   flex-shrink: 0;
   height: 24px;
@@ -320,8 +320,8 @@ watch(() => props.sessionId, (newId) => {
   align-items: center;
   gap: 8px;
   padding: 0 12px;
-  background: #1e1e1e;
-  color: #999;
+  background: var(--bg-elevated);
+  color: var(--text-muted);
   font-size: 12px;
   box-sizing: border-box;
   z-index: 5;
@@ -329,10 +329,10 @@ watch(() => props.sessionId, (newId) => {
 .spice-status-dot {
   width: 8px; height: 8px;
   border-radius: 50%;
-  background: #67c23a;
+  background: var(--success);
   flex-shrink: 0;
 }
-.spice-status-sep { color: #444; }
+.spice-status-sep { color: var(--text-disabled); }
 .spice-scale-label {
   margin-left: auto;
   font-size: 11px;

--- a/frontend/src/components/SettingsTab.vue
+++ b/frontend/src/components/SettingsTab.vue
@@ -447,7 +447,7 @@
           <span v-if="testResult != null" :class="testResult ? 'test-ok' : 'test-fail'" style="margin-left: 8px; font-size: 13px;">
             {{ testResult ? t('settings.testSuccess') : t('settings.testFailed') }}
           </span>
-          <span v-if="testError" style="margin-left: 8px; font-size: 12px; color: #e5534b; word-break: break-all;">{{ testError }}</span>
+          <span v-if="testError" style="margin-left: 8px; font-size: 12px; color: var(--error); word-break: break-all;">{{ testError }}</span>
         </el-form-item>
       </el-form>
       <template #footer>
@@ -1193,8 +1193,8 @@ function getShellLabel(path: string): string {
 .kb-key {
   display: inline-block;
   padding: 2px 8px;
-  background: var(--bg-tertiary);
-  border: 1px solid var(--border-color);
+  background: var(--bg-overlay);
+  border: 1px solid var(--border-subtle);
   border-radius: 4px;
   font-family: var(--font-mono);
   font-size: 12px;
@@ -1210,7 +1210,7 @@ function getShellLabel(path: string): string {
 .kb-table th, .kb-table td {
   padding: 10px 12px;
   text-align: left;
-  border-bottom: 1px solid var(--border-color);
+  border-bottom: 1px solid var(--border-subtle);
 }
 
 .kb-table th {

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -1487,7 +1487,7 @@ defineExpose({ focusSearch })
 }
 
 .sidebar-tab.active {
-  color: var(--accent-color);
+  color: var(--accent);
   background: var(--accent-subtle);
 }
 
@@ -1725,7 +1725,7 @@ defineExpose({ focusSearch })
 }
 
 .conn-context-menu .menu-item.danger:hover {
-  background: rgba(248, 113, 113, 0.1);
+  background: var(--error-subtle);
   color: var(--error);
 }
 
@@ -1773,7 +1773,7 @@ defineExpose({ focusSearch })
   position: fixed;
   z-index: 10001;
   background: var(--bg-surface);
-  border: 1px solid var(--border-color);
+  border: 1px solid var(--border-subtle);
   border-radius: 6px;
   box-shadow: var(--shadow-lg);
   padding: 4px;

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -1603,7 +1603,7 @@ defineExpose({ focusSearch })
 .host {
   font-family: var(--font-mono);
   font-size: 10px;
-  color: var(--text-muted);
+  color: var(--text-secondary);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/frontend/src/components/TabItem.vue
+++ b/frontend/src/components/TabItem.vue
@@ -316,12 +316,12 @@ onUnmounted(() => {
   box-shadow: inset 0 0 0 1px var(--accent-dim);
 }
 .tab-item.ai-locked {
-  box-shadow: inset 2px 0 0 var(--warning, #f59e0b);
+  box-shadow: inset 2px 0 0 var(--warning);
 }
 .tab-item.active.ai-locked {
   background: var(--bg-hover);
   color: var(--text-primary);
-  box-shadow: inset 0 0 0 1px var(--accent-dim), inset 2px 0 0 var(--warning, #f59e0b);
+  box-shadow: inset 0 0 0 1px var(--accent-dim), inset 2px 0 0 var(--warning);
 }
 .tab-name {
   font-size: 12px;
@@ -399,7 +399,7 @@ onUnmounted(() => {
   background: var(--bg-hover);
 }
 .tab-ai-lock.locked {
-  color: var(--warning, #f59e0b);
+  color: var(--warning);
 }
 .tab-close {
   display: flex;

--- a/frontend/src/components/TabsList.vue
+++ b/frontend/src/components/TabsList.vue
@@ -335,7 +335,7 @@ function onTabDrop(e: DragEvent, targetTabId: string, index: number) {
   border: none;
   border-radius: 6px;
   background: transparent;
-  color: var(--text-secondary, #888);
+  color: var(--text-secondary);
   cursor: pointer;
   display: flex;
   align-items: center;
@@ -344,7 +344,7 @@ function onTabDrop(e: DragEvent, targetTabId: string, index: number) {
   margin-left: 2px;
 }
 .tab-add-btn:hover {
-  background: var(--bg-hover, #3a3b44);
-  color: var(--text-primary, #e0e0e0);
+  background: var(--bg-hover);
+  color: var(--text-primary);
 }
 </style>

--- a/frontend/src/components/TerminalSuggestion.vue
+++ b/frontend/src/components/TerminalSuggestion.vue
@@ -270,7 +270,7 @@ function onRemove(id: string) {
 }
 
 .suggestion-item.ai-result {
-  border-left: 3px solid #34d399;
+  border-left: 3px solid var(--success);
 }
 
 .suggestion-item.ai-preview {
@@ -353,8 +353,8 @@ function onRemove(id: string) {
 }
 
 .delete-btn:hover {
-  background: rgba(255, 255, 255, 0.1);
-  color: #ef4444;
+  background: var(--error-subtle);
+  color: var(--error);
 }
 
 .history-list::-webkit-scrollbar {

--- a/frontend/src/components/TerminalTabContent.vue
+++ b/frontend/src/components/TerminalTabContent.vue
@@ -188,11 +188,11 @@ function onDrop(e: DragEvent) {
 }
 .dz {
   position: absolute;
-  background: rgba(34, 211, 238, 0.06);
+  background: var(--accent-subtle);
   transition: background 0.12s;
 }
 .dz.active {
-  background: rgba(34, 211, 238, 0.18);
+  background: var(--accent-glow);
 }
 .dz-left { left: 0; top: 0; width: 50%; height: 100%; }
 .dz-right { right: 0; top: 0; width: 50%; height: 100%; }

--- a/frontend/src/components/VNCTabContent.vue
+++ b/frontend/src/components/VNCTabContent.vue
@@ -40,7 +40,7 @@
         :active-text="t('vnc.scaleOn')"
         :inactive-text="t('vnc.scaleOff')"
         inline-prompt
-        style="--el-switch-on-color: #67c23a; --el-switch-off-color: #606266"
+        style="--el-switch-on-color: var(--success); --el-switch-off-color: var(--text-disabled)"
       />
     </div>
   </div>
@@ -312,10 +312,10 @@ watch(scaleViewport, (val) => {
   align-items: center;
   justify-content: center;
   gap: 12px;
-  color: #999;
+  color: var(--text-muted);
   z-index: 10;
 }
-.vnc-error-text { color: #f56c6c; }
+.vnc-error-text { color: var(--error); }
 .vnc-statusbar {
   position: absolute;
   bottom: 0;
@@ -326,8 +326,8 @@ watch(scaleViewport, (val) => {
   align-items: center;
   gap: 8px;
   padding: 0 12px;
-  background: #1e1e1e;
-  color: #999;
+  background: var(--bg-elevated);
+  color: var(--text-muted);
   font-size: 12px;
   box-sizing: border-box;
   z-index: 5;
@@ -335,10 +335,10 @@ watch(scaleViewport, (val) => {
 .vnc-status-dot {
   width: 8px; height: 8px;
   border-radius: 50%;
-  background: #67c23a;
+  background: var(--success);
   flex-shrink: 0;
 }
-.vnc-status-sep { color: #444; }
+.vnc-status-sep { color: var(--text-disabled); }
 .vnc-scale-label {
   margin-left: auto;
   font-size: 11px;

--- a/frontend/src/components/WindowControls.vue
+++ b/frontend/src/components/WindowControls.vue
@@ -69,7 +69,7 @@ const restoreMaskId = `rm-${Math.random().toString(36).slice(2, 9)}`
 
 .wc-btn.win.close:hover {
   background: #e81123;
-  color: #fff;
+  color: var(--on-accent);
 }
 
 .wc-btn.win.close:active {

--- a/frontend/src/components/ZmodemTransfer.vue
+++ b/frontend/src/components/ZmodemTransfer.vue
@@ -100,8 +100,8 @@ function cancelTransfer(t: ReturnType<typeof store.getTransfers>[number]) {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.transfer-status.success { color: #34d399; }
-.transfer-status.error { color: #f87171; }
+.transfer-status.success { color: var(--success); }
+.transfer-status.error { color: var(--error); }
 .transfer-status.cancelled { color: var(--text-muted); }
 .transfer-progress {
   margin-top: 6px;
@@ -140,12 +140,12 @@ function cancelTransfer(t: ReturnType<typeof store.getTransfers>[number]) {
   cursor: pointer;
 }
 .cancel-btn:hover {
-  border-color: #f87171;
-  color: #f87171;
+  border-color: var(--error);
+  color: var(--error);
 }
 .transfer-complete {
   margin-top: 4px;
   font-size: 11px;
-  color: #34d399;
+  color: var(--success);
 }
 </style>

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -11,7 +11,7 @@
   --text-primary: #e6e8ed;
   --text-secondary: #9ea3ae;
   --text-muted: #949aa5;
-  --text-disabled: #525760;
+  --text-disabled: #6b7280;
 
   /* Accent - electric cyan */
   --accent: #22d3ee;
@@ -78,7 +78,7 @@
   --el-text-color-primary: #e6e8ed;
   --el-text-color-regular: #9ea3ae;
   --el-text-color-secondary: #737984;
-  --el-text-color-placeholder: #525760;
+  --el-text-color-placeholder: #6b7280;
   --el-border-color: rgba(255, 255, 255, 0.14);
   --el-border-color-light: rgba(255, 255, 255, 0.1);
   --el-border-color-lighter: rgba(255, 255, 255, 0.08);
@@ -102,7 +102,7 @@
   --text-primary: #e2e8f4;
   --text-secondary: #94a3b8;
   --text-muted: #8e97a8;
-  --text-disabled: #4a5468;
+  --text-disabled: #64708a;
 
   --accent: #38bdf8;
   --accent-dim: #0284c7;
@@ -145,7 +145,7 @@
   --el-text-color-primary: #e2e8f4;
   --el-text-color-regular: #94a3b8;
   --el-text-color-secondary: #6b7590;
-  --el-text-color-placeholder: #4a5468;
+  --el-text-color-placeholder: #64708a;
   --el-border-color: rgba(255, 255, 255, 0.14);
   --el-border-color-light: rgba(255, 255, 255, 0.1);
   --el-border-color-lighter: rgba(255, 255, 255, 0.08);
@@ -167,7 +167,7 @@
   --text-primary: #1a1a1a;
   --text-secondary: #5a5a5a;
   --text-muted: #6e6e6e;
-  --text-disabled: #b0b0b0;
+  --text-disabled: #909090;
 
   /* Accent - Windows-style blue */
   --accent: #0078d4;
@@ -217,7 +217,7 @@
   --el-text-color-primary: #1a1a1a;
   --el-text-color-regular: #5a5a5a;
   --el-text-color-secondary: #8a8a8a;
-  --el-text-color-placeholder: #b0b0b0;
+  --el-text-color-placeholder: #909090;
   --el-border-color: rgba(0, 0, 0, 0.12);
   --el-border-color-light: rgba(0, 0, 0, 0.08);
   --el-border-color-lighter: rgba(0, 0, 0, 0.06);

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -470,6 +470,7 @@ body::before {
 .btn-sm.btn-icon {
   width: 24px;
   height: 24px;
+  padding: 0;
 }
 
 /* Ghost hover-tint modifiers for a row of mixed-purpose icon actions

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1,5 +1,5 @@
 :root {
-  /* Core palette - professional dark */
+  /* Core palette - professional dark, slight blue undertone (kept from before) */
   --bg-base: #14171d;
   --bg-elevated: #191c24;
   --bg-surface: #1f222b;
@@ -19,11 +19,32 @@
   --accent-glow: rgba(34, 211, 238, 0.15);
   --accent-subtle: rgba(34, 211, 238, 0.08);
 
+  /* Info - secondary link/informational blue, distinct from --accent */
+  --info: #4c9df0;
+  --info-subtle: rgba(76, 157, 240, 0.1);
+
+  /* Text/icon color to place on top of a solid --accent fill */
+  --on-accent: #ffffff;
+
+  /* Chart series palette - for multi-series data viz (e.g. system monitor
+     CPU/memory/disk/network) where each series needs a distinct, stable hue
+     independent of the semantic success/warning/error colors. */
+  --chart-1: #4ade80;
+  --chart-2: #60a5fa;
+  --chart-3: #fbbf24;
+  --chart-4: #a78bfa;
+  --chart-4-alt: #c4b5fd;
+
   /* Semantic */
   --success: #34d399;
   --success-dim: #059669;
+  --success-subtle: rgba(52, 211, 153, 0.06);
+  --success-glow: rgba(52, 211, 153, 0.15);
   --warning: #f59e0b;
+  --warning-subtle: rgba(245, 158, 11, 0.1);
   --error: #f87171;
+  --error-subtle: rgba(248, 113, 113, 0.06);
+  --error-glow: rgba(248, 113, 113, 0.15);
 
   /* Borders */
   --border-subtle: rgba(255, 255, 255, 0.08);
@@ -88,10 +109,25 @@
   --accent-glow: rgba(56, 189, 248, 0.18);
   --accent-subtle: rgba(56, 189, 248, 0.08);
 
+  --info: #5eb3f5;
+  --info-subtle: rgba(94, 179, 245, 0.1);
+  --on-accent: #ffffff;
+
+  --chart-1: #4ade80;
+  --chart-2: #60a5fa;
+  --chart-3: #fbbf24;
+  --chart-4: #a78bfa;
+  --chart-4-alt: #c4b5fd;
+
   --success: #34d399;
   --success-dim: #059669;
+  --success-subtle: rgba(52, 211, 153, 0.06);
+  --success-glow: rgba(52, 211, 153, 0.15);
   --warning: #f59e0b;
+  --warning-subtle: rgba(245, 158, 11, 0.1);
   --error: #f87171;
+  --error-subtle: rgba(248, 113, 113, 0.06);
+  --error-glow: rgba(248, 113, 113, 0.15);
 
   --border-subtle: rgba(255, 255, 255, 0.08);
   --border-hover: rgba(255, 255, 255, 0.14);
@@ -139,11 +175,28 @@
   --accent-glow: rgba(0, 120, 212, 0.22);
   --accent-subtle: rgba(0, 120, 212, 0.08);
 
+  --info: #006ab1;
+  --info-subtle: rgba(0, 106, 177, 0.08);
+  --on-accent: #ffffff;
+
+  /* Chart series palette - darker/more saturated than the dark theme's for
+     sufficient contrast against a white background */
+  --chart-1: #16a34a;
+  --chart-2: #2563eb;
+  --chart-3: #d97706;
+  --chart-4: #7c3aed;
+  --chart-4-alt: #a78bfa;
+
   /* Semantic */
   --success: #107c41;
   --success-dim: #0b5e30;
+  --success-subtle: rgba(16, 124, 65, 0.06);
+  --success-glow: rgba(16, 124, 65, 0.15);
   --warning: #e07b00;
+  --warning-subtle: rgba(224, 123, 0, 0.08);
   --error: #d13438;
+  --error-subtle: rgba(209, 52, 56, 0.06);
+  --error-glow: rgba(209, 52, 56, 0.15);
 
   /* Borders - cool light grays */
   --border-subtle: rgba(0, 0, 0, 0.06);
@@ -312,6 +365,117 @@ body::before {
   border-radius: var(--radius-sm);
   transition: all 0.15s ease;
 }
+
+/* ============================================================
+   Unified button system
+   Replaces the ~25 one-off "*-btn" classes that had grown across
+   components (action-icon-btn, toggle-btn, qc-action-btn, ...).
+   Compose from a single .btn base + modifiers, all theme-aware.
+   New/refactored buttons should use these instead of ad-hoc CSS.
+   ============================================================ */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  height: 28px;
+  padding: 0 12px;
+  box-sizing: border-box;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-secondary);
+  font-family: var(--font-ui);
+  font-size: 12px;
+  line-height: 1;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: background-color 0.15s ease, color 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease;
+  user-select: none;
+}
+.btn:disabled,
+.btn.is-disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Neutral/default - subtle bordered surface, for secondary actions */
+.btn-default {
+  background: var(--bg-surface);
+  border-color: var(--border-subtle);
+  color: var(--text-primary);
+}
+.btn-default:hover:not(:disabled) {
+  background: var(--bg-hover);
+  border-color: var(--border-hover);
+}
+
+/* Primary - the one accent-filled action per view */
+.btn-primary {
+  background: var(--accent-dim);
+  border-color: var(--accent-dim);
+  color: var(--on-accent);
+}
+.btn-primary:hover:not(:disabled) {
+  background: var(--accent);
+  border-color: var(--accent);
+  box-shadow: 0 0 12px var(--accent-glow);
+}
+
+/* Ghost - no border/fill until hover; the common case for toolbar/inline actions
+   (covers what most one-off "action-icon-btn"/"toggle-btn" classes were doing) */
+.btn-ghost {
+  background: transparent;
+  color: var(--text-secondary);
+}
+.btn-ghost:hover:not(:disabled) {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+.btn-ghost.is-active {
+  background: var(--accent-subtle);
+  color: var(--accent);
+}
+/* Ghost variant that turns red on hover instead of neutral - the common
+   pattern for a delete/remove icon sitting among other row-level actions */
+.btn-ghost.danger:hover:not(:disabled) {
+  background: var(--error-subtle);
+  color: var(--error);
+}
+
+/* Danger - destructive actions (delete/disconnect/etc.) */
+.btn-danger {
+  background: transparent;
+  color: var(--error);
+}
+.btn-danger:hover:not(:disabled) {
+  background: var(--error-subtle);
+  color: var(--error);
+}
+
+/* Icon-only - square, no label; pair with an 14-16px icon child */
+.btn-icon {
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  flex: none;
+}
+
+/* Compact sizing for dense toolbars */
+.btn-sm {
+  height: 24px;
+  padding: 0 8px;
+  font-size: 12px;
+}
+.btn-sm.btn-icon {
+  width: 24px;
+  height: 24px;
+}
+
+/* Ghost hover-tint modifiers for a row of mixed-purpose icon actions
+   (e.g. run/paste/copy sitting next to a plain delete) */
+.btn-ghost.run:hover:not(:disabled) { color: var(--success); }
+.btn-ghost.paste:hover:not(:disabled) { color: var(--accent); }
 
 .el-radio-button__inner {
   height: 28px !important;


### PR DESCRIPTION
## Summary / 摘要

Consolidates the frontend's scattered hardcoded colors and duplicated one-off button classes onto the existing CSS-variable theme system, and fixes several dead variable references that silently broke theme switching. No visual base palette change — dark/deep-blue/light theme tones are the same as before; this is purely a cleanup of things that were bypassing the theme system.

将前端散落的写死配色和重复的自造按钮类统一收敛进现有的 CSS 变量主题体系,并修复了几处让主题切换悄悄失效的死变量引用。**未改动配色基调** —— 暗色/deep-blue/亮色三套主题的色调与之前一致,这次纯粹是清理绕过主题体系的写死样式。

## Changes / 变更内容

**Fix dead variable references (real bugs)**
`HistoryPanel.vue` / `QuickCommandsPanel.vue` / `QuickCommandEditDialog.vue` / `Sidebar.vue` / `SettingsTab.vue` referenced `--accent-color`, `--border-color`, `--danger-color`, `--success-color`, `--bg-tertiary` — none of these were ever defined in `style.css`, so they silently fell back to hardcoded colors and theme switching never actually affected them. Repointed to the real variables (`--accent`, `--border-subtle`, `--error`, `--success`, `--bg-overlay`).

**修复死变量引用(真实 bug)**
上述文件引用的 5 个变量名从未在 `style.css` 定义过,导致主题切换对这些元素完全无效,一直吃写死的 fallback 颜色。已改为正确的已定义变量。

**Consolidate hardcoded colors into theme variables**
~100 occurrences of hardcoded `#hex`/`rgba()` across 27 components replaced with the appropriate theme variable, so every element follows dark/deep-blue/light theme switching instead of ignoring it. Added the semantic variables that were missing: `--info`/`--info-subtle`, `--on-accent`, `--success-subtle`/`--success-glow`, `--warning-subtle`, `--error-subtle`/`--error-glow`, and a `--chart-1..4` palette for multi-series data viz (system monitor CPU/mem/disk/network) that needs distinct hues independent of success/warning/error.

Colors deliberately left hardcoded (not theme-following by design): remote-desktop canvas black background (VNC/RDP/SPICE), Win32 close-button red, terminal search-bar/drop-overlay dark scrim (must stay legible over any terminal color scheme, not the UI theme), and search-highlight yellow.

**收敛写死配色到主题变量**
27 个组件里约 100 处写死的 `#hex`/`rgba()` 替换为对应主题变量,补全了缺失的语义变量(如上)。刻意保留不跟随主题的配色:远程桌面画布黑底、Win32 关闭按钮红、终端搜索栏/拖放浮层的固定深色蒙层(必须在任意终端配色方案下都保持可读,而非跟随 UI 主题)、搜索高亮黄。

**Unify button system**
Added a `.btn` base class + modifiers (`.btn-primary`/`.btn-default`/`.btn-ghost`/`.btn-danger`/`.btn-icon`/`.btn-sm`) to `style.css`, and migrated the highest-value duplicated one-off button classes onto it: `action-icon-btn` (4 files), `qc-action-btn` (2 files), `exec-btn` (3 files), `cancel-btn` (2 files). Remaining single-file button classes were left as-is since they're not cross-component duplication.

**统一按钮系统**
新增 `.btn` 基类及修饰符,收敛了 4 组跨文件重复定义的自造按钮类(共 11 处重复定义)。剩余的单文件内部按钮类未强行合并,因为它们不构成跨组件重复。

**Fix low-contrast disabled text**
`--text-disabled` (sidebar group arrows, empty-state hints, disabled menu items, input placeholders) was below WCAG AA's 3:1 minimum UI-text contrast in all three themes (dark 2.47:1, deep-blue 2.51:1, light 2.17:1). Brightened to 3.2–4.2:1 while keeping each theme's hue; `--text-primary`/`--text-secondary`/`--text-muted` were already compliant (5.6–14.6:1) and left untouched.

**修复低对比度的禁用态文字**
`--text-disabled`(侧边栏分组箭头、空状态提示、禁用菜单项、输入框占位符)在三套主题下对比度均低于 WCAG AA 的 3:1 最低要求(暗色 2.47:1、深蓝 2.51:1、亮色 2.17:1)。已提亮到 3.2–4.2:1,色相不变;其余文字层级本已合格,未改动。

## Validation / 验证

- `npm run build` passes cleanly on every commit in this PR
- Rebased onto latest `main` (including #111/#112 and the two most recent group-management/start-tab commits) — no merge conflicts; the only overlapping file (`Sidebar.vue`) touched disjoint regions (my 3 CSS-variable fixes vs. upstream's script/template logic)
- Manually swept the diff to confirm every hardcoded-color removal preserved intended behavior (e.g. status dots, chart series hues, danger/success semantics)
- No `<script>`/`<template>` logic was touched — this PR is CSS/class-attribute only

- 每个提交均通过 `npm run build`
- 已 rebase 到最新 main(含 #111/#112 及最近两个分组管理/新标签页提交),无合并冲突;唯一重叠文件 `Sidebar.vue` 两边改动区域不重合(我方 3 处纯 CSS 变量修正 vs. 上游脚本/模板逻辑)
- 逐处核对了写死配色的替换,确保状态灯、图表配色、危险/成功语义等行为不变
- 本 PR 未改动任何 `<script>`/`<template>` 逻辑,纯 CSS/class 属性变更
