### PR TITLE
fix(linux): remove empty menubar causing white line at top (#291)

### DIFF
--- a/main.go
+++ b/main.go
@@ -52,6 +52,16 @@ func main() {
 		maxW, maxH = 9999, 9999
 	}
 
+	// Only set an (empty) app menu on macOS — this is the trick that hides
+	// Wails' default Edit/Window menus there. On Linux (GTK) a non-nil Menu
+	// makes the backend create an empty GtkMenuBar at the top of the window,
+	// which shows up as a thin white line in the Frameless window. Leaving
+	// Menu as nil elsewhere avoids that. See issue #291.
+	var appMenu *menu.Menu
+	if runtime.GOOS == "darwin" {
+		appMenu = &menu.Menu{}
+	}
+
 	err := wails.Run(&options.App{
 		Title:     "uniTerm",
 		Width:     1200,
@@ -61,7 +71,7 @@ func main() {
 		MaxWidth:  maxW,
 		MaxHeight: maxH,
 		Frameless: runtime.GOOS != "darwin",
-		Menu:      &menu.Menu{},
+		Menu:      appMenu,
 		AssetServer: &assetserver.Options{
 			Assets: assets,
 		},


### PR DESCRIPTION
## Summary

A thin white line shows at the very top of the app window on Linux (Deepin 25.1), reported in #291. Regression since 1.4.0 — 1.3.3 does not have it.

## Root cause

[main.go:64](main.go#L64) sets `Menu: &menu.Menu{}` unconditionally. It was introduced in #267 to hide the default Edit/Window menus on macOS.

Wails v2's platform backends handle the `Menu` option very differently:

- **macOS (Cocoa)** — an empty menu attaches to the system menubar at the top of the screen; it does not take room inside the window. This is the intended trick from #267.
- **Windows (WebView2)** — the Menu field is not rendered inside the window.
- **Linux (GTK)** — the backend checks `Menu != nil` (not `len(items) > 0`) and creates a `GtkMenuBar` container packed at the top of the window's vbox. An empty menubar still occupies its default height (~1px in most themes) and shows the widget background color. Under our `Frameless: true` there is no title bar hiding it, so it appears as a white line above [`AppHeader.vue`](frontend/src/components/AppHeader.vue).

Before #267 the field was never set (`nil`), the GTK backend created no menubar, and there was no white line — that matches the 1.3.3-good, 1.4.x-bad regression.

## Fix

Set the empty menu only on macOS; leave it `nil` elsewhere.

```go
var appMenu *menu.Menu
if runtime.GOOS == "darwin" {
    appMenu = &menu.Menu{}
}
// ...
Menu: appMenu,
```

## Testing

- Windows: `wails dev` starts and behaves unchanged (Windows already ignores `Menu`).
- Linux: **not verified locally** (I don't have a Linux env). Fix follows directly from Wails' GTK backend logic; welcome verification from @etanman on Deepin 25.1.
- macOS: unchanged — the empty menu is still applied there so #267's default-menu-hiding still works.

Closes #291.

---

## 概要

Linux（Deepin 25.1）窗口最顶端出现一条**白色横线**，见 #291。1.4.0 起才有的回归——1.3.3 正常。

## 根因

[main.go:64](main.go#L64) 无条件设置 `Menu: &menu.Menu{}`，这是 #267 为了隐藏 macOS 默认 Edit/Window 菜单加的。

Wails v2 各平台后端对 `Menu` 处理不同：

- **macOS（Cocoa）** —— 空菜单挂到系统顶栏，不占窗口空间。这就是 #267 想要的效果。
- **Windows（WebView2）** —— 忽略 `Menu` 字段，不在窗口内渲染。
- **Linux（GTK）** —— 后端判断 `Menu != nil`（不是 `len(items) > 0`），直接创建一个 `GtkMenuBar` 容器 pack 到窗口顶部。空菜单栏也占默认高度（大多数主题下约 1px）并露出 widget 背景色。而我们又设了 `Frameless: true` 没有原生标题栏遮住，就在 [`AppHeader.vue`](frontend/src/components/AppHeader.vue) 上方形成一条白线。

#267 之前该字段完全没写（相当于 `nil`），GTK 后端不构造 menubar，也就没有白线——正好对应 1.3.3 好、1.4.x 坏的回归特征。

## 修复

只在 macOS 设置空菜单，其他平台留 `nil`：

```go
var appMenu *menu.Menu
if runtime.GOOS == "darwin" {
    appMenu = &menu.Menu{}
}
// ...
Menu: appMenu,
```

## 验证

- Windows：`wails dev` 启动正常，行为无变化（Windows 本就忽略 `Menu`）。
- Linux：**本地未验证**（无 Linux 环境）。修复思路直接源自 Wails GTK 后端逻辑，欢迎 @etanman 在 Deepin 25.1 复测。
- macOS：不变——空菜单仍生效，#267 隐藏默认菜单的能力保留。

Closes #291.
