### PR TITLE
feat: add default local shell setting

### DIFF
--- a/backend/store/settings_store.go
+++ b/backend/store/settings_store.go
@@ -94,6 +94,7 @@ type AppSettings struct {
 	AutoCheckUpdate      *bool                 `json:"autoCheckUpdate"`
 	SFTPBookmarks        SFTPBookmarks         `json:"sftpBookmarks"`
 	CustomTerminalThemes []CustomTerminalTheme `json:"customTerminalThemes"`
+	DefaultLocalShell    string                `json:"defaultLocalShell"`
 }
 
 type SFTPBookmarks struct {

--- a/frontend/src/components/SettingsTab.vue
+++ b/frontend/src/components/SettingsTab.vue
@@ -131,6 +131,23 @@
 
           <div class="setting-card">
             <div class="setting-info">
+              <div class="setting-title">{{ t('settings.defaultLocalShell') }}</div>
+              <div class="setting-desc">{{ t('settings.defaultLocalShellDesc') }}</div>
+            </div>
+            <div class="setting-control">
+              <el-select v-model="settingsStore.settings.defaultLocalShell" @change="settingsStore.save()">
+                <el-option
+                  v-for="sh in settingsStore.availableShells"
+                  :key="sh"
+                  :label="getShellLabel(sh)"
+                  :value="sh"
+                />
+              </el-select>
+            </div>
+          </div>
+
+          <div class="setting-card">
+            <div class="setting-info">
               <div class="setting-title">{{ t('settings.selectionAction') }}</div>
               <div class="setting-desc">{{ t('settings.selectionActionDesc') }}</div>
             </div>
@@ -837,7 +854,12 @@ async function testConnection() {
 }
 
 function getShellLabel(path: string): string {
+  if (!path) return 'Local'
   const lower = path.toLowerCase()
+  if (lower.startsWith('wsl://')) {
+    const distro = path.slice(6)
+    return distro ? `WSL - ${distro}` : 'WSL'
+  }
   if (lower.includes('pwsh')) return 'PowerShell'
   if (lower.includes('powershell')) return 'Windows PowerShell'
   if (lower.includes('bash')) return 'Git Bash'

--- a/frontend/src/components/StartTabContent.vue
+++ b/frontend/src/components/StartTabContent.vue
@@ -46,26 +46,31 @@
         <el-icon><Plus :size="14" /></el-icon>
         {{ t('header.newConnection') }}
       </button>
-      <el-dropdown trigger="click" placement="bottom-start" :teleported="false">
-        <button class="start-action-btn">
+      <div class="start-action-btn-group">
+        <button class="start-action-btn" @click="handleDefaultLocalTerminal">
           <el-icon><Laptop :size="14" /></el-icon>
           {{ t('conn.localTerminal') }}
         </button>
-        <template #dropdown>
-          <el-dropdown-menu>
-            <el-dropdown-item
-              v-for="sh in settingsStore.availableShells"
-              :key="sh"
-              @click="emit('local-terminal', sh, $event.ctrlKey || $event.metaKey)"
-            >
-              {{ getShellLabel(sh) }}
-            </el-dropdown-item>
-            <el-dropdown-item v-if="settingsStore.availableShells.length === 0" disabled>
-              No shells available
-            </el-dropdown-item>
-          </el-dropdown-menu>
-        </template>
-      </el-dropdown>
+        <el-dropdown trigger="click" placement="bottom-start" :teleported="false">
+          <button class="start-action-btn-dropdown-arrow">
+            <el-icon><ChevronDown :size="12" /></el-icon>
+          </button>
+          <template #dropdown>
+            <el-dropdown-menu>
+              <el-dropdown-item
+                v-for="sh in settingsStore.availableShells"
+                :key="sh"
+                @click="emit('local-terminal', sh, $event.ctrlKey || $event.metaKey)"
+              >
+                {{ getShellLabel(sh) }}
+              </el-dropdown-item>
+              <el-dropdown-item v-if="settingsStore.availableShells.length === 0" disabled>
+                No shells available
+              </el-dropdown-item>
+            </el-dropdown-menu>
+          </template>
+        </el-dropdown>
+      </div>
       <button class="start-action-btn" @click="emit('connect-serial', $event.ctrlKey || $event.metaKey)">
         <el-icon><Cable :size="14" /></el-icon>
         {{ t('sidebar.connectSerial') }}
@@ -378,7 +383,7 @@ import { useSettingsStore } from '../stores/settingsStore'
 import { useI18n } from '../i18n'
 import { GetRecentConnections } from '../../wailsjs/go/main/App'
 import { formatConnSubtitle } from '../utils/quickConnect'
-import { Filter, Plus, Laptop, Cable, SquareTerminal, Terminal, Database, DatabaseZap, Layers, Monitor, MonitorSmartphone, MonitorCloud, FolderUp, HardDrive, Cloud, Globe, Server, Folder, FolderOpen, Zap, MoreHorizontal } from '@lucide/vue'
+import { Filter, Plus, Laptop, Cable, SquareTerminal, Terminal, Database, DatabaseZap, Layers, Monitor, MonitorSmartphone, MonitorCloud, FolderUp, HardDrive, Cloud, Globe, Server, Folder, FolderOpen, Zap, MoreHorizontal, ChevronDown } from '@lucide/vue'
 
 const props = defineProps<{
   tab: StartTab
@@ -399,6 +404,21 @@ const { t } = useI18n()
 const connectionStore = useConnectionStore()
 const tabStore = useTabStore()
 const settingsStore = useSettingsStore()
+
+// ── Default local shell ──
+const effectiveDefaultShell = computed(() => {
+  const shells = settingsStore.availableShells
+  if (shells.length === 0) return ''
+  const preferred = settingsStore.settings.defaultLocalShell
+  return preferred && shells.includes(preferred) ? preferred : shells[0]
+})
+
+function handleDefaultLocalTerminal() {
+  const shell = effectiveDefaultShell.value
+  if (shell) {
+    emit('local-terminal', shell)
+  }
+}
 
 // ── Card subtitle (matches sidebar display format) ──
 function getCardSubtitle(config: ConnectionConfig): string {
@@ -1166,6 +1186,33 @@ async function doDelete(config: ConnectionConfig | null) {
 }
 .start-action-btn.primary:hover {
   filter: brightness(0.9);
+}
+
+.start-action-btn-group {
+  display: flex;
+  align-items: stretch;
+}
+
+.start-action-btn-group > .start-action-btn {
+  border-radius: var(--radius-md) 0 0 var(--radius-md);
+  border-right: none;
+}
+
+.start-action-btn-dropdown-arrow {
+  padding: 8px 10px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 0 var(--radius-md) var(--radius-md) 0;
+  background: var(--bg-surface);
+  color: var(--text-secondary);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.15s;
+}
+
+.start-action-btn-dropdown-arrow:hover {
+  background: var(--bg-hover);
 }
 
 .start-breadcrumb {

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -273,6 +273,8 @@
   "settings.colorSchemeDesc": "Farbschema des Terminals",
   "settings.fontDesc": "Schriftart des Terminals",
   "settings.fontSizeDesc": "Schriftgröße des Terminals",
+  "settings.defaultLocalShell": "Default Local Shell",
+  "settings.defaultLocalShellDesc": "Shell used when clicking the Local Terminal button on the start page",
   "settings.selectionActionDesc": "Standardaktion nach Textauswahl",
   "settings.rightClickDesc": "Rechtsklick-Verhalten im Terminal",
   "settings.middleClick": "Mittelklick-Aktion",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -276,6 +276,8 @@
   "settings.colorSchemeDesc": "Terminal color scheme",
   "settings.fontDesc": "Terminal font family",
   "settings.fontSizeDesc": "Terminal font size",
+  "settings.defaultLocalShell": "Default Local Shell",
+  "settings.defaultLocalShellDesc": "Shell used when clicking the Local Terminal button on the start page",
   "settings.selectionActionDesc": "Default action after selecting text",
   "settings.rightClickDesc": "Right-click behavior in terminal",
   "settings.middleClick": "Middle Click Action",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -273,6 +273,8 @@
   "settings.colorSchemeDesc": "Esquema de colores de la terminal",
   "settings.fontDesc": "Familia tipográfica de la terminal",
   "settings.fontSizeDesc": "Tamaño de fuente de la terminal",
+  "settings.defaultLocalShell": "Default Local Shell",
+  "settings.defaultLocalShellDesc": "Shell used when clicking the Local Terminal button on the start page",
   "settings.selectionActionDesc": "Acción predeterminada después de seleccionar texto",
   "settings.rightClickDesc": "Comportamiento del clic derecho en la terminal",
   "settings.middleClick": "Accion clic medio",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -273,6 +273,8 @@
   "settings.colorSchemeDesc": "Palette de couleurs du terminal",
   "settings.fontDesc": "Police du terminal",
   "settings.fontSizeDesc": "Taille de police du terminal",
+  "settings.defaultLocalShell": "Default Local Shell",
+  "settings.defaultLocalShellDesc": "Shell used when clicking the Local Terminal button on the start page",
   "settings.selectionActionDesc": "Action par défaut après la sélection de texte",
   "settings.rightClickDesc": "Comportement du clic droit dans le terminal",
   "settings.middleClick": "Action clic milieu",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -273,6 +273,8 @@
   "settings.colorSchemeDesc": "ターミナルのカラースキーム",
   "settings.fontDesc": "ターミナルのフォント",
   "settings.fontSizeDesc": "ターミナルのフォントサイズ",
+  "settings.defaultLocalShell": "Default Local Shell",
+  "settings.defaultLocalShellDesc": "Shell used when clicking the Local Terminal button on the start page",
   "settings.selectionActionDesc": "テキスト選択後の既定アクション",
   "settings.rightClickDesc": "ターミナル内での右クリックの動作",
   "settings.middleClick": "中ボタン機能",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -273,6 +273,8 @@
   "settings.colorSchemeDesc": "터미널 색상 구성",
   "settings.fontDesc": "터미널 글꼴 패밀리",
   "settings.fontSizeDesc": "터미널 글꼴 크기",
+  "settings.defaultLocalShell": "Default Local Shell",
+  "settings.defaultLocalShellDesc": "Shell used when clicking the Local Terminal button on the start page",
   "settings.selectionActionDesc": "텍스트 선택 후 기본 동작",
   "settings.rightClickDesc": "터미널에서 오른쪽 클릭 동작",
   "settings.middleClick": "가운데 클릭 동작",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -273,6 +273,8 @@
   "settings.colorSchemeDesc": "Цветовая схема терминала",
   "settings.fontDesc": "Шрифт терминала",
   "settings.fontSizeDesc": "Размер шрифта терминала",
+  "settings.defaultLocalShell": "Default Local Shell",
+  "settings.defaultLocalShellDesc": "Shell used when clicking the Local Terminal button on the start page",
   "settings.selectionActionDesc": "Действие по умолчанию после выделения текста",
   "settings.rightClickDesc": "Поведение правой кнопки мыши в терминале",
   "settings.middleClick": "Действие средней кнопки",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -276,6 +276,8 @@
   "settings.colorSchemeDesc": "终端窗口的配色方案",
   "settings.fontDesc": "终端显示的字体",
   "settings.fontSizeDesc": "终端字体大小",
+  "settings.defaultLocalShell": "默认本地终端",
+  "settings.defaultLocalShellDesc": "在起始页点击本地终端按钮时使用的 Shell",
   "settings.selectionActionDesc": "选中文字后的默认操作",
   "settings.rightClickDesc": "右键点击终端的行为",
   "settings.middleClick": "中键功能",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -273,6 +273,8 @@
   "settings.colorSchemeDesc": "終端機視窗的配色方案",
   "settings.fontDesc": "終端機顯示的字型",
   "settings.fontSizeDesc": "終端機字型大小",
+  "settings.defaultLocalShell": "Default Local Shell",
+  "settings.defaultLocalShellDesc": "Shell used when clicking the Local Terminal button on the start page",
   "settings.selectionActionDesc": "選取文字後的預設操作",
   "settings.rightClickDesc": "右鍵點擊終端機的行為",
   "settings.middleClick": "中鍵功能",

--- a/frontend/src/stores/settingsStore.ts
+++ b/frontend/src/stores/settingsStore.ts
@@ -228,6 +228,7 @@ function mergeSettings(loaded: AppSettings): AppSettings {
       localPaths: loaded.sftpBookmarks?.localPaths || [],
       remotePaths: loaded.sftpBookmarks?.remotePaths || []
     },
-    customTerminalThemes: loaded.customTerminalThemes || []
+    customTerminalThemes: loaded.customTerminalThemes || [],
+    defaultLocalShell: loaded.defaultLocalShell ?? DEFAULT_SETTINGS.defaultLocalShell
   }
 }

--- a/frontend/src/types/settings.ts
+++ b/frontend/src/types/settings.ts
@@ -136,6 +136,7 @@ export interface AppSettings {
   autoCheckUpdate: boolean
   sftpBookmarks: SFTPBookmarks
   customTerminalThemes: CustomTerminalTheme[]
+  defaultLocalShell: string
 }
 
 export const DEFAULT_SETTINGS: AppSettings = {
@@ -171,7 +172,8 @@ export const DEFAULT_SETTINGS: AppSettings = {
     localPaths: [],
     remotePaths: []
   },
-  customTerminalThemes: []
+  customTerminalThemes: [],
+  defaultLocalShell: ''
 }
 
 export interface TerminalThemeEntry { label: string; value: string; type: 'dark' | 'light' }

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -1137,6 +1137,7 @@ export namespace store {
 	    autoCheckUpdate?: boolean;
 	    sftpBookmarks: SFTPBookmarks;
 	    customTerminalThemes: CustomTerminalTheme[];
+	    defaultLocalShell: string;
 	
 	    static createFrom(source: any = {}) {
 	        return new AppSettings(source);
@@ -1152,6 +1153,7 @@ export namespace store {
 	        this.autoCheckUpdate = source["autoCheckUpdate"];
 	        this.sftpBookmarks = this.convertValues(source["sftpBookmarks"], SFTPBookmarks);
 	        this.customTerminalThemes = this.convertValues(source["customTerminalThemes"], CustomTerminalTheme);
+	        this.defaultLocalShell = source["defaultLocalShell"];
 	    }
 	
 		convertValues(a: any, classs: any, asMap: boolean = false): any {


### PR DESCRIPTION
Add a 'defaultLocalShell' option in terminal settings so users can choose a preferred shell for the Local Terminal button on the start page.

## Changes

- Add `defaultLocalShell` field to `AppSettings` (Go + TS)
- Add setting card in Terminal settings section (after font size)
- Change start page "Local Terminal" button to split-button: clicking the main area opens the default shell directly, the dropdown arrow still allows picking other shells
- Default value resolves to first available shell when not set
- Handle cross-environment sync: fall back to first available shell if the saved shell is not found

---

在设置中增加「默认本地终端」选项，用户可以为起始页的"本地终端"按钮选择默认 Shell。

## 改动

- `AppSettings` 新增 `defaultLocalShell` 字段
- 终端设置区新增设置项（字号下方）
- 起始页"本地终端"按钮改为 split-button：点击主体直接打开默认 Shell，右侧箭头仍可下拉选择其他 Shell
- 未设置时自动取第一个可用 Shell
- 跨环境同步兼容：已保存的 Shell 在新环境找不到时自动 fallback

Closes #149