### PR TITLE
fix(ssh): add legacy KEX algorithms for compatibility with old servers

### DIFF
--- a/backend/session/monitor_session.go
+++ b/backend/session/monitor_session.go
@@ -134,6 +134,9 @@ func (s *MonitorSession) Connect(config ConnectionConfig) error {
 		Auth:            authMethods,
 		Timeout:         30 * time.Second,
 		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		Config: ssh.Config{
+			KeyExchanges: sshKeyExchanges(),
+		},
 	}
 
 	client, err := ssh.Dial("tcp", fmt.Sprintf("%s:%d", config.Host, config.Port), clientConfig)

--- a/backend/session/mosh_session.go
+++ b/backend/session/mosh_session.go
@@ -45,6 +45,9 @@ func (s *MoshSession) Connect(config ConnectionConfig) error {
 		Auth:            authMethods,
 		Timeout:         30 * time.Second,
 		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		Config: ssh.Config{
+			KeyExchanges: sshKeyExchanges(),
+		},
 	}
 
 	conn, err := net.DialTimeout("tcp", addr, clientConfig.Timeout)

--- a/backend/session/sftp_session.go
+++ b/backend/session/sftp_session.go
@@ -81,6 +81,9 @@ func (s *SFTPSession) Connect(config ConnectionConfig) error {
 		Auth:            authMethods,
 		Timeout:         30 * time.Second,
 		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		Config: ssh.Config{
+			KeyExchanges: sshKeyExchanges(),
+		},
 	}
 
 	client, err := ssh.Dial("tcp", fmt.Sprintf("%s:%d", config.Host, config.Port), clientConfig)

--- a/backend/session/ssh_config.go
+++ b/backend/session/ssh_config.go
@@ -1,0 +1,24 @@
+package session
+
+import "golang.org/x/crypto/ssh"
+
+// sshKeyExchanges returns the KEX algorithm list for SSH connections,
+// including legacy algorithms for compatibility with older servers.
+func sshKeyExchanges() []string {
+	return []string{
+		// Default safe algorithms
+		"mlkem768x25519-sha256",
+		"curve25519-sha256",
+		"curve25519-sha256@libssh.org",
+		"ecdh-sha2-nistp256",
+		"ecdh-sha2-nistp384",
+		"ecdh-sha2-nistp521",
+		"diffie-hellman-group14-sha256",
+		"diffie-hellman-group16-sha512",
+		"diffie-hellman-group-exchange-sha256",
+		// Legacy algorithms for old servers (issue #208)
+		ssh.InsecureKeyExchangeDH14SHA1,
+		ssh.InsecureKeyExchangeDHGEXSHA1,
+		ssh.InsecureKeyExchangeDH1SHA1,
+	}
+}

--- a/backend/session/ssh_session.go
+++ b/backend/session/ssh_session.go
@@ -164,6 +164,9 @@ func (s *SSHSession) Connect(config ConnectionConfig) error {
 		Auth:            authMethods,
 		Timeout:         30 * time.Second,
 		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		Config: ssh.Config{
+			KeyExchanges: sshKeyExchanges(),
+		},
 	}
 
 	conn, err := net.DialTimeout("tcp", addr, clientConfig.Timeout)

--- a/backend/session/tunnel_service.go
+++ b/backend/session/tunnel_service.go
@@ -51,6 +51,9 @@ func (ts *TunnelService) Start(sessionID string, sshConfig ConnectionConfig, tar
 		Auth:            authMethods,
 		Timeout:         30 * time.Second,
 		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		Config: ssh.Config{
+			KeyExchanges: sshKeyExchanges(),
+		},
 	}
 
 	conn, err := net.DialTimeout("tcp", addr, clientConfig.Timeout)


### PR DESCRIPTION
Add legacy SSH key exchange algorithms for connections to older servers.

## Problem
SSH handshake fails with: no common algorithm for key exchange; peer offered: [diffie-hellman-group-exchange-sha1 diffie-hellman-group1-sha1]

## Fix
Add sshKeyExchanges() with modern + legacy algorithms. Applied to all 5 SSH connection sites. Safe algorithms prioritized first.

Closes #208

---
连接旧 SSH 服务器时握手失败，添加 legacy KEX 算法支持。

Closes #208