### PR TITLE
fix(macos): enable key-repeat by disabling press-and-hold accent picker

### DIFF
--- a/app.go
+++ b/app.go
@@ -67,6 +67,10 @@ func (a *App) startup(ctx context.Context) {
 		fmt.Printf("WARN: log.Init failed: %v\n", err)
 	}
 
+	// On macOS, disable the system press-and-hold accent picker for this app so
+	// that holding a key repeats input in the terminal (see app_darwin.go).
+	a.configureMacKeyRepeat()
+
 	a.sessionManager = session.NewSessionManager()
 	a.tunnelService = session.NewTunnelService()
 

--- a/app_darwin.go
+++ b/app_darwin.go
@@ -1,0 +1,48 @@
+//go:build darwin
+
+package main
+
+import (
+	"os/exec"
+	"strings"
+
+	"github.com/ys-ll/uniterm/backend/log"
+)
+
+// macBundleID is the app's bundle identifier. Wails derives the default
+// identifier from wails.json's "name" as com.wails.<name>, and this project
+// ships no custom build/darwin/Info.plist, so it resolves to com.wails.uniTerm.
+const macBundleID = "com.wails.uniTerm"
+
+// configureMacKeyRepeat disables macOS's press-and-hold accent picker for this
+// app's bundle only, so that holding a key down produces continuous key-repeat
+// input in the terminal (matching Windows behaviour) instead of popping up the
+// system accent/variant character picker.
+//
+// This works around the long-standing upstream xterm.js issue on macOS
+// (xtermjs/xterm.js#265, #4385): macOS intercepts a held key at the OS level to
+// show the accent popup, which suppresses the key-repeat event stream the
+// terminal expects. Scoping the preference to this bundle identifier leaves
+// every other application's behaviour untouched.
+//
+// The setting is written once (only when not already disabled) and persists
+// across runs, so it is a no-op on subsequent launches. It runs asynchronously
+// to avoid adding latency to startup.
+func (a *App) configureMacKeyRepeat() {
+	go func() {
+		// Skip the write if it's already disabled to avoid churning the
+		// preferences daemon on every launch. `defaults read` prints "0" for a
+		// false boolean.
+		if out, err := exec.Command("defaults", "read", macBundleID, "ApplePressAndHoldEnabled").Output(); err == nil {
+			if strings.TrimSpace(string(out)) == "0" {
+				return
+			}
+		}
+
+		if err := exec.Command("defaults", "write", macBundleID, "ApplePressAndHoldEnabled", "-bool", "false").Run(); err != nil {
+			log.Writef("configureMacKeyRepeat: failed to disable ApplePressAndHoldEnabled: %v", err)
+			return
+		}
+		log.Writef("configureMacKeyRepeat: disabled ApplePressAndHoldEnabled for %s (key-repeat enabled)", macBundleID)
+	}()
+}

--- a/app_notdarwin.go
+++ b/app_notdarwin.go
@@ -1,0 +1,7 @@
+//go:build !darwin
+
+package main
+
+// configureMacKeyRepeat is a no-op on non-macOS platforms; the press-and-hold
+// accent picker only exists on macOS. See app_darwin.go for details.
+func (a *App) configureMacKeyRepeat() {}


### PR DESCRIPTION
## Summary
On macOS, holding down a key in the terminal only registered a single keystroke instead of repeating like it does on Windows. This is the long-standing upstream xterm.js behaviour ([xtermjs/xterm.js#265](https://github.com/xtermjs/xterm.js/issues/265), [#4385](https://github.com/xtermjs/xterm.js/issues/4385)): macOS intercepts a held key at the OS level to show the accent/variant picker, which suppresses the key-repeat event stream the terminal expects.

This PR disables the press-and-hold accent picker **scoped to this app's bundle identifier only** (`com.wails.uniTerm`), so holding a key produces continuous repeated input. No other application's behaviour is affected, and no frontend/xterm.js change is needed.

## Changes
- `app_darwin.go` (new, `//go:build darwin`): `App.configureMacKeyRepeat()` runs `defaults write com.wails.uniTerm ApplePressAndHoldEnabled -bool false` asynchronously at startup, skipping the write when it is already disabled.
- `app_notdarwin.go` (new, `//go:build !darwin`): no-op stub for other platforms.
- `app.go`: call `a.configureMacKeyRepeat()` in `startup` after logger init.

## Validation
- `go build .` passes for darwin, linux, and windows; `go vet .` clean.
- Idempotency: `defaults read ... ApplePressAndHoldEnabled` returning `0` skips the write; a missing key errors and falls through to the write.

---

## 摘要
macOS 上长按终端按键只输入一次而非像 Windows 一样连续重复,这是 xterm.js 在 macOS 上的已知上游行为:系统层面拦截长按并弹出重音选择框,压制了终端所需的按键重复事件流。本修复仅针对本应用 bundle(`com.wails.uniTerm`)关闭长按重音弹窗,使长按变为连续输入,不影响其他应用,也无需改动前端/xterm.js。

## 改动
- `app_darwin.go`(新增,`//go:build darwin`):`App.configureMacKeyRepeat()` 启动时异步执行 `defaults write com.wails.uniTerm ApplePressAndHoldEnabled -bool false`,已关闭时跳过写入。
- `app_notdarwin.go`(新增,`//go:build !darwin`):其他平台的空实现。
- `app.go`:在 `startup` 中 logger 初始化后调用 `a.configureMacKeyRepeat()`。

## 验证
- darwin/linux/windows 三平台 `go build .` 均通过,`go vet .` 无告警。
- 幂等:`defaults read` 返回 `0` 时跳过写入,键不存在时报错并回退到写入。

Closes #155