### PR TITLE
feat: make terminal search shortcut (Ctrl+F) configurable

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -608,6 +608,10 @@ const actionHandlers: Record<ShortcutAction, () => void> = {
       closeTab(t.id)
     }
   },
+  terminalSearch: () => {
+    const pid = tabStore.getActivePanelId()
+    if (pid) window.dispatchEvent(new CustomEvent('terminal:open-search', { detail: { panelId: pid } }))
+  },
   navigatePrev: () => navigatePanel(-1),
   navigateNext: () => navigatePanel(1),
   duplicateSession: async () => {

--- a/frontend/src/components/BaseTerminal.vue
+++ b/frontend/src/components/BaseTerminal.vue
@@ -618,11 +618,6 @@ function handleTerminalKey(e: KeyboardEvent): boolean {
   // Check global shortcuts first (Ctrl+Shift+/Alt+ combos)
   if (e.type === 'keydown' && !onTerminalKey(e)) return false
 
-  if ((e.ctrlKey || e.metaKey) && e.key === 'f' && e.type === 'keydown') {
-    openSearch()
-    return false
-  }
-
   // Cmd/Ctrl+V: paste via Wails clipboard (xterm's DOM paste is unreliable in WKWebView).
   if ((e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey && (e.key === 'v' || e.key === 'V') && e.type === 'keydown') {
     e.preventDefault()

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -668,6 +668,7 @@
   "shortcut.lockAI": "KI-Fenster sperren/entsperren",
   "shortcut.newConnection": "Neuer Tab",
   "shortcut.duplicateSession": "Duplizieren",
+  "shortcut.terminalSearch": "Terminal durchsuchen",
   "shortcut.openSettings": "Einstellungen öffnen",
   "shortcut.title": "Tastenkombinationen",
   "shortcut.colFunction": "Funktion",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -673,6 +673,7 @@
   "shortcut.lockAI": "Lock/Unlock AI Window",
   "shortcut.newConnection": "New Tab",
   "shortcut.duplicateSession": "Duplicate",
+  "shortcut.terminalSearch": "Terminal Search",
   "shortcut.openSettings": "Open Settings",
   "shortcut.title": "Shortcuts",
   "shortcut.colFunction": "Function",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -668,6 +668,7 @@
   "shortcut.lockAI": "Bloquear/desbloquear ventana IA",
   "shortcut.newConnection": "Nueva pestaña",
   "shortcut.duplicateSession": "Duplicar",
+  "shortcut.terminalSearch": "Buscar en terminal",
   "shortcut.openSettings": "Abrir configuración",
   "shortcut.title": "Atajos",
   "shortcut.colFunction": "Función",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -668,6 +668,7 @@
   "shortcut.lockAI": "Verrouiller/déverrouiller la fenêtre IA",
   "shortcut.newConnection": "Nouvel onglet",
   "shortcut.duplicateSession": "Dupliquer",
+  "shortcut.terminalSearch": "Rechercher dans le terminal",
   "shortcut.openSettings": "Ouvrir les paramètres",
   "shortcut.title": "Raccourcis",
   "shortcut.colFunction": "Fonction",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -668,6 +668,7 @@
   "shortcut.lockAI": "AIウィンドウのロック/解除",
   "shortcut.newConnection": "新しいタブ",
   "shortcut.duplicateSession": "複製",
+  "shortcut.terminalSearch": "端末検索",
   "shortcut.openSettings": "設定を開く",
   "shortcut.title": "ショートカット",
   "shortcut.colFunction": "機能",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -668,6 +668,7 @@
   "shortcut.lockAI": "AI 창 잠금/잠금 해제",
   "shortcut.newConnection": "새 탭",
   "shortcut.duplicateSession": "복제",
+  "shortcut.terminalSearch": "터미널 검색",
   "shortcut.openSettings": "설정 열기",
   "shortcut.title": "단축키",
   "shortcut.colFunction": "기능",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -668,6 +668,7 @@
   "shortcut.lockAI": "Заблокировать/разблокировать ИИ-окно",
   "shortcut.newConnection": "Новая вкладка",
   "shortcut.duplicateSession": "Дублировать",
+  "shortcut.terminalSearch": "Поиск в терминале",
   "shortcut.openSettings": "Открыть настройки",
   "shortcut.title": "Горячие клавиши",
   "shortcut.colFunction": "Функция",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -673,6 +673,7 @@
   "shortcut.lockAI": "锁定/解锁AI窗口",
   "shortcut.newConnection": "新建标签页",
   "shortcut.duplicateSession": "复制连接",
+  "shortcut.terminalSearch": "终端搜索",
   "shortcut.openSettings": "打开设置",
   "shortcut.title": "快捷键",
   "shortcut.colFunction": "功能",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -668,6 +668,7 @@
   "shortcut.lockAI": "鎖定/解鎖AI視窗",
   "shortcut.newConnection": "新增標籤頁",
   "shortcut.duplicateSession": "複製連接",
+  "shortcut.terminalSearch": "終端搜尋",
   "shortcut.openSettings": "開啟設定",
   "shortcut.title": "快捷鍵",
   "shortcut.colFunction": "功能",

--- a/frontend/src/types/settings.ts
+++ b/frontend/src/types/settings.ts
@@ -84,6 +84,7 @@ export type ShortcutAction =
   | 'closePanel'
   | 'navigatePrev' | 'navigateNext'
   | 'duplicateSession'
+  | 'terminalSearch'
 
 export interface KeyBinding {
   ctrl: boolean
@@ -106,6 +107,7 @@ export const SHORTCUT_LABELS: Record<ShortcutAction, string> = {
   focusAI: 'shortcut.focusAI',
   lockAI: 'shortcut.lockAI',
   duplicateSession: 'shortcut.duplicateSession',
+  terminalSearch: 'shortcut.terminalSearch',
 }
 
 export const DEFAULT_KEYBOARD: KeyboardSettings = {
@@ -120,6 +122,7 @@ export const DEFAULT_KEYBOARD: KeyboardSettings = {
   navigateNext: { ctrl: false, shift: false, alt: true, key: 'arrowright' },
   lockAI: { ctrl: true, shift: true, alt: false, key: 'l' },
   duplicateSession: { ctrl: true, shift: true, alt: false, key: 'd' },
+  terminalSearch: { ctrl: true, shift: false, alt: false, key: 'f' },
 }
 
 export interface SFTPBookmarks {


### PR DESCRIPTION
## What

Add `terminalSearch` to the configurable keyboard shortcuts list with default binding Ctrl+F (Cmd+F on macOS). The hardcoded check in BaseTerminal has been removed — it now goes through the global shortcut system, so users can rebind or disable it via Settings → Keyboard.

Closes #274

---

## 修改内容

将终端搜索快捷键（Ctrl+F / Cmd+F）加入可配置快捷键列表，默认 Ctrl+F。

- 移除 `BaseTerminal.vue` 中硬编码的 Ctrl+F 检测
- 新增 `terminalSearch` shortcut action，走全局快捷键系统
- `actionHandlers` 通过 `terminal:open-search` CustomEvent 触发搜索
- 9 种语言已添加标签翻译

用户可以在 设置 → 快捷键 中看到「终端搜索」并自由改绑或关闭。

Closes #274