### PR TITLE
fix(build): switch Linux CI to webkit2gtk 4.1 for newer distro compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
             platform: windows/amd64
             slug: windows-amd64
             artifact: uniTerm.exe
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             platform: linux/amd64
             slug: linux-amd64
             artifact: uniTerm
@@ -72,7 +72,7 @@ jobs:
         if: matrix.platform == 'linux/amd64'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev
 
       - name: Install NSIS (Windows)
         if: matrix.platform == 'windows/amd64'
@@ -90,7 +90,7 @@ jobs:
             export PATH="/c/Program Files (x86)/NSIS/Bin:$PATH"
           fi
           echo "PATH=$PATH"
-          wails build -platform ${{ matrix.platform }} -ldflags "-s -w -X main.Version=${{ env.VERSION }}" -skipbindings ${{ matrix.platform == 'windows/amd64' && '-nsis' || '' }}
+          wails build -platform ${{ matrix.platform }} -ldflags "-s -w -X main.Version=${{ env.VERSION }}" -skipbindings ${{ matrix.platform == 'windows/amd64' && '-nsis' || '' }} ${{ matrix.platform == 'linux/amd64' && '-tags webkit2_41' || '' }}
 
       - name: Fix macOS permissions and sign
         if: matrix.platform == 'darwin/universal'


### PR DESCRIPTION
Switch Linux CI build from webkit2gtk 4.0 to 4.1 to fix runtime compatibility on newer Linux distributions that ship 4.1 by default (Deepin 25.1, Ubuntu 24.04+, Debian 12+).

### Changes
- Upgrade CI runner from `ubuntu-22.04` to `ubuntu-24.04`
- Install `libwebkit2gtk-4.1-dev` instead of `libwebkit2gtk-4.0-dev`
- Add `-tags webkit2_41` build tag for Wails to link against 4.1

### Fixes
Closes #192

---

将 Linux CI 构建从 webkit2gtk 4.0 切换到 4.1，修复在默认使用 4.1 的新版 Linux 发行版（Deepin 25.1、Ubuntu 24.04+、Debian 12+）上的运行时兼容性问题。

### 改动
- CI runner 从 `ubuntu-22.04` 升级到 `ubuntu-24.04`
- 安装 `libwebkit2gtk-4.1-dev` 替代 `libwebkit2gtk-4.0-dev`
- 添加 `-tags webkit2_41` 构建标签使 Wails 链接 4.1

### 关联
Closes #192