### PR TITLE
fix: confirm before closing when active connections exist

### DIFF
--- a/frontend/src/components/AppHeader.vue
+++ b/frontend/src/components/AppHeader.vue
@@ -44,9 +44,11 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, onUnmounted } from 'vue'
+import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { Settings, PanelLeft, Bot } from '@lucide/vue'
+import { ElMessageBox } from 'element-plus'
 import { useI18n } from '../i18n'
+import { useTabStore } from '../stores/tabStore'
 import WindowControls from './WindowControls.vue'
 import TabsList from './TabsList.vue'
 import {
@@ -62,6 +64,12 @@ import {
 } from '../../wailsjs/runtime'
 
 const { t } = useI18n()
+const tabStore = useTabStore()
+
+// Count non-start, non-settings tabs (actual connection tabs)
+const hasActiveConnections = computed(() =>
+  tabStore.tabs.some(t => t.type !== 'start' && t.type !== 'settings')
+)
 
 const emit = defineEmits<{
   'toggle-ai': []
@@ -119,7 +127,18 @@ async function linuxMaximise() {
   }
 }
 
-function onClose() {
+async function onClose() {
+  if (hasActiveConnections.value) {
+    try {
+      await ElMessageBox.confirm(
+        t('app.closeConfirm'),
+        t('app.closeTitle'),
+        { confirmButtonText: t('tab.close'), cancelButtonText: t('conn.cancel'), type: 'warning' }
+      )
+    } catch {
+      return // user cancelled
+    }
+  }
   Quit()
 }
 

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -3,6 +3,8 @@
   "header.newConnection": "New Connection",
   "header.settings": "Settings",
   "header.ai": "AI",
+  "app.closeConfirm": "Active connections are present. Close anyway?",
+  "app.closeTitle": "Close Confirmation",
   "sidebar.newConnection": "New Connection",
   "sidebar.collapse": "Collapse",
   "sidebar.personalization": "Personalization",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -3,6 +3,8 @@
   "header.newConnection": "新建连接",
   "header.settings": "设置",
   "header.ai": "AI",
+  "app.closeConfirm": "有正在活动的连接，确定关闭？",
+  "app.closeTitle": "关闭确认",
   "sidebar.newConnection": "新建连接",
   "sidebar.collapse": "收起",
   "sidebar.personalization": "个性化",


### PR DESCRIPTION
## Summary

When closing the application via the window close button, show a confirmation dialog if there are any active connection tabs (non-start, non-settings tabs). This prevents accidentally closing the app when multiple sessions are running.

If only start tabs or settings tabs are open, the app closes immediately without confirmation.

Closes #122

---

## 概述

关闭应用时，如果存在非新标签页、非设置页的标签，弹出确认对话框。只有起始页和设置页时直接关闭。

Closes #122