### PR TITLE
fix(settings): make AI model field a clickable dropdown after fetch

### DIFF
--- a/frontend/src/components/SettingsTab.vue
+++ b/frontend/src/components/SettingsTab.vue
@@ -456,11 +456,22 @@
         </el-form-item>
         <el-form-item :label="t('settings.modelModel')">
           <div class="model-fetch-row">
-            <el-autocomplete
+            <el-select
               v-model="modelForm.model"
-              :fetch-suggestions="(qs, cb) => cb(qs ? modelSuggestions.filter(s => s.value.toLowerCase().includes(qs.toLowerCase())) : modelSuggestions)"
               class="model-autocomplete"
-            />
+              filterable
+              allow-create
+              default-first-option
+              :reserve-keyword="false"
+              :placeholder="t('settings.modelModelPlaceholder')"
+            >
+              <el-option
+                v-for="s in modelSelectOptions"
+                :key="s.value"
+                :label="s.value"
+                :value="s.value"
+              />
+            </el-select>
             <el-button :loading="modelFetching" @click="fetchModelList">
               {{ t('settings.fetchModels') }}
             </el-button>
@@ -702,6 +713,18 @@ const categories = computed(() => {
 
 const showModelForm = ref(false)
 const modelSuggestions = ref<Array<{ value: string }>>([])
+// Always surface the currently-set model as an option so el-select renders it
+// when editing an existing model (before any fetch) — el-select won't display a
+// bound value that has no matching option, and allow-create only creates
+// options for values typed during the session, not a pre-set v-model.
+const modelSelectOptions = computed(() => {
+  const opts = modelSuggestions.value.slice()
+  const cur = modelForm.model?.trim()
+  if (cur && !opts.some(o => o.value === cur)) {
+    opts.unshift({ value: cur })
+  }
+  return opts
+})
 const modelFetching = ref(false)
 const testingConnection = ref(false)
 const testResult = ref<boolean | null>(null)

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -293,6 +293,7 @@
   "settings.modelName": "Name",
   "settings.modelBaseURL": "Basis-URL",
   "settings.modelModel": "Modell",
+  "settings.modelModelPlaceholder": "Modellname auswählen oder eingeben",
   "settings.modelApiKey": "API Key",
   "settings.modelUserAgent": "User-Agent",
   "settings.modelProtocol": "Protokoll",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -296,6 +296,7 @@
   "settings.modelName": "Name",
   "settings.modelBaseURL": "Base URL",
   "settings.modelModel": "Model",
+  "settings.modelModelPlaceholder": "Select or enter a model name",
   "settings.modelApiKey": "API Key",
   "settings.modelUserAgent": "User-Agent",
   "settings.modelProtocol": "Protocol",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -293,6 +293,7 @@
   "settings.modelName": "Nombre",
   "settings.modelBaseURL": "URL Base",
   "settings.modelModel": "Modelo",
+  "settings.modelModelPlaceholder": "Selecciona o escribe un nombre de modelo",
   "settings.modelApiKey": "API Key",
   "settings.modelUserAgent": "User-Agent",
   "settings.modelProtocol": "Protocolo",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -293,6 +293,7 @@
   "settings.modelName": "Nom",
   "settings.modelBaseURL": "URL de base",
   "settings.modelModel": "Modèle",
+  "settings.modelModelPlaceholder": "Sélectionnez ou saisissez un nom de modèle",
   "settings.modelApiKey": "API Key",
   "settings.modelUserAgent": "User-Agent",
   "settings.modelProtocol": "Protocole",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -293,6 +293,7 @@
   "settings.modelName": "名前",
   "settings.modelBaseURL": "Base URL",
   "settings.modelModel": "モデル",
+  "settings.modelModelPlaceholder": "モデル名を選択または入力",
   "settings.modelApiKey": "API Key",
   "settings.modelUserAgent": "User-Agent",
   "settings.modelProtocol": "プロトコル",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -293,6 +293,7 @@
   "settings.modelName": "이름",
   "settings.modelBaseURL": "Base URL",
   "settings.modelModel": "모델",
+  "settings.modelModelPlaceholder": "모델 이름 선택 또는 입력",
   "settings.modelApiKey": "API Key",
   "settings.modelUserAgent": "User-Agent",
   "settings.modelProtocol": "프로토콜",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -293,6 +293,7 @@
   "settings.modelName": "Имя",
   "settings.modelBaseURL": "Базовый URL",
   "settings.modelModel": "Модель",
+  "settings.modelModelPlaceholder": "Выберите или введите имя модели",
   "settings.modelApiKey": "API Key",
   "settings.modelUserAgent": "User-Agent",
   "settings.modelProtocol": "Протокол",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -296,6 +296,7 @@
   "settings.modelName": "名称",
   "settings.modelBaseURL": "Base URL",
   "settings.modelModel": "模型",
+  "settings.modelModelPlaceholder": "选择或输入模型名称",
   "settings.modelApiKey": "API Key",
   "settings.modelUserAgent": "User-Agent",
   "settings.modelProtocol": "协议",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -293,6 +293,7 @@
   "settings.modelName": "名稱",
   "settings.modelBaseURL": "Base URL",
   "settings.modelModel": "模型",
+  "settings.modelModelPlaceholder": "選擇或輸入模型名稱",
   "settings.modelApiKey": "API Key",
   "settings.modelUserAgent": "User-Agent",
   "settings.modelProtocol": "協議",


### PR DESCRIPTION
## Summary
In **Settings → AI Assistant → Edit Model**, after clicking **Fetch Models** the model field was an `el-autocomplete` with no dropdown affordance: the fetched list only appeared while typing. Since the existing model name was already filled in, the user saw no hint that options were available and had to delete the text and retype to trigger the dropdown.

This replaces it with a filterable, `allow-create` `el-select`. It shows a dropdown arrow, opens the full fetched list on click, still allows typing a custom model name, and — via a computed that always includes the current value as an option — correctly renders the existing model name when editing (`el-select` won't display a bound value that has no matching option, and `allow-create` only creates options for values typed during the session, not a pre-set `v-model`).

## Changes
- `SettingsTab.vue`: swap `el-autocomplete` for `el-select` (`filterable`, `allow-create`, `default-first-option`); add a `modelSelectOptions` computed that surfaces the current model value as an option.
- i18n: add `settings.modelModelPlaceholder` in all 9 locales.

## Validation
- `npm run build` passes (clean Vite cache); all 9 locale JSON files valid.

---

## 摘要
**设置 → AI 助理 → 编辑模型** 中,点击「拉取模型列表」后,模型输入框是没有下拉标识的 `el-autocomplete`:拉取到的列表只在输入时才出现。而输入框里已填了旧的模型名,用户看不到有可选项的提示,必须删掉重输才会触发下拉。

本 PR 改为可筛选、可创建的 `el-select`:带下拉箭头、点击即展开全部拉取结果,仍允许手输自定义模型名;并通过 computed 始终把当前值作为一个选项,保证编辑已有模型时能正确回显(`el-select` 不显示无匹配选项的绑定值,`allow-create` 也只为本次输入创建选项,不含预置的 `v-model`)。

## 改动
- `SettingsTab.vue`:`el-autocomplete` 换成 `el-select`(`filterable`/`allow-create`/`default-first-option`),新增 `modelSelectOptions` computed 回显当前值。
- i18n:9 种语言新增 `settings.modelModelPlaceholder`。

## 验证
- `npm run build` 通过(已清 Vite 缓存);9 个语言 JSON 均合法。