### PR TITLE
feat(db): refactor DSN construction to URL format and add user-customizable DB params

### DIFF
--- a/backend/database/engine.go
+++ b/backend/database/engine.go
@@ -6,13 +6,31 @@ import (
 	"strings"
 )
 
+// parseParams parses "key1=val1&key2=val2" into a map.
+func parseParams(s string) map[string]string {
+	m := make(map[string]string)
+	for s != "" {
+		var pair string
+		if before, after, found := strings.Cut(s, "&"); found {
+			pair, s = before, after
+		} else {
+			pair, s = s, ""
+		}
+		k, v, _ := strings.Cut(pair, "=")
+		if k != "" {
+			m[k] = v
+		}
+	}
+	return m
+}
+
 // BuildDSN builds a DSN string from connection config fields.
-func BuildDSN(dbType, host, user, password, dbName string, port int) (string, error) {
+func BuildDSN(dbType, host, user, password, dbName, extraParams string, port int) (string, error) {
 	p, err := NewProvider(dbType)
 	if err != nil {
 		return "", err
 	}
-	return p.DSN(host, port, user, password, dbName), nil
+	return p.DSN(host, port, user, password, dbName, parseParams(extraParams)), nil
 }
 
 // NewDB opens a database/sql connection for the given database type and DSN.

--- a/backend/database/provider.go
+++ b/backend/database/provider.go
@@ -26,7 +26,7 @@ type execer interface {
 // Provider encapsulates all database-type-specific behavior.
 type Provider interface {
 	// DSN generates a driver-specific connection string from connection fields.
-	DSN(host string, port int, user, password, dbName string) string
+	DSN(host string, port int, user, password, dbName string, extraParams map[string]string) string
 
 	// DriverName returns the Go SQL driver name to use for sql.Open.
 	DriverName() string

--- a/backend/database/provider_mysql.go
+++ b/backend/database/provider_mysql.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	_ "github.com/go-sql-driver/mysql"
+	"github.com/go-sql-driver/mysql"
 )
 
 type mysqlProvider struct{}
@@ -15,13 +15,27 @@ func init() {
 	Register("mysql", &mysqlProvider{})
 }
 
-func (p *mysqlProvider) DSN(host string, port int, user, password, dbName string) string {
-	addr := host
-	if port > 0 {
-		addr = fmt.Sprintf("%s:%d", host, port)
+func (p *mysqlProvider) DSN(host string, port int, user, password, dbName string, extraParams map[string]string) string {
+	if port <= 0 {
+		port = 3306
 	}
-	dsn := fmt.Sprintf("%s:%s@tcp(%s)/%s?charset=utf8mb4&parseTime=true&loc=Local&timeout=10s&readTimeout=30s", user, password, addr, dbName)
-	return dsn
+	cfg := mysql.NewConfig()
+	cfg.User = user
+	cfg.Passwd = password
+	cfg.Net = "tcp"
+	cfg.Addr = fmt.Sprintf("%s:%d", host, port)
+	cfg.DBName = dbName
+	cfg.Params = map[string]string{
+		"charset":      "utf8mb4",
+		"parseTime":    "true",
+		"loc":          "Local",
+		"timeout":      "10s",
+		"readTimeout":  "30s",
+	}
+	for k, v := range extraParams {
+		cfg.Params[k] = v
+	}
+	return cfg.FormatDSN()
 }
 
 func (p *mysqlProvider) DriverName() string {

--- a/backend/database/provider_oracle.go
+++ b/backend/database/provider_oracle.go
@@ -18,15 +18,22 @@ func init() {
 	Register("oracle", &oracleProvider{})
 }
 
-func (p *oracleProvider) DSN(host string, port int, user, password, dbName string) string {
+func (p *oracleProvider) DSN(host string, port int, user, password, dbName string, extraParams map[string]string) string {
 	if port <= 0 {
 		port = 1521
 	}
-	u := url.URL{
+	u := &url.URL{
 		Scheme: "oracle",
 		User:   url.UserPassword(user, password),
 		Host:   net.JoinHostPort(host, strconv.Itoa(port)),
 		Path:   "/" + dbName,
+	}
+	if len(extraParams) > 0 {
+		q := u.Query()
+		for k, v := range extraParams {
+			q.Set(k, v)
+		}
+		u.RawQuery = q.Encode()
 	}
 	return u.String()
 }

--- a/backend/database/provider_postgres.go
+++ b/backend/database/provider_postgres.go
@@ -3,6 +3,7 @@ package database
 import (
 	"database/sql"
 	"fmt"
+	"net/url"
 	"strings"
 
 	_ "github.com/lib/pq"
@@ -14,12 +15,23 @@ func init() {
 	Register("postgres", &postgresProvider{})
 }
 
-func (p *postgresProvider) DSN(host string, port int, user, password, dbName string) string {
+func (p *postgresProvider) DSN(host string, port int, user, password, dbName string, extraParams map[string]string) string {
 	if port <= 0 {
 		port = 5432
 	}
-	return fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=disable",
-		host, port, user, password, dbName)
+	u := &url.URL{
+		Scheme: "postgres",
+		User:   url.UserPassword(user, password),
+		Host:   fmt.Sprintf("%s:%d", host, port),
+		Path:   "/" + dbName,
+	}
+	q := u.Query()
+	q.Set("sslmode", "disable")
+	for k, v := range extraParams {
+		q.Set(k, v)
+	}
+	u.RawQuery = q.Encode()
+	return u.String()
 }
 
 func (p *postgresProvider) DriverName() string {

--- a/backend/database/provider_rqlite.go
+++ b/backend/database/provider_rqlite.go
@@ -3,6 +3,7 @@ package database
 import (
 	"database/sql"
 	"fmt"
+	"net/url"
 	"strings"
 
 	_ "github.com/rqlite/gorqlite/stdlib"
@@ -14,15 +15,23 @@ func init() {
 	Register("rqlite", &rqliteProvider{})
 }
 
-func (p *rqliteProvider) DSN(host string, port int, user, password, dbName string) string {
+func (p *rqliteProvider) DSN(host string, port int, user, password, dbName string, extraParams map[string]string) string {
 	addr := host
 	if port > 0 {
 		addr = fmt.Sprintf("%s:%d", host, port)
 	}
-	if user != "" && password != "" {
-		return fmt.Sprintf("http://%s:%s@%s/", user, password, addr)
+	u := &url.URL{Scheme: "http", Host: addr}
+	if user != "" || password != "" {
+		u.User = url.UserPassword(user, password)
 	}
-	return fmt.Sprintf("http://%s/", addr)
+	if len(extraParams) > 0 {
+		q := u.Query()
+		for k, v := range extraParams {
+			q.Set(k, v)
+		}
+		u.RawQuery = q.Encode()
+	}
+	return u.String()
 }
 
 func (p *rqliteProvider) DriverName() string {

--- a/backend/database/provider_sqlserver.go
+++ b/backend/database/provider_sqlserver.go
@@ -16,7 +16,7 @@ func init() {
 	Register("sqlserver", &sqlserverProvider{})
 }
 
-func (p *sqlserverProvider) DSN(host string, port int, user, password, dbName string) string {
+func (p *sqlserverProvider) DSN(host string, port int, user, password, dbName string, extraParams map[string]string) string {
 	if port <= 0 {
 		port = 1433
 	}
@@ -32,6 +32,9 @@ func (p *sqlserverProvider) DSN(host string, port int, user, password, dbName st
 	q.Set("encrypt", "disable")
 	q.Set("dial timeout", "10")
 	q.Set("connection timeout", "30")
+	for k, v := range extraParams {
+		q.Set(k, v)
+	}
 	u.RawQuery = q.Encode()
 	return u.String()
 }

--- a/backend/session/database_session.go
+++ b/backend/session/database_session.go
@@ -40,7 +40,7 @@ func (s *DatabaseSession) Connect(config ConnectionConfig) error {
 		s.title = fmt.Sprintf("%s:%s@%s:%d", config.DBType, config.User, config.Host, config.Port)
 	}
 
-	dsn, err := database.BuildDSN(config.DBType, config.Host, config.User, config.Password, config.DBName, config.Port)
+	dsn, err := database.BuildDSN(config.DBType, config.Host, config.User, config.Password, config.DBName, config.DBParams, config.Port)
 	if err != nil {
 		log.Writef("[DatabaseSession.Connect] BuildDSN failed: %v", err)
 		s.setStatus(StatusError)

--- a/backend/session/session.go
+++ b/backend/session/session.go
@@ -47,8 +47,9 @@ type ConnectionConfig struct {
 	SerialStopBits float64 `json:"serialStopBits,omitempty"`
 	SerialParity   string  `json:"serialParity,omitempty"`
 	// Database-specific fields
-	DBType string `json:"dbType,omitempty"` // "mysql", "postgres", "rqlite", "oracle"
-	DBName string `json:"dbName,omitempty"` // default database name
+	DBType   string `json:"dbType,omitempty"`   // "mysql", "postgres", "rqlite", "oracle", "sqlserver"
+	DBName   string `json:"dbName,omitempty"`   // default database name
+	DBParams string `json:"dbParams,omitempty"` // extra DSN query parameters, e.g. "sslmode=require&connect_timeout=30"
 	// SSH post-login script: commands to execute after successful login
 	PostLoginScript string `json:"postLoginScript,omitempty"`
 	// Post-login expect/send automation: interactive steps executed after login.

--- a/frontend/src/components/ConnectionForm.vue
+++ b/frontend/src/components/ConnectionForm.vue
@@ -87,6 +87,9 @@
             <el-form-item v-if="form.type === 'database' && form.dbType !== 'rqlite' && form.dbType !== 'redis'" :label="t('db.databases')">
               <el-input v-model="form.dbName" :placeholder="t('db.databases')" />
             </el-form-item>
+            <el-form-item v-if="form.type === 'database'" :label="t('db.params')">
+              <el-input v-model="form.dbParams" :placeholder="defaultParamsHint" style="width:100%" />
+            </el-form-item>
             <el-form-item v-if="form.type === 'local'" :label="t('conn.shell')">
               <el-select v-model="form.shellPath" filterable>
                 <el-option
@@ -520,6 +523,15 @@ const showTunnel = computed(() =>
   !TUNNEL_UNSUPPORTED.includes(form.type)
 )
 
+const defaultParamsHint = computed(() => {
+  switch (form.dbType) {
+    case 'mysql': return '默认: charset=utf8mb4'
+    case 'postgres': return '默认: sslmode=disable'
+    case 'sqlserver': return '默认: encrypt=disable'
+    default: return ''
+  }
+})
+
 const form = reactive<ConnectionConfig>({
   id: '',
   name: '',
@@ -536,6 +548,7 @@ const form = reactive<ConnectionConfig>({
   rdpSmartSizing: true,
   dbType: '',
   dbName: '',
+  dbParams: '',
   postLoginScript: '',
   postLoginExpectSteps: [],
   sftpMaxConcurrency: 5,
@@ -675,6 +688,7 @@ function resetForm() {
   form.rdpSmartSizing = true
   form.dbType = ''
   form.dbName = ''
+  form.dbParams = ''
   form.postLoginScript = ''
   form.postLoginExpectSteps = []
   postLoginMode.value = 'script'

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -534,6 +534,7 @@
   "monitor.net.ipAddrs": "IP Addresses",
   "db.database": "Database",
   "db.databases": "Databases",
+  "db.params": "Extra Params",
   "db.loading": "Loading...",
   "db.selectTableHint": "Double-click a database or table to view",
   "db.tableStructure": "Table Structure",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -534,6 +534,7 @@
   "monitor.net.ipAddrs": "IP地址",
   "db.database": "数据库",
   "db.databases": "数据库",
+  "db.params": "额外参数",
   "db.loading": "加载中...",
   "db.selectTableHint": "双击数据库或表查看",
   "db.tableStructure": "表结构",

--- a/frontend/src/types/session.ts
+++ b/frontend/src/types/session.ts
@@ -37,6 +37,7 @@ export interface ConnectionConfig {
   serialParity?: string
   dbType?: string   // database type key
   dbName?: string   // default database name
+  dbParams?: string // extra DSN query parameters, e.g. "sslmode=require&connect_timeout=30"
   postLoginScript?: string
   postLoginExpectSteps?: PostLoginExpectStep[]
   // SSH tunnel: reference to an existing SSH connection used as a jump host

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -275,6 +275,7 @@ export namespace session {
 	    serialParity?: string;
 	    dbType?: string;
 	    dbName?: string;
+	    dbParams?: string;
 	    postLoginScript?: string;
 	    postLoginExpectSteps?: PostLoginExpectStep[];
 	    tunnelSSHConnId?: string;
@@ -319,6 +320,7 @@ export namespace session {
 	        this.serialParity = source["serialParity"];
 	        this.dbType = source["dbType"];
 	        this.dbName = source["dbName"];
+	        this.dbParams = source["dbParams"];
 	        this.postLoginScript = source["postLoginScript"];
 	        this.postLoginExpectSteps = this.convertValues(source["postLoginExpectSteps"], PostLoginExpectStep);
 	        this.tunnelSSHConnId = source["tunnelSSHConnId"];


### PR DESCRIPTION
Refactor database DSN construction from `fmt.Sprintf` concatenation to safe URL/Config-based methods, preventing special character issues in passwords. Add `dbParams` field allowing users to override default DSN parameters.

## Changes

- **PostgreSQL**: switch from `key=value` space-separated to `postgres://` URL format via `url.URL`
- **MySQL**: use `mysql.Config.FormatDSN()` for proper value escaping
- **rqlite**: switch from `fmt.Sprintf` to `url.URL` construction
- **Oracle/SQL Server**: add `extraParams` merge (already used `url.URL`)
- **UI**: add "Extra Params" field in database connection form with default parameter hints

## Example

To connect to a PostgreSQL server that requires SSL, set `dbParams` to `sslmode=require`.

Closes #195

---

将数据库 DSN 拼接从 `fmt.Sprintf` 重构为安全的 URL/Config 方式，防止密码特殊字符问题。新增 `dbParams` 字段，允许用户覆盖默认 DSN 参数。

## 改动

- **PostgreSQL**: 从 `key=value` 空格分隔改为 `postgres://` URL 格式
- **MySQL**: 使用 `mysql.Config.FormatDSN()` 安全转义
- **rqlite**: 从 `fmt.Sprintf` 改为 `url.URL` 构造
- **Oracle/SQL Server**: 增加 extraParams 合并（原本已使用 url.URL）
- **UI**: 数据库连接表单新增"额外参数"输入框，显示默认参数提示

## 示例

连接需要 SSL 的 PostgreSQL 时，在 `dbParams` 填写 `sslmode=require`。

Closes #195