### PR TITLE
use CR as line terminator for commands auto-run

### DIFF
--- a/frontend/src/components/QuickCommandsPanel.vue
+++ b/frontend/src/components/QuickCommandsPanel.vue
@@ -408,11 +408,10 @@ async function sendCommand(cmd: QuickCommand, mode: 'run' | 'paste') {
       SessionWrite(sid, cmd.command)
       continue
     }
-    let text = cmd.command
-    if (!text.endsWith('\n')) text += '\n'
+    const text = cmd.command.replace(/\r\n?/g, '\n')
     const lines = text.split('\n').filter(l => l.length > 0)
     for (let i = 0; i < lines.length; i++) {
-      SessionWrite(sid, lines[i] + '\n')
+      SessionWrite(sid, lines[i] + '\r')
       if (i < lines.length - 1) await new Promise(r => setTimeout(r, 100))
     }
   }


### PR DESCRIPTION
Quick commands in run mode appended '\n' after each line, which PowerShell's PSReadLine treats as a literal newline in the buffer rather than a submit. The command would appear in the prompt but never execute until the user pressed Enter manually.

---

## 变更摘要

windows上本地终端powershell，快捷命令不能自动运行