### PR TITLE
feat: remember window size and position between sessions

### DIFF
--- a/app.go
+++ b/app.go
@@ -80,6 +80,9 @@ func (a *App) startup(ctx context.Context) {
 	go func() {
 		for evt := range a.moveResizeCh {
 			runtime.EventsEmit(a.ctx, evt)
+			if evt == "rdp:move-resize-end" {
+				a.saveWindowStateFromRuntime()
+			}
 		}
 	}()
 
@@ -146,6 +149,61 @@ func (a *App) startup(ctx context.Context) {
 			}()
 		}
 	}
+
+	// Restore window position and size from last session
+	a.restoreWindow(ctx)
+}
+
+// restoreWindow restores the saved window position and size.
+// Windows will constrain off-screen windows to the visible area, so no
+// explicit screen-boundary validation is needed.
+func (a *App) restoreWindow(ctx context.Context) {
+	ls, err := a.localStateStore.Load()
+	if err != nil {
+		return
+	}
+	if ls.WindowWidth <= 0 || ls.WindowHeight <= 0 {
+		return
+	}
+	// Move to the correct monitor first, then maximise if needed
+	runtime.WindowSetPosition(ctx, ls.WindowX, ls.WindowY)
+	if ls.WindowMaximised {
+		runtime.WindowMaximise(ctx)
+	} else {
+		runtime.WindowSetSize(ctx, ls.WindowWidth, ls.WindowHeight)
+	}
+}
+
+// saveWindowStateFromRuntime saves the current window geometry using runtime
+// API calls. Called from the WndProc event loop on Windows (WM_EXITSIZEMOVE).
+func (a *App) saveWindowStateFromRuntime() {
+	if a.localStateStore == nil {
+		return
+	}
+	ls, err := a.localStateStore.Load()
+	if err != nil {
+		return
+	}
+	ls.WindowX, ls.WindowY = runtime.WindowGetPosition(a.ctx)
+	ls.WindowWidth, ls.WindowHeight = runtime.WindowGetSize(a.ctx)
+	ls.WindowMaximised = runtime.WindowIsMaximised(a.ctx)
+	_ = a.localStateStore.Save(ls)
+}
+
+func (a *App) SaveWindowState(x, y, width, height int, maximised bool) {
+	if a.localStateStore == nil {
+		return
+	}
+	ls, err := a.localStateStore.Load()
+	if err != nil {
+		return
+	}
+	ls.WindowX = x
+	ls.WindowY = y
+	ls.WindowWidth = width
+	ls.WindowHeight = height
+	ls.WindowMaximised = maximised
+	a.localStateStore.Save(ls)
 }
 
 func (a *App) shutdown(ctx context.Context) {

--- a/backend/store/local_state_store.go
+++ b/backend/store/local_state_store.go
@@ -11,6 +11,11 @@ const localStateFileName = "local_state.json"
 type LocalState struct {
 	SidebarVisible   bool `json:"sidebarVisible"`
 	AISidebarVisible bool `json:"aiSidebarVisible"`
+	WindowX          int  `json:"windowX"`
+	WindowY          int  `json:"windowY"`
+	WindowWidth      int  `json:"windowWidth"`
+	WindowHeight     int  `json:"windowHeight"`
+	WindowMaximised  bool `json:"windowMaximised"`
 }
 
 type LocalStateStore struct {

--- a/frontend/src/components/AppHeader.vue
+++ b/frontend/src/components/AppHeader.vue
@@ -59,9 +59,12 @@ import {
   WindowUnmaximise,
   WindowIsMaximised,
   WindowSetMaxSize,
+  WindowGetPosition,
+  WindowGetSize,
   Quit,
   ScreenGetAll,
 } from '../../wailsjs/runtime'
+import { SaveWindowState } from '../../wailsjs/go/main/App'
 
 const { t } = useI18n()
 const tabStore = useTabStore()
@@ -101,7 +104,10 @@ async function onMaximise() {
   } else {
     WindowToggleMaximise()
   }
-  setTimeout(updateMaximisedState, 100)
+  setTimeout(() => {
+    updateMaximisedState()
+    saveWindowState()
+  }, 100)
 }
 
 async function linuxMaximise() {
@@ -127,6 +133,19 @@ async function linuxMaximise() {
   }
 }
 
+let saveTimer: ReturnType<typeof setTimeout> | null = null
+
+async function saveWindowState() {
+  try {
+    const maxed = await WindowIsMaximised()
+    const { x, y } = await WindowGetPosition()
+    const { w, h } = await WindowGetSize()
+    SaveWindowState(x, y, w, h, maxed)
+  } catch {
+    // ignore
+  }
+}
+
 async function onClose() {
   if (hasActiveConnections.value) {
     try {
@@ -139,6 +158,7 @@ async function onClose() {
       return // user cancelled
     }
   }
+  await saveWindowState()
   Quit()
 }
 
@@ -150,6 +170,9 @@ function onDblClick(e: MouseEvent) {
 
 function onWindowResize() {
   updateMaximisedState()
+  // Debounce save to avoid frequent writes during drag-resize
+  if (saveTimer) clearTimeout(saveTimer)
+  saveTimer = setTimeout(saveWindowState, 500)
 }
 
 onMounted(async () => {

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -207,6 +207,8 @@ export function SaveSettings(arg1:store.AppSettings):Promise<void>;
 
 export function SaveTerminalHistory(arg1:Array<store.HistoryEntry>):Promise<void>;
 
+export function SaveWindowState(arg1:number,arg2:number,arg3:number,arg4:number,arg5:boolean):Promise<void>;
+
 export function SessionEndZmodem(arg1:string):Promise<void>;
 
 export function SessionResize(arg1:string,arg2:number,arg3:number):Promise<void>;

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -402,6 +402,10 @@ export function SaveTerminalHistory(arg1) {
   return window['go']['main']['App']['SaveTerminalHistory'](arg1);
 }
 
+export function SaveWindowState(arg1, arg2, arg3, arg4, arg5) {
+  return window['go']['main']['App']['SaveWindowState'](arg1, arg2, arg3, arg4, arg5);
+}
+
 export function SessionEndZmodem(arg1) {
   return window['go']['main']['App']['SessionEndZmodem'](arg1);
 }

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -1011,6 +1011,11 @@ export namespace store {
 	export class LocalState {
 	    sidebarVisible: boolean;
 	    aiSidebarVisible: boolean;
+	    windowX: number;
+	    windowY: number;
+	    windowWidth: number;
+	    windowHeight: number;
+	    windowMaximised: boolean;
 	
 	    static createFrom(source: any = {}) {
 	        return new LocalState(source);
@@ -1020,6 +1025,11 @@ export namespace store {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.sidebarVisible = source["sidebarVisible"];
 	        this.aiSidebarVisible = source["aiSidebarVisible"];
+	        this.windowX = source["windowX"];
+	        this.windowY = source["windowY"];
+	        this.windowWidth = source["windowWidth"];
+	        this.windowHeight = source["windowHeight"];
+	        this.windowMaximised = source["windowMaximised"];
 	    }
 	}
 	export class QuickCommand {


### PR DESCRIPTION
Save and restore window geometry (position, size, maximised state) across sessions.

## Changes
- Add WindowX/Y/Width/Height/Maximised fields to LocalState
- Save on resize, move, maximize/restore (frontend + Windows WndProc)
- Save on close (frontend)
- Restore on startup, moving to the correct monitor before maximizing

Closes #207

---
窗口大小和位置跨会话记忆。

Closes #207