### PR TITLE
fix(ui): fix horizontal scrollbar on start tab when window is narrow

### DIFF
--- a/frontend/src/components/StartTabContent.vue
+++ b/frontend/src/components/StartTabContent.vue
@@ -651,7 +651,7 @@ const contentWidth = ref(0)
 
 const CARD_WIDTH = 240
 const CARD_GAP = 12
-const PADDING = 32 // .start-tab padding on each side
+const PADDING = 64 // .start-tab padding on each side
 
 function updateContentWidth() {
   const el = startTabRef.value


### PR DESCRIPTION
The `PADDING` constant used to calculate card grid content width was 32, but the actual CSS `padding` is 64px on each side. This caused the grid to be 64px wider than the available space, producing an unwanted horizontal scrollbar on narrow windows.