### PR TITLE
fix(terminal): let PrintScreen key pass through to the OS

### DIFF
--- a/frontend/src/components/BaseTerminal.vue
+++ b/frontend/src/components/BaseTerminal.vue
@@ -612,6 +612,9 @@ function writeTerminalInput(data: string, inAlternateScreen: boolean) {
 }
 
 function handleTerminalKey(e: KeyboardEvent): boolean {
+  // Let system keys pass through to the OS (e.g. PrintScreen for screenshots)
+  if (e.key === 'PrintScreen') return false
+
   // Check global shortcuts first (Ctrl+Shift+/Alt+ combos)
   if (e.type === 'keydown' && !onTerminalKey(e)) return false
 


### PR DESCRIPTION
`handleTerminalKey` returns `true` by default for all unhandled keys, which causes xterm.js to capture the PrintScreen (PrtSc) key event. This prevents Windows from receiving it and taking a screenshot while uniTerm is focused.

**Fix:** Return `false` for `PrintScreen` so the event propagates through to the OS, restoring the Windows screenshot functionality.

Closes #160.

---

`handleTerminalKey` 对所有未处理的按键默认返回 `true`，导致 xterm.js 捕获 PrtSc 截屏键事件。Windows 无法收到此按键，截屏功能在 uniTerm 置顶时失效。

**修复：** 对 `PrintScreen` 键返回 `false`，让事件穿透到操作系统，恢复 Windows 截屏功能。

Closes #160.