### PR TITLE
fix: reset model form state on new/edit, add max autonomous rounds config

### DIFF
--- a/backend/store/settings_store.go
+++ b/backend/store/settings_store.go
@@ -9,6 +9,7 @@ import (
 const settingsFileName = "settings.json"
 
 func boolPtr(b bool) *bool { return &b }
+func intPtr(i int) *int    { return &i }
 
 type TerminalSettings struct {
 	Theme            string `json:"theme"`
@@ -74,6 +75,7 @@ type AIModelConfig struct {
 }
 
 type AISettings struct {
+	MaxTurns      *int            `json:"maxTurns"`
 	Models        []AIModelConfig `json:"models"`
 	ActiveModelID string          `json:"activeModelId"`
 }
@@ -205,6 +207,7 @@ func defaultSettings() AppSettings {
 			MaxHistoryLines:  5000,
 		},
 		AI: AISettings{
+			MaxTurns: intPtr(20),
 			Models: []AIModelConfig{
 				{
 					ID:       "model-default",

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -93,7 +93,7 @@
           </KeepAlive>
         </template>
       </div>
-      <AISidebar ref="aiSidebarRef" />
+      <AISidebar ref="aiSidebarRef" @open-settings="openSettings" />
     </div>
     <ConnectionForm v-model="showConnectionForm" :edit-config="editConfig" :default-group-id="pendingGroupId" @save="onSaveOnly" @connect="(c: ConnectionConfig, ko?: boolean) => { const wasEdit = !!editConfig; editConfig = null; onConnect(c, ko, wasEdit) }" @cancel="editConfig = null" />
     <SerialConnectDialog v-model="showSerialDialog" @connect="(sid: string, portName: string, baudRate: number) => onConnectSerial(sid, portName, baudRate, serialKeepOpen)" />

--- a/frontend/src/components/AISidebar.vue
+++ b/frontend/src/components/AISidebar.vue
@@ -116,9 +116,17 @@
                 >
                   {{ m.name }}
                 </el-dropdown-item>
+                <el-dropdown-item class="add-model-item" command="__add_model__" :divided="true">
+                  <Plus :size="14" class="add-model-icon" />
+                  <span>{{ t('settings.addModel') }}</span>
+                </el-dropdown-item>
               </el-dropdown-menu>
             </template>
           </el-dropdown>
+          <button v-else class="ghost-btn model-btn add-model-btn" @click="onModelChange('__add_model__')">
+            <Plus :size="14" />
+            <span>{{ t('settings.addModel') }}</span>
+          </button>
           <div class="input-actions-right">
             <el-dropdown trigger="click" @command="onModeChange">
               <button class="ghost-btn mode-btn" :title="modeLabel">{{ modeLabel }}</button>
@@ -161,7 +169,7 @@
 
 <script setup lang="ts">
 import { ref, nextTick, computed, watch, onMounted, onUnmounted } from 'vue'
-import { X, Trash2, Expand, Shrink, History, MessageSquarePlus, Search, ChevronDown, ChevronUp, ArrowUp, Square } from '@lucide/vue'
+import { X, Trash2, Expand, Shrink, History, MessageSquarePlus, Search, ChevronDown, ChevronUp, ArrowUp, Square, Plus } from '@lucide/vue'
 import { useAIStore } from '../stores/aiStore'
 import { useSettingsStore } from '../stores/settingsStore'
 import { useTabStore } from '../stores/tabStore'
@@ -325,7 +333,18 @@ function onModeChange(mode: string) {
   aiStore.mode = mode as ExecutionMode
 }
 
+const emit = defineEmits<{
+  'open-settings': []
+}>()
+
 function onModelChange(modelId: string) {
+  if (modelId === '__add_model__') {
+    emit('open-settings')
+    nextTick(() => {
+      settingsStore.openCategory = 'ai'
+    })
+    return
+  }
   settingsStore.setActiveModel(modelId)
   const model = settingsStore.settings.ai.models.find(m => m.id === modelId)
   if (model) {
@@ -890,6 +909,12 @@ defineExpose({ focusInput })
 }
 .model-btn {
   max-width: 96px;
+}
+.add-model-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  max-width: none;
 }
 .mode-btn {
   max-width: 108px;

--- a/frontend/src/components/SettingsTab.vue
+++ b/frontend/src/components/SettingsTab.vue
@@ -410,11 +410,26 @@
         <div class="settings-group">
           <div class="setting-card">
             <div class="setting-info">
+              <div class="setting-title">{{ t('settings.maxTurns') }}</div>
+              <div class="setting-desc">{{ t('settings.maxTurnsDesc') }}</div>
+            </div>
+            <div class="setting-control">
+              <el-input-number
+                v-model="settingsStore.settings.ai.maxTurns"
+                :min="0"
+                :max="100"
+                @change="settingsStore.save()"
+              />
+            </div>
+          </div>
+
+          <div class="setting-card">
+            <div class="setting-info">
               <div class="setting-title">{{ t('settings.modelList') }}</div>
               <div class="setting-desc">{{ t('settings.modelListDesc') }}</div>
             </div>
             <div class="setting-control">
-              <el-button @click="showModelForm = true"><Plus :size="14" /> {{ t('settings.addModel') }}</el-button>
+              <el-button @click="openNewModelForm"><Plus :size="14" /> {{ t('settings.addModel') }}</el-button>
             </div>
           </div>
 
@@ -454,10 +469,20 @@
           <el-input v-model="modelForm.name" />
         </el-form-item>
         <el-form-item :label="t('settings.modelProtocol')">
-          <el-select v-model="modelForm.protocol" style="width: 100%">
-            <el-option label="Anthropic" value="anthropic" />
-            <el-option label="OpenAI" value="openai" />
-          </el-select>
+          <div class="default-toggle-group">
+            <button
+              type="button"
+              class="toggle-btn"
+              :class="{ active: modelForm.protocol === 'anthropic' }"
+              @click="modelForm.protocol = 'anthropic'"
+            >Anthropic</button>
+            <button
+              type="button"
+              class="toggle-btn"
+              :class="{ active: modelForm.protocol === 'openai' }"
+              @click="modelForm.protocol = 'openai'"
+            >OpenAI</button>
+          </div>
         </el-form-item>
         <el-form-item :label="t('settings.modelBaseURL')">
           <el-input v-model="modelForm.baseURL" :placeholder="modelForm.protocol === 'openai' ? 'https://api.openai.com/v1' : 'https://api.anthropic.com/v1'" />
@@ -762,9 +787,19 @@ const modelForm = reactive({
   userAgent: 'uniTerm' as string,
 })
 
+function openNewModelForm() {
+  editingModel.value = null
+  resetModelForm()
+  testResult.value = null
+  testError.value = ''
+  showModelForm.value = true
+}
+
 function editModel(model: AIModelConfig) {
   editingModel.value = model
   modelSuggestions.value = []
+  testResult.value = null
+  testError.value = ''
   Object.assign(modelForm, { ...model })
   showModelForm.value = true
 }
@@ -1284,6 +1319,39 @@ function getShellLabel(path: string): string {
   margin-top: 12px;
   font-size: 13px;
   font-family: var(--font-ui);
+}
+
+.default-toggle-group {
+  display: flex;
+  gap: 0;
+}
+.toggle-btn {
+  padding: 5px 14px;
+  border: 1px solid var(--border-subtle);
+  background: var(--bg-base);
+  color: var(--text-secondary);
+  font-family: var(--font-ui);
+  font-size: 12px;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+.toggle-btn:first-child {
+  border-radius: var(--radius-sm) 0 0 var(--radius-sm);
+}
+.toggle-btn:last-child {
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+}
+.toggle-btn + .toggle-btn {
+  border-left: none;
+}
+.toggle-btn:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+.toggle-btn.active {
+  background: var(--accent);
+  color: var(--on-accent);
+  border-color: var(--accent);
 }
 
 .kb-key {

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -294,6 +294,8 @@
   "settings.testFailed": "Verbindung fehlgeschlagen",
   "settings.highlight": "Texthervorhebung",
   "settings.highlightDesc": "Zeitstempel, IPs, Schlüsselwörter, Strings usw. hervorheben",
+  "settings.maxTurns": "Max. autonome Runden",
+  "settings.maxTurnsDesc": "Maximale Anzahl autonomer Interaktionsrunden pro KI-Anfrage. 0 = unbegrenzt. Standard: 20.",
   "settings.modelList": "Modellliste",
   "settings.modelListDesc": "KI-Modelle konfigurieren und verwalten",
   "settings.addModel": "Modell hinzufügen",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -297,6 +297,8 @@
   "settings.testFailed": "Connection failed",
   "settings.highlight": "Text Highlight",
   "settings.highlightDesc": "Highlight timestamps, IPs, keywords, strings, etc.",
+  "settings.maxTurns": "Max Autonomous Rounds",
+  "settings.maxTurnsDesc": "Maximum autonomous interaction rounds per AI request. Set to 0 for unlimited. Default 20.",
   "settings.modelList": "Model List",
   "settings.modelListDesc": "Configure and manage AI models",
   "settings.addModel": "Add Model",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -294,6 +294,8 @@
   "settings.testFailed": "Conexión fallida",
   "settings.highlight": "Resaltado de Texto",
   "settings.highlightDesc": "Resaltar marcas de tiempo, IPs, palabras clave, cadenas, etc.",
+  "settings.maxTurns": "Máx. rondas autónomas",
+  "settings.maxTurnsDesc": "Rondas máximas de interacción autónoma por solicitud de IA. 0 = ilimitado. Predeterminado: 20.",
   "settings.modelList": "Lista de Modelos",
   "settings.modelListDesc": "Configurar y gestionar modelos de IA",
   "settings.addModel": "Agregar Modelo",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -294,6 +294,8 @@
   "settings.testFailed": "Échec de la connexion",
   "settings.highlight": "Surlignage du texte",
   "settings.highlightDesc": "Surligner les horodatages, IP, mots-clés, chaînes, etc.",
+  "settings.maxTurns": "Max. de tours autonomes",
+  "settings.maxTurnsDesc": "Nombre maximum de tours d'interaction autonome par requête IA. 0 = illimité. Défaut : 20.",
   "settings.modelList": "Liste des modèles",
   "settings.modelListDesc": "Configurer et gérer les modèles d'IA",
   "settings.addModel": "Ajouter un modèle",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -294,6 +294,8 @@
   "settings.testFailed": "接続失敗",
   "settings.highlight": "テキストハイライト",
   "settings.highlightDesc": "タイムスタンプ、IP、キーワード、文字列などをハイライト",
+  "settings.maxTurns": "AI自律対話の最大ラウンド数",
+  "settings.maxTurnsDesc": "AIリクエストあたりの自律的な対話ラウンドの上限。0は無制限。デフォルト：20。",
   "settings.modelList": "モデル一覧",
   "settings.modelListDesc": "AI モデルの設定と管理",
   "settings.addModel": "モデルを追加",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -294,6 +294,8 @@
   "settings.testFailed": "연결 실패",
   "settings.highlight": "텍스트 강조",
   "settings.highlightDesc": "타임스탬프, IP, 키워드, 문자열 등을 강조 표시",
+  "settings.maxTurns": "AI 자율 상호작용 최대 라운드",
+  "settings.maxTurnsDesc": "AI 요청당 자율 상호작용 라운드의 최대 횟수. 0은 무제한. 기본값: 20.",
   "settings.modelList": "모델 목록",
   "settings.modelListDesc": "AI 모델 구성 및 관리",
   "settings.addModel": "모델 추가",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -294,6 +294,8 @@
   "settings.testFailed": "Соединение не удалось",
   "settings.highlight": "Подсветка текста",
   "settings.highlightDesc": "Выделять метки времени, IP, ключевые слова, строки и т.д.",
+  "settings.maxTurns": "Макс. автономных раундов",
+  "settings.maxTurnsDesc": "Максимальное количество автономных раундов взаимодействия на один запрос ИИ. 0 — без ограничений. По умолчанию: 20.",
   "settings.modelList": "Список моделей",
   "settings.modelListDesc": "Настройка и управление ИИ-моделями",
   "settings.addModel": "Добавить модель",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -297,6 +297,8 @@
   "settings.testFailed": "连接失败",
   "settings.highlight": "文本高亮",
   "settings.highlightDesc": "自动高亮时间、IP、关键词、字符串等模式",
+  "settings.maxTurns": "AI 自主交互最大轮次",
+  "settings.maxTurnsDesc": "AI 自主执行命令与反馈的对话轮数上限。设为 0 表示不限制。默认 20。",
   "settings.modelList": "模型列表",
   "settings.modelListDesc": "配置和管理 AI 模型",
   "settings.addModel": "添加模型",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -294,6 +294,8 @@
   "settings.testFailed": "連線失敗",
   "settings.highlight": "文字高亮",
   "settings.highlightDesc": "自動高亮時間、IP、關鍵詞、字串等模式",
+  "settings.maxTurns": "AI 自主互動最大輪次",
+  "settings.maxTurnsDesc": "AI 自主執行命令與回饋的對話輪數上限。設為 0 表示不限制。預設 20。",
   "settings.modelList": "模型列表",
   "settings.modelListDesc": "設定和管理 AI 模型",
   "settings.addModel": "新增模型",

--- a/frontend/src/services/agent.ts
+++ b/frontend/src/services/agent.ts
@@ -1,6 +1,7 @@
 import { chat, AVAILABLE_TOOLS, ChatCancelledError } from './llm'
 import { executeCommand, startCommand, captureTerminal, collectOutput, sendTerminalKey } from './terminalAgent'
 import { useAIStore } from '../stores/aiStore'
+import { useSettingsStore } from '../stores/settingsStore'
 import { useTabStore } from '../stores/tabStore'
 import { usePanelStore } from '../stores/panelStore'
 import { EventsOn } from '../../wailsjs/runtime'
@@ -240,9 +241,9 @@ export async function runAgent(userInput: string) {
   }
 
   let turnCount = 0
-  const maxTurns = 20
+  const maxTurns = useSettingsStore().settings.ai.maxTurns ?? 20
 
-  while (turnCount < maxTurns) {
+  while (maxTurns === 0 || turnCount < maxTurns) {
     turnCount++
 
     if (store.stopRequested) {

--- a/frontend/src/stores/settingsStore.ts
+++ b/frontend/src/stores/settingsStore.ts
@@ -216,6 +216,7 @@ function mergeSettings(loaded: AppSettings): AppSettings {
         : loaded.terminal?.theme || DEFAULT_SETTINGS.terminal.theme
     },
     ai: {
+      maxTurns: loaded.ai?.maxTurns ?? DEFAULT_SETTINGS.ai.maxTurns,
       models: loaded.ai?.models?.length ? loaded.ai.models : DEFAULT_SETTINGS.ai.models,
       activeModelId: loaded.ai?.activeModelId || DEFAULT_SETTINGS.ai.activeModelId
     },

--- a/frontend/src/types/settings.ts
+++ b/frontend/src/types/settings.ts
@@ -73,6 +73,7 @@ export const USER_AGENT_PRESETS: { label: string; value: string }[] = [
 ]
 
 export interface AISettings {
+  maxTurns: number
   models: AIModelConfig[]
   activeModelId: string
 }
@@ -154,6 +155,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
     highlightEnabled: true
   },
   ai: {
+    maxTurns: 20,
     models: [
       {
         id: 'model-default',

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -957,6 +957,7 @@ export namespace store {
 	}
 	
 	export class AISettings {
+	    maxTurns?: number;
 	    models: AIModelConfig[];
 	    activeModelId: string;
 	
@@ -966,6 +967,7 @@ export namespace store {
 	
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.maxTurns = source["maxTurns"];
 	        this.models = this.convertValues(source["models"], AIModelConfig);
 	        this.activeModelId = source["activeModelId"];
 	    }


### PR DESCRIPTION
## What

- Fix model form dialog not clearing previous data when clicking 'Add Model' after editing a model
- Fix test connection result persisting across different model edits
- Add max autonomous interaction rounds config (0=unlimited, default 20) as first setting in AI Assistant page
- Change protocol selector from dropdown to toggle buttons (reuses existing `.toggle-btn` style)
- Add 'Add Model' entry in AI sidebar model dropdown menu
- Show '+ Add Model' button when no models are configured (instead of blank)
- Add i18n translations for new keys across all 9 locales

---

## 修改内容

- 修复编辑模型后再点击新建，表单数据未清除导致保存时更新旧模型而非新建的问题
- 修复测试连接结果在编辑不同模型时串扰的问题
- AI 助手设置页新增「AI 自主交互最大轮次」配置项（0=不限制，默认20），置于设置首位
- 协议选择从下拉菜单改为 toggle 按钮，复用项目已有的 `.toggle-btn` 样式
- AI 边栏模型下拉菜单底部新增「添加模型」入口，点击跳转至 AI 设置页
- 无模型时不再隐藏选择区域，改为显示「+ 添加模型」按钮
- 9 种语言均已完成翻译