### PR TITLE
fix(fonts): scan per-user registry/font dir on Windows, not just HKLM

### DIFF
--- a/backend/platform/fonts_windows.go
+++ b/backend/platform/fonts_windows.go
@@ -11,12 +11,56 @@ import (
 	"golang.org/x/sys/windows/registry"
 )
 
+// getSystemFonts enumerates monospaced font families from both the
+// machine-wide registry/font store and the per-user one. Windows 10 1809+
+// allows installing a font without admin rights ("Install for me only" /
+// double-click a .ttf preview and hit Install as a standard user), which
+// writes to HKCU + %LOCALAPPDATA%\Microsoft\Windows\Fonts instead of HKLM +
+// C:\Windows\Fonts. Other apps see such fonts via the GDI/DirectWrite system
+// font enumeration APIs, which cover both scopes; our hand-rolled registry
+// walk needs to check both explicitly or it silently misses user-installed
+// fonts (https://github.com/ys-ll/uniterm/issues/145).
 func getSystemFonts() ([]string, error) {
-	key, err := registry.OpenKey(
-		registry.LOCAL_MACHINE,
-		`SOFTWARE\Microsoft\Windows NT\CurrentVersion\Fonts`,
-		registry.QUERY_VALUE,
-	)
+	var families []string
+	var firstErr error
+
+	if fam, err := readFontFamilies(registry.LOCAL_MACHINE, `SOFTWARE\Microsoft\Windows NT\CurrentVersion\Fonts`, `C:\Windows\Fonts`); err != nil {
+		firstErr = err
+	} else {
+		families = append(families, fam...)
+	}
+
+	// Per-user scope is optional: on systems/setups where nothing was ever
+	// installed at user scope this key simply doesn't exist, which is normal
+	// and not reported as an error as long as the machine-wide scan above
+	// found something.
+	if userFontDir := userFontsDir(); userFontDir != "" {
+		if fam, err := readFontFamilies(registry.CURRENT_USER, `Software\Microsoft\Windows NT\CurrentVersion\Fonts`, userFontDir); err == nil {
+			families = append(families, fam...)
+		}
+	}
+
+	if len(families) == 0 && firstErr != nil {
+		return nil, firstErr
+	}
+	return families, nil
+}
+
+// userFontsDir returns the per-user font install directory, or "" if
+// %LOCALAPPDATA% isn't set (unexpected, but avoids a bogus relative path).
+func userFontsDir() string {
+	local := os.Getenv("LOCALAPPDATA")
+	if local == "" {
+		return ""
+	}
+	return filepath.Join(local, "Microsoft", "Windows", "Fonts")
+}
+
+// readFontFamilies reads one Fonts registry key (HKLM or HKCU) and resolves
+// each value against fontDir, returning the unique monospaced family names
+// found in that scope.
+func readFontFamilies(root registry.Key, keyPath, fontDir string) ([]string, error) {
+	key, err := registry.OpenKey(root, keyPath, registry.QUERY_VALUE)
 	if err != nil {
 		return nil, fmt.Errorf("open registry: %w", err)
 	}
@@ -27,7 +71,6 @@ func getSystemFonts() ([]string, error) {
 		return nil, fmt.Errorf("read value names: %w", err)
 	}
 
-	fontDir := `C:\Windows\Fonts`
 	var families []string
 	seen := make(map[string]bool)
 


### PR DESCRIPTION
## Summary

Fixes uniterm's Windows font picker missing fonts that were installed at **per-user scope** instead of machine-wide scope, even though other applications can see and use those same fonts fine.

修复 uniterm 在 Windows 上的字体选择器漏掉"用户级安装"字体的问题——即使其他软件（比如 mobaxterm）能正常看到并使用同一款字体，uniterm 的字体列表里也不会出现它。

## Changes

- `backend/platform/fonts_windows.go`: `getSystemFonts()` previously only scanned `HKEY_LOCAL_MACHINE\...\Fonts` and resolved relative paths against `C:\Windows\Fonts`. Windows 10 1809+ lets a standard (non-admin) user install a font by double-clicking its preview and hitting "Install" — this writes to `HKEY_CURRENT_USER\...\Fonts` and `%LOCALAPPDATA%\Microsoft\Windows\Fonts` instead. Other apps see both scopes via the GDI/DirectWrite system font enumeration APIs; our hand-rolled registry walk needs to check both explicitly.
- Extracted the per-scope registry scan into a reusable `readFontFamilies(root, keyPath, fontDir)` helper, now called once for HKLM (machine-wide) and once for HKCU (per-user), merging the results. The per-user scan is best-effort — a missing HKCU key (nothing ever installed at user scope on that machine) is not treated as an error as long as the machine-wide scan succeeded.

- `backend/platform/fonts_windows.go`：`getSystemFonts()` 原来只扫描 `HKEY_LOCAL_MACHINE\...\Fonts`，相对路径也只按 `C:\Windows\Fonts` 解析。Windows 10 1809 之后，普通用户（非管理员）双击字体预览点"安装"就能装字体，但这种方式写入的是 `HKEY_CURRENT_USER\...\Fonts` 和 `%LOCALAPPDATA%\Microsoft\Windows\Fonts`。其他软件通过 GDI/DirectWrite 系统字体枚举 API 能同时看到两个作用域的字体，而我们自己手写的注册表遍历需要显式检查这两处。
- 把单作用域的注册表扫描逻辑抽成可复用的 `readFontFamilies(root, keyPath, fontDir)`，现在分别对 HKLM（机器级）和 HKCU（用户级）各扫一次并合并结果。用户级扫描是尽力而为——如果 HKCU 下这个键不存在（这台机器从没在用户级装过字体），只要机器级扫描成功，就不算错误。

## Validation

- `gofmt -l backend/platform/fonts_windows.go` — clean
- `GOOS=windows GOARCH=amd64 go vet ./backend/platform/...` — no warnings
- `GOOS=windows GOARCH=amd64 go build ./backend/...` — builds cleanly
- Cannot repro on a real Windows box with a user-scope font install in this environment; logic was reviewed against the documented registry/directory layout for both install scopes (HKLM+`C:\Windows\Fonts` vs HKCU+`%LOCALAPPDATA%\Microsoft\Windows\Fonts`).

- `gofmt -l backend/platform/fonts_windows.go` — 无输出，格式干净
- `GOOS=windows GOARCH=amd64 go vet ./backend/platform/...` — 无警告
- `GOOS=windows GOARCH=amd64 go build ./backend/...` — 编译通过
- 当前环境没有真实 Windows 机器可复现用户级字体安装场景，逻辑已对照两种安装作用域（HKLM+`C:\Windows\Fonts` 与 HKCU+`%LOCALAPPDATA%\Microsoft\Windows\Fonts`）的官方注册表/目录结构人工核对。

Closes #145
