### PR TITLE
fix: prevent suggestion selection reset race condition

### DIFF
--- a/frontend/src/components/BaseTerminal.vue
+++ b/frontend/src/components/BaseTerminal.vue
@@ -400,30 +400,26 @@ async function applySuggestion(item: ReturnType<typeof suggestions.getSelectedIt
     return
   }
 
-  const currentLine = terminalInput.lineBuffer.value
-  const currentToken = terminalInput.currentToken.value
   const sid = props.sessionId
 
   if (item.type === 'ai-result' || item.type === 'history' || item.type === 'quick-command') {
     // Replace entire line with Ctrl+U. Using backspaces only works when the
     // replacement is exactly the currentToken; for multi-token input (e.g.
     // "git che" → "git checkout") backspaces leave the earlier text behind.
-    if (currentLine) {
-      if (props.broadcastActive && props.workspaceId) {
-        const tab = tabStore.tabs.find(t => t.id === props.workspaceId)
-        if (tab && tab.type === 'workspace') {
-          for (const pid of tab.panelIds) {
-            const p = panelStore.getPanel(pid)
-            if (p?.sessionId && (p.type === 'ssh' || p.type === 'local')) {
-              SessionWrite(p.sessionId, '\x15')
-              SessionWrite(p.sessionId, item.value)
-            }
+    if (props.broadcastActive && props.workspaceId) {
+      const tab = tabStore.tabs.find(t => t.id === props.workspaceId)
+      if (tab && tab.type === 'workspace') {
+        for (const pid of tab.panelIds) {
+          const p = panelStore.getPanel(pid)
+          if (p?.sessionId && (p.type === 'ssh' || p.type === 'local')) {
+            SessionWrite(p.sessionId, '\x15')
+            SessionWrite(p.sessionId, item.value)
           }
         }
-      } else if (sid) {
-        SessionWrite(sid, '\x15')
-        SessionWrite(sid, item.value)
       }
+    } else if (sid) {
+      SessionWrite(sid, '\x15')
+      SessionWrite(sid, item.value)
     }
     terminalInput.lineBuffer.value = item.value
     terminalInput.cursorIndex.value = item.value.length

--- a/frontend/src/composables/useSuggestions.ts
+++ b/frontend/src/composables/useSuggestions.ts
@@ -378,6 +378,12 @@ export function useSuggestions() {
 
   function selectNext() {
     if (state.value.items.length === 0) return
+    // Cancel any pending suggestion update to prevent the debounced
+    // timer from resetting selectedIndex after the user has navigated.
+    if (debounceTimer) {
+      clearTimeout(debounceTimer)
+      debounceTimer = null
+    }
     if (state.value.selectedIndex < 0) {
       state.value.selectedIndex = 0
     } else {
@@ -387,6 +393,12 @@ export function useSuggestions() {
 
   function selectPrev() {
     if (state.value.items.length === 0) return
+    // Cancel any pending suggestion update to prevent the debounced
+    // timer from resetting selectedIndex after the user has navigated.
+    if (debounceTimer) {
+      clearTimeout(debounceTimer)
+      debounceTimer = null
+    }
     if (state.value.selectedIndex < 0) {
       state.value.selectedIndex = state.value.items.length - 1
     } else {


### PR DESCRIPTION
Cancel the debounced `updateSuggestions` timer when the user navigates with ArrowUp/ArrowDown, and remove the `if (currentLine)` guard in `applySuggestion` so `SessionWrite` always fires.

## Root Cause

`updateSuggestions` runs inside a 150ms debounced `setTimeout` and always resets `selectedIndex` to -1. When the user navigates with arrow keys and the pending timer fires after the selection was made, `selectedIndex` is spuriously reset. This causes the Enter key handler to not intercept Enter, leading to:

- **#172**: `handleInput('\r')` clears the virtual line buffer but no suggestion is applied — current input disappears and nothing is pasted.
- **#244**: In non-standard CLI environments (e.g., vppctl), the corrupted state after the race may cause the remote connection to close.

## Changes

1. **`useSuggestions.ts`**: Cancel the pending debounce timer in `selectNext`/`selectPrev` to prevent it from overwriting the user's selection.
2. **`BaseTerminal.vue`**: Remove the `if (currentLine)` guard in `applySuggestion` so `SessionWrite` always fires when applying a suggestion, even when called from `onTerminalData` where `handleInput` has already cleared the virtual buffer.

---

`updateSuggestions` 在 150ms 的 debounce `setTimeout` 中执行并总将 `selectedIndex` 重置为 -1。当用户用方向键选中建议后，待处理的定时器到期，会覆盖用户的选择。导致 Enter 键处理路径不拦截 Enter：

- **#172**：`handleInput('\r')` 清空了虚拟行缓冲区但没有填入建议 — 当前输入消失，什么都没发生。
- **#244**：在 vppctl 等非标准 CLI 环境中，竞态后的异常状态可能导致远端连接关闭。

## 改动

1. **`useSuggestions.ts`**：`selectNext`/`selectPrev` 中取消待处理的 debounce 定时器
2. **`BaseTerminal.vue`**：移除 `applySuggestion` 中的 `if (currentLine)` 守卫

Closes #172
Closes #244