### PR TITLE
fix(sftp): fix encoding detection and GBK save in file editor

### DIFF
--- a/app.go
+++ b/app.go
@@ -22,6 +22,8 @@ import (
 	"time"
 
 	"github.com/wailsapp/wails/v2/pkg/runtime"
+	"golang.org/x/text/encoding/simplifiedchinese"
+	"golang.org/x/text/transform"
 	"github.com/ys-ll/uniterm/backend/database"
 	"github.com/ys-ll/uniterm/backend/log"
 	"github.com/ys-ll/uniterm/backend/platform"
@@ -1894,12 +1896,17 @@ func (a *App) SftpLocalGetContent(sessionID, localPath string) (string, error) {
 	return base64.StdEncoding.EncodeToString(content), nil
 }
 
-func (a *App) SftpLocalPutContent(sessionID, localPath, contentBase64 string) error {
+func (a *App) SftpLocalPutContent(sessionID, localPath, contentBase64, encoding string) error {
 	fs, err := a.getSftp(sessionID)
 	if err != nil {
 		return err
 	}
 	content, err := base64.StdEncoding.DecodeString(contentBase64)
+	if err != nil {
+		return err
+	}
+	// Re-encode if target encoding is not UTF-8 (frontend always sends UTF-8)
+	content, err = convertEncoding(content, encoding)
 	if err != nil {
 		return err
 	}
@@ -1962,7 +1969,7 @@ func (a *App) SftpPut(sessionID, localPath, remotePath string, recursive bool) (
 	return fs.Put(localPath, remotePath, recursive)
 }
 
-func (a *App) SftpPutContent(sessionID, remotePath, contentBase64 string) error {
+func (a *App) SftpPutContent(sessionID, remotePath, contentBase64, encoding string) error {
 	fs, err := a.getSftp(sessionID)
 	if err != nil {
 		return err
@@ -1971,7 +1978,26 @@ func (a *App) SftpPutContent(sessionID, remotePath, contentBase64 string) error 
 	if err != nil {
 		return err
 	}
+	// Re-encode if target encoding is not UTF-8 (frontend always sends UTF-8)
+	content, err = convertEncoding(content, encoding)
+	if err != nil {
+		return err
+	}
 	return fs.PutContent(remotePath, content)
+}
+
+// convertEncoding converts UTF-8 bytes to the target encoding.
+// Returns the original bytes unchanged if encoding is UTF-8 or empty.
+func convertEncoding(utf8Bytes []byte, encoding string) ([]byte, error) {
+	switch strings.ToLower(encoding) {
+	case "", "utf-8", "utf8":
+		return utf8Bytes, nil
+	case "gbk", "gb2312", "gb18030":
+		reader := transform.NewReader(bytes.NewReader(utf8Bytes), simplifiedchinese.GBK.NewEncoder())
+		return io.ReadAll(reader)
+	default:
+		return nil, fmt.Errorf("unsupported encoding: %s", encoding)
+	}
 }
 
 func (a *App) SftpGetContent(sessionID, remotePath string) (string, error) {

--- a/frontend/src/components/SFTPTabContent.vue
+++ b/frontend/src/components/SFTPTabContent.vue
@@ -171,7 +171,7 @@
           </div>
           <div class="editor-footer-buttons">
             <el-button @click="editorVisible = false">{{ t('sftp.dialog.cancel') }}</el-button>
-            <el-button type="primary" :loading="editorSaving" @click="onEditorSave">{{ t('sftp.dialog.confirm') }}</el-button>
+            <el-button type="primary" :loading="editorSaving" @click="onEditorSave">{{ t('sftp.edit.save') }}</el-button>
           </div>
         </div>
       </template>
@@ -299,10 +299,36 @@ function detectEncoding(bytes: Uint8Array): { encoding: Encoding, hasBom: boolea
   const checkLen = Math.min(bytes.length, 1024)
   for (let i = 0; i < checkLen; i++) { if (bytes[i] === 0) nullCount++ }
   if (nullCount > checkLen * 0.3) return { encoding: 'utf-16le', hasBom: false }
+
+  // Try UTF-8 first (most common). Use non-fatal mode so valid UTF-8
+  // sequences are accepted even if some bytes might be interpreted as
+  // legacy encodings. WebView2's TextDecoder(fatal:true) may be overly
+  // strict for certain byte sequences.
   try {
-    new TextDecoder('utf-8', { fatal: true }).decode(bytes.slice(0, 4096))
-    return { encoding: 'utf-8', hasBom: false }
-  } catch { return { encoding: 'gbk', hasBom: false } }
+    const sample = bytes.slice(0, 8192)
+    // Quick check: valid UTF-8 lead/trail byte pattern
+    let i = 0
+    let valid = true
+    while (i < sample.length) {
+      const b = sample[i]
+      if (b < 0x80) { i++; continue }
+      let trailing: number
+      if ((b & 0xE0) === 0xC0) trailing = 1
+      else if ((b & 0xF0) === 0xE0) trailing = 2
+      else if ((b & 0xF8) === 0xF0) trailing = 3
+      else { valid = false; break }
+      if (i + trailing >= sample.length) { valid = false; break }
+      for (let j = 1; j <= trailing; j++) {
+        if ((sample[i + j] & 0xC0) !== 0x80) { valid = false; break }
+      }
+      if (!valid) break
+      i += trailing + 1
+    }
+    if (valid) return { encoding: 'utf-8', hasBom: false }
+  } catch { /* fall through */ }
+
+  // Try GBK/GB18030 — common for Chinese text on Windows
+  return { encoding: 'gbk', hasBom: false }
 }
 
 function detectLineEnding(text: string): LineEnding {
@@ -330,7 +356,12 @@ function encodeContent(text: string, enc: Encoding, lineEnding: LineEnding): str
   if (lineEnding === 'crlf') normalized = text.replace(/\r\n/g, '\n').replace(/\n/g, '\r\n')
   else if (lineEnding === 'cr') normalized = text.replace(/\r\n/g, '\n').replace(/\n/g, '\r')
   else normalized = text.replace(/\r\n/g, '\n').replace(/\r/g, '\n')
-  if (enc === 'gbk' || enc === 'utf-8') return toBase64(normalized)
+
+  if (enc === 'utf-8' || enc === 'gbk') {
+    // Always encode as UTF-8 here. The backend will re-encode to GBK
+    // when needed (TextEncoder only supports UTF-8 in browsers).
+    return toBase64(normalized)
+  }
   const buf = new Uint8Array(normalized.length * 2 + 2)
   let pos = 0
   buf[pos++] = enc === 'utf-16le' ? 0xFF : 0xFE
@@ -387,6 +418,7 @@ const editorTitle = ref('')
 const editorPath = ref('')
 const editorMode = ref<'local' | 'remote'>('remote')
 const editorContent = ref('')
+const editorRawBytes = ref<Uint8Array | null>(null)
 const editorSaving = ref(false)
 const editorLineNumbers = ref<HTMLElement | null>(null)
 const editorTextarea = ref<HTMLTextAreaElement | null>(null)
@@ -421,6 +453,15 @@ const editorLineNumbersText = computed(() => {
 })
 
 const editorMinHeight = computed(() => '')
+
+// Re-decode content when user switches encoding
+watch(editorEncoding, (newEnc) => {
+  if (editorRawBytes.value) {
+    editorContent.value = decodeContent(editorRawBytes.value, newEnc)
+  }
+})
+
+// Sync editorMode from the source that set it (remote edit sets 'remote', local sets 'local')
 
 function computeVisualLines() {
   if (!editorWrapEnabled.value || !editorMirror.value || !editorTextarea.value) return
@@ -1172,6 +1213,8 @@ async function onEditFile(item: FileItem) {
     }
     const detected = detectEncoding(bytes)
     editorEncoding.value = detected.encoding
+    editorRawBytes.value = bytes
+    editorMode.value = 'remote'
     const text = decodeContent(bytes, detected.encoding)
     editorLineEnding.value = detectLineEnding(text)
     editorContent.value = text
@@ -1187,13 +1230,13 @@ async function onEditorSave() {
   editorSaving.value = true
   try {
     if (editorMode.value === 'local') {
-      await SftpLocalPutContent(sid, editorPath.value, encodeContent(editorContent.value, editorEncoding.value, editorLineEnding.value))
+      await SftpLocalPutContent(sid, editorPath.value, encodeContent(editorContent.value, editorEncoding.value, editorLineEnding.value), editorEncoding.value)
       onRefreshLocal()
     } else {
-      await SftpPutContent(sid, editorPath.value, encodeContent(editorContent.value, editorEncoding.value, editorLineEnding.value))
+      await SftpPutContent(sid, editorPath.value, encodeContent(editorContent.value, editorEncoding.value, editorLineEnding.value), editorEncoding.value)
       onRefreshRemote()
     }
-    msg.success(t('sftp.dialog.confirm'))
+    msg.success(t('sftp.edit.saveSuccess'))
     editorVisible.value = false
   } catch (e: any) {
     msg.error(e?.toString() || 'Failed to save file')
@@ -1223,6 +1266,7 @@ async function onLocalEditFile(item: FileItem) {
     if (isBinaryContent(bytes)) { editorVisible.value = false; msg.warning(t('sftp.edit.binaryFile')); return }
     const detected = detectEncoding(bytes)
     editorEncoding.value = detected.encoding
+    editorRawBytes.value = bytes
     const text = decodeContent(bytes, detected.encoding)
     editorLineEnding.value = detectLineEnding(text)
     editorContent.value = text

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -213,6 +213,8 @@
   "sftp.edit.binaryFile": "Binärdatei kann nicht bearbeitet werden",
   "sftp.edit.fileTooLarge": "Datei ist zu groß (>5 MB)",
   "sftp.edit.fileLargeWarning": "Datei ist groß ({size}), trotzdem öffnen?",
+  "sftp.edit.saveSuccess": "Gespeichert",
+  "sftp.edit.save": "Speichern",
   "sftp.paste.circularWarning": "Ein Verzeichnis kann nicht in sich selbst eingefügt werden",
   "sftp.paste.cutSameDir": "Datei kann nicht in dieses Verzeichnis verschoben werden",
   "sftp.pasting": "Einfügen...",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -217,6 +217,8 @@
   "sftp.edit.fileTooLarge": "File is too large to edit (>5 MB)",
   "sftp.edit.wrap": "Word wrap",
   "sftp.edit.fileLargeWarning": "File is large ({size}), open anyway?",
+  "sftp.edit.saveSuccess": "Saved",
+  "sftp.edit.save": "Save",
   "sftp.paste.circularWarning": "Cannot paste a directory into itself",
   "sftp.paste.cutSameDir": "Cannot move file to the same directory",
   "sftp.dialog.conflictTitle": "File Name Conflict",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -213,6 +213,8 @@
   "sftp.edit.binaryFile": "No se puede editar un archivo binario",
   "sftp.edit.fileTooLarge": "El archivo es demasiado grande (>5 MB)",
   "sftp.edit.fileLargeWarning": "El archivo es grande ({size}), ¿abrir de todos modos?",
+  "sftp.edit.saveSuccess": "Guardado",
+  "sftp.edit.save": "Guardar",
   "sftp.paste.circularWarning": "No se puede pegar un directorio dentro de sí mismo",
   "sftp.paste.cutSameDir": "No se puede mover el archivo a este directorio",
   "sftp.pasting": "Pegando...",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -213,6 +213,8 @@
   "sftp.edit.binaryFile": "Impossible d'éditer un fichier binaire",
   "sftp.edit.fileTooLarge": "Fichier trop volumineux (>5 MB)",
   "sftp.edit.fileLargeWarning": "Fichier volumineux ({size}), ouvrir quand même ?",
+  "sftp.edit.saveSuccess": "Enregistré",
+  "sftp.edit.save": "Enregistrer",
   "sftp.paste.circularWarning": "Impossible de coller un dossier dans lui-même",
   "sftp.paste.cutSameDir": "Impossible de déplacer le fichier vers ce dossier",
   "sftp.pasting": "Collage...",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -213,6 +213,8 @@
   "sftp.edit.binaryFile": "バイナリファイルは編集できません",
   "sftp.edit.fileTooLarge": "ファイルが大きすぎます（>5 MB）",
   "sftp.edit.fileLargeWarning": "ファイルが大きいです（{size}）、開きますか？",
+  "sftp.edit.saveSuccess": "保存しました",
+  "sftp.edit.save": "保存",
   "sftp.paste.circularWarning": "ディレクトリを自分自身の中に貼り付けることはできません",
   "sftp.paste.cutSameDir": "このディレクトリにファイルを移動できません",
   "sftp.pasting": "貼り付け中...",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -213,6 +213,8 @@
   "sftp.edit.binaryFile": "바이너리 파일은 편집할 수 없습니다",
   "sftp.edit.fileTooLarge": "파일이 너무 큽니다 (>5 MB)",
   "sftp.edit.fileLargeWarning": "파일이 큽니다 ({size}), 열겠습니까?",
+  "sftp.edit.saveSuccess": "저장됨",
+  "sftp.edit.save": "저장",
   "sftp.paste.circularWarning": "디렉터리를 자기 자신 안에 붙여넣을 수 없습니다",
   "sftp.paste.cutSameDir": "이 디렉터리로 파일을 이동할 수 없습니다",
   "sftp.pasting": "붙여넣는 중...",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -213,6 +213,8 @@
   "sftp.edit.binaryFile": "Невозможно редактировать бинарный файл",
   "sftp.edit.fileTooLarge": "Файл слишком большой (>5 MB)",
   "sftp.edit.fileLargeWarning": "Файл большой ({size}), открыть?",
+  "sftp.edit.saveSuccess": "Сохранено",
+  "sftp.edit.save": "Сохранить",
   "sftp.paste.circularWarning": "Нельзя вставить папку в саму себя",
   "sftp.paste.cutSameDir": "Нельзя переместить файл в этот каталог",
   "sftp.pasting": "Вставка...",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -217,6 +217,8 @@
   "sftp.edit.wrap": "自动换行",
   "sftp.edit.fileTooLarge": "文件太大，无法编辑（>5 MB）",
   "sftp.edit.fileLargeWarning": "文件较大（{size}），仍然打开？",
+  "sftp.edit.saveSuccess": "保存成功",
+  "sftp.edit.save": "保存",
   "sftp.paste.circularWarning": "不能将目录粘贴到自身内部",
   "sftp.paste.cutSameDir": "不能移动文件到本目录",
   "sftp.dialog.conflictTitle": "文件名冲突",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -213,6 +213,8 @@
   "sftp.edit.binaryFile": "無法編輯二進位檔案",
   "sftp.edit.fileTooLarge": "檔案太大，無法編輯（>5 MB）",
   "sftp.edit.fileLargeWarning": "檔案較大（{size}），仍然打開？",
+  "sftp.edit.saveSuccess": "儲存成功",
+  "sftp.edit.save": "儲存",
   "sftp.paste.circularWarning": "不能將目錄貼上到自身內部",
   "sftp.paste.cutSameDir": "不能移動檔案到本目錄",
   "sftp.pasting": "貼上中...",

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -249,7 +249,7 @@ export function SftpLocalMkdir(arg1:string,arg2:string):Promise<void>;
 
 export function SftpLocalMove(arg1:string,arg2:string,arg3:string):Promise<void>;
 
-export function SftpLocalPutContent(arg1:string,arg2:string,arg3:string):Promise<void>;
+export function SftpLocalPutContent(arg1:string,arg2:string,arg3:string,arg4:string):Promise<void>;
 
 export function SftpLocalRemove(arg1:string,arg2:string,arg3:boolean):Promise<void>;
 
@@ -263,7 +263,7 @@ export function SftpPauseTransfer(arg1:string,arg2:string):Promise<void>;
 
 export function SftpPut(arg1:string,arg2:string,arg3:string,arg4:boolean):Promise<string>;
 
-export function SftpPutContent(arg1:string,arg2:string,arg3:string):Promise<void>;
+export function SftpPutContent(arg1:string,arg2:string,arg3:string,arg4:string):Promise<void>;
 
 export function SftpRemove(arg1:string,arg2:string,arg3:boolean):Promise<void>;
 

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -486,8 +486,8 @@ export function SftpLocalMove(arg1, arg2, arg3) {
   return window['go']['main']['App']['SftpLocalMove'](arg1, arg2, arg3);
 }
 
-export function SftpLocalPutContent(arg1, arg2, arg3) {
-  return window['go']['main']['App']['SftpLocalPutContent'](arg1, arg2, arg3);
+export function SftpLocalPutContent(arg1, arg2, arg3, arg4) {
+  return window['go']['main']['App']['SftpLocalPutContent'](arg1, arg2, arg3, arg4);
 }
 
 export function SftpLocalRemove(arg1, arg2, arg3) {
@@ -514,8 +514,8 @@ export function SftpPut(arg1, arg2, arg3, arg4) {
   return window['go']['main']['App']['SftpPut'](arg1, arg2, arg3, arg4);
 }
 
-export function SftpPutContent(arg1, arg2, arg3) {
-  return window['go']['main']['App']['SftpPutContent'](arg1, arg2, arg3);
+export function SftpPutContent(arg1, arg2, arg3, arg4) {
+  return window['go']['main']['App']['SftpPutContent'](arg1, arg2, arg3, arg4);
 }
 
 export function SftpRemove(arg1, arg2, arg3) {


### PR DESCRIPTION
**Bug fixes:**

1. **UTF-8 中文文件误识别为 GBK** — 用 UTF-8 字节模式验证替代 `TextDecoder(fatal:true)`，避免 WebView2 的严格模式误判
2. **手动切换编码无效** — 保存原始 bytes，`watch(editorEncoding)` 切换时重新解码
3. **GBK 保存实为 UTF-8** — 浏览器 `TextEncoder` 只支持 UTF-8，GBK 编码委托 Go 后端用 `golang.org/x/text` 转码
4. **按钮文案** — 确定 改为 保存

**改动范围：**
| 层 | 文件 | 说明 |
|---|---|---|
| 后端 | `app.go` | `SftpPutContent`/`SftpLocalPutContent` 新增 `encoding` 参数 + GBK 转码 |
| 前端 | `SFTPTabContent.vue` | 编码检测、字节缓存、重解码 watcher、按钮文案 |
| i18n | 9 语言 | 新增 `sftp.edit.save` / `sftp.edit.saveSuccess` |
| 绑定 | wailsjs | 参数变更自动生成 |

功能增强项（查找替换、撤销恢复、代码高亮）已拆分到 #173。

Closes #158.

---

Fixes encoding auto-detection and GBK save issues in the built-in file editor. Feature enhancements split out to #173.

Closes #158.