### PR TITLE
fix: shorten SSH keepalive interval and fix Git Bash mojibake on Windows

### DIFF
--- a/backend/session/local_session_windows.go
+++ b/backend/session/local_session_windows.go
@@ -13,9 +13,55 @@ import (
 	"strings"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/UserExistsError/conpty"
+	"golang.org/x/sys/windows"
 )
+
+const cpUTF8 = 65001
+
+var (
+	kernel32Dll        = windows.NewLazySystemDLL("kernel32.dll")
+	procAttachConsole  = kernel32Dll.NewProc("AttachConsole")
+	procFreeConsoleWin = kernel32Dll.NewProc("FreeConsole")
+
+	// AttachConsole/FreeConsole operate on process-wide state (a process can
+	// only be attached to one console at a time), so concurrent calls from
+	// multiple local sessions being opened at once must be serialized.
+	consoleAttachMu sync.Mutex
+)
+
+// forceUTF8ConsoleCodePage attaches to the hidden conhost that ConPTY
+// created for pid and forces its input/output code page to UTF-8 (65001),
+// then detaches. Without this, the pseudo console inherits the system's
+// default ANSI/OEM code page (e.g. GBK/936 on zh-CN Windows); MSYS2 shells
+// like Git Bash write raw UTF-8 to their controlling console, which the
+// console then reinterprets under that legacy code page before ConPTY
+// re-serializes it as the VT stream uniterm reads, producing mojibake that
+// does not occur in standalone Git Bash (which runs under mintty and never
+// goes through the Win32 console subsystem). Windows Terminal and VS Code's
+// integrated terminal apply the same fix. uniterm's own process is a GUI
+// subsystem app with no console of its own, so AttachConsole/FreeConsole
+// here only ever touches the child's console, never uniterm's.
+func forceUTF8ConsoleCodePage(pid int) {
+	consoleAttachMu.Lock()
+	defer consoleAttachMu.Unlock()
+
+	// The child's console may not be immediately attachable right after
+	// CreateProcess returns; a few short retries comfortably cover that
+	// without noticeably delaying session startup.
+	for attempt := 0; attempt < 10; attempt++ {
+		ret, _, _ := procAttachConsole.Call(uintptr(pid))
+		if ret != 0 {
+			_ = windows.SetConsoleCP(cpUTF8)
+			_ = windows.SetConsoleOutputCP(cpUTF8)
+			procFreeConsoleWin.Call()
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
 
 type LocalSession struct {
 	baseSession
@@ -54,6 +100,7 @@ func (s *LocalSession) Connect(config ConnectionConfig) error {
 
 	var commandLine string
 	var cmd *exec.Cmd
+	isMSYSBash := false
 
 	if distro, ok := parseWSLPath(shell); ok {
 		if distro == "" {
@@ -73,6 +120,7 @@ func (s *LocalSession) Connect(config ConnectionConfig) error {
 			} else {
 				cmd = exec.Command(shell, "--login", "-i")
 				cmd.Env = append(os.Environ(), "TERM=xterm-256color")
+				isMSYSBash = true
 			}
 		} else {
 			cmd = exec.Command(shell)
@@ -91,6 +139,9 @@ func (s *LocalSession) Connect(config ConnectionConfig) error {
 		c, err := conpty.Start(commandLine, conpty.ConPtyDimensions(cols, rows))
 		if err == nil {
 			s.cpty = c
+			if isMSYSBash {
+				go forceUTF8ConsoleCodePage(c.Pid())
+			}
 			go func() {
 				_, _ = s.cpty.Wait(context.Background())
 				s.Disconnect()

--- a/backend/session/ssh_session.go
+++ b/backend/session/ssh_session.go
@@ -18,8 +18,13 @@ import (
 )
 
 const (
-	sshKeepAliveInterval = 60 * time.Second
-	sshKeepAliveTimeout  = 10 * time.Second
+	// Kept well under common corporate firewall/NAT/VPN idle-connection
+	// timeouts (commonly 5-15 minutes, sometimes as low as a few minutes),
+	// which otherwise silently drop the TCP session while the user is
+	// idle-reading in an editor (e.g. vim in normal mode) with no traffic
+	// flowing between keystrokes.
+	sshKeepAliveInterval = 20 * time.Second
+	sshKeepAliveTimeout  = 5 * time.Second
 	sshKeepAliveMaxFail  = 3
 )
 

--- a/backend/session/tunnel_service.go
+++ b/backend/session/tunnel_service.go
@@ -14,6 +14,7 @@ import (
 type tunnelEntry struct {
 	sshClient *ssh.Client
 	listener  net.Listener
+	quit      chan struct{}
 }
 
 // TunnelService manages SSH tunnel lifecycles.
@@ -55,6 +56,13 @@ func (ts *TunnelService) Start(sessionID string, sshConfig ConnectionConfig, tar
 	conn, err := net.DialTimeout("tcp", addr, clientConfig.Timeout)
 	if err != nil {
 		return 0, fmt.Errorf("tunnel ssh dial: %w", err)
+	}
+	// TCP keepalive: same interval as direct SSH sessions, so an idle tunnel
+	// (e.g. forwarding a single long-lived vim/editor session through a jump
+	// host) doesn't get silently dropped by a firewall/NAT idle timeout.
+	if tcpConn, ok := conn.(*net.TCPConn); ok {
+		tcpConn.SetKeepAlive(true)
+		tcpConn.SetKeepAlivePeriod(sshKeepAliveInterval)
 	}
 
 	sshConn, chans, reqs, err := ssh.NewClientConn(conn, addr, clientConfig)
@@ -107,12 +115,60 @@ func (ts *TunnelService) Start(sessionID string, sshConfig ConnectionConfig, tar
 		}
 	}()
 
+	quit := make(chan struct{})
 	ts.tunnels[sessionID] = &tunnelEntry{
 		sshClient: client,
 		listener:  listener,
+		quit:      quit,
 	}
+	go tunnelKeepAlive(client, quit)
 
 	return localPort, nil
+}
+
+// tunnelKeepAlive periodically pings the tunnel's SSH connection with a
+// global keepalive request (same cadence/threshold as SSHSession's) and
+// closes the connection if the remote stops responding, so a dead jump-host
+// hop doesn't linger silently while the forwarded session on top of it hangs.
+func tunnelKeepAlive(client *ssh.Client, quit chan struct{}) {
+	ticker := time.NewTicker(sshKeepAliveInterval)
+	defer ticker.Stop()
+
+	failures := 0
+	for {
+		select {
+		case <-ticker.C:
+			done := make(chan error, 1)
+			go func() {
+				defer func() {
+					if r := recover(); r != nil {
+						done <- fmt.Errorf("panic: %v", r)
+					}
+				}()
+				_, _, err := client.SendRequest("keepalive@openssh.com", true, nil)
+				done <- err
+			}()
+
+			select {
+			case err := <-done:
+				if err != nil {
+					failures++
+				} else {
+					failures = 0
+				}
+			case <-time.After(sshKeepAliveTimeout):
+				failures++
+			}
+
+			if failures >= sshKeepAliveMaxFail {
+				client.Close()
+				return
+			}
+
+		case <-quit:
+			return
+		}
+	}
 }
 
 // Stop closes the tunnel and SSH connection for the given session.
@@ -126,6 +182,7 @@ func (ts *TunnelService) Stop(sessionID string) {
 	}
 	delete(ts.tunnels, sessionID)
 
+	close(entry.quit)
 	entry.listener.Close()
 	entry.sshClient.Close()
 }
@@ -141,6 +198,7 @@ func (ts *TunnelService) Shutdown() {
 	ts.mu.Unlock()
 
 	for _, entry := range entries {
+		close(entry.quit)
 		entry.listener.Close()
 		entry.sshClient.Close()
 	}


### PR DESCRIPTION
## Summary / 摘要

Fixes two Windows-reported bugs: SSH sessions disconnecting within ~10 minutes while idle-editing in vim, and garbled Chinese output in the Git Bash local terminal.

修复两个 Windows 环境下反馈的问题:vim 编辑时 SSH 会话约 10 分钟内断开、Git Bash 本地终端中文输出乱码。

Closes #131, Closes #132

## Changes / 变更内容

**SSH keepalive interval too long for strict idle-connection timeouts**
`sshKeepAliveInterval` was 60s / 10s-timeout / 3-failures, giving ~3 minutes of grace after the last successful keepalive. That's inside common corporate firewall/NAT/VPN idle timeouts (5-15 min typical), but the first probe doesn't fire until 60s after the last real traffic - on stricter networks that's too late to refresh the connection's NAT/conntrack state in time. Tightened to 20s interval / 5s timeout (same 3-failure threshold), so idle connections get refreshed ~3x more often without materially increasing traffic. Also added the same TCP + SSH-level keepalive to `TunnelService`'s jump-host SSH client, which previously had none - a dead tunnel hop would strand the forwarded session silently even though the session's own keepalive looked fine.

**SSH keepalive 间隔对严格的空闲超时策略来说太长**
原 60 秒间隔/10 秒超时/3 次失败,意味着从最后一次成功心跳到判定失败有约 3 分钟宽限,而企业防火墙/NAT/VPN 的空闲超时常见为 5-15 分钟——但问题在于第一个心跳包要等 60 秒才发出,在网络策略更严格的环境下经常来不及刷新连接状态。已收紧为 20 秒间隔/5 秒超时(失败阈值不变),同时给跳板机隧道的 SSH client 补上了此前完全没有的 keepalive 机制。

**Git Bash local terminal mojibake on Windows**
uniterm hosts local shells via ConPTY, which creates a real hidden Win32 console for the child process; standalone Git Bash instead runs under mintty and never touches the Win32 console subsystem. Under ConPTY, MSYS2 bash's raw UTF-8 writes get reinterpreted by the hidden console's inherited system code page (GBK/936 on zh-CN Windows) before ConPTY re-serializes them - producing "UTF-8 bytes misread as GBK" mojibake that doesn't occur outside uniterm. Fixed by attaching to the child's hidden console right after `conpty.Start()` for a Git-Bash-style shell and forcing UTF-8 code pages via `SetConsoleCP`/`SetConsoleOutputCP`, then detaching - the same fix Windows Terminal and VS Code apply for MSYS2/Cygwin shells. Scoped to just the Git-Bash branch (not cmd.exe/PowerShell/WSL), since those weren't reported as affected and `chcp 65001` has known compatibility quirks with legacy OEM-code-page-dependent batch scripts.

**Windows 下 Git Bash 本地终端乱码**
uniterm 用 ConPTY 承载本地 shell,会为子进程创建一个真实的隐藏 Win32 控制台;而独立运行的 Git Bash 走 mintty,完全不经过 Win32 控制台子系统。在 ConPTY 路径下,MSYS2 bash 写出的原始 UTF-8 字节会先被隐藏控制台按继承来的系统代码页(中文 Windows 默认是 GBK/936)重新解析,再被 ConPTY 序列化成 VT 流——这正是"UTF-8 字节被当 GBK 误读"的乱码模式,且只在 uniterm 内出现。修复方式是在 `conpty.Start()` 之后针对 Git Bash 场景附加到隐藏控制台,强制设为 UTF-8 代码页后立即分离,这与 Windows Terminal、VS Code 处理 MSYS2/Cygwin shell 的方式一致。改动范围严格限定在 Git Bash 分支,不涉及 cmd.exe/PowerShell/WSL。

## Validation / 验证

- `go build ./...` passes on both darwin (native) and windows (cross-compiled with `GOOS=windows GOARCH=amd64`), since the encoding fix lives in a `//go:build windows`-only file
- `go vet ./...` shows only pre-existing unrelated warnings (IPv6 address format, present on `main` before this branch)
- Manually reviewed for concurrency safety: `AttachConsole`/`FreeConsole` touch process-wide state, guarded with a mutex so concurrent local-session creation can't interleave; keepalive goroutines are per-connection and torn down via existing `quit`/`Stop()`/`Shutdown()` paths
- Rebased onto latest `main` (including #116 SMB/WebDAV/S3, the start-page redesign #128, and the header spacing/sidebar-default fixes) - cherry-picked cleanly with zero conflicts since neither fix touches the files those commits changed

- `go build ./...` 在 darwin(本机)和 windows(交叉编译 `GOOS=windows GOARCH=amd64`)均通过,因为编码修复位于 `//go:build windows` 专属文件中
- `go vet ./...` 仅显示改动前就存在、与本次改动无关的既有警告(IPv6 地址格式)
- 人工核对并发安全性:`AttachConsole`/`FreeConsole` 是进程级状态,已用互斥锁保护避免多个本地会话并发创建时互相干扰;keepalive goroutine 按连接独立,通过既有的 `quit`/`Stop()`/`Shutdown()` 路径正确回收
- 已基于最新 main(含 #116 SMB/WebDAV/S3、开始页重构 #128、标题栏间距/侧边栏默认状态修复)cherry-pick,零冲突,因为两处修复都没有触碰这些提交改动的文件

## Note / 说明

I don't have a Windows machine to manually reproduce and verify these fixes end-to-end — both are based on code-level root-cause analysis (git history for the SSH keepalive regression pattern, and known ConPTY/MSYS2 code-page behavior matching the reported mojibake pattern exactly). Would appreciate a Windows-side smoke test before merging.

我这边没有 Windows 机器做端到端手动复现验证,两处修复都基于代码级根因分析(SSH keepalive 的历史回归模式、与已知 ConPTY/MSYS2 代码页行为完全吻合的乱码模式)。合并前如有条件请在 Windows 上做一次冒烟测试。
