### PR TITLE
ci: detect prerelease from tag instead of hardcoding

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -233,10 +233,18 @@ jobs:
       - name: Extract changelog
         run: sed -n "/^## ${{ github.ref_name }}$/,/^## v/p" CHANGELOG.md | sed '$d' > release_body.md
 
+      - name: Detect prerelease
+        run: |
+          if echo "${{ github.ref_name }}" | grep -qiE '\-(rc|beta|alpha|pre|dev)'; then
+            echo "PRERELEASE=true" >> $GITHUB_ENV
+          else
+            echo "PRERELEASE=false" >> $GITHUB_ENV
+          fi
+
       - name: Create Release
         uses: softprops/action-gh-release@v3
         with:
-          prerelease: true
+          prerelease: ${{ env.PRERELEASE == 'true' }}
           body_path: release_body.md
           files: |
             uniterm-*.zip


### PR DESCRIPTION
Tags containing `-rc`, `-beta`, `-alpha`, `-pre`, or `-dev` are marked as prerelease. Clean version tags (e.g. `v1.5.0`) are stable.

Previously all releases were hardcoded as prerelease, which prevented package manager auto-update from picking up stable versions.