### PR TITLE
revert(ui): restore header/sidebar chrome styling from #228

### DIFF
--- a/frontend/src/components/AISidebar.vue
+++ b/frontend/src/components/AISidebar.vue
@@ -565,7 +565,7 @@ defineExpose({ focusInput })
 
 <style scoped>
 .ai-sidebar {
-  background: var(--bg-base);
+  background: var(--bg-elevated);
   display: flex;
   flex-direction: column;
   position: relative;
@@ -592,15 +592,44 @@ defineExpose({ focusInput })
   left: 0;
   top: 0;
   bottom: 0;
-  width: 3px;
+  width: 6px;
   cursor: col-resize;
   z-index: 10;
-  background: var(--border-subtle);
+  background: transparent;
   transition: background 0.15s ease;
 }
 
-.resize-handle:hover {
+.resize-handle::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 1px;
+  background: linear-gradient(
+    180deg,
+    transparent 0%,
+    var(--accent-subtle) 20%,
+    var(--accent-glow) 50%,
+    var(--accent-subtle) 80%,
+    transparent 100%
+  );
+  transition: opacity 0.15s;
+}
+
+.resize-handle:hover::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 3px;
   background: var(--accent);
+  box-shadow: 0 0 6px var(--accent-glow);
+}
+
+.resize-handle:hover::before {
+  opacity: 0;
 }
 .ai-header {
   display: flex;

--- a/frontend/src/components/AppHeader.vue
+++ b/frontend/src/components/AppHeader.vue
@@ -201,7 +201,7 @@ onUnmounted(() => {
   height: 44px;
   padding: 0 8px;
   gap: 2px;
-  background: var(--border-subtle);
+  background: var(--bg-elevated);
   flex-shrink: 0;
   position: relative;
   z-index: 10;
@@ -212,6 +212,23 @@ onUnmounted(() => {
   height: 52px;
   padding: 0 10px;
   gap: 8px;
+}
+
+.app-header::after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 1px;
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    var(--accent-subtle) 20%,
+    var(--accent-glow) 50%,
+    var(--accent-subtle) 80%,
+    transparent 100%
+  );
 }
 
 .header-tabs {
@@ -256,6 +273,16 @@ onUnmounted(() => {
   font-size: 14px;
 }
 
+[data-theme="light"] .app-header::after {
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    var(--accent-subtle) 20%,
+    var(--accent-glow) 50%,
+    var(--accent-subtle) 80%,
+    transparent 100%
+  );
+}
 
 .mac-traffic-light-spacer {
   width: 72px;

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -1482,7 +1482,7 @@ defineExpose({ focusSearch, openChangeGroupFor })
 
 <style scoped>
 .sidebar {
-  background: var(--bg-base);
+  background: var(--bg-elevated);
   display: flex;
   flex-direction: column;
   flex-shrink: 0;
@@ -1500,18 +1500,43 @@ defineExpose({ focusSearch, openChangeGroupFor })
 
 .resize-handle {
   position: absolute;
-  right: 0;
+  right: -6px;
   top: 0;
   bottom: 0;
-  width: 3px;
+  width: 6px;
   cursor: col-resize;
   z-index: 10;
-  background: var(--border-subtle);
-  transition: background 0.15s ease;
+  background: transparent;
 }
 
-.resize-handle:hover {
+/* Decorative line stays at the sidebar right edge */
+.resize-handle::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 1px;
+  background: linear-gradient(
+    180deg,
+    transparent 0%,
+    var(--accent-subtle) 20%,
+    var(--accent-glow) 50%,
+    var(--accent-subtle) 80%,
+    transparent 100%
+  );
+}
+
+/* Hover: 3px accent bar extending into sidebar */
+.resize-handle:hover::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 3px;
   background: var(--accent);
+  box-shadow: 0 0 6px var(--accent-glow);
 }
 
 .sidebar-header {

--- a/frontend/src/components/TabBar.vue
+++ b/frontend/src/components/TabBar.vue
@@ -303,11 +303,13 @@ function clearDragState() {
   align-items: center;
   height: 40px;
   background: var(--bg-base);
+  border-bottom: 1px solid var(--border-subtle);
   position: relative;
-  transition: background 0.15s;
+  transition: background 0.15s, border-color 0.15s;
 }
 .tab-bar.drag-over {
   background: var(--accent-subtle);
+  border-bottom-color: var(--accent-dim);
 }
 .tabs-list {
   display: flex;


### PR DESCRIPTION
Revert the window-chrome visual changes introduced in #228, while keeping the AI input-toolbar redesign and message-rendering improvements from that PR.

Restored:
- **Header** — background and the gradient separator line under the app header.
- **Sidebar** — background and the decorative resize-handle (gradient line + accent hover glow).
- **Tab bar** — bottom border and drag-over border color.
- **AI sidebar** — background and the left resize-handle (gradient decorative line + accent hover glow).

Not touched: the AI input toolbar (icon buttons, ghost selectors, layout), message avatars/`<p>` rendering, and the i18n label changes from #228 all remain as-is.

---

还原 #228 引入的窗口/边栏视觉样式改动，同时保留该 PR 中 AI 输入工具栏改造与消息渲染优化。

已还原：
- **标题栏** —— 背景色与标题栏下方的渐变分割线。
- **边栏** —— 背景色与分割条装饰（渐变线 + hover 高亮）。
- **标签栏** —— 底部边框及拖拽悬停边框色。
- **AI 边栏** —— 背景色与左侧分割条（渐变装饰线 + hover 高亮）。

未改动：#228 中的 AI 输入工具栏（图标按钮、ghost 选择器、布局）、消息头像/`<p>` 渲染，以及 i18n 文案改动均保持不变。