### PR TITLE
fix: S3 path shows bucket name in breadcrumb, SMB supports share browsing

### DIFF
--- a/backend/session/s3_session.go
+++ b/backend/session/s3_session.go
@@ -53,7 +53,11 @@ func (s *S3Session) Connect(config ConnectionConfig) error {
 
 	s.s3 = s3Client
 	s.bucket = config.S3Bucket
-	s.cwd = "/"
+	if s.bucket != "" {
+		s.cwd = "/" + s.bucket
+	} else {
+		s.cwd = "/"
+	}
 	s.setStatus(StatusConnected)
 	return nil
 }
@@ -92,6 +96,11 @@ func (s *S3Session) resolveRemote(p string) (string, error) {
 func (s *S3Session) s3Key(p string) string {
 	// S3 keys don't start with "/", they're relative to the bucket root.
 	p = strings.TrimPrefix(p, "/")
+	// Strip bucket name prefix if present (paths include bucket for breadcrumb display)
+	if s.bucket != "" {
+		bucketPrefix := s.bucket + "/"
+		p = strings.TrimPrefix(p, bucketPrefix)
+	}
 	return p
 }
 
@@ -190,26 +199,45 @@ func (s *S3Session) ChangeRemoteDir(dir string) (FileListResult, error) {
 	}
 
 	// Handle bucket-level navigation
-	if s.bucket == "" && target == "/" {
-		// Already at bucket list root, just refresh
-		return s.ListRemote("/")
-	}
 	if s.bucket == "" {
+		if target == "/" {
+			// Already at bucket list root, just refresh
+			return s.ListRemote("/")
+		}
 		// Navigating into a bucket from the bucket list
 		bucketName := strings.TrimPrefix(target, "/")
 		s.mu.Lock()
 		s.bucket = bucketName
-		s.cwd = "/"
+		s.cwd = "/" + bucketName
 		s.mu.Unlock()
-		return s.ListRemote("/")
+		return s.ListRemote("/" + bucketName)
 	}
-	if target == "/" && s.cwd == "/" {
-		// Already at bucket root, navigating up goes back to bucket list
+
+	// Inside a bucket: navigating up from bucket root returns to bucket list
+	bucketRoot := "/" + s.bucket
+	if target == bucketRoot || dir == ".." {
+		parts := strings.Split(strings.TrimPrefix(s.cwd, "/"+s.bucket), "/")
+		if len(parts) == 0 || (len(parts) == 1 && parts[0] == "") {
+			// At bucket root, go back to bucket list
+			s.mu.Lock()
+			s.bucket = ""
+			s.cwd = "/"
+			s.mu.Unlock()
+			return s.ListRemote("/")
+		}
+	}
+
+	// Navigate to parent when dir is ".." within a bucket
+	if dir == ".." {
+		parent := path.Dir(s.cwd)
+		if parent == bucketRoot || parent == "/"+s.bucket || parent == "/" {
+			// Parent is the bucket root
+			parent = bucketRoot
+		}
 		s.mu.Lock()
-		s.bucket = ""
-		s.cwd = "/"
+		s.cwd = parent
 		s.mu.Unlock()
-		return s.ListRemote("/")
+		return s.ListRemote(parent)
 	}
 
 	// Validate directory exists by listing it
@@ -227,7 +255,6 @@ func (s *S3Session) ChangeRemoteDir(dir string) (FileListResult, error) {
 	if err != nil {
 		return FileListResult{}, fmt.Errorf("no such directory: %s", target)
 	}
-	// If no objects and no common prefixes and prefix is not empty, the directory might not exist
 	if len(resp.Objects) == 0 && len(resp.CommonPrefixes) == 0 && prefix != "" {
 		// Could be a "virtual" directory (no marker object). Allow it.
 	}

--- a/backend/session/smb_session.go
+++ b/backend/session/smb_session.go
@@ -71,32 +71,23 @@ func (s *SMBSession) Connect(config ConnectionConfig) error {
 		return fmt.Errorf("smb handshake: %w", err)
 	}
 
-	shareName := config.SmbShare
-	if shareName == "" {
-		shares, err := smbConn.ListSharenames()
+	// If a share is specified, mount it immediately.
+	// Otherwise leave share nil — ListRemote will show the share list at root.
+	if config.SmbShare != "" {
+		share, err := smbConn.Mount(config.SmbShare)
 		if err != nil {
 			smbConn.Logoff()
 			s.setStatus(StatusError)
-			return fmt.Errorf("smb list shares: %w", err)
+			return fmt.Errorf("smb mount share %s: %w", config.SmbShare, err)
 		}
-		if len(shares) == 0 {
-			smbConn.Logoff()
-			s.setStatus(StatusError)
-			return fmt.Errorf("no shares available on %s", config.Host)
-		}
-		shareName = shares[0]
-	}
-
-	share, err := smbConn.Mount(shareName)
-	if err != nil {
-		smbConn.Logoff()
-		s.setStatus(StatusError)
-		return fmt.Errorf("smb mount share %s: %w", shareName, err)
+		s.share = share
+		s.cwd = "/"
 	}
 
 	s.conn = smbConn
-	s.share = share
-	s.cwd = ""
+	if s.share == nil {
+		s.cwd = "/"
+	}
 	s.setStatus(StatusConnected)
 	return nil
 }
@@ -113,6 +104,7 @@ func (s *SMBSession) Disconnect() error {
 		s.conn.Logoff()
 		s.conn = nil
 	}
+	s.cwd = "/"
 	s.setStatus(StatusDisconnected)
 	return nil
 }
@@ -200,10 +192,36 @@ func (s *SMBSession) mkdirAllRemote(dir string) error {
 	return s.share.Mkdir(dir, 0755)
 }
 
-func (s *SMBSession) ListRemote(dir string) (FileListResult, error) {
-	if err := s.requireShare(); err != nil {
-		return FileListResult{}, err
+// listShares returns all available shares as directory entries.
+func (s *SMBSession) listShares() (FileListResult, error) {
+	if s.conn == nil {
+		return FileListResult{}, fmt.Errorf("SMB session not connected")
 	}
+	names, err := s.conn.ListSharenames()
+	if err != nil {
+		return FileListResult{}, fmt.Errorf("smb list shares: %w", err)
+	}
+	files := make([]FileItem, 0, len(names))
+	for _, name := range names {
+		files = append(files, FileItem{
+			Name:  name,
+			Size:  0,
+			Mode:  "drwxr-xr-x",
+			IsDir: true,
+		})
+	}
+	return FileListResult{Files: files, Dir: "/"}, nil
+}
+
+func (s *SMBSession) ListRemote(dir string) (FileListResult, error) {
+	// No share mounted: show share list at root
+	if s.share == nil {
+		if s.conn == nil {
+			return FileListResult{}, fmt.Errorf("SMB session not connected")
+		}
+		return s.listShares()
+	}
+
 	target, err := s.resolveRemote(dir)
 	if err != nil {
 		return FileListResult{}, err
@@ -230,13 +248,51 @@ func (s *SMBSession) ListRemote(dir string) (FileListResult, error) {
 }
 
 func (s *SMBSession) ChangeRemoteDir(dir string) (FileListResult, error) {
-	if err := s.requireShare(); err != nil {
-		return FileListResult{}, err
+	// No share mounted yet: navigating into a share name mounts it
+	if s.share == nil {
+		if s.conn == nil {
+			return FileListResult{}, fmt.Errorf("SMB session not connected")
+		}
+		shareName := strings.TrimPrefix(dir, "/")
+		if shareName == "" || shareName == "/" {
+			return s.listShares()
+		}
+		share, err := s.conn.Mount(shareName)
+		if err != nil {
+			return FileListResult{}, fmt.Errorf("smb mount share %s: %w", shareName, err)
+		}
+		s.share = share
+		s.cwd = "/" + shareName
+		return s.ListRemote("")
 	}
+
 	target, err := s.resolveRemote(dir)
 	if err != nil {
 		return FileListResult{}, err
 	}
+
+	// Navigate up: handle going from share root back to share list
+	if dir == ".." {
+		// If at share root (cwd is "/sharename" or ""), unmount and list shares
+		cwdTrimmed := strings.TrimPrefix(strings.TrimSuffix(s.cwd, "/"), "/")
+		if cwdTrimmed == "" || !strings.Contains(cwdTrimmed, "/") {
+			// At share root, go back to share list
+			s.share.Umount()
+			s.share = nil
+			s.cwd = "/"
+			return s.listShares()
+		}
+		// Navigate to parent directory
+		parent := smbDir(target)
+		if parent == "" {
+			parent = ""
+		}
+		s.mu.Lock()
+		s.cwd = parent
+		s.mu.Unlock()
+		return s.ListRemote(parent)
+	}
+
 	// Root directory: skip Stat (SMB can't stat empty path)
 	if target != "" {
 		fi, err := s.share.Stat(target)

--- a/frontend/src/components/ConnectionForm.vue
+++ b/frontend/src/components/ConnectionForm.vue
@@ -142,7 +142,7 @@
                 <el-input v-model="form.smbDomain" placeholder="e.g. WORKGROUP" />
               </el-form-item>
               <el-form-item label="Share">
-                <el-input v-model="form.smbShare" placeholder="Share name (leave empty to browse)" />
+                <el-input v-model="form.smbShare" placeholder="Share name (leave empty to browse all)" />
               </el-form-item>
             </template>
             <template v-if="form.type === 'webdav'">


### PR DESCRIPTION
## Summary

Fixed two file transfer issues:
1. **S3**: Bucket name now appears in the path breadcrumb when navigating inside a bucket
2. **SMB**: Leaving the share field empty now shows all available shares for browsing instead of auto-mounting the first one

## S3 Fix

Changed `cwd` to include the bucket name (e.g. `/my-bucket` instead of `/`). Updated `s3Key()` to strip the bucket prefix when constructing S3 object keys. The breadcrumb now shows `/my-bucket/path/to/dir` instead of just `/path/to/dir`.

## SMB Fix

- `Connect()`: When share is empty, authenticate to the server without mounting a share
- New `listShares()`: Returns all available shares as directory entries
- `ListRemote(/)`: Shows share list when no share is mounted
- `ChangeRemoteDir()`: Mounts the selected share when navigating into it from root; ".." at share root returns to the share list

## Changed Files
- `backend/session/s3_session.go` — bucket-aware paths
- `backend/session/smb_session.go` — share browsing support
- `frontend/src/components/ConnectionForm.vue` — updated share field placeholder

Closes #120

---

## 概述

修复两个文件传输问题：S3 路径栏显示桶名、SMB 支持空共享名浏览所有共享。

Closes #120