### PR TITLE
fix(ui): persist sidebar group collapse state to prevent auto-expand on group add/delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,45 @@
 # Changelog
 
+## v1.4.0-alpha
+
+### What's Changed
+
+**New Features**
+- SSH Tunnel Manager with 3 forwarding modes: Local (-L), Remote (-R), and Dynamic (-D, SOCKS5). Tunnels are listed in a dedicated sidebar tab with status indicators, grouped by drag-and-drop, and support auto-start on launch. (@surenwuyuwuqiu)
+- AI message queue. Messages can now be sent while the AI agent is running or awaiting confirmation. Queued messages are shown as removable chips above the input and are processed at the next turn boundary of the agent loop.
+
+**Improvements**
+- Ctrl+scroll wheel now adjusts terminal font size (±1px, range 8–32px), persisted to settings. (@surenwuyuwuqiu)
+- AI command end detection now strips ANSI from captured prompts and uses an idle heuristic for dynamic prompts, improving reliability.
+- AI sidebar toolbar optimized: send/stop replaced with icon buttons, model/mode selectors use ghost style, avatars removed with wider message layout, markdown rendered in `<p>` tags.
+- AI user cancellation now shows a friendly "interrupted" hint instead of raw "API Error: context canceled".
+- New and edit connection forms: host and port merged into a single row for a cleaner layout.
+
+**Bug Fixes**
+- RDP blank screen on modern Windows. Added NLA (Network Level Authentication) toggle — enabled by default using CredSSP for modern Windows; when disabled, uses RDP standard security with password field for auto-login.
+- Fixed system font names containing spaces (e.g. DejaVu Sans Mono, Fira Code) causing double-width character rendering in terminal due to CSS font-family parsing. (@surenwuyuwuqiu)
+
+Thanks to @surenwuyuwuqiu for their contributions to this release.
+
+### 更新内容
+
+**新功能**
+- SSH 隧道管理器，支持三种转发模式：本地转发 (-L)、远程转发 (-R) 和动态转发 (-D, SOCKS5)。隧道在侧边栏独立标签页中展示，带状态指示灯，支持拖拽分组、启动时自动启动。（@surenwuyuwuqiu）
+- AI 消息队列。AI 运行中或等待确认时仍可发送消息，待处理消息显示为可移除的标签条，在 agent 循环的下一轮边界自动注入处理。
+
+**改进**
+- Ctrl+滚轮调整终端字体大小（±1px，范围 8–32px），设置自动持久化。（@surenwuyuwuqiu）
+- AI 命令结束检测优化：从捕获的提示符中剥离 ANSI 转义序列，并为动态提示符增加空闲启发式检测，提升判断可靠性。
+- AI 侧边栏工具栏优化：发送/停止改为图标按钮，模型/模式选择器使用 ghost 样式，移除头像并拓宽消息布局，markdown 用 `<p>` 标签包裹。
+- AI 用户取消操作时显示友好的"已中断"提示，而非原始的 "API Error: context canceled"。
+- 连接新建和编辑表单主机与端口合并为单行，布局更简洁。
+
+**Bug 修复**
+- 修复现代 Windows RDP 连接白屏问题。新增 NLA（网络级认证）开关 — 默认启用 CredSSP 兼容现代 Windows；关闭后使用 RDP 标准安全并显示密码字段用于自动登录。
+- 修复系统字体名含空格（如 DejaVu Sans Mono、Fira Code）时，CSS font-family 解析错误导致终端字符占双格、比例失调的问题。（@surenwuyuwuqiu）
+
+感谢 @surenwuyuwuqiu 对本版本的贡献。
+
 ## v1.3.3
 
 ### What's Changed

--- a/backend/store/local_state_store.go
+++ b/backend/store/local_state_store.go
@@ -9,13 +9,14 @@ import (
 const localStateFileName = "local_state.json"
 
 type LocalState struct {
-	SidebarVisible   bool `json:"sidebarVisible"`
-	AISidebarVisible bool `json:"aiSidebarVisible"`
-	WindowX          int  `json:"windowX"`
-	WindowY          int  `json:"windowY"`
-	WindowWidth      int  `json:"windowWidth"`
-	WindowHeight     int  `json:"windowHeight"`
-	WindowMaximised  bool `json:"windowMaximised"`
+	SidebarVisible    bool     `json:"sidebarVisible"`
+	AISidebarVisible  bool     `json:"aiSidebarVisible"`
+	CollapsedGroupIds []string `json:"collapsedGroupIds"`
+	WindowX           int      `json:"windowX"`
+	WindowY           int      `json:"windowY"`
+	WindowWidth       int      `json:"windowWidth"`
+	WindowHeight      int      `json:"windowHeight"`
+	WindowMaximised   bool     `json:"windowMaximised"`
 }
 
 type LocalStateStore struct {

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -476,6 +476,7 @@ import CustomThemeEditor from './CustomThemeEditor.vue'
 import type { ConnectionConfig, ConnectionGroup } from '../types/session'
 import { parseQuickConnect, formatConnSubtitle } from '../utils/quickConnect'
 import { FONT_OPTIONS, LANGUAGE_OPTIONS } from '../types/settings'
+import { LoadLocalState, SaveLocalState } from '../../wailsjs/go/main/App'
 import { formatFontFamily } from '../utils/formatFontFamily'
 import { useTerminalThemeOptions } from '../composables/useTerminalThemeOptions'
 import { GetSystemFonts } from '../../wailsjs/go/main/App'
@@ -582,13 +583,33 @@ function matchTypeFilter(conn: ConnectionConfig, filter: string): boolean {
 
 // ── Expand/collapse state ──
 const expandedGroups = ref<Set<string>>(new Set())
+const collapsedGroupIds = ref<Set<string>>(new Set())
 
-function toggleGroup(groupId: string) {
+// Build expandedGroups from all known group IDs minus those explicitly collapsed
+function syncExpandedFromCollapsed(groupIds: string[]) {
+  expandedGroups.value = new Set(groupIds.filter(id => !collapsedGroupIds.value.has(id)))
+}
+
+// Persist collapsedGroupIds to LocalState
+async function persistCollapsedState() {
+  try {
+    const state = await LoadLocalState()
+    state.collapsedGroupIds = [...collapsedGroupIds.value]
+    await SaveLocalState(state)
+  } catch {
+    // ignore errors — collapse state is not critical
+  }
+}
+
+async function toggleGroup(groupId: string) {
   if (expandedGroups.value.has(groupId)) {
     expandedGroups.value.delete(groupId)
+    collapsedGroupIds.value.add(groupId)
   } else {
     expandedGroups.value.add(groupId)
+    collapsedGroupIds.value.delete(groupId)
   }
+  await persistCollapsedState()
 }
 
 // ── Multi-select ──
@@ -652,26 +673,96 @@ watch(filteredGrouped, () => {
   }
 }, { immediate: true })
 
-// Auto-expand all groups by default
+// Track the previous group ID set so we can detect new vs deleted groups
+const prevGroupIds = ref<Set<string>>(new Set())
+const collapsedStateLoaded = ref(false)
+
+// Sync expanded state when groups change (add/delete/rename) — preserve user collapse choices
 watch(() => connectionStore.groups, (groups) => {
+  if (!collapsedStateLoaded.value) return
+  const currentIds = new Set<string>()
   for (const g of groups) {
-    expandedGroups.value.add(g.id)
+    currentIds.add(g.id)
   }
   if (groups.length > 0) {
-    expandedGroups.value.add('__ungrouped__')
+    currentIds.add('__ungrouped__')
   }
-}, { immediate: true })
 
-// Auto-expand groups when searching
+  // Remove stale group IDs from both expanded and collapsed
+  const allKnown = new Set([...expandedGroups.value, ...collapsedGroupIds.value])
+  for (const id of allKnown) {
+    if (id === '__ungrouped__' && groups.length === 0) continue
+    if (id !== '__ungrouped__' && !currentIds.has(id)) {
+      expandedGroups.value.delete(id)
+      collapsedGroupIds.value.delete(id)
+    }
+  }
+
+  // New groups (and __ungrouped__ if first time) — expand by default
+  for (const id of currentIds) {
+    if (!prevGroupIds.value.has(id) && !collapsedGroupIds.value.has(id)) {
+      expandedGroups.value.add(id)
+    }
+  }
+
+  prevGroupIds.value = currentIds
+})
+
+// Initialize collapse state from persisted LocalState
+async function initCollapseState() {
+  try {
+    const state = await LoadLocalState()
+    if (state.collapsedGroupIds && state.collapsedGroupIds.length > 0) {
+      collapsedGroupIds.value = new Set(state.collapsedGroupIds)
+    }
+  } catch {
+    // Use default (all expanded)
+  }
+
+  // Build initial expandedGroups and prevGroupIds
+  const allIds: string[] = []
+  for (const g of connectionStore.groups) {
+    allIds.push(g.id)
+  }
+  if (connectionStore.groups.length > 0) {
+    allIds.push('__ungrouped__')
+  }
+  expandedGroups.value = new Set(allIds.filter(id => !collapsedGroupIds.value.has(id)))
+  prevGroupIds.value = new Set(allIds)
+  collapsedStateLoaded.value = true
+}
+
+// Track previous search query state
+const wasSearching = ref(false)
+
+// Auto-expand all groups while searching; restore persisted state when search is cleared
 watch(searchQuery, (q) => {
-  if (q.trim()) {
+  const isSearching = !!q.trim()
+  if (isSearching && !wasSearching.value) {
+    // Entering search mode — expand all visually (don't touch collapsedGroupIds)
+    expandedGroups.value = new Set()
     for (const g of filteredGrouped.value.groups) {
       expandedGroups.value.add(g.group.id)
     }
     if (connectionStore.groups.length > 0) {
       expandedGroups.value.add('__ungrouped__')
     }
+  } else if (!isSearching && wasSearching.value) {
+    // Exiting search mode — restore from persisted collapsed state
+    const allIds: string[] = []
+    for (const g of connectionStore.groups) {
+      allIds.push(g.id)
+    }
+    if (connectionStore.groups.length > 0) {
+      allIds.push('__ungrouped__')
+    }
+    syncExpandedFromCollapsed(allIds)
+    // Clean stale entries from collapsedGroupIds
+    collapsedGroupIds.value = new Set(
+      [...collapsedGroupIds.value].filter(id => id === '__ungrouped__' || connectionStore.groups.some(g => g.id === id))
+    )
   }
+  wasSearching.value = isSearching
 })
 
 // ── Resize ──
@@ -1453,6 +1544,8 @@ onMounted(async () => {
     closeGroupMenu()
     closeEmptyAreaMenu()
   })
+  // Restore group collapse state from persisted settings
+  await initCollapseState()
   // Load system fonts for personalization panel
   try {
     const fonts = await GetSystemFonts()

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -1155,6 +1155,7 @@ export namespace store {
 	export class LocalState {
 	    sidebarVisible: boolean;
 	    aiSidebarVisible: boolean;
+	    collapsedGroupIds: string[];
 	    windowX: number;
 	    windowY: number;
 	    windowWidth: number;
@@ -1169,6 +1170,7 @@ export namespace store {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.sidebarVisible = source["sidebarVisible"];
 	        this.aiSidebarVisible = source["aiSidebarVisible"];
+	        this.collapsedGroupIds = source["collapsedGroupIds"];
 	        this.windowX = source["windowX"];
 	        this.windowY = source["windowY"];
 	        this.windowWidth = source["windowWidth"];


### PR DESCRIPTION
## Summary

Store connection sidebar group collapse/expand state in `LocalState` (`local_state.json`), so creating or deleting a connection group no longer expands all previously collapsed groups. Collapse state persists across app restarts.

### Problem
When creating a new group or deleting a group via right-click, the `Sidebar.vue` watcher on `connectionStore.groups` unconditionally expanded all groups, discarding the user's collapse choices.

### Fix
- Add `CollapsedGroupIds []string` to the Go `LocalState` struct
- Update the TypeScript `LocalState` model with `collapsedGroupIds: string[]`
- Rewrite Sidebar.vue collapse logic:
  - `toggleGroup()` updates `collapsedGroupIds` and persists to LocalState
  - Groups watcher only expands **new** groups; existing groups keep their collapse state
  - Search mode expands all groups visually without changing persisted state; clearing search restores collapse state
  - On mount, `initCollapseState()` loads persisted state before the groups watcher activates
  - Stale group IDs (from deleted groups) are cleaned up from both expanded and collapsed sets

Closes #209 (issue 1).

---

## 概述

将连接侧边栏分组的折叠/展开状态持久化到 `LocalState`（`local_state.json`），以避免新建/删除分组时所有已折叠的分组被自动展开，并支持重启后恢复折叠状态。

### 问题
新建分组或右键删除分组时，`Sidebar.vue` 对 `connectionStore.groups` 的 watcher 会无条件展开所有分组。

### 修复
- Go `LocalState` 结构体新增 `CollapsedGroupIds []string` 字段
- TypeScript `LocalState` 模型新增 `collapsedGroupIds: string[]`
- 重写 Sidebar.vue 折叠逻辑，详见英文部分

Closes #209（问题1）