### PR TITLE
fix(ui): unify all toast messages with close button and lower offset

### DIFF
--- a/frontend/src/components/CustomThemeEditor.vue
+++ b/frontend/src/components/CustomThemeEditor.vue
@@ -93,7 +93,8 @@
 
 <script setup lang="ts">
 import { ref, computed, watch } from 'vue'
-import { ElMessageBox, ElMessage } from 'element-plus'
+import { ElMessageBox } from 'element-plus'
+import { msg } from '../services/message'
 import { Upload, Download } from '@lucide/vue'
 import { useSettingsStore } from '../stores/settingsStore'
 import { useI18n } from '../i18n'
@@ -227,9 +228,9 @@ async function onImport() {
       const base = path.split(/[\\/]/).pop() || ''
       draft.value.name = base.replace(/\.itermcolors$/i, '') || draft.value.name
     }
-    ElMessage.success(t('theme.importSuccess'))
+    msg.success(t('theme.importSuccess'))
   } catch {
-    ElMessage.error(t('theme.importFailed'))
+    msg.error(t('theme.importFailed'))
   }
 }
 
@@ -245,9 +246,9 @@ async function onExport() {
   try {
     const xml = buildItermColors(draft.value.colors)
     await WriteFileBase64(path, btoa(xml))
-    ElMessage.success(t('theme.exportSuccess'))
+    msg.success(t('theme.exportSuccess'))
   } catch {
-    ElMessage.error(t('theme.exportFailed'))
+    msg.error(t('theme.exportFailed'))
   }
 }
 </script>

--- a/frontend/src/components/RedisTabContent.vue
+++ b/frontend/src/components/RedisTabContent.vue
@@ -267,7 +267,8 @@
 
 <script setup lang="ts">
 import { ref, watch, onUnmounted } from 'vue'
-import { ElMessage, ElMessageBox } from 'element-plus'
+import { ElMessageBox } from 'element-plus'
+import { msg } from '../services/message'
 import { Trash2, Plus, GripVertical, RefreshCw, ChevronLeft, ChevronRight } from '@lucide/vue'
 import { useI18n } from '../i18n'
 import {
@@ -393,7 +394,7 @@ async function doScan(cursor: number) {
     nextCursor.value = result.cursor
     hasMore.value = result.cursor !== 0
   } catch (e: any) {
-    ElMessage.error(`Scan failed: ${e?.message || e}`)
+    msg.error(`Scan failed: ${e?.message || e}`)
     keys.value = []
   } finally {
     loading.value = false
@@ -439,7 +440,7 @@ async function onSwitchDB(idx: number) {
     await fetchDBSize()
     await doScan(0)
   } catch (e: any) {
-    ElMessage.error(`Switch DB failed: ${e?.message || e}`)
+    msg.error(`Switch DB failed: ${e?.message || e}`)
   }
 }
 
@@ -460,7 +461,7 @@ async function onSelectKey(info: RedisKeyInfo) {
       case 'set': { const members = await RedisGetSetAll(props.sessionId, info.name); setEntries.value = members || []; break }
       case 'zset': { const members = await RedisGetSortedSetRange(props.sessionId, info.name, '-inf', '+inf'); zsetEntries.value = members || []; break }
     }
-  } catch (e: any) { ElMessage.error(`Load key failed: ${e?.message || e}`) }
+  } catch (e: any) { msg.error(`Load key failed: ${e?.message || e}`) }
   finally { keyLoading.value = false }
 }
 
@@ -501,10 +502,10 @@ async function onSave() {
         break
       }
     }
-    ElMessage.success(t('redis.saved'))
+    msg.success(t('redis.saved'))
     const info = await RedisGetKeyInfo(props.sessionId, key)
     if (info) { selectedKeyInfo.value = info; editTTL.value = info.ttl }
-  } catch (e: any) { ElMessage.error(`Save failed: ${e?.message || e}`) }
+  } catch (e: any) { msg.error(`Save failed: ${e?.message || e}`) }
   finally { saving.value = false }
 }
 
@@ -513,10 +514,10 @@ async function onSetTTL() {
   if (!selectedKey.value) return
   try {
     await RedisSetKeyTTL(props.sessionId, selectedKey.value, editTTL.value)
-    ElMessage.success(t('redis.ttlUpdated'))
+    msg.success(t('redis.ttlUpdated'))
     const info = await RedisGetKeyInfo(props.sessionId, selectedKey.value)
     if (info) selectedKeyInfo.value = info
-  } catch (e: any) { ElMessage.error(`Set TTL failed: ${e?.message || e}`) }
+  } catch (e: any) { msg.error(`Set TTL failed: ${e?.message || e}`) }
 }
 
 // --- Revert ---
@@ -533,18 +534,18 @@ async function onDeleteKey() {
   deleting.value = true
   try {
     await RedisDeleteKey(props.sessionId, selectedKey.value)
-    ElMessage.success('Key deleted')
+    msg.success('Key deleted')
     selectedKey.value = ''
     selectedKeyInfo.value = null
     await doScan(cursorStack.value.length > 0 ? cursorStack.value[cursorStack.value.length - 1] : 0)
-  } catch (e: any) { ElMessage.error(`Delete failed: ${e?.message || e}`) }
+  } catch (e: any) { msg.error(`Delete failed: ${e?.message || e}`) }
   finally { deleting.value = false }
 }
 
 // --- New key ---
 function onShowNewKeyDialog() { resetNewKeyForm(); showNewKeyDialog.value = true }
 async function onCreateKey() {
-  if (!newKeyName.value.trim()) { ElMessage.warning(t('redis.keyNameRequired')); return }
+  if (!newKeyName.value.trim()) { msg.warning(t('redis.keyNameRequired')); return }
   try {
     switch (newKeyType.value) {
       case 'string': await RedisSetString(props.sessionId, newKeyName.value, newStringValue.value); break
@@ -574,9 +575,9 @@ async function onCreateKey() {
     }
     if (newKeyTTL.value >= 0) { await RedisSetKeyTTL(props.sessionId, newKeyName.value, newKeyTTL.value) }
     showNewKeyDialog.value = false
-    ElMessage.success(t('redis.keyCreated'))
+    msg.success(t('redis.keyCreated'))
     await doScan(cursorStack.value.length > 0 ? cursorStack.value[cursorStack.value.length - 1] : 0)
-  } catch (e: any) { ElMessage.error(`Create key failed: ${e?.message || e}`) }
+  } catch (e: any) { msg.error(`Create key failed: ${e?.message || e}`) }
 }
 
 // --- List drag reorder ---

--- a/frontend/src/components/SFTPTabContent.vue
+++ b/frontend/src/components/SFTPTabContent.vue
@@ -220,7 +220,7 @@
 
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted, onActivated, onDeactivated, watch, nextTick } from 'vue'
-import { ElMessage } from 'element-plus'
+
 import { msg } from '../services/message'
 import { usePanelStore } from '../stores/panelStore'
 import { useSettingsStore } from '../stores/settingsStore'
@@ -555,7 +555,7 @@ onMounted(async () => {
         onRefreshLocal()
         onRefreshRemote().then(() => doInitialAutoNav())
       } else if (payload.status === 'error') {
-        ElMessage.error(t('sftp.connectError'))
+        msg.error(t('sftp.connectError'))
       }
     }
   })
@@ -565,7 +565,7 @@ onMounted(async () => {
     // Connection failed messages from backend (SFTP/FTP async connect errors)
     const connMatch = payload.data.match(/\[Connection failed: ([^\]]+)\]/)
     if (connMatch) {
-      ElMessage.error(connMatch[1])
+      msg.error(connMatch[1])
       return
     }
     const match = payload.data.match(/\x1b\]633;S([^\x07]*)\x07/)
@@ -961,7 +961,7 @@ function onCopyToClipboard(items: FileItem[]) {
     sourceDir: cwd.value,
     mode: 'copy'
   }
-  ElMessage.success(t('sftp.copy'))
+  msg.success(t('sftp.copy'))
 }
 
 function onCutToClipboard(items: FileItem[]) {
@@ -970,7 +970,7 @@ function onCutToClipboard(items: FileItem[]) {
     sourceDir: cwd.value,
     mode: 'cut'
   }
-  ElMessage.success(t('sftp.cut'))
+  msg.success(t('sftp.cut'))
 }
 
 function onClearClipboard() {
@@ -983,7 +983,7 @@ function onLocalCopyToClipboard(items: FileItem[]) {
     sourceDir: localCwd.value,
     mode: 'copy'
   }
-  ElMessage.success(t('sftp.copy'))
+  msg.success(t('sftp.copy'))
 }
 
 function onLocalCutToClipboard(items: FileItem[]) {
@@ -992,7 +992,7 @@ function onLocalCutToClipboard(items: FileItem[]) {
     sourceDir: localCwd.value,
     mode: 'cut'
   }
-  ElMessage.success(t('sftp.cut'))
+  msg.success(t('sftp.cut'))
 }
 
 function onLocalClearClipboard() {
@@ -1059,7 +1059,7 @@ async function onPaste() {
 
   // Cut to same directory: error immediately, no conflict dialog
   if (mode === 'cut' && sourceDir === targetDir) {
-    ElMessage.warning(t('sftp.paste.cutSameDir'))
+    msg.warning(t('sftp.paste.cutSameDir'))
     pasteLoadingRemote.value = false
     return
   }
@@ -1086,7 +1086,7 @@ async function onPaste() {
       // copy mode (cut already blocked at top level)
     } else if (isPathInside(target, source)) {
     // Circular check (only when source !== target)
-      ElMessage.warning(t('sftp.paste.circularWarning'))
+      msg.warning(t('sftp.paste.circularWarning'))
       continue
     }
     const forceRename = source === target && mode === 'copy'
@@ -1113,9 +1113,9 @@ async function onPaste() {
   if (pasteCancelled) {
     // keep clipboard so user can retry
   } else if (failed.length > 0) {
-    ElMessage.error(`Copied/Moved ${success}/${items.length}, ${failed.length} failed`)
+    msg.error(`Copied/Moved ${success}/${items.length}, ${failed.length} failed`)
   } else {
-    ElMessage.success(t('sftp.paste'))
+    msg.success(t('sftp.paste'))
   }
 
   if (!pasteCancelled) clipboard.value = null
@@ -1149,7 +1149,7 @@ async function onEditFile(item: FileItem) {
   if (!sid) return
 
   if (item.size > 5 * 1024 * 1024) {
-    ElMessage.warning(t('sftp.edit.fileTooLarge'))
+    msg.warning(t('sftp.edit.fileTooLarge'))
     return
   }
   if (item.size > 500 * 1024) {
@@ -1167,7 +1167,7 @@ async function onEditFile(item: FileItem) {
     const bytes = fromBase64(rawB64)
     if (isBinaryContent(bytes)) {
       editorVisible.value = false
-      ElMessage.warning(t('sftp.edit.binaryFile'))
+      msg.warning(t('sftp.edit.binaryFile'))
       return
     }
     const detected = detectEncoding(bytes)
@@ -1177,7 +1177,7 @@ async function onEditFile(item: FileItem) {
     editorContent.value = text
   } catch (e: any) {
     editorVisible.value = false
-    ElMessage.error(e?.toString() || 'Failed to read file')
+    msg.error(e?.toString() || 'Failed to read file')
   }
 }
 
@@ -1193,10 +1193,10 @@ async function onEditorSave() {
       await SftpPutContent(sid, editorPath.value, encodeContent(editorContent.value, editorEncoding.value, editorLineEnding.value))
       onRefreshRemote()
     }
-    ElMessage.success(t('sftp.dialog.confirm'))
+    msg.success(t('sftp.dialog.confirm'))
     editorVisible.value = false
   } catch (e: any) {
-    ElMessage.error(e?.toString() || 'Failed to save file')
+    msg.error(e?.toString() || 'Failed to save file')
   } finally {
     editorSaving.value = false
   }
@@ -1209,7 +1209,7 @@ async function onLocalEditFile(item: FileItem) {
   const sid = panel.value?.sessionId
   if (!sid) return
   if (item.size > 5 * 1024 * 1024) {
-    ElMessage.warning(t('sftp.edit.fileTooLarge'))
+    msg.warning(t('sftp.edit.fileTooLarge'))
     return
   }
   editorPath.value = joinPath(localCwd.value, item.name)
@@ -1220,7 +1220,7 @@ async function onLocalEditFile(item: FileItem) {
   try {
     const rawB64 = await SftpLocalGetContent(sid, editorPath.value)
     const bytes = fromBase64(rawB64)
-    if (isBinaryContent(bytes)) { editorVisible.value = false; ElMessage.warning(t('sftp.edit.binaryFile')); return }
+    if (isBinaryContent(bytes)) { editorVisible.value = false; msg.warning(t('sftp.edit.binaryFile')); return }
     const detected = detectEncoding(bytes)
     editorEncoding.value = detected.encoding
     const text = decodeContent(bytes, detected.encoding)
@@ -1228,7 +1228,7 @@ async function onLocalEditFile(item: FileItem) {
     editorContent.value = text
   } catch (e: any) {
     editorVisible.value = false
-    ElMessage.error(e?.toString() || 'Failed to read file')
+    msg.error(e?.toString() || 'Failed to read file')
   }
 }
 
@@ -1254,7 +1254,7 @@ async function onLocalPaste() {
   pasteLoadingLocal.value = true
   const targetDir = localCwd.value
   if (mode === 'cut' && sourceDir === targetDir) {
-    ElMessage.warning(t('sftp.paste.cutSameDir'))
+    msg.warning(t('sftp.paste.cutSameDir'))
     pasteLoadingLocal.value = false
     return
   }
@@ -1287,8 +1287,8 @@ async function onLocalPaste() {
   }
   pasteLoadingLocal.value = false
   if (!localPasteCancelled) {
-    if (failed.length > 0) ElMessage.error(`Copied/Moved ${success}/${items.length}, ${failed.length} failed`)
-    else ElMessage.success(t('sftp.paste'))
+    if (failed.length > 0) msg.error(`Copied/Moved ${success}/${items.length}, ${failed.length} failed`)
+    else msg.success(t('sftp.paste'))
   }
   if (!localPasteCancelled) localClipboard.value = null
   onRefreshLocal()
@@ -1322,10 +1322,10 @@ async function onNewFileCreate() {
       await SftpPutContent(sid, targetPath, '')
       onRefreshRemote()
     }
-    ElMessage.success(t('sftp.dialog.confirm'))
+    msg.success(t('sftp.dialog.confirm'))
     newFileVisible.value = false
   } catch (e: any) {
-    ElMessage.error(e?.toString() || 'Failed to create file')
+    msg.error(e?.toString() || 'Failed to create file')
   } finally {
     newFileCreating.value = false
   }

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -460,7 +460,8 @@
 <script setup lang="ts">
 import { ref, onMounted, onUnmounted, computed, watch, nextTick } from 'vue'
 import { X, ChevronRight, ChevronDown, Filter, Check, Network, Zap, Clock, Plus, Palette, SquareTerminal, Terminal, FolderUp, HardDrive, Cloud, Globe, Monitor, MonitorCloud, MonitorSmartphone, Database, DatabaseZap, Activity, Laptop, Cable, Pencil, MoreHorizontal } from '@lucide/vue'
-import { ElMessageBox, ElMessage } from 'element-plus'
+import { ElMessageBox } from 'element-plus'
+import { msg } from '../services/message'
 import { useConnectionStore } from '../stores/connectionStore'
 import { useSettingsStore } from '../stores/settingsStore'
 import { useI18n } from '../i18n'
@@ -1136,7 +1137,7 @@ async function confirmNewGroup() {
   const name = newGroupName.value.trim()
   if (!name) return
   if (connectionStore.groups.some(g => g.name === name)) {
-    ElMessage.warning(t('conn.groupNameDuplicate'))
+    msg.warning(t('conn.groupNameDuplicate'))
     return
   }
   await connectionStore.addGroup(name)
@@ -1210,7 +1211,7 @@ async function confirmChangeNewGroup() {
   const name = changeNewGroupName.value.trim()
   if (!name) return
   if (connectionStore.groups.some(g => g.name === name)) {
-    ElMessage.warning(t('conn.groupNameDuplicate'))
+    msg.warning(t('conn.groupNameDuplicate'))
     return
   }
   const group = await connectionStore.addGroup(name)

--- a/frontend/src/components/StartTabContent.vue
+++ b/frontend/src/components/StartTabContent.vue
@@ -365,7 +365,8 @@
 
 <script setup lang="ts">
 import { ref, computed, watch, nextTick, onMounted, onUnmounted } from 'vue'
-import { ElMessageBox, ElMessage } from 'element-plus'
+import { ElMessageBox } from 'element-plus'
+import { msg } from '../services/message'
 import type { StartTab } from '../types/workspace'
 import type { ConnectionConfig, ConnectionGroup } from '../types/session'
 import { useConnectionStore } from '../stores/connectionStore'
@@ -922,7 +923,7 @@ async function doAddGroup() {
   const name = newGroupDialogName.value.trim()
   if (!name) return
   if (connectionStore.groups.some(g => g.name === name)) {
-    ElMessage.warning(t('conn.groupNameDuplicate'))
+    msg.warning(t('conn.groupNameDuplicate'))
     return
   }
   await connectionStore.addGroup(name)

--- a/frontend/src/composables/useUpdateCheck.ts
+++ b/frontend/src/composables/useUpdateCheck.ts
@@ -24,6 +24,7 @@ function showUpdateNotification(info: UpdateInfo) {
     type: 'success',
     duration: 0,
     showClose: true,
+    offset: 50,
   })
 }
 

--- a/frontend/src/services/message.ts
+++ b/frontend/src/services/message.ts
@@ -1,6 +1,6 @@
 import { ElMessage } from 'element-plus'
 
-const CLOSABLE = { showClose: true, duration: 5000 }
+const CLOSABLE = { showClose: true, duration: 5000, offset: 50 }
 
 export const msg = {
   success(m: string) { ElMessage.success({ message: m, ...CLOSABLE }) },


### PR DESCRIPTION
Replace all direct `ElMessage` calls with the centralized `msg` wrapper, which provides `showClose`, `duration`, and `offset` consistently across all toast notifications.

**Changes:**
- `message.ts`: add `offset: 50` to `CLOSABLE` defaults
- Replace ~42 direct `ElMessage.xxx()` calls with `msg.xxx()` across 5 components
- `useUpdateCheck.ts`: add `offset: 50` to the special `ElMessage({...})` call

**Fixes:**
- All error/success/warning/info messages now have a visible close button
- Messages are positioned 50px from top, no longer covering the tab bar
- rqlite connection error and all other notifications behave consistently

Closes #153.

---

将所有直接 `ElMessage` 调用替换为统一的 `msg` 封装，确保所有提示消息都有关闭按钮、5 秒自动消失、下移 50px 不遮挡标签栏。

Closes #153.