### PR TITLE
fix: hide default macOS Edit/Window menus

### DIFF
--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/wailsapp/wails/v2"
 	"github.com/wailsapp/wails/v2/pkg/options"
 	"github.com/wailsapp/wails/v2/pkg/options/assetserver"
+	"github.com/wailsapp/wails/v2/pkg/menu"
 	"github.com/wailsapp/wails/v2/pkg/options/mac"
 	"github.com/wailsapp/wails/v2/pkg/options/windows"
 	"github.com/ys-ll/uniterm/backend/log"
@@ -60,6 +61,7 @@ func main() {
 		MaxWidth:  maxW,
 		MaxHeight: maxH,
 		Frameless: runtime.GOOS != "darwin",
+		Menu:      &menu.Menu{},
 		AssetServer: &assetserver.Options{
 			Assets: assets,
 		},


### PR DESCRIPTION
Wails v2 auto-generates an Edit menu and a Window menu on macOS when no custom menu is provided. These menus only contain English labels regardless of system and app language settings, which creates inconsistency for non-English users.

Since uniTerm handles all functionality through its own UI (shortcuts, context menus, window controls), the native Edit/Window menus are unnecessary. This change sets an empty application menu to prevent Wails from injecting the default menus.

Closes #236

---

Wails v2 在未设置自定义菜单时，会在 macOS 上自动生成 Edit 和 Window 菜单。这些菜单的标签是硬编码的英文，无论系统语言和应用语言设置如何都不会改变，对非英文用户造成不一致体验。

uniTerm 的所有功能都通过自有 UI 实现（快捷键、右键菜单、窗口控制等），不需要原生 Edit/Window 菜单。此改动通过设置空菜单来阻止 Wails 注入默认菜单。

Closes #236