### PR TITLE
fix(ui): wrap system font names with CSS quotes to fix double-width rendering

### DIFF
--- a/frontend/src/components/SettingsTab.vue
+++ b/frontend/src/components/SettingsTab.vue
@@ -517,6 +517,7 @@ import { useUpdateCheck } from '../composables/useUpdateCheck'
 import { useI18n, locale } from '../i18n'
 import { BrowserOpenURL } from '../../wailsjs/runtime'
 import { FONT_OPTIONS, LANGUAGE_OPTIONS, DEFAULT_KEYBOARD, SHORTCUT_LABELS, USER_AGENT_PRESETS } from '../types/settings'
+import { formatFontFamily } from '../utils/formatFontFamily'
 import type { AIModelConfig, ShortcutAction, KeyBinding, KeyboardSettings } from '../types/settings'
 import { useTerminalThemeOptions } from '../composables/useTerminalThemeOptions'
 import { uninstallGlobalListener, installGlobalListener } from '../composables/useKeyboardShortcuts'
@@ -583,7 +584,7 @@ onMounted(async () => {
   try {
     const fonts = await GetSystemFonts()
     if (fonts && fonts.length > 0) {
-      systemFonts.value = fonts.map(f => ({ label: f, value: f }))
+      systemFonts.value = fonts.map(f => ({ label: f, value: formatFontFamily(f) }))
     }
   } catch {
     // Fall back to FONT_OPTIONS

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -472,6 +472,7 @@ import CustomThemeEditor from './CustomThemeEditor.vue'
 import type { ConnectionConfig, ConnectionGroup } from '../types/session'
 import { parseQuickConnect, formatConnSubtitle } from '../utils/quickConnect'
 import { FONT_OPTIONS, LANGUAGE_OPTIONS } from '../types/settings'
+import { formatFontFamily } from '../utils/formatFontFamily'
 import { useTerminalThemeOptions } from '../composables/useTerminalThemeOptions'
 import { GetSystemFonts } from '../../wailsjs/go/main/App'
 
@@ -1452,7 +1453,7 @@ onMounted(async () => {
   try {
     const fonts = await GetSystemFonts()
     if (fonts && fonts.length > 0) {
-      systemFonts.value = fonts.map(f => ({ label: f, value: f }))
+      systemFonts.value = fonts.map(f => ({ label: f, value: formatFontFamily(f) }))
     }
   } catch {
     // Fall back to FONT_OPTIONS

--- a/frontend/src/services/terminalManager.ts
+++ b/frontend/src/services/terminalManager.ts
@@ -4,6 +4,7 @@ import { Unicode11Addon } from '@xterm/addon-unicode11'
 import { SearchAddon } from '@xterm/addon-search'
 import { getXtermTheme } from '../composables/useTerminal'
 import type { CustomTerminalTheme } from '../types/settings'
+import { formatFontFamily } from '../utils/formatFontFamily'
 
 export interface TerminalOptions {
   fontSize?: number
@@ -65,7 +66,7 @@ export function acquireTerminal(
   } else {
     const terminal = new Terminal({
       fontSize: options.fontSize ?? 13,
-      fontFamily: options.fontFamily ?? 'Consolas, "Courier New", monospace',
+      fontFamily: formatFontFamily(options.fontFamily ?? 'Consolas, "Courier New", monospace'),
       theme: getXtermTheme(options.themeName ?? 'dark', customThemes),
       cursorBlink: true,
       rightClickSelectsWord: false,

--- a/frontend/src/utils/formatFontFamily.ts
+++ b/frontend/src/utils/formatFontFamily.ts
@@ -1,0 +1,21 @@
+/**
+ * Format a font family name for use in CSS `font-family` declarations.
+ *
+ * System fonts that contain spaces (e.g. "DejaVu Sans Mono", "Fira Code",
+ * "GB18030 Bitmap") must be wrapped in CSS quotes so the browser treats them
+ * as a single family name. Without quotes, "DejaVu Sans Mono" is parsed as
+ * three separate families (DejaVu, Sans, Mono), the browser can't find the
+ * intended font, and xterm.js canvas width measurement diverges from actual
+ * rendering — causing double-width characters and layout corruption.
+ *
+ * An already-formatted CSS font-family stack (containing commas) is passed
+ * through unchanged.
+ */
+export function formatFontFamily(name: string): string {
+  if (!name) return name
+  // Already a CSS font-family stack (has commas) — pass through
+  if (name.includes(',')) return name
+  const needsQuotes = /\s/.test(name)
+  const quoted = needsQuotes ? `"${name}"` : name
+  return `${quoted}, monospace`
+}


### PR DESCRIPTION
## Summary

System font names containing spaces (e.g. DejaVu Sans Mono, GB18030 Bitmap, Fira Code) were passed as bare CSS `font-family` values to xterm.js. The browser parsed the spaces as separators between multiple family names, failed to find the intended font, and fell back to a proportional font — causing canvas character width measurement to diverge from actual rendering, resulting in double-width characters and layout corruption. Fonts without spaces (Monaco, Menlo) were unaffected.

This fix adds a `formatFontFamily()` utility that wraps space-containing names in CSS quotes and appends a `monospace` fallback.

## 摘要

系统字体枚举返回的含空格字体名（DejaVu Sans Mono、GB18030 Bitmap、Fira Code 等）作为裸 CSS `font-family` 值传入 xterm.js 后，空格被 CSS 解析器拆成多个独立字体名，浏览器找不到目标字体、回退到比例字体，导致 canvas 字符宽度测量与实际渲染不一致——终端文字占双格、比例失调。Monaco 等无空格字体名不受影响。

新增 `formatFontFamily()` 工具函数对含空格字体名加 CSS 双引号并追加 `monospace` fallback。

## Changes

| File | Change |
|---|---|
| `frontend/src/utils/formatFontFamily.ts` | **NEW** — utility to quote space-containing names and append `monospace` |
| `frontend/src/components/SettingsTab.vue` | Apply `formatFontFamily` to system font mapping |
| `frontend/src/components/Sidebar.vue` | Apply `formatFontFamily` to system font mapping |
| `frontend/src/services/terminalManager.ts` | Apply `formatFontFamily` as defensive wrapper at terminal creation |

## 验证

- [x] `npm run build` passes
- [x] 在 macOS 上选择 DejaVu Sans Mono / GB18030 Bitmap / Fira Code 连接节点，终端文本渲染正常、比例正确
- [x] Monaco / Menlo 等无空格字体仍然正常

Closes #223