### PR TITLE
feat(shortcut): 为 macOS 添加 Cmd+, 打开设置的快捷键

### DIFF
--- a/backend/store/settings_store.go
+++ b/backend/store/settings_store.go
@@ -82,6 +82,7 @@ type AISettings struct {
 
 type KeyBinding struct {
 	Ctrl  bool   `json:"ctrl"`
+	Meta  bool   `json:"meta"`
 	Shift bool   `json:"shift"`
 	Alt   bool   `json:"alt"`
 	Key   string `json:"key"`
@@ -243,6 +244,6 @@ func defaultKeyboard() map[string]KeyBinding {
 		"closePanel":       {Ctrl: true, Shift: true, Alt: false, Key: "q"},
 		"navigatePrev":     {Ctrl: false, Shift: false, Alt: true, Key: "arrowleft"},
 		"navigateNext":     {Ctrl: false, Shift: false, Alt: true, Key: "arrowright"},
-		"openSettings":     {Ctrl: true, Shift: true, Alt: false, Key: "c"},
+		"openSettings":     {Ctrl: false, Meta: true, Shift: false, Alt: false, Key: ","},
 	}
 }

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -167,7 +167,7 @@ import { useQuickCommandStore } from './stores/quickCommandStore'
 import { useTunnelStore } from './stores/tunnelStore'
 import { useUpdateCheck } from './composables/useUpdateCheck'
 import { loadKeybindings, installGlobalListener, uninstallGlobalListener } from './composables/useKeyboardShortcuts'
-import type { ShortcutAction } from '../types/settings'
+import type { ShortcutAction } from './types/settings'
 import { useI18n } from './i18n'
 import { CreateSession, CloseSession, RDPHide, RDPShow, RDPSetPosition, RDPSetFocus, LoadLocalState, SaveLocalState, RecordRecentConnection } from '../wailsjs/go/main/App'
 import { EventsOn } from '../wailsjs/runtime'
@@ -616,6 +616,7 @@ const actionHandlers: Record<ShortcutAction, () => void> = {
   },
   navigatePrev: () => navigatePanel(-1),
   navigateNext: () => navigatePanel(1),
+  openSettings: () => openSettings(),
   duplicateSession: async () => {
     const pid = tabStore.getActivePanelId()
     if (!pid) return

--- a/frontend/src/components/SettingsTab.vue
+++ b/frontend/src/components/SettingsTab.vue
@@ -570,7 +570,7 @@
 import { ref, reactive, watch, computed, onMounted } from 'vue'
 import { Settings, Monitor, MessageCircleMore, Info, RefreshCw, Pencil, Trash2, Globe, Keyboard, Plus, BookOpen } from '@lucide/vue'
 import { msg } from '../services/message'
-import { FetchModels, ChatCompletion, GetSystemFonts } from '../../wailsjs/go/main/App'
+import { FetchModels, ChatCompletion, GetPlatform, GetSystemFonts } from '../../wailsjs/go/main/App'
 import { useSettingsStore } from '../stores/settingsStore'
 import { useSyncStore } from '../stores/syncStore'
 import { useUpdateCheck } from '../composables/useUpdateCheck'
@@ -591,6 +591,8 @@ const settingsStore = useSettingsStore()
 const syncStore = useSyncStore()
 const updateCheck = useUpdateCheck()
 const { t } = useI18n()
+const platform = ref('')
+const isMac = computed(() => platform.value === 'darwin')
 
 function openEditRepo() {
   syncStore.showEditRepo = true
@@ -642,6 +644,11 @@ function openThemeEditor(sourceThemeId?: string) {
 
 onMounted(async () => {
   try {
+    platform.value = await GetPlatform()
+  } catch {
+    platform.value = ''
+  }
+  try {
     const fonts = await GetSystemFonts()
     if (fonts && fonts.length > 0) {
       systemFonts.value = fonts.map(f => ({ label: f, value: formatFontFamily(f) }))
@@ -666,6 +673,7 @@ function bindingDisplay(action: ShortcutAction): string {
   if (!b) return ''
   const parts: string[] = []
   if (b.ctrl) parts.push('Ctrl')
+  if (b.meta) parts.push(isMac.value ? 'Cmd' : 'Meta')
   if (b.shift) parts.push('Shift')
   if (b.alt) parts.push('Alt')
   parts.push(b.key)
@@ -677,6 +685,7 @@ function isDefaultBinding(action: ShortcutAction): boolean {
   const def = DEFAULT_KEYBOARD[action]
   if (!current || !def) return true
   return current.ctrl === def.ctrl && current.shift === def.shift
+    && (current.meta || false) === (def.meta || false)
     && current.alt === def.alt && current.key === def.key
 }
 
@@ -713,7 +722,7 @@ function stopRebind() {
 function clearBinding(action: ShortcutAction) {
   settingsStore.settings.keyboard = {
     ...settingsStore.settings.keyboard,
-    [action]: { ctrl: false, shift: false, alt: false, key: '' }
+    [action]: { ctrl: false, meta: false, shift: false, alt: false, key: '' }
   }
   settingsStore.save()
   stopRebind()
@@ -728,7 +737,8 @@ function onRebindKeydown(e: KeyboardEvent) {
   if (key === 'Control' || key === 'Shift' || key === 'Alt' || key === 'Meta') return
 
   const binding: KeyBinding = {
-    ctrl: e.ctrlKey || e.metaKey,
+    ctrl: e.ctrlKey,
+    meta: e.metaKey,
     shift: e.shiftKey,
     alt: e.altKey,
     key: key.toLowerCase(),
@@ -747,15 +757,18 @@ function onRebindKeydown(e: KeyboardEvent) {
 }
 
 function findConflict(binding: KeyBinding): ShortcutAction | null {
-  const targetKey = `${binding.ctrl ? 'ctrl+' : ''}${binding.shift ? 'shift+' : ''}${binding.alt ? 'alt+' : ''}${binding.key.toLowerCase()}`
+  const targetKey = bindingKey(binding)
   const kb = settingsStore.settings.keyboard
   for (const [action, b] of Object.entries(kb) as [ShortcutAction, KeyBinding][]) {
     if (action === rebindingAction.value) continue
     if (!b.key) continue
-    const key = `${b.ctrl ? 'ctrl+' : ''}${b.shift ? 'shift+' : ''}${b.alt ? 'alt+' : ''}${b.key.toLowerCase()}`
-    if (key === targetKey) return action
+    if (bindingKey(b) === targetKey) return action
   }
   return null
+}
+
+function bindingKey(binding: KeyBinding): string {
+  return `${binding.ctrl ? 'ctrl+' : ''}${binding.meta ? 'meta+' : ''}${binding.shift ? 'shift+' : ''}${binding.alt ? 'alt+' : ''}${binding.key.toLowerCase()}`
 }
 
 function onRebindBlur() {

--- a/frontend/src/composables/useKeyboardShortcuts.ts
+++ b/frontend/src/composables/useKeyboardShortcuts.ts
@@ -3,8 +3,10 @@ import type { KeyboardSettings, KeyBinding, ShortcutAction } from '../types/sett
 type ActionHandlers = Record<ShortcutAction, () => void>
 
 function bindingKey(b: KeyBinding): string {
+  if (!b.key) return ''
   let k = ''
   if (b.ctrl) k += 'ctrl+'
+  if (b.meta) k += 'meta+'
   if (b.shift) k += 'shift+'
   if (b.alt) k += 'alt+'
   k += b.key.toLowerCase()
@@ -13,7 +15,8 @@ function bindingKey(b: KeyBinding): string {
 
 function normalize(e: KeyboardEvent): string {
   const parts: string[] = []
-  if (e.ctrlKey || e.metaKey) parts.push('ctrl')
+  if (e.ctrlKey) parts.push('ctrl')
+  if (e.metaKey) parts.push('meta')
   if (e.shiftKey) parts.push('shift')
   if (e.altKey) parts.push('alt')
   parts.push(e.key.toLowerCase())
@@ -30,9 +33,13 @@ export function loadKeybindings(bindings: KeyboardSettings, handlers: ActionHand
   actionKeyMap.clear()
   for (const [action, b] of Object.entries(bindings) as [ShortcutAction, KeyBinding][]) {
     const key = bindingKey(b)
+    if (!key) continue
     const handler = handlers[action]
     if (handler) {
       shortcutMap.set(key, handler)
+      if (!b.meta && b.ctrl) {
+        shortcutMap.set(key.replace(/^ctrl\+/, 'meta+'), handler)
+      }
       actionKeyMap.set(action, key)
     }
   }

--- a/frontend/src/types/settings.ts
+++ b/frontend/src/types/settings.ts
@@ -86,9 +86,11 @@ export type ShortcutAction =
   | 'navigatePrev' | 'navigateNext'
   | 'duplicateSession'
   | 'terminalSearch'
+  | 'openSettings'
 
 export interface KeyBinding {
   ctrl: boolean
+  meta?: boolean
   shift: boolean
   alt: boolean
   key: string
@@ -109,6 +111,7 @@ export const SHORTCUT_LABELS: Record<ShortcutAction, string> = {
   lockAI: 'shortcut.lockAI',
   duplicateSession: 'shortcut.duplicateSession',
   terminalSearch: 'shortcut.terminalSearch',
+  openSettings: 'shortcut.openSettings',
 }
 
 export const DEFAULT_KEYBOARD: KeyboardSettings = {
@@ -124,6 +127,7 @@ export const DEFAULT_KEYBOARD: KeyboardSettings = {
   lockAI: { ctrl: true, shift: true, alt: false, key: 'l' },
   duplicateSession: { ctrl: true, shift: true, alt: false, key: 'd' },
   terminalSearch: { ctrl: true, shift: false, alt: false, key: 'f' },
+  openSettings: { ctrl: false, meta: true, shift: false, alt: false, key: ',' },
 }
 
 export interface SFTPBookmarks {

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -1092,6 +1092,7 @@ export namespace store {
 	}
 	export class KeyBinding {
 	    ctrl: boolean;
+	    meta: boolean;
 	    shift: boolean;
 	    alt: boolean;
 	    key: string;
@@ -1103,6 +1104,7 @@ export namespace store {
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.ctrl = source["ctrl"];
+	        this.meta = source["meta"];
 	        this.shift = source["shift"];
 	        this.alt = source["alt"];
 	        this.key = source["key"];


### PR DESCRIPTION
## 摘要
- 新增显式的 `openSettings` 快捷键动作，接到现有的打开设置标签页逻辑。
- 将 Command 键建模为 `meta`，使 macOS 默认快捷键真正是 `Cmd+,` 而非 Ctrl 的别名。
- 在 macOS 的快捷键表中显示 `Cmd`，同时保留旧快捷键的 Ctrl→Cmd 兼容。

Closes #270

## 验证
- `npm run build`
- `go test ./...`

---

## Summary
- Add an explicit `openSettings` shortcut action wired to the existing Settings tab opener.
- Model the Command key as `meta` so the default macOS shortcut is truly `Cmd+,` instead of a Ctrl alias.
- Show `Cmd` in the shortcut table on macOS while preserving existing Ctrl-to-Cmd compatibility for older shortcuts.

Closes #270

## Validation
- `npm run build`
- `go test ./...`