### PR TITLE
fix: call fitAddon.fit() on every resize to prevent stale terminal dimensions

### DIFF
--- a/frontend/src/components/BaseTerminal.vue
+++ b/frontend/src/components/BaseTerminal.vue
@@ -442,6 +442,14 @@ function resize() {
     // Skip resize when the component is hidden (e.g. during tab switching
     // with KeepAlive). A zero-size resize would corrupt xterm.js buffers.
     if (rect.width === 0 || rect.height === 0) return
+
+    // Always fit first to update CSS dimensions on the .xterm element.
+    // Without this, stale inline pixel dimensions from a previous fit()
+    // prevent the terminal from filling the container after window resize
+    // (e.g. after duplicating a session tab).
+    fitAddon.fit()
+    if (terminal.cols <= 0 || terminal.rows <= 0) return
+
     let cellWidth = 0
     let cellHeight = 0
     try {
@@ -457,8 +465,6 @@ function resize() {
     }
 
     if (cellWidth === 0 || cellHeight === 0) {
-      fitAddon.fit()
-      if (terminal.cols <= 0 || terminal.rows <= 0) return
       SessionResize(sid, terminal.cols, terminal.rows).catch(() => {})
       return
     }


### PR DESCRIPTION
## Summary

Fixed issue where duplicating a session tab and then resizing the window caused the terminal to render only within a portion of the container, leaving a dark blank area below.

## Root Cause

The `resize()` function in BaseTerminal had two code paths:
1. **Cell dimensions unknown**: calls `fitAddon.fit()` which updates both CSS pixel dimensions on the `.xterm` element and the character grid
2. **Cell dimensions known**: only calls `terminal.resize(cols, rows)` — does NOT update CSS dimensions

After duplicating a session, the initial `fit()` set inline CSS pixel dimensions on `.xterm`. When the user then resized the window, `resize()` took path 2 (cell dimensions were already known), only updating the character grid. The stale inline pixel dimensions from the initial `fit()` overrode the CSS `width: 100%; height: 100%` rule, constraining the terminal to the old size.

## Fix

Move `fitAddon.fit()` before the cell dimension check so it runs on every resize. The manual cols/rows calculation still runs afterward for optimal terminal sizing with padding/scrollbar adjustments.

## Changed Files
- `frontend/src/components/BaseTerminal.vue` — always call `fitAddon.fit()` in `resize()`

Closes #71

---

## 概述

修复了复制会话标签页后拖动窗口调整尺寸时，终端渲染无法填满窗口、下方出现黑色空白区域的问题。

## 原因

`resize()` 有两个分支：当 cell 尺寸已知时不调 `fitAddon.fit()`，导致 `.xterm` 的 CSS 像素尺寸停留在初始值，覆盖了 `width: 100%` 规则。

## 修复

将 `fitAddon.fit()` 提到 cell 尺寸检查之前，每次 resize 都更新 CSS 尺寸。

Closes #71