### PR TITLE
fix: unify accent color to follow theme (#287)

### DIFF
--- a/frontend/src/components/AIMessage.vue
+++ b/frontend/src/components/AIMessage.vue
@@ -764,7 +764,7 @@ function escapeHtml(text: string): string {
 .text :deep(blockquote) {
   margin: 8px 0;
   padding: 6px 8px 6px 12px;
-  border-left: 3px solid var(--accent-dim);
+  border-left: 3px solid var(--accent);
   background: var(--bg-overlay);
   border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
   color: var(--text-secondary);
@@ -917,7 +917,7 @@ function escapeHtml(text: string): string {
   background: var(--accent-subtle);
 }
 .out-box .tool-box-label {
-  background: var(--accent-dim);
+  background: var(--accent);
   color: var(--on-accent);
 }
 .tool-pairs {

--- a/frontend/src/components/AISidebar.vue
+++ b/frontend/src/components/AISidebar.vue
@@ -1376,7 +1376,7 @@ defineExpose({ focusInput })
   transition: background 0.12s ease, opacity 0.12s ease;
 }
 .send-btn:hover:not(:disabled) {
-  background: var(--accent-dim);
+  background: var(--accent);
 }
 .send-btn:disabled {
   background: var(--bg-active);

--- a/frontend/src/components/ConnectionForm.vue
+++ b/frontend/src/components/ConnectionForm.vue
@@ -1002,7 +1002,7 @@ function onConnect() {
 }
 
 .subtype-btn.active {
-  background: linear-gradient(135deg, var(--accent-dim), var(--accent));
+  background: linear-gradient(135deg, var(--accent), var(--accent));
   color: var(--on-accent);
   border-color: var(--accent-glow);
   box-shadow: 0 0 0 1px var(--accent-glow), 0 2px 8px var(--accent-glow);

--- a/frontend/src/components/GroupTreeItem.vue
+++ b/frontend/src/components/GroupTreeItem.vue
@@ -202,7 +202,7 @@ function onMoreClick(e: MouseEvent, conn: ConnectionConfig) {
 }
 .connection-item.active {
   background: var(--accent-subtle);
-  box-shadow: inset 0 0 0 1px var(--accent-dim);
+  box-shadow: inset 0 0 0 1px var(--accent);
 }
 .connection-item.active .name {
   color: var(--accent);

--- a/frontend/src/components/HistoryPanel.vue
+++ b/frontend/src/components/HistoryPanel.vue
@@ -354,7 +354,7 @@ watch(searchQuery, () => {
 
 .qc-item.active {
   background: var(--accent-subtle);
-  box-shadow: inset 0 0 0 1px var(--accent-dim);
+  box-shadow: inset 0 0 0 1px var(--accent);
 }
 
 .qc-item.active .history-command { color: var(--accent); }

--- a/frontend/src/components/Panel.vue
+++ b/frontend/src/components/Panel.vue
@@ -307,7 +307,7 @@ watch(() => props.isActive, (active) => {
 }
 .panel-active .panel-header {
   background: var(--bg-elevated);
-  border-bottom-color: var(--accent-dim);
+  border-bottom-color: var(--accent);
 }
 .panel-header.ai-locked {
   border-left: 3px solid var(--warning);
@@ -329,7 +329,7 @@ watch(() => props.isActive, (active) => {
   font-family: inherit;
   color: var(--text-primary);
   background: var(--bg-base);
-  border: 1px solid var(--accent-dim);
+  border: 1px solid var(--accent);
   border-radius: var(--radius-sm);
   padding: 2px 6px;
   width: 120px;

--- a/frontend/src/components/QuickCommandsPanel.vue
+++ b/frontend/src/components/QuickCommandsPanel.vue
@@ -662,7 +662,7 @@ watch(searchQuery, (q) => {
 
 .qc-item.active {
   background: var(--accent-subtle);
-  box-shadow: inset 0 0 0 1px var(--accent-dim);
+  box-shadow: inset 0 0 0 1px var(--accent);
 }
 
 .qc-item.active .qc-item-name {

--- a/frontend/src/components/RenderNode.vue
+++ b/frontend/src/components/RenderNode.vue
@@ -141,7 +141,7 @@ function onPanelDragStart(e: DragEvent, panelId: string) {
   img.style.cssText = `
     position: fixed; left: -9999px; top: -9999px;
     padding: 6px 14px; background: var(--bg-surface);
-    border: 1px solid var(--accent-dim); border-radius: var(--radius-sm);
+    border: 1px solid var(--accent); border-radius: var(--radius-sm);
     color: var(--text-primary); font-size: 12px; font-family: var(--font-ui);
     box-shadow: var(--shadow-md); white-space: nowrap; pointer-events: none;
   `

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -1891,7 +1891,7 @@ defineExpose({ focusSearch, openChangeGroupFor, openChangeGroupForGroup })
 
 .connection-item.active {
   background: var(--accent-subtle);
-  box-shadow: inset 0 0 0 1px var(--accent-dim);
+  box-shadow: inset 0 0 0 1px var(--accent);
 }
 
 .connection-item.active .name {

--- a/frontend/src/components/StartTabContent.vue
+++ b/frontend/src/components/StartTabContent.vue
@@ -1532,7 +1532,7 @@ async function doDelete(config: ConnectionConfig | null) {
 .start-card-icon.database { color: var(--warning); }
 .start-card-icon.rdp,
 .start-card-icon.vnc,
-.start-card-icon.spice { color: var(--accent-dim); }
+.start-card-icon.spice { color: var(--accent); }
 .start-card-icon.serial { color: var(--success-dim); }
 .start-card-icon.group { color: var(--text-secondary); }
 .start-card-icon.ungrouped { color: var(--text-muted); }

--- a/frontend/src/components/TabBar.vue
+++ b/frontend/src/components/TabBar.vue
@@ -309,7 +309,7 @@ function clearDragState() {
 }
 .tab-bar.drag-over {
   background: var(--accent-subtle);
-  border-bottom-color: var(--accent-dim);
+  border-bottom-color: var(--accent);
 }
 .tabs-list {
   display: flex;

--- a/frontend/src/components/TabItem.vue
+++ b/frontend/src/components/TabItem.vue
@@ -452,7 +452,7 @@ onUnmounted(() => {
 .tab-item.active {
   background: var(--bg-hover);
   color: var(--text-primary);
-  box-shadow: inset 0 0 0 1px var(--accent-dim);
+  box-shadow: inset 0 0 0 1px var(--accent);
 }
 .tab-item.ai-locked {
   box-shadow: inset 2px 0 0 var(--warning);
@@ -460,7 +460,7 @@ onUnmounted(() => {
 .tab-item.active.ai-locked {
   background: var(--bg-hover);
   color: var(--text-primary);
-  box-shadow: inset 0 0 0 1px var(--accent-dim), inset 2px 0 0 var(--warning);
+  box-shadow: inset 0 0 0 1px var(--accent), inset 2px 0 0 var(--warning);
 }
 .tab-name {
   font-size: 12px;
@@ -514,7 +514,7 @@ onUnmounted(() => {
   font-family: inherit;
   color: var(--text-primary);
   background: var(--bg-base);
-  border: 1px solid var(--accent-dim);
+  border: 1px solid var(--accent);
   border-radius: var(--radius-sm);
   padding: 2px 6px;
   width: 120px;

--- a/frontend/src/components/TunnelEditDialog.vue
+++ b/frontend/src/components/TunnelEditDialog.vue
@@ -256,7 +256,7 @@ function resetForm() {
   border-color: var(--border-default);
 }
 .mode-btn.active {
-  background: linear-gradient(135deg, var(--accent-dim), var(--accent));
+  background: linear-gradient(135deg, var(--accent), var(--accent));
   color: var(--on-accent);
   border-color: var(--accent-glow);
   box-shadow: 0 0 0 1px var(--accent-glow), 0 2px 8px var(--accent-glow);

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -15,7 +15,6 @@
 
   /* Accent - electric cyan */
   --accent: #22d3ee;
-  --accent-dim: #0891b2;
   --accent-glow: rgba(34, 211, 238, 0.15);
   --accent-subtle: rgba(34, 211, 238, 0.08);
 
@@ -69,6 +68,13 @@
   --scrollbar-thumb-hover: rgba(255, 255, 255, 0.3);
 
   /* Element Plus theme overrides */
+  /* Primary color family - align Element Plus internals (el-select focus ring,
+     el-input focus border, el-input-tag focus ring, etc.) with our --accent so
+     they follow the active theme instead of falling back to EP's default #409eff.
+     Kept in :root only; the value resolves against whatever --accent the
+     currently-applied [data-theme] defines. */
+  --el-color-primary: var(--accent);
+  --el-input-focus-border-color: var(--accent);
   --el-bg-color: #14171d;
   --el-bg-color-page: #14171d;
   --el-fill-color-blank: #1f222b;
@@ -105,7 +111,6 @@
   --text-disabled: #64708a;
 
   --accent: #38bdf8;
-  --accent-dim: #0284c7;
   --accent-glow: rgba(56, 189, 248, 0.18);
   --accent-subtle: rgba(56, 189, 248, 0.08);
 
@@ -171,7 +176,6 @@
 
   /* Accent - Windows-style blue */
   --accent: #0078d4;
-  --accent-dim: #005a9e;
   --accent-glow: rgba(0, 120, 212, 0.22);
   --accent-subtle: rgba(0, 120, 212, 0.08);
 
@@ -412,8 +416,8 @@ body::before {
 
 /* Primary - the one accent-filled action per view */
 .btn-primary {
-  background: var(--accent-dim);
-  border-color: var(--accent-dim);
+  background: var(--accent);
+  border-color: var(--accent);
   color: var(--on-accent);
 }
 .btn-primary:hover:not(:disabled) {
@@ -567,7 +571,7 @@ body::before {
 .el-input-number .el-input__wrapper.is-focus,
 .el-select .el-input.is-focus .el-input__wrapper,
 .el-textarea__inner:focus {
-  box-shadow: 0 0 0 1px var(--accent-dim) inset, 0 0 0 3px var(--accent-glow) !important;
+  box-shadow: 0 0 0 1px var(--accent) inset, 0 0 0 3px var(--accent-glow) !important;
 }
 
 /* --- tags --- */
@@ -679,15 +683,15 @@ body::before {
 }
 
 .el-radio-button__original-radio:checked + .el-radio-button__inner {
-  background-color: var(--accent-dim) !important;
-  border-color: var(--accent-dim) !important;
+  background-color: var(--accent) !important;
+  border-color: var(--accent) !important;
   color: #fff !important;
-  box-shadow: -1px 0 0 0 var(--accent-dim) !important;
+  box-shadow: -1px 0 0 0 var(--accent) !important;
 }
 
 .el-button--primary {
-  background: var(--accent-dim) !important;
-  border-color: var(--accent-dim) !important;
+  background: var(--accent) !important;
+  border-color: var(--accent) !important;
 }
 .el-button--primary:hover {
   background: var(--accent) !important;


### PR DESCRIPTION
## Summary

Application config inputs (e.g. the theme dropdown in Sidebar → Personalization) show a **fixed sky-blue focus border** instead of following the active theme. Reported in #287.

Root cause is twofold:

1. **`--accent` / `--accent-dim` split** — the palette defined two accent shades (`--accent` for foregrounds, `--accent-dim` for fills/borders). Focus rings, active tab underlines, primary-button fill, etc. used `--accent-dim`, which visually did not match what the user perceived as "the theme color" (`--accent`).
2. **Element Plus internals unpatched** — `<el-select>` and `<el-input-tag>` use their own `.el-select__wrapper.is-focused` / `.el-input-tag__wrapper.is-focus` selectors that read `--el-color-primary`. That variable was never overridden, so EP fell back to its default `#409eff` regardless of theme.

## Changes

- Removed `--accent-dim` from all three themes (`:root`, `[data-theme="deep-blue"]`, `[data-theme="light"]`) and rewrote every `var(--accent-dim)` in `style.css` and 13 Vue components to `var(--accent)`.
- Added Element Plus overrides in `:root`:
  ```css
  --el-color-primary: var(--accent);
  --el-input-focus-border-color: var(--accent);
  ```
  Only in `:root`; since `--accent` is redefined per `[data-theme]`, these cascade automatically on theme switch.

## Trade-off

`.btn-primary` / `.el-button--primary` used to have a two-tone hover stepping (`--accent-dim` → `--accent`). That gradient is now flat; only the `--accent-glow` box-shadow remains as hover feedback. Same applies to the two `linear-gradient(--accent-dim, --accent)` uses in `ConnectionForm.vue` and `TunnelEditDialog.vue`, which degenerate to a solid color.

Closes #287.

---

## 概要

应用配置项的输入框（例如侧边栏 → 个性化 → 主题下拉框）聚焦边框固定显示为天蓝色，不跟随主题。原因见 #287。

根本原因两处：

1. **`--accent` / `--accent-dim` 双变量拆分** —— 调色板原先把强调色拆成 `--accent`（前景）和 `--accent-dim`（填充/描边）。聚焦边框、激活 tab 下划线、主按钮底色等都用 `--accent-dim`，观感上和用户认为的"主题色 `--accent`"不一致。
2. **Element Plus 内部变量未被覆盖** —— `<el-select>` / `<el-input-tag>` 走的是它们自己的 `.el-select__wrapper.is-focused` / `.el-input-tag__wrapper.is-focus` 选择器，读取 `--el-color-primary`。项目里从未覆盖该变量，EP 一直用默认值 `#409eff`，因此不跟随主题。

## 改动

- 三个主题（`:root`、`[data-theme="deep-blue"]`、`[data-theme="light"]`）中删除 `--accent-dim` 定义；`style.css` 及 13 个 Vue 组件里的 `var(--accent-dim)` 全部替换为 `var(--accent)`。
- 在 `:root` 增加 Element Plus 变量覆盖：
  ```css
  --el-color-primary: var(--accent);
  --el-input-focus-border-color: var(--accent);
  ```
  只放 `:root`；由于 `--accent` 会随 `[data-theme]` 重定义，切主题时这两个 EP 变量自动级联跟随。

## 取舍

`.btn-primary` / `.el-button--primary` 原先 hover 是 `--accent-dim` → `--accent` 的两阶配色，现在两态同色，仅保留 `--accent-glow` 外发光作为反馈。`ConnectionForm.vue` 与 `TunnelEditDialog.vue` 里两处 `linear-gradient(--accent-dim, --accent)` 同样退化为纯色。

Closes #287.
