### PR TITLE
fix(terminal): only show suggestion delete button on mouse hover

### DIFF
--- a/frontend/src/components/TerminalSuggestion.vue
+++ b/frontend/src/components/TerminalSuggestion.vue
@@ -346,8 +346,7 @@ function onRemove(id: string) {
   transition: opacity 0.12s ease, visibility 0.12s ease;
 }
 
-.suggestion-item:hover .delete-btn.visible,
-.suggestion-item.selected .delete-btn.visible {
+.suggestion-item:hover .delete-btn.visible {
   visibility: visible;
   opacity: 1;
 }


### PR DESCRIPTION
Remove `.selected` from the delete button visibility CSS rule so the trash icon only appears on mouse hover, not on keyboard navigation. This prevents accidental deletion when pressing Enter after using arrow keys to select a history item.

Closes #172.

---

删除按钮的 CSS 显隐规则中移除 `.selected`，垃圾桶图标仅在鼠标悬停时显示，键盘上下键导航选中时不再出现。防止方向键选择历史记录后按 Enter 误触发删除。

Closes #172.