### PR TITLE
fix: normalize line endings when pasting to terminal to prevent extra CR in vim

### DIFF
--- a/frontend/src/components/BaseTerminal.vue
+++ b/frontend/src/components/BaseTerminal.vue
@@ -1333,7 +1333,10 @@ async function pasteToSession(text: string) {
   if (props.mode === 'ssh' || props.mode === 'local') {
     const sid = props.sessionId
     if (sid) {
-      SessionWrite(sid, text)
+      // Normalize line endings: \r\n -> \r to prevent extra newlines
+      // when pasting into editors like vim (Windows clipboard often has \r\n)
+      const normalized = text.replace(/\r\n/g, '\n').replace(/\r/g, '')
+      SessionWrite(sid, normalized)
     }
   }
 }


### PR DESCRIPTION
## Summary

Fixed issue where pasting text copied from one terminal window into vim in another terminal window produced extra blank lines.

## Root Cause

When copying text on Windows, the clipboard contains `\r\n` (CRLF) line endings. When pasting directly into a terminal session via `SessionWrite`, the `\r` character is interpreted by the terminal as an additional carriage return (Enter key), causing vim to see extra newlines.

## Fix

In `pasteToSession()`, normalize line endings before sending to the session:
- `\r\n` → `\n` (convert Windows line endings to Unix)
- Strip any remaining standalone `\r` characters

## Changed Files
- `frontend/src/components/BaseTerminal.vue` — normalize pasted text in `pasteToSession()`

Closes #117

---

## 概述

修复了从一个终端窗口复制文本粘贴到另一个窗口的 vim 中出现多余空行的问题。

## 原因

Windows 剪贴板文本使用 `\r\n` 换行符。直接通过 `SessionWrite` 发送到终端时，`\r` 被终端解释为额外的回车键，导致 vim 中多出空行。

## 修复

在 `pasteToSession()` 中归一化换行符：
- `\r\n` → `\n`（Windows 换行转 Unix）
- 去除剩余的独立 `\r`

Closes #117