### PR TITLE
fix(ui): fix database advanced config toggle and tunnel selector not showing

### DIFF
--- a/frontend/src/components/ConnectionForm.vue
+++ b/frontend/src/components/ConnectionForm.vue
@@ -295,6 +295,7 @@
                   <el-option label="Latin-1" value="latin-1" />
                 </el-select>
               </el-form-item>
+            </template>
             <el-form-item v-if="showTunnel" :label="t('conn.tunnel')">
               <el-select
                 v-model="form.tunnelSSHConnId"
@@ -310,7 +311,6 @@
                 />
               </el-select>
             </el-form-item>
-            </template>
             </template>
           </el-form>
         </div>
@@ -873,7 +873,7 @@ function onConnect() {
 .conn-layout {
   display: flex;
   gap: 0;
-  min-height: 420px;
+  min-height: 360px;
 }
 
 /* ── Left sidebar ── */
@@ -983,8 +983,6 @@ function onConnect() {
 
 /* ── Form fields ── */
 .conn-fields {
-  flex: 1;
-  overflow-y: auto;
   padding-right: 4px;
 }
 


### PR DESCRIPTION
## Summary

Fixed a bug where clicking "Advanced Configuration" when creating/editing a database connection showed no content, because the tunnel SSH selector was incorrectly nested inside the FTP type template condition (`v-if="form.type === 'ftp'"). Additionally improved the dialog layout to prevent blank space and internal scrollbar issues.

## Changes

1. **Move tunnel selector out of FTP template** — The `<el-form-item v-if="showTunnel">` was nested inside `<template v-if="form.type === 'ftp'">`, causing it to not render for database and other non-FTP connection types. Moved the closing `</template>` tag before the tunnel form-item.
2. **Reduce dialog min-height** — `420px` → `360px` to reduce unnecessary blank space for shorter forms (database, etc.).
3. **Remove flex stretching on form area** — Removed `flex: 1` and `overflow-y: auto` from `.conn-fields` so the dialog grows naturally with content instead of showing an internal scrollbar.

---

## 修复内容

修复了创建/编辑数据库连接时点击「高级配置」无响应的 bug。根因是 tunnel SSH 隧道选择器被错误地嵌套在 FTP 类型的条件模板内，导致非 FTP 连接类型无法渲染。同时优化了对话框布局，消除空白区域和内部滚动条问题。

Closes #249