### PR TITLE
confirm before closing tabs/panels with active connections

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -156,6 +156,7 @@ import SyncConflictDialog from './components/SyncConflictDialog.vue'
 import SerialConnectDialog from './components/SerialConnectDialog.vue'
 import CredentialPrompt from './components/CredentialPrompt.vue'
 import type { CredentialResult } from './components/CredentialPrompt.vue'
+import { ElMessageBox } from 'element-plus'
 import { useConnectionStore } from './stores/connectionStore'
 import { useTabStore } from './stores/tabStore'
 import { usePanelStore } from './stores/panelStore'
@@ -679,6 +680,26 @@ async function closeTab(tabId: string) {
       }
     })
     return
+  }
+  // Confirm before closing connected sessions to prevent accidental disconnect
+  if (tab && tab.type !== 'settings') {
+    const panelIds = tab.type === 'workspace' ? tab.panelIds : 'panelId' in tab ? [tab.panelId] : []
+    const hasConnected = panelIds.some(pid => {
+      const p = panelStore.getPanel(pid)
+      if (!p?.sessionId) return false
+      return sessionStore.getStatus(p.sessionId) === 'connected'
+    })
+    if (hasConnected) {
+      try {
+        await ElMessageBox.confirm(
+          t('tab.closeConnectedConfirm'),
+          t('tab.closeConfirmTitle'),
+          { confirmButtonText: t('tab.close'), cancelButtonText: t('conn.cancel'), type: 'warning' }
+        )
+      } catch {
+        return
+      }
+    }
   }
   if (tab && tab.type === 'rdp') {
     const p = panelStore.getPanel(tab.panelId)

--- a/frontend/src/components/WorkspaceContent.vue
+++ b/frontend/src/components/WorkspaceContent.vue
@@ -25,10 +25,13 @@ defineOptions({ name: 'WorkspaceContent' })
 
 import { useTabStore } from '../stores/tabStore'
 import { usePanelStore } from '../stores/panelStore'
+import { useSessionStore } from '../stores/sessionStore'
 import type { WorkspaceTab } from '../types/workspace'
 import type { ConnectionConfig } from '../types/session'
 import PanelGrid from './PanelGrid.vue'
-import { CreateSession } from '../../wailsjs/go/main/App'
+import { CreateSession, CloseSession } from '../../wailsjs/go/main/App'
+import { ElMessageBox } from 'element-plus'
+import { useI18n } from '../i18n'
 
 const props = defineProps<{
   tab: WorkspaceTab
@@ -36,9 +39,26 @@ const props = defineProps<{
 
 const tabStore = useTabStore()
 const panelStore = usePanelStore()
+const sessionStore = useSessionStore()
+const { t } = useI18n()
 
-function closePanel(panelId: string) {
+async function closePanel(panelId: string) {
   const panel = panelStore.getPanel(panelId)
+  const connected = !!panel?.sessionId && sessionStore.getStatus(panel.sessionId) === 'connected'
+  if (connected) {
+    try {
+      await ElMessageBox.confirm(
+        t('tab.closeConnectedConfirm'),
+        t('tab.closeConfirmTitle'),
+        { confirmButtonText: t('tab.close'), cancelButtonText: t('conn.cancel'), type: 'warning' }
+      )
+    } catch {
+      return
+    }
+  }
+  if (panel?.sessionId) {
+    try { await CloseSession(panel.sessionId) } catch (_) {}
+  }
   tabStore.removePanelFromWorkspaceTab(props.tab.id, panelId)
   if (panel) {
     panelStore.removePanel(panel.id)

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -86,6 +86,8 @@
   "tab.closeLeft": "Tabs links schließen",
   "tab.closeOther": "Andere Tabs schließen",
   "tab.close": "Schließen",
+  "tab.closeConfirmTitle": "Schließen bestätigen",
+  "tab.closeConnectedConfirm": "Dieser Tab hat eine aktive Verbindung. Beim Schließen wird die Verbindung getrennt. Wirklich schließen?",
   "tab.more": "Weitere Tabs",
   "terminal.duplicate": "Duplizieren",
   "terminal.more": "Mehr",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -88,6 +88,8 @@
   "tab.closeLeft": "Close Tabs to the Left",
   "tab.closeOther": "Close Other Tabs",
   "tab.close": "Close",
+  "tab.closeConfirmTitle": "Close Confirmation",
+  "tab.closeConnectedConfirm": "This tab has an active connection. Closing it will disconnect. Are you sure?",
   "tab.more": "More Tabs",
   "terminal.duplicate": "Duplicate",
   "terminal.more": "More",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -86,6 +86,8 @@
   "tab.closeLeft": "Cerrar pestañas a la izquierda",
   "tab.closeOther": "Cerrar otras pestañas",
   "tab.close": "Cerrar",
+  "tab.closeConfirmTitle": "Confirmar Cierre",
+  "tab.closeConnectedConfirm": "Esta pestaña está conectada. Al cerrarla se desconectará. ¿Continuar?",
   "tab.more": "Más pestañas",
   "terminal.duplicate": "Duplicar",
   "terminal.more": "Más",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -86,6 +86,8 @@
   "tab.closeLeft": "Fermer les onglets à gauche",
   "tab.closeOther": "Fermer les autres onglets",
   "tab.close": "Fermer",
+  "tab.closeConfirmTitle": "Confirmer la fermeture",
+  "tab.closeConnectedConfirm": "Cet onglet est connecté. Le fermer déconnectera la session. Continuer ?",
   "tab.more": "Plus d'onglets",
   "terminal.duplicate": "Dupliquer",
   "terminal.more": "Plus",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -86,6 +86,8 @@
   "tab.closeLeft": "左側のタブを閉じる",
   "tab.closeOther": "他のタブを閉じる",
   "tab.close": "閉じる",
+  "tab.closeConfirmTitle": "閉じる確認",
+  "tab.closeConnectedConfirm": "このタブは接続中です。閉じると切断されます。本当に閉じますか？",
   "tab.more": "他のタブ",
   "terminal.duplicate": "複製",
   "terminal.more": "さらに表示",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -86,6 +86,8 @@
   "tab.closeLeft": "왼쪽 탭 닫기",
   "tab.closeOther": "다른 탭 닫기",
   "tab.close": "닫기",
+  "tab.closeConfirmTitle": "닫기 확인",
+  "tab.closeConnectedConfirm": "이 탭은 연결되어 있습니다. 닫으면 연결이 끊어집니다. 계속하시겠습니까?",
   "tab.more": "더 많은 탭",
   "terminal.duplicate": "복제",
   "terminal.more": "더 보기",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -86,6 +86,8 @@
   "tab.closeLeft": "Закрыть вкладки слева",
   "tab.closeOther": "Закрыть другие вкладки",
   "tab.close": "Закрыть",
+  "tab.closeConfirmTitle": "Подтверждение закрытия",
+  "tab.closeConnectedConfirm": "Эта вкладка подключена. Закрытие приведёт к разрыву соединения. Продолжить?",
   "tab.more": "Еще вкладки",
   "terminal.duplicate": "Дублировать",
   "terminal.more": "Ещё",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -88,6 +88,8 @@
   "tab.closeLeft": "关闭左侧标签",
   "tab.closeOther": "关闭其他标签",
   "tab.close": "关闭",
+  "tab.closeConfirmTitle": "关闭确认",
+  "tab.closeConnectedConfirm": "该窗口已连接，关闭将断开连接。确定要关闭吗？",
   "tab.more": "更多标签",
   "terminal.duplicate": "复制连接",
   "terminal.more": "更多",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -86,6 +86,8 @@
   "tab.closeLeft": "關閉左側分頁",
   "tab.closeOther": "關閉其他分頁",
   "tab.close": "關閉",
+  "tab.closeConfirmTitle": "關閉確認",
+  "tab.closeConnectedConfirm": "該視窗已連線，關閉將中斷連線。確定要關閉嗎？",
   "tab.more": "更多分頁",
   "terminal.duplicate": "複製連接",
   "terminal.more": "更多",


### PR DESCRIPTION
Add a safety prompt when closing a tab or workspace panel that has a connected session, to prevent accidental disconnects.

Closes #185

---

当关闭一个已经链接的会话时进行提示，防止误操作

Closes #185
