### PR TITLE
fix(terminal): paste via Wails clipboard and bracketed paste

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,10 @@
+# uniterm
+
+Wails + Vue（前端 xterm.js 终端）+ Go 后端。
+
+## 约定
+
+- **注释宜少不宜多**：只在意图不明处点一句，不为「改一行代码写五六行注释」。代码自解释优先。
+- 提交：PR 标题用英文 conventional commit，正文中英对照；issue 用中文。
+- 一分支一修复，基于最新 main。
+- 前端改动后 `npm --prefix frontend run build` 验证；终端行为需 `wails dev` 实测。

--- a/frontend/src/components/BaseTerminal.vue
+++ b/frontend/src/components/BaseTerminal.vue
@@ -79,7 +79,7 @@ import { WebLinksAddon } from '@xterm/addon-web-links'
 import '@xterm/xterm/css/xterm.css'
 import { SessionWrite, SessionResize, SessionEndZmodem } from '../../wailsjs/go/main/App'
 import { WriteFileBase64, SaveFileDialog, FrontendLog, WriteTempFile } from '../../wailsjs/go/main/App'
-import { EventsOn, BrowserOpenURL } from '../../wailsjs/runtime'
+import { EventsOn, BrowserOpenURL, ClipboardGetText } from '../../wailsjs/runtime'
 import { useSettingsStore } from '../stores/settingsStore'
 import { highlight } from '../composables/useHighlight'
 import { onTerminalKey } from '../composables/useKeyboardShortcuts'
@@ -616,6 +616,17 @@ function handleTerminalKey(e: KeyboardEvent): boolean {
     return false
   }
 
+  // Cmd/Ctrl+V: paste via Wails clipboard (xterm's DOM paste is unreliable in WKWebView).
+  if ((e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey && (e.key === 'v' || e.key === 'V') && e.type === 'keydown') {
+    e.preventDefault()
+    if (props.mode === 'ssh' || props.mode === 'local') {
+      ClipboardGetText().then(text => {
+        if (text) pasteToSession(text)
+      }).catch(() => {})
+    }
+    return false
+  }
+
   // Ctrl+Shift+C: copy terminal selection to clipboard
   if ((e.ctrlKey || e.metaKey) && e.shiftKey && (e.key === 'c' || e.key === 'C') && e.type === 'keydown') {
     const sel = terminal?.getSelection()
@@ -987,9 +998,9 @@ onMounted(() => {
     if (action !== 'paste') return
     event.preventDefault()
     event.stopPropagation()
-    navigator.clipboard.readText().then(text => {
+    ClipboardGetText().then(text => {
       if (text && props.sessionId) {
-        SessionWrite(props.sessionId, text)
+        pasteToSession(text)
       }
     }).catch(() => {})
   }
@@ -1445,6 +1456,17 @@ function pasteToTerminal(text: string) {
   }
 }
 
+// Wrap in bracketed-paste markers when the app enabled the mode, so vim etc.
+// don't re-indent each pasted line.
+function bracketPaste(text: string): string {
+  const sid = props.sessionId
+  const managed = sid ? getManagedTerminal(sid) : undefined
+  if (managed?.terminal.modes.bracketedPasteMode) {
+    return '\x1b[200~' + text + '\x1b[201~'
+  }
+  return text
+}
+
 async function pasteToSession(text: string) {
   if (props.mode === 'ssh' || props.mode === 'local') {
     const sid = props.sessionId
@@ -1452,7 +1474,7 @@ async function pasteToSession(text: string) {
       // Normalize line endings: \r\n -> \r to prevent extra newlines
       // when pasting into editors like vim (Windows clipboard often has \r\n)
       const normalized = text.replace(/\r\n/g, '\n').replace(/\r/g, '')
-      SessionWrite(sid, normalized)
+      SessionWrite(sid, bracketPaste(normalized))
     }
   }
 }
@@ -1468,7 +1490,9 @@ const menu = useTerminalMenu({
           for (const pid of tab.panelIds) {
             const p = panelStore.getPanel(pid)
             if (p?.sessionId && (p.type === 'ssh' || p.type === 'local')) {
-              SessionWrite(p.sessionId, filtered)
+              // Bracket per target session — each has its own paste mode.
+              const wrap = getManagedTerminal(p.sessionId)?.terminal.modes.bracketedPasteMode
+              SessionWrite(p.sessionId, wrap ? '\x1b[200~' + filtered + '\x1b[201~' : filtered)
             }
           }
         }

--- a/frontend/src/composables/useTerminalMenu.ts
+++ b/frontend/src/composables/useTerminalMenu.ts
@@ -1,6 +1,7 @@
 import { ref, onMounted, onUnmounted } from 'vue'
 import type { Ref } from 'vue'
 import { useSettingsStore } from '../stores/settingsStore'
+import { ClipboardGetText } from '../../wailsjs/runtime/runtime'
 
 export interface UseTerminalMenuOptions {
   getSelection: () => string
@@ -82,7 +83,9 @@ export function useTerminalMenu(options: UseTerminalMenuOptions): UseTerminalMen
 
   async function pasteFromClipboard() {
     try {
-      const text = await navigator.clipboard.readText()
+      // Wails clipboard, not navigator.clipboard.readText() — the latter pops
+      // a system "Paste" confirmation on macOS WKWebView.
+      const text = await ClipboardGetText()
       if (text) {
         await options.onPaste(text)
       }


### PR DESCRIPTION
## 摘要

修复终端两个粘贴问题（#276、#277）。

## 改动

- **剪贴板读取改用 Wails runtime** `ClipboardGetText()`，替代 `navigator.clipboard.readText()` —— 后者在 macOS WKWebView 下会弹系统「Paste」确认，导致右键/中键粘贴要多点一次。改后直接生效。
- **新增 Cmd/Ctrl+V 快捷键** 粘贴处理：xterm 内置 DOM paste 在 WKWebView 下不可靠（macOS Cmd+V 原本无效）。
- **bracketed paste**：粘贴内容在远端启用该模式时用 `ESC[200~` … `ESC[201~` 包裹（右键/中键/broadcast 三条路径），vim insert 模式粘贴多行代码不再逐行缩进错位。
- 新增 `CLAUDE.md` 记录项目约定。

Closes #276
Closes #277

## 验证

- `npm --prefix frontend run build` 通过
- 本地 `wails dev`：右键/中键/Cmd+V 粘贴直接生效；vim insert 粘贴代码格式正常

---

## Summary

Fixes two terminal paste issues (#276, #277).

## Changes

- Read the clipboard via the Wails runtime `ClipboardGetText()` instead of `navigator.clipboard.readText()`, which triggers a system "Paste" confirmation on macOS WKWebView (right/middle-click paste now apply directly).
- Add a Cmd/Ctrl+V paste handler — xterm's DOM paste is unreliable in WKWebView (Cmd+V previously did nothing).
- Wrap pasted text in bracketed-paste markers (`ESC[200~` … `ESC[201~`) when the remote app enabled the mode, so vim in insert mode no longer re-indents each pasted line.
- Add `CLAUDE.md` with project conventions.

Closes #276
Closes #277

## Validation

- `npm --prefix frontend run build` passes
- Local `wails dev`: right/middle-click and Cmd+V paste apply directly; pasting code in vim insert mode keeps formatting
