### PR TITLE
feat: export terminal content to text file

### DIFF
--- a/frontend/src/components/BaseTerminal.vue
+++ b/frontend/src/components/BaseTerminal.vue
@@ -52,6 +52,7 @@
         {{ t('terminal.copyAndPaste') }}
       </div>
       <div class="menu-item" @click="menu.pasteFromClipboard">{{ t('terminal.paste') }}</div>
+      <div class="menu-item" @click="menu.closeMenu(); exportContent()">{{ t('terminal.export') }}</div>
     </div>
 
     <!-- Terminal suggestions popup -->
@@ -77,8 +78,7 @@ import type { Terminal } from '@xterm/xterm'
 import { WebLinksAddon } from '@xterm/addon-web-links'
 import '@xterm/xterm/css/xterm.css'
 import { SessionWrite, SessionResize, SessionEndZmodem } from '../../wailsjs/go/main/App'
-import { WriteTempFile } from '../../wailsjs/go/main/App'
-import { FrontendLog } from '../../wailsjs/go/main/App'
+import { WriteFileBase64, SaveFileDialog, FrontendLog } from '../../wailsjs/go/main/App'
 import { EventsOn, BrowserOpenURL } from '../../wailsjs/runtime'
 import { useSettingsStore } from '../stores/settingsStore'
 import { highlight } from '../composables/useHighlight'
@@ -154,6 +154,7 @@ let unsubscribe: (() => void) | null = null
 let statusUnsubscribe: (() => void) | null = null
 let onDocumentMouseDown: ((e: MouseEvent) => void) | null = null
 let onOpenSearch: ((e: Event) => void) | null = null
+let onExport: ((e: Event) => void) | null = null
 let onSendRz: ((e: Event) => void) | null = null
 
 let resizeTimer: ReturnType<typeof setTimeout> | null = null
@@ -166,6 +167,7 @@ let isZmodemStarting = false
 let zmodemStartTimer: ReturnType<typeof setTimeout> | null = null
 let zmodemDirection: 'upload' | 'download' | undefined = undefined
 let zmodemCancellingUntil = 0
+let exporting = false
 
 function initZmodemService(sessionId: string) {
   if (!sessionId || props.mode !== 'ssh') return
@@ -491,6 +493,46 @@ function write(data: string) {
 
 function focus() {
   terminal?.focus()
+}
+
+function toBase64(str: string): string {
+  const encoder = new TextEncoder()
+  const bytes = encoder.encode(str)
+  let binary = ''
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i])
+  }
+  return btoa(binary)
+}
+
+async function exportContent() {
+  if (!terminal || exporting) return
+  exporting = true
+  try {
+    let content = ''
+    try {
+      const buffer = terminal.buffer.active
+      const totalLines = buffer.length
+      const lines = new Array(totalLines)
+      for (let i = 0; i < totalLines; i++) {
+        const line = buffer.getLine(i)
+        lines[i] = line ? line.translateToString() : ''
+      }
+      content = lines.join('\n')
+    } catch (e) {
+      console.error('Buffer read failed:', e)
+      return
+    }
+    try {
+      const filePath = await SaveFileDialog('terminal.txt')
+      if (!filePath) return
+      await WriteFileBase64(filePath, toBase64(content))
+    } catch (e) {
+      console.error('Export failed:', e)
+    }
+  } finally {
+    exporting = false
+  }
 }
 
 function setRetryOnEnter(value: boolean) {
@@ -1059,11 +1101,20 @@ onMounted(() => {
   window.addEventListener('split:resize-start', onSplitResizeStart)
   window.addEventListener('split:resize-end', onSplitResizeEnd)
   onOpenSearch = (e: Event) => {
+    if (!isActive.value) return
     const detail = (e as CustomEvent).detail
-    if (detail?.panelId && detail.panelId !== props.panelId) return
+    if (!props.panelId || detail?.panelId !== props.panelId) return
     openSearch()
   }
   window.addEventListener('terminal:open-search', onOpenSearch)
+
+  onExport = (e: Event) => {
+    if (!isActive.value) return
+    const detail = (e as CustomEvent).detail
+    if (!props.panelId || detail?.panelId !== props.panelId) return
+    exportContent()
+  }
+  window.addEventListener('terminal:export', onExport)
 
   onSendRz = (e: Event) => {
     const detail = (e as CustomEvent).detail
@@ -1321,6 +1372,7 @@ onUnmounted(() => {
   window.removeEventListener('split:resize-start', onSplitResizeStart)
   window.removeEventListener('split:resize-end', onSplitResizeEnd)
   if (onOpenSearch) window.removeEventListener('terminal:open-search', onOpenSearch)
+  if (onExport) window.removeEventListener('terminal:export', onExport)
   if (onSendRz) window.removeEventListener('terminal:send-rz', onSendRz)
   suggestions.close()
   if (!zmodemStore.getActiveTransfer(props.sessionId || '')) {

--- a/frontend/src/components/Panel.vue
+++ b/frontend/src/components/Panel.vue
@@ -51,6 +51,7 @@
             <div v-if="panel.type === 'ssh'" class="menu-item" @click="uploadFileRz(); moreMenuVisible = false">{{ t('terminal.uploadFileRz') }}</div>
             <div v-if="panel.type === 'ssh'" class="menu-item" @click="connectMonitor(); moreMenuVisible = false">{{ t('sidebar.connectMonitor') }}</div>
             <div class="menu-item" @click="triggerSearch(); moreMenuVisible = false">{{ t('terminal.searchText') }}</div>
+            <div class="menu-item" @click="triggerExport(); moreMenuVisible = false">{{ t('terminal.export') }}</div>
           </div>
         </div>
         <button class="panel-close" @click.stop="emit('close', panel.id)"><X :size="14" /></button>
@@ -138,6 +139,10 @@ function connectMonitor() {
 
 function triggerSearch() {
   window.dispatchEvent(new CustomEvent('terminal:open-search', { detail: { panelId: props.panel.id } }))
+}
+
+function triggerExport() {
+  window.dispatchEvent(new CustomEvent('terminal:export', { detail: { panelId: props.panel.id } }))
 }
 
 function onDocumentClick() {

--- a/frontend/src/components/TabItem.vue
+++ b/frontend/src/components/TabItem.vue
@@ -67,6 +67,7 @@
         <div v-if="tab.type === 'terminal' && panelStore.getPanel(tab.panelId)?.type === 'ssh'" class="menu-item" @click="uploadFileRz">{{ t('terminal.uploadFileRz') }}</div>
         <div v-if="tab.type === 'terminal' && panelStore.getPanel(tab.panelId)?.type === 'ssh'" class="menu-item" @click="openMonitor">{{ t('sidebar.connectMonitor') }}</div>
         <div v-if="tab.type === 'terminal'" class="menu-item" @click="triggerSearch">{{ t('terminal.searchText') }}</div>
+        <div v-if="tab.type === 'terminal'" class="menu-item" @click="triggerExport">{{ t('terminal.export') }}</div>
         <div v-if="tab.type === 'terminal'" class="menu-item" @click="startEdit">{{ t('tab.rename') }}</div>
         <div v-if="tab.type === 'terminal'" class="menu-divider" />
         <div class="menu-item" @click="closeTab">{{ t('tab.close') }}</div>
@@ -286,6 +287,11 @@ function openMonitor() {
 
 function triggerSearch() {
   window.dispatchEvent(new CustomEvent('terminal:open-search', { detail: { panelId: (props.tab as TerminalTab).panelId } }))
+  closeContextMenu()
+}
+
+function triggerExport() {
+  window.dispatchEvent(new CustomEvent('terminal:export', { detail: { panelId: (props.tab as TerminalTab).panelId } }))
   closeContextMenu()
 }
 

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -101,6 +101,7 @@
   "terminal.searchPrev": "Previous",
   "terminal.searchNext": "Next",
   "terminal.searchClose": "Close",
+  "terminal.export": "Export to Text",
   "input.cut": "Cut",
   "input.copy": "Copy",
   "input.paste": "Paste",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -101,6 +101,7 @@
   "terminal.searchPrev": "上一个",
   "terminal.searchNext": "下一个",
   "terminal.searchClose": "关闭",
+  "terminal.export": "导出内容到文本",
   "input.cut": "剪切",
   "input.copy": "复制",
   "input.paste": "粘贴",


### PR DESCRIPTION
## Summary

Added terminal content export functionality accessible from 3 locations:

1. **Terminal right-click menu** — "导出内容到文本"
2. **Tab right-click menu** — for terminal tabs
3. **Workspace Panel menu** — for panels in workspace

## Details

- Uses `SaveFileDialog` for native file save dialog (default: terminal.txt)
- Uses `WriteFileBase64` with `TextEncoder` for proper UTF-8 handling
- Exports full terminal buffer content (including scrollback)
- Fixed `isActive` check on `terminal:open-search` and `terminal:export` event handlers to prevent duplicate responses from KeepAlive-cached BaseTerminal instances

Closes #114

---

## 概述

终端右键、Tab 右键、Panel 菜单三处都加了"导出内容到文本"，支持完整终端缓冲区导出。

Closes #114