### PR TITLE
feat: show close button on inactive tab hover

### DIFF
--- a/frontend/src/components/TabItem.vue
+++ b/frontend/src/components/TabItem.vue
@@ -4,12 +4,14 @@
     :class="{ active: isActive, 'ai-locked': isAILocked }"
     :data-tab-id="tab.id"
     @click="$emit('activate', tab.id)"
+    @mouseenter="hovered = true"
+    @mouseleave="hovered = false"
     draggable="true"
     @dragstart="onDragStart"
     @contextmenu="onContextMenu"
   >
     <button
-      v-if="isActive"
+      v-if="isActive || hovered"
       class="tab-close"
       @click.stop="$emit('close', tab.id)"
     ><X /></button>
@@ -109,6 +111,7 @@ const tabStore = useTabStore()
 const panelStore = usePanelStore()
 const { t } = useI18n()
 
+const hovered = ref(false)
 const contextMenuVisible = ref(false)
 const contextMenuStyle = ref({ left: '0px', top: '0px' })
 


### PR DESCRIPTION
## What

Replace the type icon with a close (X) button when hovering over an inactive tab, so users can close it in a single click instead of clicking to activate first.

Closes #273

---

## 修改内容

鼠标悬停在非激活标签上时，图标自动变为关闭（X）按钮，无需先点击激活标签再点关闭，一次点击即可关闭。

Closes #273