### PR TITLE
fix: S3/SMB breadcrumb, share browsing, auto-navigate, icon fixes

### DIFF
--- a/backend/session/s3_session.go
+++ b/backend/session/s3_session.go
@@ -53,11 +53,7 @@ func (s *S3Session) Connect(config ConnectionConfig) error {
 
 	s.s3 = s3Client
 	s.bucket = config.S3Bucket
-	if s.bucket != "" {
-		s.cwd = "/" + s.bucket
-	} else {
-		s.cwd = "/"
-	}
+	s.cwd = "/"
 	s.setStatus(StatusConnected)
 	return nil
 }
@@ -96,7 +92,11 @@ func (s *S3Session) resolveRemote(p string) (string, error) {
 func (s *S3Session) s3Key(p string) string {
 	// S3 keys don't start with "/", they're relative to the bucket root.
 	p = strings.TrimPrefix(p, "/")
-	// Strip bucket name prefix if present (paths include bucket for breadcrumb display)
+	// Bucket root: path equals the bucket name → empty key
+	if s.bucket != "" && p == s.bucket {
+		return ""
+	}
+	// Strip bucket name prefix from subdirectory paths (e.g. "mybucket/dir" → "dir")
 	if s.bucket != "" {
 		bucketPrefix := s.bucket + "/"
 		p = strings.TrimPrefix(p, bucketPrefix)
@@ -198,13 +198,12 @@ func (s *S3Session) ChangeRemoteDir(dir string) (FileListResult, error) {
 		return FileListResult{}, err
 	}
 
-	// Handle bucket-level navigation
+	// ── Bucket list level ──
 	if s.bucket == "" {
 		if target == "/" {
-			// Already at bucket list root, just refresh
-			return s.ListRemote("/")
+			return s.ListRemote("/") // refresh bucket list
 		}
-		// Navigating into a bucket from the bucket list
+		// Enter a bucket
 		bucketName := strings.TrimPrefix(target, "/")
 		s.mu.Lock()
 		s.bucket = bucketName
@@ -213,27 +212,29 @@ func (s *S3Session) ChangeRemoteDir(dir string) (FileListResult, error) {
 		return s.ListRemote("/" + bucketName)
 	}
 
-	// Inside a bucket: navigating up from bucket root returns to bucket list
+	// ── Inside a bucket ──
 	bucketRoot := "/" + s.bucket
-	if target == bucketRoot || dir == ".." {
-		parts := strings.Split(strings.TrimPrefix(s.cwd, "/"+s.bucket), "/")
-		if len(parts) == 0 || (len(parts) == 1 && parts[0] == "") {
-			// At bucket root, go back to bucket list
-			s.mu.Lock()
-			s.bucket = ""
-			s.cwd = "/"
-			s.mu.Unlock()
-			return s.ListRemote("/")
-		}
+
+	// "/" inside a bucket means the bucket list root
+	if target == "/" {
+		s.mu.Lock()
+		s.bucket = ""
+		s.cwd = "/"
+		s.mu.Unlock()
+		return s.ListRemote("/")
 	}
 
-	// Navigate to parent when dir is ".." within a bucket
+	// Navigate to bucket root via breadcrumb or direct path
+	if target == bucketRoot {
+		s.mu.Lock()
+		s.cwd = bucketRoot
+		s.mu.Unlock()
+		return s.ListRemote(bucketRoot)
+	}
+
+	// ".." navigation within the bucket
 	if dir == ".." {
 		parent := path.Dir(s.cwd)
-		if parent == bucketRoot || parent == "/"+s.bucket || parent == "/" {
-			// Parent is the bucket root
-			parent = bucketRoot
-		}
 		s.mu.Lock()
 		s.cwd = parent
 		s.mu.Unlock()

--- a/backend/session/s3_session.go
+++ b/backend/session/s3_session.go
@@ -53,7 +53,11 @@ func (s *S3Session) Connect(config ConnectionConfig) error {
 
 	s.s3 = s3Client
 	s.bucket = config.S3Bucket
-	s.cwd = "/"
+	if s.bucket != "" {
+		s.cwd = "/" + s.bucket
+	} else {
+		s.cwd = "/"
+	}
 	s.setStatus(StatusConnected)
 	return nil
 }
@@ -92,6 +96,11 @@ func (s *S3Session) resolveRemote(p string) (string, error) {
 func (s *S3Session) s3Key(p string) string {
 	// S3 keys don't start with "/", they're relative to the bucket root.
 	p = strings.TrimPrefix(p, "/")
+	// Strip bucket name prefix if present (paths include bucket for breadcrumb display)
+	if s.bucket != "" {
+		bucketPrefix := s.bucket + "/"
+		p = strings.TrimPrefix(p, bucketPrefix)
+	}
 	return p
 }
 
@@ -190,26 +199,45 @@ func (s *S3Session) ChangeRemoteDir(dir string) (FileListResult, error) {
 	}
 
 	// Handle bucket-level navigation
-	if s.bucket == "" && target == "/" {
-		// Already at bucket list root, just refresh
-		return s.ListRemote("/")
-	}
 	if s.bucket == "" {
+		if target == "/" {
+			// Already at bucket list root, just refresh
+			return s.ListRemote("/")
+		}
 		// Navigating into a bucket from the bucket list
 		bucketName := strings.TrimPrefix(target, "/")
 		s.mu.Lock()
 		s.bucket = bucketName
-		s.cwd = "/"
+		s.cwd = "/" + bucketName
 		s.mu.Unlock()
-		return s.ListRemote("/")
+		return s.ListRemote("/" + bucketName)
 	}
-	if target == "/" && s.cwd == "/" {
-		// Already at bucket root, navigating up goes back to bucket list
+
+	// Inside a bucket: navigating up from bucket root returns to bucket list
+	bucketRoot := "/" + s.bucket
+	if target == bucketRoot || dir == ".." {
+		parts := strings.Split(strings.TrimPrefix(s.cwd, "/"+s.bucket), "/")
+		if len(parts) == 0 || (len(parts) == 1 && parts[0] == "") {
+			// At bucket root, go back to bucket list
+			s.mu.Lock()
+			s.bucket = ""
+			s.cwd = "/"
+			s.mu.Unlock()
+			return s.ListRemote("/")
+		}
+	}
+
+	// Navigate to parent when dir is ".." within a bucket
+	if dir == ".." {
+		parent := path.Dir(s.cwd)
+		if parent == bucketRoot || parent == "/"+s.bucket || parent == "/" {
+			// Parent is the bucket root
+			parent = bucketRoot
+		}
 		s.mu.Lock()
-		s.bucket = ""
-		s.cwd = "/"
+		s.cwd = parent
 		s.mu.Unlock()
-		return s.ListRemote("/")
+		return s.ListRemote(parent)
 	}
 
 	// Validate directory exists by listing it
@@ -227,7 +255,6 @@ func (s *S3Session) ChangeRemoteDir(dir string) (FileListResult, error) {
 	if err != nil {
 		return FileListResult{}, fmt.Errorf("no such directory: %s", target)
 	}
-	// If no objects and no common prefixes and prefix is not empty, the directory might not exist
 	if len(resp.Objects) == 0 && len(resp.CommonPrefixes) == 0 && prefix != "" {
 		// Could be a "virtual" directory (no marker object). Allow it.
 	}

--- a/backend/session/smb_session.go
+++ b/backend/session/smb_session.go
@@ -71,23 +71,10 @@ func (s *SMBSession) Connect(config ConnectionConfig) error {
 		return fmt.Errorf("smb handshake: %w", err)
 	}
 
-	// If a share is specified, mount it immediately.
-	// Otherwise leave share nil — ListRemote will show the share list at root.
-	if config.SmbShare != "" {
-		share, err := smbConn.Mount(config.SmbShare)
-		if err != nil {
-			smbConn.Logoff()
-			s.setStatus(StatusError)
-			return fmt.Errorf("smb mount share %s: %w", config.SmbShare, err)
-		}
-		s.share = share
-		s.cwd = "/"
-	}
-
+	// Always start at share list root. If a share was specified, the frontend
+	// will auto-navigate into it after the initial listing.
 	s.conn = smbConn
-	if s.share == nil {
-		s.cwd = "/"
-	}
+	s.cwd = "/"
 	s.setStatus(StatusConnected)
 	return nil
 }
@@ -138,19 +125,28 @@ func smbJoin(base, p string) string {
 	return base + "/" + p
 }
 
-func (s *SMBSession) resolveRemote(p string) (string, error) {
-	// "" means "list current directory" (used by refresh), return current cwd.
-	// "/" means "go to root directory".
-	if p == "" {
-		return s.cwd, nil
-	}
-	if p == "/" {
-		return "", nil
-	}
-	// Absolute path from frontend: strip leading slash.
+// smbInternal converts a frontend/internal path (with share prefix) to the raw
+// SMB path used by the share's ReadDir/Open/etc. methods.
+// E.g. "/sharename/dir/file" → "dir/file", "/sharename" → ""
+func (s *SMBSession) smbInternal(p string) string {
 	p = strings.TrimPrefix(p, "/")
 	if p == "" {
-		return "", nil
+		return ""
+	}
+	// Find the first segment (share name) and strip it
+	idx := strings.Index(p, "/")
+	if idx < 0 {
+		// p is just the share name → share root
+		return ""
+	}
+	// Return everything after the share name
+	return p[idx+1:]
+}
+
+func (s *SMBSession) resolveRemote(p string) (string, error) {
+	// "" means "list current directory" (used by refresh).
+	if p == "" {
+		return s.cwd, nil
 	}
 	return p, nil
 }
@@ -226,7 +222,8 @@ func (s *SMBSession) ListRemote(dir string) (FileListResult, error) {
 	if err != nil {
 		return FileListResult{}, err
 	}
-	entries, err := s.share.ReadDir(target)
+	internal := s.smbInternal(target)
+	entries, err := s.share.ReadDir(internal)
 	if err != nil {
 		return FileListResult{}, err
 	}
@@ -271,6 +268,14 @@ func (s *SMBSession) ChangeRemoteDir(dir string) (FileListResult, error) {
 		return FileListResult{}, err
 	}
 
+	// "/" from inside a share → go back to share list
+	if target == "/" {
+		s.share.Umount()
+		s.share = nil
+		s.cwd = "/"
+		return s.listShares()
+	}
+
 	// Navigate up: handle going from share root back to share list
 	if dir == ".." {
 		// If at share root (cwd is "/sharename" or ""), unmount and list shares
@@ -294,8 +299,9 @@ func (s *SMBSession) ChangeRemoteDir(dir string) (FileListResult, error) {
 	}
 
 	// Root directory: skip Stat (SMB can't stat empty path)
-	if target != "" {
-		fi, err := s.share.Stat(target)
+	internal := s.smbInternal(target)
+	if internal != "" {
+		fi, err := s.share.Stat(internal)
 		if err != nil {
 			return FileListResult{}, fmt.Errorf("no such directory: %s", target)
 		}
@@ -317,7 +323,7 @@ func (s *SMBSession) MakeDir(dir string) error {
 	if err != nil {
 		return err
 	}
-	return s.share.Mkdir(p, 0755)
+	return s.share.Mkdir(s.smbInternal(p), 0755)
 }
 
 func (s *SMBSession) Remove(p string, recursive bool) error {
@@ -328,15 +334,16 @@ func (s *SMBSession) Remove(p string, recursive bool) error {
 	if err != nil {
 		return err
 	}
+	internal := s.smbInternal(target)
 	if recursive {
-		return s.share.RemoveAll(target)
+		return s.share.RemoveAll(internal)
 	}
-	fi, err := s.share.Stat(target)
+	fi, err := s.share.Stat(internal)
 	if err != nil {
 		return err
 	}
 	if fi.IsDir() {
-		entries, err := s.share.ReadDir(target)
+		entries, err := s.share.ReadDir(internal)
 		if err != nil {
 			return err
 		}
@@ -344,7 +351,7 @@ func (s *SMBSession) Remove(p string, recursive bool) error {
 			return fmt.Errorf("directory not empty (%d items)", len(entries))
 		}
 	}
-	return s.share.Remove(target)
+	return s.share.Remove(internal)
 }
 
 func (s *SMBSession) Rename(oldName, newName string) error {
@@ -359,7 +366,7 @@ func (s *SMBSession) Rename(oldName, newName string) error {
 	if err != nil {
 		return err
 	}
-	return s.share.Rename(old, n)
+	return s.share.Rename(s.smbInternal(old), s.smbInternal(n))
 }
 
 func (s *SMBSession) Chmod(p string, mode os.FileMode) error {
@@ -370,7 +377,7 @@ func (s *SMBSession) Chmod(p string, mode os.FileMode) error {
 	if err != nil {
 		return err
 	}
-	return s.share.Chmod(target, mode)
+	return s.share.Chmod(s.smbInternal(target), mode)
 }
 
 func (s *SMBSession) Copy(oldPath, newPath string) error {
@@ -385,18 +392,19 @@ func (s *SMBSession) Copy(oldPath, newPath string) error {
 	if err != nil {
 		return err
 	}
-	fi, err := s.share.Stat(old)
+	oldInternal := s.smbInternal(old)
+	fi, err := s.share.Stat(oldInternal)
 	if err != nil {
 		return err
 	}
 	if fi.IsDir() {
 		return fmt.Errorf("cannot copy directory via SMB: %s", old)
 	}
-	data, err := s.readRemoteFile(old)
+	data, err := s.readRemoteFile(oldInternal)
 	if err != nil {
 		return err
 	}
-	return s.writeRemoteFile(n, data)
+	return s.writeRemoteFile(s.smbInternal(n), data)
 }
 
 func (s *SMBSession) Move(oldPath, newPath string) error {
@@ -411,7 +419,7 @@ func (s *SMBSession) GetContent(remotePath string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	return s.readRemoteFile(p)
+	return s.readRemoteFile(s.smbInternal(p))
 }
 
 func (s *SMBSession) PutContent(remotePath string, content []byte) error {
@@ -422,11 +430,12 @@ func (s *SMBSession) PutContent(remotePath string, content []byte) error {
 	if err != nil {
 		return err
 	}
-	parentDir := smbDir(p)
+	internal := s.smbInternal(p)
+	parentDir := smbDir(internal)
 	if err := s.mkdirAllRemote(parentDir); err != nil {
 		return err
 	}
-	return s.writeRemoteFile(p, content)
+	return s.writeRemoteFile(internal, content)
 }
 
 func (s *SMBSession) Get(remotePath, localPath string, recursive bool) (string, error) {
@@ -437,6 +446,7 @@ func (s *SMBSession) Get(remotePath, localPath string, recursive bool) (string, 
 	if err != nil {
 		return "", err
 	}
+	rp = s.smbInternal(rp)
 	lp := localPath
 	if !filepath.IsAbs(lp) {
 		lp = filepath.Join(s.localCwd, lp)
@@ -489,6 +499,7 @@ func (s *SMBSession) Put(localPath, remotePath string, recursive bool) (string, 
 	if err != nil {
 		return "", err
 	}
+	rp = s.smbInternal(rp)
 	task := &TransferTask{
 		ID:         s.nextTaskID("ul"),
 		Type:       "upload",

--- a/backend/session/smb_session.go
+++ b/backend/session/smb_session.go
@@ -71,32 +71,23 @@ func (s *SMBSession) Connect(config ConnectionConfig) error {
 		return fmt.Errorf("smb handshake: %w", err)
 	}
 
-	shareName := config.SmbShare
-	if shareName == "" {
-		shares, err := smbConn.ListSharenames()
+	// If a share is specified, mount it immediately.
+	// Otherwise leave share nil — ListRemote will show the share list at root.
+	if config.SmbShare != "" {
+		share, err := smbConn.Mount(config.SmbShare)
 		if err != nil {
 			smbConn.Logoff()
 			s.setStatus(StatusError)
-			return fmt.Errorf("smb list shares: %w", err)
+			return fmt.Errorf("smb mount share %s: %w", config.SmbShare, err)
 		}
-		if len(shares) == 0 {
-			smbConn.Logoff()
-			s.setStatus(StatusError)
-			return fmt.Errorf("no shares available on %s", config.Host)
-		}
-		shareName = shares[0]
-	}
-
-	share, err := smbConn.Mount(shareName)
-	if err != nil {
-		smbConn.Logoff()
-		s.setStatus(StatusError)
-		return fmt.Errorf("smb mount share %s: %w", shareName, err)
+		s.share = share
+		s.cwd = "/"
 	}
 
 	s.conn = smbConn
-	s.share = share
-	s.cwd = ""
+	if s.share == nil {
+		s.cwd = "/"
+	}
 	s.setStatus(StatusConnected)
 	return nil
 }
@@ -113,6 +104,7 @@ func (s *SMBSession) Disconnect() error {
 		s.conn.Logoff()
 		s.conn = nil
 	}
+	s.cwd = "/"
 	s.setStatus(StatusDisconnected)
 	return nil
 }
@@ -200,10 +192,36 @@ func (s *SMBSession) mkdirAllRemote(dir string) error {
 	return s.share.Mkdir(dir, 0755)
 }
 
-func (s *SMBSession) ListRemote(dir string) (FileListResult, error) {
-	if err := s.requireShare(); err != nil {
-		return FileListResult{}, err
+// listShares returns all available shares as directory entries.
+func (s *SMBSession) listShares() (FileListResult, error) {
+	if s.conn == nil {
+		return FileListResult{}, fmt.Errorf("SMB session not connected")
 	}
+	names, err := s.conn.ListSharenames()
+	if err != nil {
+		return FileListResult{}, fmt.Errorf("smb list shares: %w", err)
+	}
+	files := make([]FileItem, 0, len(names))
+	for _, name := range names {
+		files = append(files, FileItem{
+			Name:  name,
+			Size:  0,
+			Mode:  "drwxr-xr-x",
+			IsDir: true,
+		})
+	}
+	return FileListResult{Files: files, Dir: "/"}, nil
+}
+
+func (s *SMBSession) ListRemote(dir string) (FileListResult, error) {
+	// No share mounted: show share list at root
+	if s.share == nil {
+		if s.conn == nil {
+			return FileListResult{}, fmt.Errorf("SMB session not connected")
+		}
+		return s.listShares()
+	}
+
 	target, err := s.resolveRemote(dir)
 	if err != nil {
 		return FileListResult{}, err
@@ -230,13 +248,51 @@ func (s *SMBSession) ListRemote(dir string) (FileListResult, error) {
 }
 
 func (s *SMBSession) ChangeRemoteDir(dir string) (FileListResult, error) {
-	if err := s.requireShare(); err != nil {
-		return FileListResult{}, err
+	// No share mounted yet: navigating into a share name mounts it
+	if s.share == nil {
+		if s.conn == nil {
+			return FileListResult{}, fmt.Errorf("SMB session not connected")
+		}
+		shareName := strings.TrimPrefix(dir, "/")
+		if shareName == "" || shareName == "/" {
+			return s.listShares()
+		}
+		share, err := s.conn.Mount(shareName)
+		if err != nil {
+			return FileListResult{}, fmt.Errorf("smb mount share %s: %w", shareName, err)
+		}
+		s.share = share
+		s.cwd = "/" + shareName
+		return s.ListRemote("")
 	}
+
 	target, err := s.resolveRemote(dir)
 	if err != nil {
 		return FileListResult{}, err
 	}
+
+	// Navigate up: handle going from share root back to share list
+	if dir == ".." {
+		// If at share root (cwd is "/sharename" or ""), unmount and list shares
+		cwdTrimmed := strings.TrimPrefix(strings.TrimSuffix(s.cwd, "/"), "/")
+		if cwdTrimmed == "" || !strings.Contains(cwdTrimmed, "/") {
+			// At share root, go back to share list
+			s.share.Umount()
+			s.share = nil
+			s.cwd = "/"
+			return s.listShares()
+		}
+		// Navigate to parent directory
+		parent := smbDir(target)
+		if parent == "" {
+			parent = ""
+		}
+		s.mu.Lock()
+		s.cwd = parent
+		s.mu.Unlock()
+		return s.ListRemote(parent)
+	}
+
 	// Root directory: skip Stat (SMB can't stat empty path)
 	if target != "" {
 		fi, err := s.share.Stat(target)

--- a/frontend/src/components/ConnectionForm.vue
+++ b/frontend/src/components/ConnectionForm.vue
@@ -56,13 +56,13 @@
               </el-select>
             </el-form-item>
             <el-form-item :label="form.type === 's3' ? 'Endpoint' : t('conn.host')" required v-if="form.type !== 'local' && form.type !== 'serial'">
-              <el-input v-model="form.host" :placeholder="t('conn.hostPlaceholder')" />
+              <el-input v-model="form.host" :placeholder="form.type === 's3' ? 'e.g. s3.amazonaws.com' : t('conn.hostPlaceholder')" />
             </el-form-item>
             <el-form-item :label="t('conn.port')" v-if="form.type !== 'local' && form.type !== 'serial' && form.type !== 's3'">
               <el-input-number v-model="form.port" :min="0" :max="65535" />
             </el-form-item>
             <el-form-item v-if="form.type !== 'vnc' && form.type !== 'spice' && !(form.type === 'database' && form.dbType === 'rqlite') && form.type !== 'local' && form.type !== 'serial'" :label="form.type === 's3' ? 'Access Key' : t('conn.user')">
-              <el-input v-model="form.user" :placeholder="t('conn.userPlaceholder')" />
+              <el-input v-model="form.user" :placeholder="form.type === 's3' ? 'Access Key ID' : t('conn.userPlaceholder')" />
             </el-form-item>
             <el-form-item v-if="form.type === 'ssh' || form.type === 'mosh'" :label="t('conn.authType')">
               <el-radio-group v-model="form.authType">
@@ -71,7 +71,7 @@
               </el-radio-group>
             </el-form-item>
             <el-form-item v-if="form.type !== 'local' && form.type !== 'serial' && (form.authType === 'password' || form.type === 'rdp' || form.type === 'vnc' || form.type === 'spice' || form.type === 'database' || form.type === 'mosh' || form.type === 'telnet' || form.type === 'ftp' || form.type === 'smb' || form.type === 'webdav' || form.type === 's3') && !(form.type === 'database' && form.dbType === 'rqlite')" :label="form.type === 's3' ? 'Secret Key' : t('conn.password')">
-              <el-input v-model="form.password" type="password" show-password :key="passwordInputKey" />
+              <el-input v-model="form.password" type="password" show-password :key="passwordInputKey" :placeholder="form.type === 's3' ? 'Secret Access Key' : ''" />
             </el-form-item>
             <el-form-item v-if="form.authType === 'key' && (form.type === 'ssh' || form.type === 'mosh')" :label="t('conn.keyPath')">
               <el-input v-model="form.keyPath" :placeholder="t('conn.keyPathPlaceholder')">

--- a/frontend/src/components/ConnectionForm.vue
+++ b/frontend/src/components/ConnectionForm.vue
@@ -142,7 +142,7 @@
                 <el-input v-model="form.smbDomain" placeholder="e.g. WORKGROUP" />
               </el-form-item>
               <el-form-item label="Share">
-                <el-input v-model="form.smbShare" placeholder="Share name (leave empty to browse)" />
+                <el-input v-model="form.smbShare" placeholder="Share name (leave empty to browse all)" />
               </el-form-item>
             </template>
             <template v-if="form.type === 'webdav'">

--- a/frontend/src/components/SFTPTabContent.vue
+++ b/frontend/src/components/SFTPTabContent.vue
@@ -11,7 +11,7 @@
         <div v-if="dragOverLocal" class="drop-overlay">
           <span>{{ t('sftp.dropHere') }}</span>
         </div>
-        <SFTPPathBreadcrumb :label="t('sftp.local')" :path="localCwd" :drives="localDrives" bookmark-mode="local" :saved-paths="settingsStore.sftpBookmarks.localPaths" @navigate="onLocalNavigate" @save-bookmark="onSaveBookmark('local', $event)" @remove-bookmark="onRemoveBookmark('local', $event)" />
+        <SFTPPathBreadcrumb :path="localCwd" :drives="localDrives" bookmark-mode="local" :saved-paths="settingsStore.sftpBookmarks.localPaths" @navigate="onLocalNavigate" @save-bookmark="onSaveBookmark('local', $event)" @remove-bookmark="onRemoveBookmark('local', $event)" />
         <SFTPFileList
           mode="local"
           :files="localFiles"
@@ -47,7 +47,7 @@
         <div v-if="dragOverRemote" class="drop-overlay">
           <span>{{ t('sftp.dropHere') }}</span>
         </div>
-        <SFTPPathBreadcrumb :label="panel?.config?.host || t('sftp.remote')" :path="cwd" bookmark-mode="remote" :saved-paths="settingsStore.sftpBookmarks.remotePaths" @navigate="onRemoteNavigate" @save-bookmark="onSaveBookmark('remote', $event)" @remove-bookmark="onRemoveBookmark('remote', $event)" />
+        <SFTPPathBreadcrumb :path="cwd" bookmark-mode="remote" :saved-paths="settingsStore.sftpBookmarks.remotePaths" @navigate="onRemoteNavigate" @save-bookmark="onSaveBookmark('remote', $event)" @remove-bookmark="onRemoveBookmark('remote', $event)" />
         <SFTPFileList
           mode="remote"
           :files="remoteFiles"
@@ -546,13 +546,14 @@ function parseMode(mode: string) {
 
 let unsubscribe: (() => void) | null = null
 let unsubscribeStatus: (() => void) | null = null
+let initialNavDone = false
 
 onMounted(async () => {
   unsubscribeStatus = EventsOn('session:status', (payload: { id: string; status: string }) => {
     if (payload.id === panel.value?.sessionId) {
       if (payload.status === 'connected') {
         onRefreshLocal()
-        onRefreshRemote()
+        onRefreshRemote().then(() => doInitialAutoNav())
       } else if (payload.status === 'error') {
         ElMessage.error(t('sftp.connectError'))
       }
@@ -647,7 +648,7 @@ onMounted(async () => {
       const sess = sessions.find(s => s.id === sid)
       if (sess && sess.status === 'connected') {
         onRefreshLocal()
-        onRefreshRemote()
+        onRefreshRemote().then(() => doInitialAutoNav())
       }
     } catch {}
   }
@@ -737,6 +738,23 @@ async function onRefreshRemote() {
     msg.error(e?.toString() || 'Failed to list remote files')
   } finally {
     if (version === loadVersionRemote) loadingRemote.value = false
+  }
+}
+
+// Auto-navigate into the configured share/bucket on initial load.
+async function doInitialAutoNav() {
+  if (initialNavDone) return
+  initialNavDone = true
+  const cfg = panel.value?.config
+  if (!cfg) return
+  let target = ''
+  if (cfg.type === 'smb' && cfg.smbShare) {
+    target = '/' + cfg.smbShare
+  } else if (cfg.type === 's3' && cfg.s3Bucket) {
+    target = '/' + cfg.s3Bucket
+  }
+  if (target) {
+    await onRemoteNavigate(target)
   }
 }
 

--- a/frontend/src/components/StartTabContent.vue
+++ b/frontend/src/components/StartTabContent.vue
@@ -222,11 +222,22 @@
         >
           <div class="start-card-top">
             <div class="start-card-icon" :class="config.type">
-              <el-icon v-if="config.type === 'ssh' || config.type === 'telnet' || config.type === 'mosh'"><SquareTerminal :size="28" /></el-icon>
+              <el-icon v-if="config.type === 'ssh'"><SquareTerminal :size="28" /></el-icon>
+              <el-icon v-else-if="config.type === 'telnet'"><Terminal :size="28" /></el-icon>
+              <el-icon v-else-if="config.type === 'mosh'"><Zap :size="28" /></el-icon>
               <el-icon v-else-if="config.type === 'local'"><Laptop :size="28" /></el-icon>
-              <el-icon v-else-if="config.type === 'database'"><Database :size="28" /></el-icon>
-              <el-icon v-else-if="config.type === 'rdp' || config.type === 'vnc' || config.type === 'spice'"><Monitor :size="28" /></el-icon>
               <el-icon v-else-if="config.type === 'serial'"><Cable :size="28" /></el-icon>
+              <el-icon v-else-if="config.type === 'ftp' || config.type === 'sftp'"><FolderUp :size="28" /></el-icon>
+              <el-icon v-else-if="config.type === 'smb'"><HardDrive :size="28" /></el-icon>
+              <el-icon v-else-if="config.type === 's3'"><Cloud :size="28" /></el-icon>
+              <el-icon v-else-if="config.type === 'webdav'"><Globe :size="28" /></el-icon>
+              <el-icon v-else-if="config.type === 'rdp'"><Monitor :size="28" /></el-icon>
+              <el-icon v-else-if="config.type === 'vnc'"><MonitorSmartphone :size="28" /></el-icon>
+              <el-icon v-else-if="config.type === 'spice'"><MonitorCloud :size="28" /></el-icon>
+              <el-icon v-else-if="config.type === 'database'">
+                <DatabaseZap v-if="config.dbType === 'redis'" :size="28" />
+                <Database v-else :size="28" />
+              </el-icon>
               <el-icon v-else><Server :size="28" /></el-icon>
             </div>
             <div>
@@ -360,7 +371,7 @@ import { useSettingsStore } from '../stores/settingsStore'
 import { useI18n } from '../i18n'
 import { GetRecentConnections } from '../../wailsjs/go/main/App'
 import { formatConnSubtitle } from '../utils/quickConnect'
-import { Filter, Plus, Laptop, Cable, SquareTerminal, Database, Monitor, Server, Folder, FolderOpen, Zap } from '@lucide/vue'
+import { Filter, Plus, Laptop, Cable, SquareTerminal, Terminal, Database, DatabaseZap, Monitor, MonitorSmartphone, MonitorCloud, FolderUp, HardDrive, Cloud, Globe, Server, Folder, FolderOpen, Zap } from '@lucide/vue'
 
 const props = defineProps<{
   tab: StartTab


### PR DESCRIPTION
## Summary

- **S3**: bucket-aware breadcrumb `/bucket/path`, fix `s3Key()` for root navigation
- **SMB**: share browsing — empty share shows all shares as directories, `/share/path` breadcrumb
- **SFTP**: auto-navigate to configured share/bucket on initial connect
- **StartTab**: fix missing icon imports (Terminal, DatabaseZap, MonitorSmartphone, MonitorCloud, FolderUp, HardDrive, Cloud, Globe), unify all 3 card icon sections
- **ConnectionForm**: S3-specific placeholders (Endpoint, Access Key, Secret Key)
- **SFTPTabContent**: remove "本地"/"远程" breadcrumb labels

Closes #120

---

## 概述

- S3/SMB 面包屑按 /bucket/path 和 /share/path 组织
- SMB 支持空共享名浏览所有共享
- 首次连接自动导航到配置的 bucket/share
- 修复 StartTab 卡片图标缺失
- S3 表单 placeholder 改为专属文案

Closes #120