### PR TITLE
fix: support Command+F (macOS) for terminal search

### DIFF
--- a/frontend/src/components/BaseTerminal.vue
+++ b/frontend/src/components/BaseTerminal.vue
@@ -572,7 +572,7 @@ function handleTerminalKey(e: KeyboardEvent): boolean {
   // Check global shortcuts first (Ctrl+Shift+/Alt+ combos)
   if (e.type === 'keydown' && !onTerminalKey(e)) return false
 
-  if (e.ctrlKey && e.key === 'f' && e.type === 'keydown') {
+  if ((e.ctrlKey || e.metaKey) && e.key === 'f' && e.type === 'keydown') {
     openSearch()
     return false
   }


### PR DESCRIPTION
## Summary

Added `e.metaKey` check alongside `e.ctrlKey` so that **Command+F** (macOS) also triggers the terminal search bar, in addition to **Ctrl+F** (Windows/Linux).

Closes #119

---

## 概述

新增 `e.metaKey` 支持，macOS 用户按 **Command+F** 也能打开终端搜索栏。

Closes #119