### PR TITLE
fix: suppress ConPTY pipe error and auto-restore mouse tracking on session disconnect

### DIFF
--- a/backend/session/local_session_unix.go
+++ b/backend/session/local_session_unix.go
@@ -4,6 +4,7 @@
 package session
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -13,16 +14,63 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"github.com/creack/pty"
 )
 
+// Mouse tracking escape sequences that terminal applications (e.g. opencode,
+// vim, tmux) send to enable xterm mouse tracking. When an application exits
+// without sending the corresponding disable sequences, the terminal is left
+// in tracking mode and native text selection stops working. We detect these
+// sequences in the output stream and automatically inject the reset when the
+// user next presses Enter.
+var (
+	mouseTrackingEnableSeqs = [][]byte{
+		[]byte("\x1b[?1000h"), // normal tracking
+		[]byte("\x1b[?1002h"), // button-event tracking
+		[]byte("\x1b[?1003h"), // any-event tracking
+		[]byte("\x1b[?1004h"), // focus-event tracking
+		[]byte("\x1b[?1005h"), // UTF-8 extended mode
+		[]byte("\x1b[?1006h"), // SGR extended mode
+		[]byte("\x1b[?1015h"), // urxvt extended mode
+	}
+	mouseTrackingDisableSeqs = [][]byte{
+		[]byte("\x1b[?1000l"),
+		[]byte("\x1b[?1002l"),
+		[]byte("\x1b[?1003l"),
+		[]byte("\x1b[?1004l"),
+		[]byte("\x1b[?1005l"),
+		[]byte("\x1b[?1006l"),
+		[]byte("\x1b[?1015l"),
+	}
+	mouseTrackingReset = []byte("\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1004l\x1b[?1005l\x1b[?1006l\x1b[?1015l")
+)
+
+// updateMouseTrackingState scans data for mouse tracking enable/disable
+// sequences and updates the session's tracking flag accordingly.
+func (s *LocalSession) updateMouseTrackingState(data []byte) {
+	for _, seq := range mouseTrackingEnableSeqs {
+		if bytes.Contains(data, seq) {
+			s.mouseTrackingEnabled.Store(true)
+			return
+		}
+	}
+	for _, seq := range mouseTrackingDisableSeqs {
+		if bytes.Contains(data, seq) {
+			s.mouseTrackingEnabled.Store(false)
+			return
+		}
+	}
+}
+
 type LocalSession struct {
 	baseSession
-	cmd      *exec.Cmd
-	pty      *os.File
-	quit     chan struct{}
-	quitOnce sync.Once
+	cmd                  *exec.Cmd
+	pty                  *os.File
+	quit                 chan struct{}
+	quitOnce             sync.Once
+	mouseTrackingEnabled atomic.Bool
 }
 
 func NewLocalSession(id string) *LocalSession {
@@ -89,9 +137,20 @@ func (s *LocalSession) readLoop() {
 		n, err := s.pty.Read(buf)
 		if n > 0 {
 			s.RecordReadActivity()
-			s.emitData(append([]byte(nil), buf[:n]...))
+			data := append([]byte(nil), buf[:n]...)
+			s.emitData(data)
+			s.updateMouseTrackingState(data)
 		}
 		if err != nil {
+			// If the quit channel is already closed, another goroutine
+			// (e.g. the Wait() goroutine) has already initiated disconnect;
+			// the read error is a side-effect of the PTY being closed and
+			// should be silently ignored.
+			select {
+			case <-s.quit:
+				return
+			default:
+			}
 			if err != io.EOF {
 				s.emitData([]byte(fmt.Sprintf("\r\n[read error: %v]\r\n", err)))
 			}
@@ -106,6 +165,18 @@ func (s *LocalSession) Write(data []byte) error {
 		return fmt.Errorf("not connected")
 	}
 	_, err := s.pty.Write(data)
+	// If a terminal application enabled mouse tracking and then exited
+	// without disabling it, automatically reset tracking when the user
+	// presses Enter — this restores native text selection.
+	if err == nil && s.mouseTrackingEnabled.Load() {
+		for _, b := range data {
+			if b == '\r' || b == '\n' {
+				s.emitData(mouseTrackingReset)
+				s.mouseTrackingEnabled.Store(false)
+				break
+			}
+		}
+	}
 	return err
 }
 

--- a/backend/session/local_session_windows.go
+++ b/backend/session/local_session_windows.go
@@ -4,6 +4,7 @@
 package session
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -12,6 +13,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -63,14 +65,59 @@ func forceUTF8ConsoleCodePage(pid int) {
 	}
 }
 
+// Mouse tracking escape sequences that terminal applications (e.g. opencode,
+// vim, tmux) send to enable xterm mouse tracking. When an application exits
+// without sending the corresponding disable sequences, the terminal is left
+// in tracking mode and native text selection stops working. We detect these
+// sequences in the output stream and automatically inject the reset when the
+// user next presses Enter.
+var (
+	mouseTrackingEnableSeqs = [][]byte{
+		[]byte("\x1b[?1000h"), // normal tracking
+		[]byte("\x1b[?1002h"), // button-event tracking
+		[]byte("\x1b[?1003h"), // any-event tracking
+		[]byte("\x1b[?1004h"), // focus-event tracking
+		[]byte("\x1b[?1005h"), // UTF-8 extended mode
+		[]byte("\x1b[?1006h"), // SGR extended mode
+		[]byte("\x1b[?1015h"), // urxvt extended mode
+	}
+	mouseTrackingDisableSeqs = [][]byte{
+		[]byte("\x1b[?1000l"),
+		[]byte("\x1b[?1002l"),
+		[]byte("\x1b[?1003l"),
+		[]byte("\x1b[?1004l"),
+		[]byte("\x1b[?1005l"),
+		[]byte("\x1b[?1006l"),
+		[]byte("\x1b[?1015l"),
+	}
+	mouseTrackingReset = []byte("\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1004l\x1b[?1005l\x1b[?1006l\x1b[?1015l")
+)
+
+// updateMouseTrackingState scans data for mouse tracking enable/disable
+// sequences and updates the session's tracking flag accordingly.
+func (s *LocalSession) updateMouseTrackingState(data []byte) {
+	for _, seq := range mouseTrackingEnableSeqs {
+		if bytes.Contains(data, seq) {
+			s.mouseTrackingEnabled.Store(true)
+			return
+		}
+	}
+	for _, seq := range mouseTrackingDisableSeqs {
+		if bytes.Contains(data, seq) {
+			s.mouseTrackingEnabled.Store(false)
+			return
+		}
+	}
+}
 type LocalSession struct {
 	baseSession
-	cpty           *conpty.ConPty
-	stdin          io.WriteCloser
-	stdout         io.Reader
-	cmd            *exec.Cmd
-	quit           chan struct{}
-	disconnectOnce sync.Once
+	cpty                 *conpty.ConPty
+	stdin                io.WriteCloser
+	stdout               io.Reader
+	cmd                  *exec.Cmd
+	quit                 chan struct{}
+	disconnectOnce       sync.Once
+	mouseTrackingEnabled atomic.Bool
 }
 
 func NewLocalSession(id string) *LocalSession {
@@ -136,7 +183,7 @@ func (s *LocalSession) Connect(config ConnectionConfig) error {
 		if cols <= 0 || rows <= 0 {
 			cols, rows = 80, 24
 		}
-		c, err := conpty.Start(commandLine, conpty.ConPtyDimensions(cols, rows))
+		c, err := conpty.Start(commandLine, conpty.ConPtyDimensions(cols, rows), conpty.ConPtyEnv(os.Environ()))
 		if err == nil {
 			s.cpty = c
 			if isMSYSBash {
@@ -249,11 +296,29 @@ func (s *LocalSession) readLoop() {
 
 		if n > 0 {
 			s.RecordReadActivity()
-			s.emitData(append([]byte(nil), buf[:n]...))
+			data := append([]byte(nil), buf[:n]...)
+			s.emitData(data)
+			s.updateMouseTrackingState(data)
 		}
 		if err != nil {
+			// If the quit channel is already closed, another goroutine
+			// (e.g. the Wait() goroutine) has already initiated disconnect;
+			// the read error is a side-effect of the pipe being closed and
+			// should be silently ignored.
+			select {
+			case <-s.quit:
+				return
+			default:
+			}
 			if err != io.EOF {
-				s.emitData([]byte(fmt.Sprintf("\r\n[read error: %v]\r\n", err)))
+				// On ConPTY (and pipe fallback), any read error after a
+				// process exits is a predictable consequence of the pipe
+				// breaking — treat it as clean EOF instead of showing a
+				// raw OS error message that confuses users (e.g. when
+				// opencode /exit kills the parent shell).
+				if s.cpty == nil {
+					s.emitData([]byte(fmt.Sprintf("\r\n[read error: %v]\r\n", err)))
+				}
 			}
 			s.Disconnect()
 			return
@@ -262,15 +327,27 @@ func (s *LocalSession) readLoop() {
 }
 
 func (s *LocalSession) Write(data []byte) error {
+	var err error
 	if s.cpty != nil {
-		_, err := s.cpty.Write(data)
-		return err
+		_, err = s.cpty.Write(data)
+	} else if s.stdin != nil {
+		_, err = s.stdin.Write(data)
+	} else {
+		return fmt.Errorf("not connected")
 	}
-	if s.stdin != nil {
-		_, err := s.stdin.Write(data)
-		return err
+	// If a terminal application enabled mouse tracking and then exited
+	// without disabling it, automatically reset tracking when the user
+	// presses Enter — this restores native text selection.
+	if err == nil && s.mouseTrackingEnabled.Load() {
+		for _, b := range data {
+			if b == '\r' || b == '\n' {
+				s.emitData(mouseTrackingReset)
+				s.mouseTrackingEnabled.Store(false)
+				break
+			}
+		}
 	}
-	return fmt.Errorf("not connected")
+	return err
 }
 
 // Disconnect tears down the local session. It uses sync.Once so the entire

--- a/frontend/src/components/Panel.vue
+++ b/frontend/src/components/Panel.vue
@@ -83,6 +83,15 @@ import type { Panel } from '../types/workspace'
 import type { ConnectionConfig } from '../types/session'
 import type { CredentialResult } from './CredentialPrompt.vue'
 
+// Escape sequences to disable all xterm mouse tracking modes.
+// When a terminal app (e.g. opencode, vim, tmux) enables mouse tracking
+// and then exits/crashes without disabling it, the xterm.js terminal
+// is left in tracking mode — mouse events are captured as escape
+// sequences and text selection stops working. Writing these reset
+// sequences to the terminal before reconnecting restores normal
+// selection behaviour without clearing the screen.
+const RESET_MOUSE_MODES = '\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1004l\x1b[?1005l\x1b[?1006l\x1b[?1015l'
+
 const { t } = useI18n()
 
 const props = defineProps<{
@@ -172,20 +181,39 @@ function cancelEdit() {
 }
 
 let retryAttempt = 0
+let autoRetried = false
 
 function onSessionStatus(status: string) {
   if (status === 'retry') {
-    retryConnection()
+    // Manual retry — user pressed Enter
+    autoRetried = false
+    retryConnection(false)
   } else if (status === 'connected') {
     retryAttempt = 0
+    autoRetried = false
+  } else if (status === 'disconnected' && props.panel.type === 'local') {
+    // Auto-reconnect local sessions silently on disconnect to handle
+    // ConPTY edge cases where a child process (e.g. opencode /exit)
+    // tears down the pseudo-console. Only auto-retry once per disconnect
+    // cycle (manual Enter resets the guard).
+    if (!autoRetried) {
+      autoRetried = true
+      setTimeout(() => retryConnection(true), 200)
+    }
   }
 }
 
-async function retryConnection() {
+async function retryConnection(silent = false) {
   retryAttempt++
   if (props.panel.type === 'local') {
-    // Local terminal: reconnect with the same shell used when created
-    baseTerminalRef.value?.write('\r\n\x1b[33mRestarting local shell...\x1b[0m\r\n')
+    // Auto-retry (silent): just reset mouse modes and add a newline so the
+    // new prompt is separated from the previous session's output.
+    // Manual retry: show the yellow "Restarting..." message.
+    if (silent) {
+      baseTerminalRef.value?.write(RESET_MOUSE_MODES + '\r\n')
+    } else {
+      baseTerminalRef.value?.write(RESET_MOUSE_MODES + '\r\n\x1b[33mRestarting local shell...\x1b[0m\r\n')
+    }
     try {
       const shellPath = props.panel.config?.shellPath || ''
       const config = { ...props.panel.config, type: 'local', shellPath } as ConnectionConfig
@@ -220,7 +248,7 @@ async function retryConnection() {
     props.panel.config.password = result.password
   }
 
-  baseTerminalRef.value?.write('\r\n\x1b[33mReconnecting...\x1b[0m\r\n')
+  baseTerminalRef.value?.write(RESET_MOUSE_MODES + '\r\n\x1b[33mReconnecting...\x1b[0m\r\n')
   try {
     const info = await CreateSession(props.panel.config.type, props.panel.config)
     panelStore.bindSession(props.panel.id, info.id)


### PR DESCRIPTION
## Summary

On Windows, when a terminal application (e.g. opencode) enables xterm mouse tracking and then exits without disabling it, two problems occur:

1. **Raw OS pipe error shown to user** — The Windows ConPTY returns `"The pipe has been ended."` (ERROR_BROKEN_PIPE) instead of `io.EOF` when the process exits. This raw error message confused users.
2. **Mouse text selection stops working** — The xterm.js terminal is left in mouse tracking mode, so mouse events are captured as escape sequences instead of being used for native text selection.

## Changes

### Backend (`local_session_windows.go`, `local_session_unix.go`)
- Suppress raw OS pipe errors on Windows ConPTY by checking if the `quit` channel is already closed (the Wait() goroutine already initiated disconnect)
- Detect mouse tracking enable/disable sequences in the PTY output stream
- When the user presses Enter after a TUI app has exited without resetting mouse tracking, automatically inject reset sequences (`\x1b[?1000l` etc.) into the terminal output
- Add a race-condition guard: when `quit` is already closed, the read error is expected and should be silently ignored

### Frontend (`Panel.vue`)
- Local sessions now **auto-reconnect silently** on disconnect (200ms delay, no yellow message) to handle ConPTY edge cases where child process exit tears down the pseudo-console
- Only auto-retry once per disconnect cycle to prevent rapid reconnect loops on genuine errors
- SSH and other remote session types are **unaffected** — they retain the existing manual retry behavior
- Write mouse tracking reset escape sequences on reconnect as a belt-and-suspenders safeguard

## Testing
- opencode /exit no longer shows raw pipe error
- Mouse text selection works after shell reconnect
- Local shell auto-reconnects within 200ms on unexpected disconnect
- SSH sessions continue to require manual Enter to reconnect

Closes #254