### PR TITLE
fix(ui): keep terminal focused after quick command / drag / scrollbar (#285)

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -167,6 +167,7 @@ import { useQuickCommandStore } from './stores/quickCommandStore'
 import { useTunnelStore } from './stores/tunnelStore'
 import { useUpdateCheck } from './composables/useUpdateCheck'
 import { loadKeybindings, installGlobalListener, uninstallGlobalListener } from './composables/useKeyboardShortcuts'
+import { focusPanelTerminal, installTerminalFocusRestore } from './composables/useFocusTerminal'
 import type { ShortcutAction } from './types/settings'
 import { useI18n } from './i18n'
 import { CreateSession, CloseSession, RDPHide, RDPShow, RDPSetPosition, RDPSetFocus, LoadLocalState, SaveLocalState, RecordRecentConnection } from '../wailsjs/go/main/App'
@@ -183,6 +184,7 @@ const sessionStore = useSessionStore()
 const aiStore = useAIStore()
 const settingsStore = useSettingsStore()
 const updateCheck = useUpdateCheck()
+let uninstallFocusRestore: (() => void) | null = null
 const { t, locale } = useI18n()
 const EL_LOCALE_MAP: Record<string, typeof enUs> = {
   'zh-CN': zhCn, 'zh-TW': zhTw, en: enUs, ja, ko, de, es, fr, ru,
@@ -562,6 +564,10 @@ onMounted(async () => {
   applyKeybindings()
   installGlobalListener()
 
+  // Restore terminal focus after window drags and sidebar scrollbar clicks
+  // (issue #285) — see composables/useFocusTerminal.ts for the policy.
+  uninstallFocusRestore = installTerminalFocusRestore()
+
   // RDP blur/focus: notify Go side so it can manage focus on the native RDP window
   window.addEventListener('blur', () => {
     const sid = getActiveRdpSessionId()
@@ -614,16 +620,6 @@ onMounted(async () => {
   }) as EventListener)
 
 })
-
-function focusPanelTerminal(panelId: string, attempt = 0) {
-  if (attempt > 10) return
-  const el = document.querySelector(`[data-panel-id="${panelId}"] .xterm-helper-textarea`)
-  if (el instanceof HTMLTextAreaElement) {
-    el.focus()
-  } else {
-    setTimeout(() => focusPanelTerminal(panelId, attempt + 1), 100)
-  }
-}
 
 function navigatePanel(dir: number) {
   const t = tabStore.activeTab
@@ -723,6 +719,7 @@ function applyKeybindings() {
 
 onUnmounted(() => {
   uninstallGlobalListener()
+  uninstallFocusRestore?.()
   window.removeEventListener('input:contextmenu', onInputContextMenu)
   window.removeEventListener('global:close-context-menus', closeInputMenu)
   document.removeEventListener('click', closeInputMenu)

--- a/frontend/src/components/HistoryPanel.vue
+++ b/frontend/src/components/HistoryPanel.vue
@@ -78,6 +78,7 @@ import { useQuickCommandStore } from '../stores/quickCommandStore'
 import { SessionWrite } from '../../wailsjs/go/main/App'
 import { useI18n } from '../i18n'
 import { msg } from '../services/message'
+import { focusActivePanelTerminal } from '../composables/useFocusTerminal'
 import QuickCommandEditDialog from './QuickCommandEditDialog.vue'
 
 const { t } = useI18n()
@@ -216,6 +217,8 @@ function runCommand(entry: HistoryEntry) {
   for (const sid of sids) {
     SessionWrite(sid, text)
   }
+  // Return focus to the terminal (issue #285).
+  focusActivePanelTerminal()
 }
 
 function pasteCommand(entry: HistoryEntry) {
@@ -224,6 +227,8 @@ function pasteCommand(entry: HistoryEntry) {
   for (const sid of sids) {
     SessionWrite(sid, entry.command)
   }
+  // Return focus to the terminal (issue #285).
+  focusActivePanelTerminal()
 }
 
 async function copyCommand(entry: HistoryEntry) {

--- a/frontend/src/components/QuickCommandsPanel.vue
+++ b/frontend/src/components/QuickCommandsPanel.vue
@@ -242,6 +242,7 @@ import { usePanelStore } from '../stores/panelStore'
 import { SessionWrite } from '../../wailsjs/go/main/App'
 import { useI18n } from '../i18n'
 import { msg } from '../services/message'
+import { focusActivePanelTerminal } from '../composables/useFocusTerminal'
 import QuickCommandEditDialog from './QuickCommandEditDialog.vue'
 
 const { t } = useI18n()
@@ -415,6 +416,10 @@ async function sendCommand(cmd: QuickCommand, mode: 'run' | 'paste') {
       if (i < lines.length - 1) await new Promise(r => setTimeout(r, 100))
     }
   }
+  // Return focus to the terminal so the user can press Enter/edit without
+  // an extra mouse click (issue #285). In broadcast mode, focus the active
+  // panel — the one the user is looking at.
+  focusActivePanelTerminal()
 }
 
 function runCommand(cmd: QuickCommand) { sendCommand(cmd, 'run') }

--- a/frontend/src/composables/useFocusTerminal.ts
+++ b/frontend/src/composables/useFocusTerminal.ts
@@ -1,0 +1,117 @@
+/**
+ * Terminal-focus helpers shared across the app.
+ *
+ * xterm.js listens for keystrokes on an internal <textarea class="xterm-helper-textarea">.
+ * To type into a terminal it must be the document's active element. Any UI action
+ * that writes to a session — quick commands, history replay, paste — should
+ * restore that focus so the user can immediately press Enter without an extra
+ * click. And chrome-only mouse gestures (dragging the frameless window, clicking
+ * the sidebar scrollbar) must not steal focus away from the terminal either.
+ *
+ * All lookups are DOM-based (via `[data-panel-id="..."]`) so we avoid the ref
+ * plumbing that would be needed to reach BaseTerminal from unrelated components.
+ */
+
+import { useTabStore } from '../stores/tabStore'
+
+/**
+ * Focus the terminal in the given panel. Retries a few times because xterm's
+ * internal textarea can be temporarily absent right after a KeepAlive
+ * re-mount or during a session reconnect.
+ */
+export function focusPanelTerminal(panelId: string, attempt = 0) {
+  if (attempt > 10) return
+  const el = document.querySelector(`[data-panel-id="${panelId}"] .xterm-helper-textarea`)
+  if (el instanceof HTMLTextAreaElement) {
+    el.focus()
+  } else {
+    setTimeout(() => focusPanelTerminal(panelId, attempt + 1), 100)
+  }
+}
+
+/** Focus the terminal in the currently active panel of the active tab. */
+export function focusActivePanelTerminal() {
+  const tabStore = useTabStore()
+  const panelId = tabStore.getActivePanelId()
+  if (panelId) focusPanelTerminal(panelId)
+}
+
+/**
+ * Install a document-level guard that restores terminal focus after mouse
+ * gestures that would otherwise steal it from xterm without the user meaning to
+ * — dragging the frameless window by the header, or dragging the sidebar
+ * scrollbar. Genuine clicks on interactive controls (buttons, inputs, links)
+ * are left alone; they change focus intentionally.
+ *
+ * Runs on `window` in the capture phase so the check fires before any
+ * component handlers, and only arms the mouseup restore when focus was on a
+ * terminal at mousedown time.
+ *
+ * Returns a teardown function.
+ */
+export function installTerminalFocusRestore(): () => void {
+  const INTERACTIVE_SEL = 'input, textarea, select, button, a, [role="button"], [contenteditable="true"], .xterm-helper-textarea'
+
+  // Walk ancestors looking for the --wails-draggable custom property so we
+  // can tell a frameless-window drag region apart from ordinary chrome. Any
+  // ancestor tagged `no-drag` short-circuits to false — same precedence Wails
+  // itself uses when deciding whether to hand the mouse to the OS.
+  const isWailsDraggable = (el: HTMLElement | null): boolean => {
+    let cur = el
+    while (cur) {
+      const val = getComputedStyle(cur).getPropertyValue('--wails-draggable').trim()
+      if (val === 'drag') return true
+      if (val === 'no-drag') return false
+      cur = cur.parentElement
+    }
+    return false
+  }
+
+  const onMouseDown = (e: MouseEvent) => {
+    const active = document.activeElement
+    const wasTerminal = active instanceof HTMLElement &&
+      active.classList.contains('xterm-helper-textarea')
+    if (!wasTerminal) return
+
+    const target = e.target as HTMLElement | null
+    // If the press lands on an interactive control the user is deliberately
+    // moving focus — do not fight it.
+    if (target && target.closest(INTERACTIVE_SEL)) return
+
+    const capturedPanelId = active.closest('[data-panel-id]')?.getAttribute('data-panel-id') || null
+
+    const restore = () => {
+      const now = document.activeElement
+      if (now instanceof HTMLElement && now.classList.contains('xterm-helper-textarea')) {
+        return // browser kept us on the terminal, nothing to do
+      }
+      if (capturedPanelId) {
+        focusPanelTerminal(capturedPanelId)
+      } else {
+        focusActivePanelTerminal()
+      }
+    }
+
+    // Frameless-window drag: as soon as mousedown fires inside a
+    // --wails-draggable: drag region, WebView2 hands the mouse to the OS and
+    // no mouseup ever reaches the DOM. Fall back to a short-delay reclaim
+    // instead of waiting on an event that will never arrive.
+    if (isWailsDraggable(target)) {
+      setTimeout(restore, 100)
+      return
+    }
+
+    // Otherwise (sidebar scrollbar, empty regions) we can wait for the real
+    // mouseup so we don't fight the browser's own focus bookkeeping mid-drag.
+    const onUp = () => {
+      window.removeEventListener('mouseup', onUp, true)
+      // Defer so the browser has finished its own focus bookkeeping for the
+      // gesture before we try to reclaim.
+      setTimeout(restore, 0)
+    }
+    window.addEventListener('mouseup', onUp, true)
+  }
+
+  window.addEventListener('mousedown', onMouseDown, true)
+  return () => window.removeEventListener('mousedown', onMouseDown, true)
+}


### PR DESCRIPTION
## Summary

Two related focus-loss annoyances from #285:

1. **Quick command / history injection didn't refocus the terminal.** The sidebar wrote to the session (`SessionWrite`) but left focus on itself, so hitting Enter did nothing until the user clicked back into the terminal.
2. **Dragging the frameless window and dragging the sidebar scrollbar stole focus** from the terminal for the same reason — mousedown moved focus to the drag region / sidebar, and nothing put it back.

## Approach

Added a small shared helper — [`composables/useFocusTerminal.ts`](frontend/src/composables/useFocusTerminal.ts) — with three exports:

- **`focusPanelTerminal(panelId)`** — DOM-based, targets `[data-panel-id="…"] .xterm-helper-textarea`. Retries a few times to survive KeepAlive re-mounts and reconnects. Replaces the private copy that lived in `App.vue`.
- **`focusActivePanelTerminal()`** — reads `tabStore.getActivePanelId()` and forwards to the one above. Used by any component that writes to the current terminal without knowing its panel id.
- **`installTerminalFocusRestore()`** — a window-level `mousedown` guard (capture phase). If focus was on a terminal when the press starts and the target is not an interactive control (`input, textarea, button, a, [role="button"], select, [contenteditable]`), it schedules a re-focus after the gesture. Genuine clicks on chrome (sidebar buttons, connection items, form fields) are left alone, so users can still move focus deliberately.

### The frameless-drag corner case

Wails' `--wails-draggable: drag` region hands the mouse to the OS on `mousedown`, so **no `mouseup` ever reaches the DOM** — waiting on it was why "drag saves focus" didn't work in the first attempt. The helper walks up the DOM looking for the `--wails-draggable` computed value; a `drag` region falls back to a short-timer reclaim (100ms) instead of a `mouseup` listener. Scrollbars and empty regions still use the real `mouseup` path since they're plain DOM interactions.

## Where the helper is called

- [`QuickCommandsPanel.sendCommand`](frontend/src/components/QuickCommandsPanel.vue) — after the writes, both run and paste modes, so the user can immediately hit Enter (run mode) or edit the pasted text (paste mode).
- [`HistoryPanel.runCommand` / `pasteCommand`](frontend/src/components/HistoryPanel.vue) — same reasoning.
- [`App.vue`](frontend/src/App.vue) — installs the focus-restore guard on mount, cleans up on unmount, and drops its private `focusPanelTerminal` in favor of the shared import.

## Testing

Manual, on Windows dev build (`wails dev`):

- ✅ Quick command "run" and "paste" → terminal is immediately focused (Enter works).
- ✅ History entry "run" and "paste" → same.
- ✅ Drag the window by the header while the terminal was focused → returns to the terminal after release.
- ✅ Drag the sidebar scrollbar while the terminal was focused → returns to the terminal after release.
- ✅ Click a sidebar button / connection item / search box → focus moves there and stays (no snap-back).

Broadcast mode: focus returns to the active panel, which is the one the user is looking at.

---

## 概要

#285 里两个相关的"焦点丢失"问题：

1. **侧栏的快捷命令 / 历史命令注入完不聚焦终端。** 侧栏写入 session 后焦点还在侧栏上，用户必须再点回终端才能回车。
2. **拖动无边框窗口、拖侧栏滚动条也会把终端的焦点抢走**，原因一样——mousedown 让焦点转到 chrome 上后再没有恢复。

## 方案

新增一个共享 helper —— [`composables/useFocusTerminal.ts`](frontend/src/composables/useFocusTerminal.ts)，三个导出：

- **`focusPanelTerminal(panelId)`** —— 基于 DOM，锁定 `[data-panel-id="…"] .xterm-helper-textarea`，带重试以应对 KeepAlive 重挂载和会话重连。取代之前只放在 `App.vue` 里的私有实现。
- **`focusActivePanelTerminal()`** —— 读 `tabStore.getActivePanelId()` 后转发。给"不知道自己是哪个 panel"的组件用。
- **`installTerminalFocusRestore()`** —— window 级 `mousedown` 捕获守卫。如果按下时焦点在终端，且目标不是交互控件（`input, textarea, button, a, [role="button"], select, [contenteditable]`），操作结束后自动回焦。用户主动点侧栏按钮、连接项、搜索框仍能正常抢焦。

### 无边框拖窗的特殊处理

Wails 的 `--wails-draggable: drag` 区域一旦 mousedown，鼠标就交给 OS，**mouseup 不会再冒泡到 DOM**——这是我第一版拖窗没生效的原因。Helper 会沿 DOM 向上查 `--wails-draggable` 的计算值：命中 `drag` 时用短延时（100ms）兜底回焦，而不是等永远不会来的 mouseup。滚动条和空白区仍走 mouseup 分支，避开与浏览器 focus 处理竞态。

## 调用点

- [`QuickCommandsPanel.sendCommand`](frontend/src/components/QuickCommandsPanel.vue) —— 写入结束后调用，run/paste 两个模式都加，用户可直接回车（run）或编辑（paste）。
- [`HistoryPanel.runCommand` / `pasteCommand`](frontend/src/components/HistoryPanel.vue) —— 同上。
- [`App.vue`](frontend/src/App.vue) —— mount 时安装守卫，unmount 时清理；顺便把自己内部的 `focusPanelTerminal` 也切换到共享 helper。

## 验证

Windows 本地 `wails dev` 手测：

- ✅ 快捷命令 run / paste → 立即聚焦终端（可直接回车）。
- ✅ 历史命令 run / paste → 同上。
- ✅ 终端聚焦状态拖动窗口 → 松手后回到终端。
- ✅ 终端聚焦状态拖侧栏滚动条 → 松手后回到终端。
- ✅ 点侧栏按钮 / 连接项 / 搜索框 → 焦点正常给它们，不被拽回终端。

广播模式下回焦的是当前 active panel，即用户正在看的那个。

Closes #285.
