### PR TITLE
fix: hide RDP connection type on macOS and Linux

### DIFF
--- a/frontend/src/components/ConnectionForm.vue
+++ b/frontend/src/components/ConnectionForm.vue
@@ -342,12 +342,12 @@
 </template>
 
 <script setup lang="ts">
-import { reactive, computed, watch, ref, onMounted } from 'vue'
+import { reactive, computed, watch, ref } from 'vue'
 import { useConnectionStore } from '../stores/connectionStore'
 import { useSettingsStore } from '../stores/settingsStore'
 import { useI18n } from '../i18n'
 import type { ConnectionConfig, PostLoginExpectStep } from '../types/session'
-import { GetPlatform, OpenFileDialog } from '../../wailsjs/go/main/App'
+import { OpenFileDialog } from '../../wailsjs/go/main/App'
 import { Plus, Trash2, ChevronRight, FolderOpen, RefreshCw, Terminal, Monitor, Database, DatabaseZap, Layers, SquareTerminal, Zap, Laptop, Cable, FolderUp, HardDrive, Cloud, Globe, MonitorCloud, MonitorSmartphone } from '@lucide/vue'
 import { ListSerialPorts } from '../../wailsjs/go/main/App'
 
@@ -385,7 +385,7 @@ const allSubTypes = computed(() => ({
     { type: 'webdav', label: 'WebDAV', icon: Globe },
   ],
   remote: [
-    { type: 'rdp', label: 'RDP', icon: Monitor },
+    ...(isWindows.value ? [{ type: 'rdp', label: 'RDP', icon: Monitor }] : []),
     { type: 'vnc', label: 'VNC', icon: MonitorSmartphone },
     { type: 'spice', label: 'SPICE', icon: MonitorCloud },
   ],
@@ -444,7 +444,7 @@ const shellOptions = computed(() =>
   settingsStore.availableShells.map(sh => ({ label: getShellLabel(sh), value: sh }))
 )
 
-const isWindows = ref(true)
+const isWindows = ref(/windows/i.test(navigator.userAgent))
 const passwordInputKey = ref(0)
 const postLoginMode = ref<'script' | 'expect'>('script')
 const showAdvanced = ref(false)
@@ -482,10 +482,6 @@ function queryBaudRateSuggestions(queryString: string, cb: (results: { value: st
     .map(r => ({ value: String(r) }))
   cb(suggestions)
 }
-
-onMounted(async () => {
-  try { isWindows.value = (await GetPlatform()) === 'windows' } catch (_) {}
-})
 
 const props = defineProps<{
   modelValue: boolean


### PR DESCRIPTION
## Summary

Filter RDP from the connection type sub-type grid when running on non-Windows platforms, since RDP is only supported on Windows (via ActiveX embedding).

### Changes

- Use synchronous `navigator.userAgent` detection instead of async `GetPlatform()` for platform check
- Conditionally include RDP in `allSubTypes.remote` only when `isWindows` is true
- Remove now-unnecessary `onMounted` hook and `GetPlatform` import

### Behavior

| Platform | Before | After |
|----------|--------|-------|
| macOS/Linux | RDP shown in type grid | RDP hidden |
| Windows | RDP shown (after async delay) | RDP shown immediately |

Closes #252

---

## 概要

非 Windows 平台下从连接类型网格中隐藏 RDP 选项，因为 RDP 仅支持 Windows（通过 ActiveX 嵌入实现）。

### 改动

- 使用同步的 `navigator.userAgent` 替代异步 `GetPlatform()` 进行平台检测
- RDP 仅在 `isWindows` 为 true 时才出现在 `allSubTypes.remote` 中
- 移除不再需要的 `onMounted` 钩子和 `GetPlatform` 导入

Closes #252