### PR TITLE
feat: add Scoop, Homebrew, Winget, Chocolatey package manager support

### DIFF
--- a/.github/workflows/update-choco.yml
+++ b/.github/workflows/update-choco.yml
@@ -1,0 +1,59 @@
+name: Update Chocolatey
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  update:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout choco repo
+        uses: actions/checkout@v7
+        with:
+          repository: ys-ll/choco-uniterm
+          token: ${{ secrets.PAT }}
+
+      - name: Get version
+        shell: bash
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          VERSION="${TAG#v}"
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "TAG=$TAG" >> $GITHUB_ENV
+
+      - name: Download installer and compute hash
+        shell: bash
+        run: |
+          URL="https://github.com/ys-ll/uniterm/releases/download/$TAG/uniterm-windows-amd64-installer-$TAG.exe"
+          curl -sLo /tmp/uniterm-installer.exe "$URL"
+          SHA256=$(sha256sum /tmp/uniterm-installer.exe | cut -d' ' -f1)
+          echo "SHA256=$SHA256" >> $GITHUB_ENV
+
+      - name: Update nuspec
+        shell: bash
+        run: |
+          sed -i "s|<version>.*</version>|<version>$VERSION</version>|" uniterm.nuspec
+
+      - name: Update install script
+        shell: pwsh
+        run: |
+          (Get-Content tools/chocolateyinstall.ps1) `
+            -replace '\$version = .*', "`$version = '$env:VERSION'" `
+            -replace '\$checksum64 = .*', "`$checksum64 = '$env:SHA256'" |
+            Set-Content tools/chocolateyinstall.ps1
+
+      - name: Build and push
+        shell: pwsh
+        run: |
+          choco pack uniterm.nuspec
+          choco push uniterm.$env:VERSION.nupkg --source https://push.chocolatey.org/ --api-key ${{ secrets.CHOCO_API_KEY }}
+
+      - name: Commit manifest update
+        shell: bash
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git add uniterm.nuspec tools/chocolateyinstall.ps1
+          git commit -m "Update to $TAG" || true
+          git push

--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -1,0 +1,43 @@
+name: Update Homebrew Cask
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout homebrew tap repo
+        uses: actions/checkout@v7
+        with:
+          repository: ys-ll/homebrew-uniterm
+          token: ${{ secrets.PAT }}
+
+      - name: Get version
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          VERSION="${TAG#v}"
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "TAG=$TAG" >> $GITHUB_ENV
+
+      - name: Download macOS DMG and compute hash
+        run: |
+          URL="https://github.com/ys-ll/uniterm/releases/download/$TAG/uniterm-darwin-universal-$TAG.dmg"
+          curl -sLo /tmp/uniterm.dmg "$URL"
+          SHA256=$(sha256sum /tmp/uniterm.dmg | cut -d' ' -f1)
+          echo "SHA256=$SHA256" >> $GITHUB_ENV
+
+      - name: Update formula
+        run: |
+          sed -i "s/version \".*\"/version \"$VERSION\"/" Formula/uniterm.rb
+          sed -i "s/sha256 arm:.*/sha256 arm:   \"$SHA256\"/" Formula/uniterm.rb
+          sed -i "s/    intel:.*/     intel: \"$SHA256\"/" Formula/uniterm.rb
+
+      - name: Commit and push
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git add Formula/uniterm.rb
+          git commit -m "Update to $TAG" || true
+          git push

--- a/.github/workflows/update-scoop.yml
+++ b/.github/workflows/update-scoop.yml
@@ -1,0 +1,45 @@
+name: Update Scoop Bucket
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout scoop bucket repo
+        uses: actions/checkout@v7
+        with:
+          repository: ys-ll/scoop-uniterm
+          token: ${{ secrets.PAT }}
+
+      - name: Get version
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          VERSION="${TAG#v}"
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "TAG=$TAG" >> $GITHUB_ENV
+
+      - name: Download portable zip and compute hash
+        run: |
+          URL="https://github.com/ys-ll/uniterm/releases/download/$TAG/uniterm-windows-amd64-portable-$TAG.zip"
+          curl -sLo /tmp/uniterm.zip "$URL"
+          SHA256=$(sha256sum /tmp/uniterm.zip | cut -d' ' -f1)
+          echo "SHA256=$SHA256" >> $GITHUB_ENV
+
+      - name: Update manifest
+        run: |
+          jq --arg v "$VERSION" \
+             --arg h "sha256:$SHA256" \
+             --arg url "https://github.com/ys-ll/uniterm/releases/download/$TAG/uniterm-windows-amd64-portable-$TAG.zip" \
+             '.version = $v | .architecture."64bit".url = $url | .architecture."64bit".hash = $h' \
+             bucket/uniterm.json > tmp.json && mv tmp.json bucket/uniterm.json
+
+      - name: Commit and push
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git add bucket/uniterm.json
+          git commit -m "Update to $TAG" || true
+          git push

--- a/.github/workflows/update-winget.yml
+++ b/.github/workflows/update-winget.yml
@@ -1,0 +1,16 @@
+name: Update Winget
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  update:
+    runs-on: windows-latest
+    steps:
+      - name: Submit to Winget
+        uses: vedantmgoyal9/winget-releaser@main
+        with:
+          identifier: ys-ll.uniTerm
+          max-versions-to-keep: 5
+          token: ${{ secrets.WINGET_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -138,7 +138,23 @@ Get the latest pre-built binaries from [GitHub Releases](https://github.com/ys-l
 
 - **Windows**: installer `uniterm-windows-amd64-installer-*.exe`, or portable `uniterm-windows-amd64-portable-*.zip`
 - **macOS**: Download `uniterm-darwin-universal-*.dmg`
-- **Linux**: Download `uniterm-linux-amd64-*.tar.gz`
+- **Linux**: Download `uniterm-linux-amd64-*.tar.gz`, `.deb`, or `.rpm`
+
+### Package Managers
+
+```bash
+# Windows
+winget install ys-ll.uniTerm
+scoop bucket add uniterm https://github.com/ys-ll/scoop-uniterm && scoop install uniterm
+choco install uniterm
+
+# macOS
+brew install ys-ll/uniterm/uniterm
+
+# Linux (deb)
+curl -sLo uniterm.deb https://github.com/ys-ll/uniterm/releases/latest/download/uniterm-linux-amd64-*.deb
+sudo dpkg -i uniterm.deb
+```
 
 ### Runtime Dependencies
 

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -138,7 +138,23 @@ Oracle Database 支持基于纯 Go 驱动实现。uniTerm 不随安装包分发 
 
 - **Windows**: 安装包 `uniterm-windows-amd64-installer-*.exe`，或便携版 `uniterm-windows-amd64-portable-*.zip`
 - **macOS**: 下载 `uniterm-darwin-universal-*.dmg`
-- **Linux**: 下载 `uniterm-linux-amd64-*.tar.gz`
+- **Linux**: 下载 `uniterm-linux-amd64-*.tar.gz`、`.deb` 或 `.rpm`
+
+### 包管理器安装
+
+```bash
+# Windows
+winget install ys-ll.uniTerm
+scoop bucket add uniterm https://github.com/ys-ll/scoop-uniterm && scoop install uniterm
+choco install uniterm
+
+# macOS
+brew install ys-ll/uniterm/uniterm
+
+# Linux (deb)
+curl -sLo uniterm.deb https://github.com/ys-ll/uniterm/releases/latest/download/uniterm-linux-amd64-*.deb
+sudo dpkg -i uniterm.deb
+```
 
 ### 运行依赖
 


### PR DESCRIPTION
## Changes

Add support for 4 package managers with auto-update on release:

| Manager | Platform | Install | Auto-update |
|---------|----------|---------|-------------|
| **Scoop** | Windows | `scoop install uniterm` | ✅ |
| **Homebrew** | macOS | `brew install ys-ll/uniterm/uniterm` | ✅ |
| **Winget** | Windows | `winget install ys-ll.uniTerm` | ✅ |
| **Chocolatey** | Windows | `choco install uniterm` | ✅ |

### New repos
- [scoop-uniterm](https://github.com/ys-ll/scoop-uniterm) — Scoop bucket manifest
- [homebrew-uniterm](https://github.com/ys-ll/homebrew-uniterm) — Homebrew cask formula
- [choco-uniterm](https://github.com/ys-ll/choco-uniterm) — Chocolatey package

### CI workflows
4 new workflows triggered on GitHub Release `published`:
- `update-scoop.yml` — Compute hash, update JSON, push to scoop-uniterm
- `update-homebrew.yml` — Compute hash, update .rb, push to homebrew-uniterm
- `update-winget.yml` — Submit to microsoft/winget-pkgs via winget-releaser
- `update-choco.yml` — Compute hash, pack, push to Chocolatey

### Required secrets
| Secret | Purpose |
|--------|---------|
| `PAT` | Classic PAT with `repo` scope for cross-repo pushes |
| `WINGET_TOKEN` | Classic PAT for winget-releaser to create PRs on microsoft/winget-pkgs |
| `CHOCO_API_KEY` | Chocolatey API key from chocolatey.org |

### Manual bootstrap (one-time)
- **Winget**: First version must be manually submitted to [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs)
- **Chocolatey**: Register at [chocolatey.org](https://community.chocolatey.org/account/register) to get API key

## 变更

为 4 个包管理器添加自动更新支持，触发时机为 GitHub Release 发布。

### 需要配置的 Secrets

| Secret | 用途 |
|--------|------|
| `PAT` | 跨仓库推送的经典 PAT（repo 权限） |
| `WINGET_TOKEN` | winget-releaser 提 PR 到 microsoft/winget-pkgs |
| `CHOCO_API_KEY` | chocolatey.org 的 API Key |

### 一次性手动操作
- **Winget**: 首次需手动提交一个版本到 microsoft/winget-pkgs repo 做 bootstrap
- **Chocolatey**: 在 chocolatey.org 注册账号获取 API Key