### PR TITLE
fix: scroll terminal to bottom on reactivation to fix mouse wheel state

### DIFF
--- a/frontend/src/components/BaseTerminal.vue
+++ b/frontend/src/components/BaseTerminal.vue
@@ -1135,6 +1135,12 @@ onActivated(() => {
   bindListeners?.()
   // Terminal dimensions may be stale after tab switch; recalculate.
   resize()
+  // Ensure viewport is at the bottom after reactivation so scroll wheel
+  // state is consistent — stale scrollTop from deactivation can cause
+  // mouse wheel to misbehave (scroll up broken, scroll down jumps to top).
+  nextTick(() => {
+    terminal?.scrollToBottom()
+  })
   // Re-initialize zmodem service only if it was disposed in onDeactivated.
   // If a transfer was active, the service is still running — skip recreate.
   // safe: no focus() call here, avoids WebView2 crash race with native dialogs.


### PR DESCRIPTION
## Summary

Fixed issue where reactivating a background tab (switching back to it) caused the mouse scroll wheel to misbehave: scrolling up didn't work and scrolling down jumped to the very top.

## Root Cause

When a tab is deactivated via KeepAlive, the xterm viewport's scroll position can become stale. Upon reactivation, the resize process didn't reset the viewport scroll state, leaving it in an inconsistent state where the scroll wheel events didn't map correctly to the terminal buffer.

## Fix

Call `terminal.scrollToBottom()` after resize in `onActivated` to ensure the viewport is in a consistent state. This resets the scroll position to the bottom (showing latest output), allowing normal scroll wheel behavior.

## Changed Files
- `frontend/src/components/BaseTerminal.vue` — add `scrollToBottom()` in `onActivated`

Closes #121

---

## 概述

修复了重新激活后台标签页后鼠标滚轮异常的问题：向上滚动无效、向下滚动跳回顶部。

## 修复

在 `onActivated` 中 resize 后调用 `scrollToBottom()` 重置视口状态。

Closes #121