### PR TITLE
fix(sftp): prevent bookmark dropdown from overflowing viewport on right pane

### DIFF
--- a/frontend/src/components/SFTPPathBreadcrumb.vue
+++ b/frontend/src/components/SFTPPathBreadcrumb.vue
@@ -374,7 +374,8 @@ function toggleBookmarkMenu(event?: MouseEvent) {
     const rect = (event.target as HTMLElement).closest('.bookmark-btn')?.getBoundingClientRect()
     if (rect) {
       bookmarkMenuStyle.value = {
-        left: (rect.right - 200) + 'px',
+        left: 'auto',
+        right: (window.innerWidth - rect.right) + 'px',
         top: (rect.bottom + 4) + 'px'
       }
     }


### PR DESCRIPTION
The dropdown was positioned with `left: rect.right - 200`, which assumes the dropdown is always 200px wide. When bookmark paths are long, the dropdown can grow up to max-width 320px, causing the right edge (and the delete button) to overflow beyond the viewport.

The right-pane bookmark button is near the window edge, so the overflow clips the delete button. The left pane has more margin and was not affected.

**Fix:** Use CSS `right` positioning to anchor the dropdown's right edge to the button's right edge, so the dropdown always extends leftward and never overflows the right viewport edge.

Closes #167.

---

下拉菜单使用 `left: rect.right - 200` 定位，假定下拉菜单始终为 200px 宽。当收藏路径较长时，菜单宽度可能达到 max-width 320px，导致右边缘（含删除按钮）溢出视口。

右侧 SFTP 窗口的书签按钮靠近窗口右边缘，溢出的部分被裁切，删除按钮无法点击。左侧距离右边缘有余量，不受影响。

**修复：** 改用 CSS `right` 定位，让下拉菜单右边缘始终对齐按钮右边缘，菜单向左展开，永不超出视口右边界。

Closes #167.