### PR TITLE
fix: add '(no group)' option to all group tree dropdowns

### DIFF
--- a/frontend/src/components/ConnectionForm.vue
+++ b/frontend/src/components/ConnectionForm.vue
@@ -37,7 +37,7 @@
             <el-form-item :label="t('conn.name')">
               <el-input v-model="form.name" :placeholder="t('conn.namePlaceholder')" />
             </el-form-item>
-            <el-form-item :label="t('conn.moveTo')">
+            <el-form-item :label="t('conn.group')">
               <div style="display:flex;gap:6px;width:100%">
                 <el-tree-select
                   v-model="selectedGroupId"
@@ -615,7 +615,10 @@ const groupTreeData = computed<TreeOption[]>(() => {
       children: node.children.length > 0 ? buildTree(node.children) : undefined,
     }))
   }
-  return buildTree(connectionStore.groupedConnections.roots)
+  return [
+    { value: '__none__', label: t('conn.noGroup') },
+    ...buildTree(connectionStore.groupedConnections.roots),
+  ]
 })
 
 const selectedGroupName = computed(() => {
@@ -761,7 +764,7 @@ function resetForm() {
 
 // Sync tree-select value to form
 watch(selectedGroupId, (val) => {
-  form.groupId = val || undefined
+  form.groupId = val === '__none__' ? undefined : (val || undefined)
 })
 
 function onNodeClick(data: any) {

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -366,7 +366,7 @@
     </el-dialog>
 
     <!-- Move to dialog -->
-    <el-dialog v-model="showChangeGroupDialog" :title="t('conn.moveTo')" width="400px">
+    <el-dialog v-model="showChangeGroupDialog" :title="t('conn.group')" width="400px">
       <el-tree-select
         v-model="changeGroupTargetId"
         :data="groupTreeData"
@@ -1244,7 +1244,10 @@ const groupTreeData = computed<TreeOption[]>(() => {
       children: node.children.length > 0 ? buildTree(node.children) : undefined,
     }))
   }
-  return buildTree(connectionStore.groupedConnections.roots)
+  return [
+    { value: '__none__', label: t('conn.noGroup') },
+    ...buildTree(connectionStore.groupedConnections.roots),
+  ]
 })
 
 function doNewConnInGroup() {
@@ -1270,7 +1273,7 @@ async function confirmNewGroup() {
   const name = newGroupName.value.trim()
   if (!name) return
   showNewGroupDialog.value = false
-  const parentId = newGroupParentId.value
+  const parentId = newGroupParentId.value === '__none__' ? undefined : newGroupParentId.value
   newGroupParentId.value = undefined
   newGroupName.value = ''
   // save in background, don't block dialog close
@@ -1375,7 +1378,8 @@ async function confirmChangeNewGroup() {
   const name = changeNewGroupName.value.trim()
   if (!name) return
   showChangeNewGroupDialog.value = false
-  const group = await connectionStore.addGroup(name, changeNewGroupParentId.value)
+  const parentId = changeNewGroupParentId.value === '__none__' ? undefined : changeNewGroupParentId.value
+  const group = await connectionStore.addGroup(name, parentId)
   changeNewGroupParentId.value = undefined
   changeNewGroupName.value = ''
   const ids = getChangeGroupIds()

--- a/frontend/src/components/StartTabContent.vue
+++ b/frontend/src/components/StartTabContent.vue
@@ -1075,7 +1075,7 @@ async function doAddGroup() {
   const name = newGroupDialogName.value.trim()
   if (!name) return
   showNewGroupDialog.value = false
-  const parentId = newGroupParentId.value
+  const parentId = newGroupParentId.value === '__none__' ? undefined : newGroupParentId.value
   newGroupDialogName.value = ''
   newGroupParentId.value = undefined
   connectionStore.addGroup(name, parentId)
@@ -1095,7 +1095,10 @@ const groupTreeData = computed<TreeOption[]>(() => {
       children: node.children.length > 0 ? buildTree(node.children) : undefined,
     }))
   }
-  return buildTree(connectionStore.groupedConnections.roots)
+  return [
+    { value: '__none__', label: t('conn.noGroup') },
+    ...buildTree(connectionStore.groupedConnections.roots),
+  ]
 })
 
 // Group context menu: New Group (child of current)

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -64,7 +64,7 @@
   "conn.expectRemoveStep": "删除步骤",
   "conn.expectVariableHint": "变量：${password}、${user}、${host}。Expect 匹配忽略大小写。",
   "conn.sftpMaxConcurrency": "SFTP 最大并发传输",
-  "conn.group": "所属分组",
+  "conn.group": "分组",
   "conn.noGroup": "(无分组)",
   "conn.newGroup": "+ 新建分组",
   "conn.newGroupTitle": "新建分组",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -62,7 +62,7 @@
   "conn.expectRemoveStep": "移除步驟",
   "conn.expectVariableHint": "變數：${password}、${user}、${host}。Expect 比對忽略大小寫。",
   "conn.sftpMaxConcurrency": "SFTP 最大並行傳輸",
-  "conn.group": "所屬分組",
+  "conn.group": "分組",
   "conn.noGroup": "(無分組)",
   "conn.newGroup": "+ 新增分組",
   "conn.newGroupTitle": "新增分組",


### PR DESCRIPTION
## What

- Add `(none)` / `(无分组)` entry to all group tree dropdowns (Sidebar, ConnectionForm, StartTabContent)
- Rename dialog/form labels from `conn.moveTo` to `conn.group`
- Map `__none__` to `undefined` in all save handlers so selecting the no-group option works correctly
- Simplify zh-CN/zh-TW `conn.group` label from '所属分组' to '分组'

---

## 修改内容

- 所有分组树下拉菜单（移动连接、新建分组选择父分组）新增「(无分组)」选项
- 对话框标题和表单标签从「移动到」改为「分组」，右键菜单保持「移动到」
- 4 处保存逻辑均映射 `__none__` → `undefined`
- zh-CN/zh-TW 的 `conn.group` 从「所属分组」简化为「分组」