### PR TITLE
fix(ui): reduce connection dialog category icon size

### DIFF
--- a/frontend/src/components/ConnectionForm.vue
+++ b/frontend/src/components/ConnectionForm.vue
@@ -10,7 +10,7 @@
           :class="{ active: category === cat.key }"
           @click="onCategorySelect(cat.key)"
         >
-          <component :is="cat.icon" :size="28" />
+          <component :is="cat.icon" :size="20" />
           <span>{{ cat.label }}</span>
         </div>
       </div>


### PR DESCRIPTION
Reduce the left sidebar category icons in the new/edit connection dialog from 28px to 20px. The large icons felt too bold and didn't match the app's refined UI style.

Ref: #148

---

将新建/编辑连接对话框左侧分类图标从 28px 缩小到 20px，风格更克制，与设置页面等其他 UI 保持一致。

Ref: #148