### PR TITLE
fix(rdp): enable NLA/CredSSP by removing forced legacy auth settings

### DIFF
--- a/backend/session/rdp_session.go
+++ b/backend/session/rdp_session.go
@@ -329,8 +329,6 @@ func (s *RDPSession) Connect(config ConnectionConfig) error {
 			adv.PutProperty("RedirectDrives", true)
 			adv.PutProperty("DisplayConnectionBar", false)
 			adv.PutProperty("EnableAutoReconnect", true)
-			adv.PutProperty("AuthenticationLevel", 0)
-			adv.PutProperty("EnableCredSspSupport", false)
 			adv.PutProperty("WarnOnDirectConnect", false)
 			adv.PutProperty("ContainerHandledFullScreen", true)
 			if config.RdpSmartSizing {
@@ -350,26 +348,14 @@ func (s *RDPSession) Connect(config ConnectionConfig) error {
 		if advHigh != nil {
 			a := advHigh.ToIDispatch()
 			if a != nil {
-				a.PutProperty("AuthenticationLevel", 0)
 				a.PutProperty("ContainerHandledFullScreen", true)
-				a.PutProperty("EnableCredSspSupport", false)
 				a.PutProperty("WarnOnDirectConnect", false)
 				a.Release()
-				log.Writef("[RDP] AdvancedSettings%d: AuthLevel=0, CredSsp=false", ver)
+				log.Writef("[RDP] AdvancedSettings%d: security prompts suppressed", ver)
 			}
 		}
 	}
 
-	// SecuredSettings2: disable security layer negotiation
-	secObj, _ := dispatch.GetProperty("SecuredSettings2")
-	if secObj != nil {
-		sec := secObj.ToIDispatch()
-		if sec != nil {
-			sec.PutProperty("NegotiateSecurityLayer", false)
-			sec.Release()
-			log.Writef("[RDP] SecuredSettings2: NegotiateSecurityLayer=false")
-		}
-	}
 
 	// Suppress server certificate warning at OS level
 	setAuthLevelOverride()
@@ -701,8 +687,6 @@ func (s *RDPSession) configureNonScriptable(password string) {
 		nsUnk.PutProperty("AllowPromptingForCredentials", false)
 		nsUnk.PutProperty("PromptForCredentials", false)
 		nsUnk.PutProperty("PromptForCredentialsOnce", false)
-		nsUnk.PutProperty("AuthenticationLevel", 0)
-		nsUnk.PutProperty("EnableCredSspSupport", false)
 		nsUnk.PutProperty("MarkRdpSettingsSecure", true)
 		nsUnk.CallMethod("MarkRdpSettingsSecure", true)
 		if password != "" {


### PR DESCRIPTION
## Summary

The RDP ActiveX control was forcing legacy authentication (AuthenticationLevel=0, EnableCredSspSupport=false, NegotiateSecurityLayer=false), which disabled NLA/CredSSP. If the remote server requires NLA — enabled by default on Windows 10/11 — Connect() returned success but the session never initialized, resulting in a white screen with no error feedback.

## Root Cause

The code explicitly disabled CredSSP and forced legacy RDP security layer negotiation across four locations (AdvancedSettings2, AdvancedSettings3-9, SecuredSettings2, NonScriptable). When the remote server requires NLA, the session silently fails to start — the window is already visible but shows nothing.

## Changes

Removed all forced legacy auth overrides:
- **AdvancedSettings2**: Removed AuthenticationLevel=0 and EnableCredSspSupport=false
- **AdvancedSettings3-9**: Removed AuthenticationLevel=0 and EnableCredSspSupport=false
- **SecuredSettings2**: Removed entire NegotiateSecurityLayer=false block
- **NonScriptable**: Removed AuthenticationLevel=0 and EnableCredSspSupport=false

The ActiveX control now uses default NLA/CredSSP negotiation, matching the official Remote Desktop client behavior. Security prompt suppression (AllowPromptingForCredentials=false, autoDismissSecurityDialogs) is preserved.

Refs #184
Refs #200

---

## 摘要

RDP ActiveX 控件强制使用旧版认证协议，禁用了 NLA/CredSSP。若远程服务器要求 NLA（Windows 10/11 默认开启），Connect() 返回成功但会话实际未初始化，导致白屏且无错误提示。

## 根本原因

代码在四处显式关闭了 CredSSP 并强制使用旧版 RDP 安全层。当远程服务器要求 NLA 时，会话静默失败 — 窗口已显示但无内容。

## 改动

移除所有强制旧版认证覆盖项，ActiveX 控件现在使用默认 NLA/CredSSP 协商，与官方远程桌面客户端行为一致。保留了安全弹窗抑制功能。

Refs #184
Refs #200