### PR TITLE
fix(terminal): ensure SessionResize is always called after container resize

### DIFF
--- a/backend/session/ssh_session.go
+++ b/backend/session/ssh_session.go
@@ -467,7 +467,6 @@ func (s *SSHSession) Resize(cols, rows int) error {
 	if s.session == nil {
 		return fmt.Errorf("session not connected")
 	}
-	fmt.Printf("[Resize] %s -> cols=%d rows=%d\n", s.id, cols, rows)
 	return s.session.WindowChange(rows, cols)
 }
 

--- a/frontend/src/components/BaseTerminal.vue
+++ b/frontend/src/components/BaseTerminal.vue
@@ -479,10 +479,8 @@ function resize() {
     const newCols = Math.max(2, cols)
     const newRows = Math.max(1, rows)
 
-    if (terminal.cols !== newCols || terminal.rows !== newRows) {
-      terminal.resize(newCols, newRows)
-      SessionResize(sid, newCols, newRows).catch(() => {})
-    }
+    terminal.resize(newCols, newRows)
+    SessionResize(sid, newCols, newRows).catch(() => {})
   } else {
     getFitAddon()?.fit()
   }


### PR DESCRIPTION
Commit c20e113 (PR #136) moved `fitAddon.fit()` before the manual cols/rows calculation in `resize()`. Since `fit()` internally calls `terminal.resize()`, it updates `terminal.cols`/`terminal.rows`. The subsequent manual calculation often produces the same values, causing the conditional to skip both `terminal.resize()` and `SessionResize()`. This prevented the backend PTY from receiving SIGWINCH, so TUI apps like k9s never learned the new terminal size when the window was resized.

**Fix:** Remove the conditional — always call `terminal.resize()` (no-op if dimensions unchanged in xterm.js) and `SessionResize()` after the manual calculation.

Also removes a leftover debug `fmt.Printf` in `ssh_session.go`.

Closes #166.

---

Commit c20e113（PR #136）把 `fitAddon.fit()` 提到了手动计算 cols/rows 之前。由于 `fit()` 内部会调用 `terminal.resize()` 并更新 `terminal.cols`/`terminal.rows`，后续手动计算的结果往往与 `fit()` 相同，导致条件判断为 false，跳过了 `terminal.resize()` 和 `SessionResize()`。后端 PTY 收不到 SIGWINCH，k9s 等 TUI 应用无法感知终端窗口大小变化。

**修复：** 移除条件判断，每次都调用 `terminal.resize()`（xterm.js 内部尺寸未变时为空操作）和 `SessionResize()`。

同时删除 `ssh_session.go` 中遗留的 debug 日志。

Closes #166.