### PR TITLE
fix(ssh): stop forwarding terminal query responses in alternate screen

### DIFF
--- a/backend/session/session.go
+++ b/backend/session/session.go
@@ -217,42 +217,37 @@ func (s *baseSession) emitBinary(data []byte) {
 	}
 }
 
+// looksLikeZmodemHeader reports whether data contains a ZMODEM frame header.
+// A real header is ZPAD ZPAD ZDLE frame-type: `**` `\x18` `[A-C]`. The ZDLE
+// (0x18) control byte is mandatory and effectively never appears in ordinary
+// terminal output, so requiring it avoids false positives — e.g. vim rendering
+// a file whose content contains `**` followed by a long hex string, which used
+// to trip a looser heuristic and flip the session into binary mode, crashing
+// the remote shell (issue #242).
 func looksLikeZmodemHeader(data []byte) bool {
-	for i := 0; i < len(data); i++ {
-		if data[i] != '*' {
-			continue
-		}
-		if i+1 >= len(data) || data[i+1] != '*' {
-			continue
-		}
-
-		if i+3 < len(data) && data[i+2] == 0x18 && data[i+3] >= 'A' && data[i+3] <= 'C' {
-			return true
-		}
-
-		hexCount := 0
-		for j := i + 2; j < len(data); j++ {
-			if isHexDigit(data[j]) {
-				hexCount++
-			} else {
-				break
-			}
-		}
-		if hexCount >= 14 {
+	for i := 0; i+3 < len(data); i++ {
+		if data[i] == '*' && data[i+1] == '*' && data[i+2] == 0x18 &&
+			data[i+3] >= 'A' && data[i+3] <= 'C' {
 			return true
 		}
 	}
 	return false
 }
 
-func isHexDigit(c byte) bool {
-	return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')
-}
-
 // RecordReadActivity updates the last-read timestamp for idle detection.
 // Each session's readLoop should call this whenever data is received.
 func (s *baseSession) RecordReadActivity() {
 	s.lastReadTime.Store(time.Now().UnixNano())
+}
+
+// idleSince reports how long since the last read activity. Returns -1 if no
+// read has ever been recorded. Used for disconnect diagnostics.
+func (s *baseSession) idleSince() time.Duration {
+	ns := s.lastReadTime.Load()
+	if ns == 0 {
+		return -1
+	}
+	return time.Since(time.Unix(0, ns))
 }
 
 // waitIdle blocks until no read activity has occurred for the given idle

--- a/backend/session/ssh_session.go
+++ b/backend/session/ssh_session.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"golang.org/x/crypto/ssh"
@@ -15,6 +16,8 @@ import (
 	"golang.org/x/text/encoding/simplifiedchinese"
 	"golang.org/x/text/encoding/traditionalchinese"
 	"golang.org/x/text/transform"
+
+	"github.com/ys-ll/uniterm/backend/log"
 )
 
 const (
@@ -24,8 +27,12 @@ const (
 	// idle-reading in an editor (e.g. vim in normal mode) with no traffic
 	// flowing between keystrokes.
 	sshKeepAliveInterval = 20 * time.Second
-	sshKeepAliveTimeout  = 5 * time.Second
-	sshKeepAliveMaxFail  = 3
+	// Timeout for a single keepalive request. Kept generous: a jump host or
+	// target that is merely slow to answer keepalive@openssh.com under load
+	// must not be mistaken for a dead connection (a too-aggressive 5s value
+	// falsely closed healthy tunnels, see issue #242).
+	sshKeepAliveTimeout = 15 * time.Second
+	sshKeepAliveMaxFail = 4
 )
 
 type SSHSession struct {
@@ -43,6 +50,13 @@ type SSHSession struct {
 	enc            encoding.Encoding // input(write) codec; nil = utf-8 passthrough
 	decoder        *encoding.Decoder // persistent streaming decoder for output(read)
 	decodeLeftover []byte            // trailing partial multibyte bytes between reads
+
+	// Keepalive diagnostics (see startKeepAlive / disconnect logs).
+	kaFailures   atomic.Int32 // consecutive keepalive failures at last tick
+	kaLastErr    atomic.Value // string: last keepalive error ("" if ok)
+	kaLastOKUnix atomic.Int64 // unix ns of last successful keepalive
+	lastRecv     atomic.Value // []byte: tail of most recent server output (diagnostics)
+	lastSent     atomic.Value // []byte: most recent input sent to server (diagnostics)
 }
 
 func NewSSHSession(id string) *SSHSession {
@@ -240,7 +254,10 @@ func (s *SSHSession) Connect(config ConnectionConfig) error {
 	}
 
 	go func() {
-		_ = session.Wait()
+		werr := session.Wait()
+		last, _ := s.lastRecv.Load().([]byte)
+		sent, _ := s.lastSent.Load().([]byte)
+		log.Writef("ssh disconnect: session.Wait returned (%v), %s lastRecv=%s lastSent=%s", werr, s.kaDiag(), tailHex(last, 64), tailHex(sent, 32))
 		s.Disconnect()
 	}()
 
@@ -289,10 +306,12 @@ func (s *SSHSession) readLoop() {
 		if n > 0 {
 			s.RecordReadActivity()
 			data := append([]byte(nil), buf[:n]...)
+			s.lastRecv.Store(append([]byte(nil), data...))
 			s.offerExpectOutput(data)
 			if s.IsZmodemMode() {
 				s.emitBinary(data)
 			} else if looksLikeZmodemHeader(data) {
+				log.Writef("ssh: zmodem header detected in output, switching to binary mode (may be a false positive on vim/TUI output)")
 				s.SetZmodemMode(true)
 				s.emitBinary(data)
 			} else {
@@ -301,14 +320,44 @@ func (s *SSHSession) readLoop() {
 		}
 		if err != nil {
 			if err != io.EOF {
+				log.Writef("ssh disconnect: read error: %v, %s", err, s.kaDiag())
 				s.emitData([]byte(fmt.Sprintf("\r\n\x1b[31m[read error: %v]\x1b[0m\r\n", err)))
 			} else {
+				last, _ := s.lastRecv.Load().([]byte)
+				sent, _ := s.lastSent.Load().([]byte)
+				log.Writef("ssh disconnect: remote closed (EOF), %s lastRecv=%s lastSent=%s", s.kaDiag(), tailHex(last, 64), tailHex(sent, 32))
 				s.emitData([]byte("\r\n\x1b[31mConnection closed by remote host. Press Enter to reconnect.\x1b[0m\r\n"))
 			}
 			s.Disconnect()
 			return
 		}
 	}
+}
+
+// tailHex returns up to the last max bytes of b as hex, for disconnect
+// diagnostics (what the server sent right before closing).
+func tailHex(b []byte, max int) string {
+	if len(b) > max {
+		b = b[len(b)-max:]
+	}
+	return fmt.Sprintf("% x", b)
+}
+
+// kaDiag formats keepalive/idle state for disconnect diagnostics: how long
+// since the last byte from the server, the last-keepalive outcome, and the
+// consecutive-failure count. A long idle with healthy keepalives points to a
+// server-side idle timeout that ignores global keepalive requests.
+func (s *SSHSession) kaDiag() string {
+	lastErr, _ := s.kaLastErr.Load().(string)
+	if lastErr == "" {
+		lastErr = "ok"
+	}
+	okAgo := "never"
+	if ns := s.kaLastOKUnix.Load(); ns != 0 {
+		okAgo = time.Since(time.Unix(0, ns)).Truncate(time.Second).String()
+	}
+	return fmt.Sprintf("idle=%v lastKeepalive=%s lastOK=%s ago failures=%d",
+		s.idleSince().Truncate(time.Second), lastErr, okAgo, s.kaFailures.Load())
 }
 
 func (s *SSHSession) offerExpectOutput(data []byte) {
@@ -411,14 +460,20 @@ func (s *SSHSession) startKeepAlive() {
 			case err := <-done:
 				if err != nil {
 					failures++
+					s.kaLastErr.Store(err.Error())
 				} else {
 					failures = 0
+					s.kaLastErr.Store("")
+					s.kaLastOKUnix.Store(time.Now().UnixNano())
 				}
 			case <-time.After(sshKeepAliveTimeout):
 				failures++
+				s.kaLastErr.Store("timeout")
 			}
+			s.kaFailures.Store(int32(failures))
 
 			if failures >= sshKeepAliveMaxFail {
+				log.Writef("ssh disconnect: keepalive timeout, %s", s.kaDiag())
 				s.emitData([]byte("\r\n\x1b[31mConnection lost. Press Enter to reconnect.\x1b[0m\r\n"))
 				s.Disconnect()
 				return
@@ -442,7 +497,9 @@ func (s *SSHSession) Write(data []byte) error {
 	if s.stdin == nil {
 		return fmt.Errorf("not connected")
 	}
-	_, err := s.stdin.Write(s.encodeInput(data))
+	enc := s.encodeInput(data)
+	s.lastSent.Store(append([]byte(nil), enc...))
+	_, err := s.stdin.Write(enc)
 	return err
 }
 
@@ -467,6 +524,7 @@ func (s *SSHSession) Disconnect() error {
 func (s *SSHSession) Resize(cols, rows int) error {
 	// Always save the desired size so it can be applied after Connect finishes.
 	s.SetPendingSize(cols, rows)
+	log.Writef("ssh resize: cols=%d rows=%d", cols, rows)
 	if s.session == nil {
 		return fmt.Errorf("session not connected")
 	}

--- a/backend/session/tunnel_forward.go
+++ b/backend/session/tunnel_forward.go
@@ -63,7 +63,7 @@ func (ts *TunnelService) StartTunnel(t Tunnel, resolve ConnResolver) TunnelState
 
 	// Watch the exit client: keepalive actively closes a dead chain, and Wait
 	// unblocks when the connection drops, so we can flip the tunnel to error.
-	go tunnelKeepAlive(exit, quit)
+	go tunnelKeepAlive(exit, quit, "tunnel="+t.ID)
 	go func() {
 		exit.Wait()
 		select {

--- a/backend/session/tunnel_service.go
+++ b/backend/session/tunnel_service.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"golang.org/x/crypto/ssh"
+
+	"github.com/ys-ll/uniterm/backend/log"
 )
 
 // tunnelEntry holds the SSH client and listener for a single tunnel.
@@ -132,7 +134,7 @@ func (ts *TunnelService) Start(sessionID string, sshConfig ConnectionConfig, tar
 		listener:  listener,
 		quit:      quit,
 	}
-	go tunnelKeepAlive(client, quit)
+	go tunnelKeepAlive(client, quit, "session="+sessionID)
 
 	return localPort, nil
 }
@@ -141,7 +143,7 @@ func (ts *TunnelService) Start(sessionID string, sshConfig ConnectionConfig, tar
 // global keepalive request (same cadence/threshold as SSHSession's) and
 // closes the connection if the remote stops responding, so a dead jump-host
 // hop doesn't linger silently while the forwarded session on top of it hangs.
-func tunnelKeepAlive(client *ssh.Client, quit chan struct{}) {
+func tunnelKeepAlive(client *ssh.Client, quit chan struct{}, label string) {
 	ticker := time.NewTicker(sshKeepAliveInterval)
 	defer ticker.Stop()
 
@@ -172,6 +174,7 @@ func tunnelKeepAlive(client *ssh.Client, quit chan struct{}) {
 			}
 
 			if failures >= sshKeepAliveMaxFail {
+				log.Writef("tunnel keepalive: closing jump-host client after %d failures (%s) — sessions riding this tunnel will get EOF", failures, label)
 				client.Close()
 				return
 			}

--- a/backend/session/zmodem_detect_test.go
+++ b/backend/session/zmodem_detect_test.go
@@ -1,0 +1,27 @@
+package session
+
+import "testing"
+
+// Regression test for issue #242: vim rendering a file whose content contains
+// `**` followed by a long hex string (hashes, IDs in YAML/JSON) must NOT be
+// mistaken for a ZMODEM header. A real header requires the ZDLE (0x18) byte.
+func TestLooksLikeZmodemHeader(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+		want bool
+	}{
+		{"real ZRQINIT", []byte("**\x18B00000000000000"), true},
+		{"real with ZPAD run", []byte("rz waiting...\r\n**\x18A0123456789abcdef"), true},
+		{"vim content stars+hex (no ZDLE)", []byte("value: **B0a1b2c3d4e5f60718"), false},
+		{"markdown bold", []byte("see **B1234567890 for details"), false},
+		{"plain stars", []byte("=====**=====\r\n"), false},
+		{"empty", []byte(""), false},
+		{"stars at end truncated", []byte("abc**\x18"), false},
+	}
+	for _, tt := range tests {
+		if got := looksLikeZmodemHeader(tt.data); got != tt.want {
+			t.Errorf("%s: looksLikeZmodemHeader(%q) = %v, want %v", tt.name, tt.data, got, tt.want)
+		}
+	}
+}

--- a/frontend/src/components/BaseTerminal.vue
+++ b/frontend/src/components/BaseTerminal.vue
@@ -570,18 +570,25 @@ function onSplitResizeEnd() {
 }
 
 // Strip OSC sequences that xterm.js generates internally (color queries etc.)
-// and, in normal screen, also strip CSI responses (CPR, DA, window size,
-// focus events) that the remote shell may echo back as garbage.
+// and CSI *responses* it auto-generates when the remote app queries the
+// terminal (CPR cursor-position, DSR status, DA device-attributes, cell/window
+// size). These are xterm.js talking back to a query — echoing them to the
+// remote as if they were user input corrupts the app: a stray `ESC[2;2R`
+// arriving mid-render makes some remote vims exit, closing the channel (issue
+// #242). This must happen in the alternate screen too — vim/less/tmux are
+// exactly the apps that emit `ESC[6n` and friends. Focus in/out (I/O) is left
+// intact in the alternate screen because full-screen apps legitimately want
+// FocusGained/FocusLost.
 function filterTerminalInput(input: string, inAlternateScreen: boolean): string {
   // OSC sequences: ESC ] ... BEL or ESC ] ... ESC \
   let filtered = input.replace(/\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g, '')
+  // Terminal query responses — strip in both normal and alternate screens.
+  filtered = filtered.replace(/\x1b\[(?:[?>][\d;]*|[\d;]*)([Rntc])/g, '')
   if (inAlternateScreen) {
     return filtered
   }
-  // Normal screen: strip terminal-generated CSI responses.
-  // Covers CPR (R), status report (n), window/cell size (t),
-  // device attributes (c), and focus in/out (I/O).
-  filtered = filtered.replace(/\x1b\[(?:[?>][\d;]*|[\d;]*)([RntcIO])/g, '')
+  // Normal screen only: also strip focus in/out, which a shell doesn't want.
+  filtered = filtered.replace(/\x1b\[(?:[?>][\d;]*|[\d;]*)([IO])/g, '')
   return filtered
 }
 
@@ -1045,9 +1052,16 @@ onMounted(() => {
         zmodemService.consume(payload.data)
         return
       }
-      // zmodem HEX header: *** <ZDLE> B hex_digits
-      const ZMODEM_HEX_RE = /\*{2,}(?:\x18)?[ABC][0-9a-fA-F]{10,}/
+      // Real ZMODEM headers always contain the ZDLE control byte (0x18)
+      // before the frame type: `**` (ZPAD ZPAD) `\x18` (ZDLE) `[ABC]` then
+      // hex digits. Requiring the 0x18 avoids false positives on ordinary
+      // terminal output — e.g. vim rendering a file whose content happens to
+      // contain `**B<hex>` — which previously flipped the session into binary
+      // ZMODEM mode and made the sentry write protocol bytes back to the
+      // server, crashing the remote shell (issue #242).
+      const ZMODEM_HEX_RE = /\*{2,}\x18[ABC][0-9a-fA-F]{10,}/
       if (ZMODEM_HEX_RE.test(payload.data)) {
+        console.debug('[zmodem] header detected, entering transfer mode')
         isZmodemStarting = true
         if (zmodemStartTimer) clearTimeout(zmodemStartTimer)
         zmodemStartTimer = setTimeout(() => {


### PR DESCRIPTION
## 摘要

修复 issue #242：会话在活跃使用中（尤其 vim 等全屏应用里）突然报 `Connection closed by remote host` 断开。

**根因**：全屏应用（vim/less/tmux）会查询终端（如 `ESC[6n` 查光标位置），xterm.js 自动生成应答（CPR `ESC[2;2R`）。`filterTerminalInput` 只在普通屏过滤这类查询应答，在 alternate screen（vim）里提前 return 直接透传，于是 CPR 被当作用户输入发回远端。一个非预期的光标位置报告在渲染途中到达，导致远端 vim 退出、channel 被关闭 —— 与日志完全吻合（`idle=0s`、keepalive 健康、`lastSent=1b5b323b3252` 即 `ESC[2;2R`）。

## 改动

- `BaseTerminal.vue`：终端查询应答（CPR/DSR/DA/尺寸）在**两种屏幕都过滤**；焦点事件 I/O 仅普通屏过滤（全屏应用需要 FocusGained/Lost）。
- 排查过程中顺带加固：
  - ZMODEM header 检测要求 ZDLE(0x18) 字节（前后端一致），避免 YAML/JSON 里 `**B<hex>` 之类内容误触发二进制传输模式；加回归单测。
  - keepalive 超时 5s→15s、失败阈值 3→4，并在隧道关闭跳板机连接时记日志，避免慢响应的堡垒机被误判掉线。
  - 新增断开诊断日志（idle/keepalive 状态、收发末尾字节、resize、session.Wait 原因），本次正是靠它定位根因。

Closes #242

## 验证

- `go build ./...`（darwin/windows）+ `go test ./backend/session/` 通过（含 ZMODEM 误判回归单测）
- `npm --prefix frontend run build` 通过
- 本地 `wails dev`：反复 `vim` 编辑远端文件、切窗口，不再断开；正常 rz/sz 传输仍工作

---

## Summary

Fixes #242: SSH sessions dropped with `Connection closed by remote host` during active use, especially inside full-screen apps like vim.

**Root cause**: full-screen apps query the terminal (e.g. `ESC[6n` cursor position); xterm.js auto-generates the reply (CPR `ESC[2;2R`). `filterTerminalInput` stripped these query responses only on the normal screen and returned early in the alternate screen, so the CPR was forwarded to the remote app as user input. A stray cursor-position report arriving mid-render made the remote vim exit and tore down the channel — matching the logs (`idle=0s`, keepalive healthy, `lastSent` = `ESC[2;2R`).

## Changes

- `BaseTerminal.vue`: strip terminal query responses (CPR/DSR/DA/size) in **both** screens; keep focus in/out only on the normal screen.
- Hardening found while diagnosing: tighten ZMODEM detection to require ZDLE (front+back, with a regression test); relax keepalive timeout 5s→15s / maxFail 3→4 and log jump-host keepalive closes; add disconnect diagnostics.

Closes #242

## Validation

- `go build ./...` (darwin/windows) + `go test ./backend/session/` pass
- `npm --prefix frontend run build` pass
- Local `wails dev`: repeated remote `vim` editing no longer disconnects; rz/sz still works
