### PR TITLE
fix: default local terminal working directory to user home

### DIFF
--- a/backend/session/local_session_unix.go
+++ b/backend/session/local_session_unix.go
@@ -48,10 +48,19 @@ func (s *LocalSession) Connect(config ConnectionConfig) error {
 		shell = defaultShell()
 	}
 
+	// Determine working directory: use config.Cwd if set, otherwise user home.
+	workDir := config.Cwd
+	if workDir == "" {
+		if home, err := os.UserHomeDir(); err == nil {
+			workDir = home
+		}
+	}
+
 	s.title = shellName(shell)
 
 	s.cmd = exec.Command(shell, loginShellArgs(shell)...)
 	s.cmd.Env = ensureTerminalEnv(os.Environ())
+	s.cmd.Dir = workDir
 
 	ptyFile, err := pty.Start(s.cmd)
 	if err != nil {

--- a/backend/session/local_session_windows.go
+++ b/backend/session/local_session_windows.go
@@ -96,6 +96,14 @@ func (s *LocalSession) Connect(config ConnectionConfig) error {
 		shell = defaultShell()
 	}
 
+	// Determine working directory: use config.Cwd if set, otherwise user home.
+	workDir := config.Cwd
+	if workDir == "" {
+		if home, err := os.UserHomeDir(); err == nil {
+			workDir = home
+		}
+	}
+
 	s.title = shellName(shell)
 
 	var commandLine string
@@ -129,6 +137,7 @@ func (s *LocalSession) Connect(config ConnectionConfig) error {
 	}
 
 	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
+	cmd.Dir = workDir
 
 	// Try ConPTY first for a real pseudo-terminal experience.
 	if conpty.IsConPtyAvailable() {
@@ -136,7 +145,7 @@ func (s *LocalSession) Connect(config ConnectionConfig) error {
 		if cols <= 0 || rows <= 0 {
 			cols, rows = 80, 24
 		}
-		c, err := conpty.Start(commandLine, conpty.ConPtyDimensions(cols, rows))
+		c, err := conpty.Start(commandLine, conpty.ConPtyDimensions(cols, rows), conpty.ConPtyWorkDir(workDir))
 		if err == nil {
 			s.cpty = c
 			if isMSYSBash {

--- a/backend/session/session.go
+++ b/backend/session/session.go
@@ -41,6 +41,8 @@ type ConnectionConfig struct {
 	RdpEnableNLA  bool `json:"rdpEnableNLA"`
 	// Local terminal shell path
 	ShellPath string `json:"shellPath,omitempty"`
+	// Working directory for local terminal (defaults to user home directory if empty)
+	Cwd string `json:"cwd,omitempty"`
 	// Serial port configuration
 	SerialPort     string  `json:"serialPort,omitempty"`
 	SerialBaudRate int     `json:"serialBaudRate,omitempty"`

--- a/frontend/src/types/session.ts
+++ b/frontend/src/types/session.ts
@@ -30,6 +30,8 @@ export interface ConnectionConfig {
   rdpEnableNLA?: boolean
   // Local terminal shell path
   shellPath?: string
+  // Working directory for local terminal (defaults to user home)
+  cwd?: string
   // Serial port
   serialPort?: string
   serialBaudRate?: number

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -269,6 +269,7 @@ export namespace session {
 	    rdpSmartSizing: boolean;
 	    rdpEnableNLA: boolean;
 	    shellPath?: string;
+	    cwd?: string;
 	    serialPort?: string;
 	    serialBaudRate?: number;
 	    serialDataBits?: number;
@@ -315,6 +316,7 @@ export namespace session {
 	        this.rdpSmartSizing = source["rdpSmartSizing"];
 	        this.rdpEnableNLA = source["rdpEnableNLA"];
 	        this.shellPath = source["shellPath"];
+	        this.cwd = source["cwd"];
 	        this.serialPort = source["serialPort"];
 	        this.serialBaudRate = source["serialBaudRate"];
 	        this.serialDataBits = source["serialDataBits"];


### PR DESCRIPTION
## Summary

Local terminal sessions were inheriting the app's installation directory (e.g. `C:\Program Files\uniTerm`) instead of the user's home directory. This sets `cmd.Dir` and `ConPtyWorkDir` to default to `os.UserHomeDir()` when no `cwd` is specified in the connection config.

### Changes

- Add `cwd` field to `ConnectionConfig` in both frontend TypeScript types and backend Go types
- Set working directory in `local_session_windows.go`: `cmd.Dir` for pipe fallback, `conpty.ConPtyWorkDir()` for ConPTY
- Set working directory in `local_session_unix.go`: `s.cmd.Dir`

### Scope

| Platform | Path | Mechanism |
|----------|------|-----------|
| Windows (ConPTY) | `local_session_windows.go` | `conpty.ConPtyWorkDir(workDir)` |
| Windows (pipe) | `local_session_windows.go` | `cmd.Dir = workDir` |
| WSL | `local_session_windows.go` | `cmd.Dir = workDir` |
| macOS/Linux | `local_session_unix.go` | `s.cmd.Dir = workDir` |

---

## 概要

本地终端会话打开时默认工作目录为应用安装路径（如 `C:\Program Files\uniTerm`），而非用户家目录。修复后默认使用 `os.UserHomeDir()`。

### 改动

- 前后端 `ConnectionConfig` 新增 `cwd` 字段
- Windows：ConPTY 路径用 `ConPtyWorkDir`，pipe 回退用 `cmd.Dir`
- macOS/Linux：设置 `s.cmd.Dir`

所有本地终端类型（Windows/WSL/macOS/Linux）均已覆盖。