### PR TITLE
ci: add Windows ARM64 build target

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,7 +108,7 @@ jobs:
             BUILD_ARGS="$BUILD_ARGS -nsis"
           fi
 
-          if [[ "$PLATFORM" == windows/* ]] || [ "${PLATFORM%/*}" = "linux" ]; then
+          if [ "${PLATFORM%/*}" = "linux" ]; then
             BUILD_ARGS="$BUILD_ARGS -upx -upxflags=\"--best --lzma\""
           fi
 
@@ -135,19 +135,22 @@ jobs:
           hdiutil create -volname uniTerm -srcfolder dmg_staging -ov -format UDZO ../../uniterm-darwin-universal-${VERSION}.dmg
           rm -rf dmg_staging
 
-      - name: Package Windows portable
+      - name: UPX compress Windows AMD64
         if: startsWith(matrix.platform, 'windows')
         shell: bash
+        run: upx --best --lzma build/bin/uniTerm-amd64.exe
+
+      - name: Package Windows portable
+        if: startsWith(matrix.platform, 'windows')
+        shell: pwsh
         run: |
-          VERSION="${{ env.VERSION }}"
-          for arch in amd64 arm64; do
-            cd build/bin
-            mkdir -p ../../dist_tmp
-            cp uniTerm-${arch}.exe ../../dist_tmp/uniTerm.exe
-            cd ../..
-            (cd dist_tmp && zip -q ../uniterm-windows-${arch}-portable-${VERSION}.zip uniTerm.exe)
-            rm -rf dist_tmp
-          done
+          $VERSION = "${{ env.VERSION }}"
+          foreach ($arch in @('amd64', 'arm64')) {
+            New-Item -ItemType Directory -Force -Path dist_tmp | Out-Null
+            Copy-Item "build/bin/uniTerm-$arch.exe" "dist_tmp/uniTerm.exe"
+            Compress-Archive -Path dist_tmp/* -DestinationPath "uniterm-windows-$arch-portable-$VERSION.zip" -Force
+            Remove-Item -Recurse -Force dist_tmp
+          }
 
       - name: Rename NSIS installers (Windows)
         if: startsWith(matrix.platform, 'windows')

--- a/build/windows/installer/project.nsi
+++ b/build/windows/installer/project.nsi
@@ -8,7 +8,11 @@ ManifestDPIAware true
 !endif
 
 Name "${PRODUCT_NAME}"
-OutFile "..\..\bin\uniTerm-amd64-installer.exe"
+!ifdef ARG_WAILS_AMD64_BINARY
+  OutFile "..\..\bin\uniTerm-amd64-installer.exe"
+!else
+  OutFile "..\..\bin\uniTerm-arm64-installer.exe"
+!endif
 InstallDir "$PROGRAMFILES64\${PRODUCT_NAME}"
 RequestExecutionLevel admin
 SetCompressor /SOLID lzma
@@ -58,7 +62,11 @@ FunctionEnd
 
 Section "Install"
   SetOutPath "$INSTDIR"
+!ifdef ARG_WAILS_AMD64_BINARY
   File "/oname=${BINARY}" "${ARG_WAILS_AMD64_BINARY}"
+!else
+  File "/oname=${BINARY}" "${ARG_WAILS_ARM64_BINARY}"
+!endif
   CreateShortCut "$DESKTOP\${PRODUCT_NAME}.lnk" "$INSTDIR\${BINARY}"
   CreateDirectory "$SMPROGRAMS\${PRODUCT_NAME}"
   CreateShortCut "$SMPROGRAMS\${PRODUCT_NAME}\${PRODUCT_NAME}.lnk" "$INSTDIR\${BINARY}"


### PR DESCRIPTION
Build both `windows/amd64` and `windows/arm64` from a single runner via Wails cross-compilation.

### New artifacts

| Architecture | Formats |
|---|---|
| **amd64** (existing) | installer `.exe` + portable `.zip` |
| **arm64** (new) | installer `.exe` + portable `.zip` |

### Changes

- Matrix platform: `windows/amd64` → `windows/amd64,windows/arm64`
- NSIS script: add `!ifdef ARG_WAILS_AMD64_BINARY` for dual-arch support
- UPX: skip ARM64 (unsupported), compress only AMD64 post-build