### PR TITLE
fix(win): tab add button ignores clicks when swallowed by header drag (#234)

### DIFF
--- a/frontend/src/components/TabsList.vue
+++ b/frontend/src/components/TabsList.vue
@@ -342,6 +342,7 @@ function onTabDrop(e: DragEvent, targetTabId: string, index: number) {
   justify-content: center;
   transition: background 0.15s, color 0.15s;
   margin-left: 2px;
+  --wails-draggable: no-drag;
 }
 .tab-add-btn:hover {
   background: var(--bg-hover);


### PR DESCRIPTION
## Summary

The `+` button in the tab bar occasionally does nothing on Windows (Windows 11, WebView2). macOS and Linux are unaffected. Reported in #234.

## Root cause

The header opts every child into native window dragging via `--wails-draggable: drag`. On Windows, WebView2 handles that by watching the pointer between `mousedown` and `mouseup`: as soon as it moves past a small threshold, it hands the gesture to the OS as a window drag and **the pending `click` is silently dropped**. Even sub-pixel movement between press and release is enough on some setups, which is why the button responds "sometimes."

Every other clickable child in the header opts out with `--wails-draggable: no-drag;`:

- `.header-btn` — [`AppHeader.vue:295`](frontend/src/components/AppHeader.vue#L295)
- `.window-controls` — [`AppHeader.vue:325`](frontend/src/components/AppHeader.vue#L325)
- `.tab-item` — [`TabItem.vue:446`](frontend/src/components/TabItem.vue#L446)
- `.tab-more-btn` — [`TabsList.vue:310`](frontend/src/components/TabsList.vue#L310)
- `WindowControls` buttons — [`WindowControls.vue:46`](frontend/src/components/WindowControls.vue#L46)

`.tab-add-btn` was the only one missing that declaration.

## Fix

One CSS line on `.tab-add-btn`, matching the surrounding pattern.

## Testing

Windows `wails dev`: before the change, rapid successive clicks on the `+` button drop some events. After the change every click creates a new Start tab reliably.

Closes #234.

---

## 概要

Windows 11 (WebView2) 上标签栏最右侧的 `+` 按钮偶尔点击无反应；macOS 和 Linux 无此问题。见 #234。

## 根因

Header 通过 `--wails-draggable: drag` 把子元素全部纳入原生窗口拖动。Windows WebView2 在 `mousedown` 到 `mouseup` 间监视指针移动，一旦超过一个很小的阈值就把手势交给 OS 做窗口拖动，同时**丢弃待触发的 `click`**。哪怕按下抬起间只有极小的位移都会命中，所以用户看到的是"有时能点，有时不能点"。

Header 里其它可点击子元素都显式加了 `--wails-draggable: no-drag;`：

- `.header-btn` —— [`AppHeader.vue:295`](frontend/src/components/AppHeader.vue#L295)
- `.window-controls` —— [`AppHeader.vue:325`](frontend/src/components/AppHeader.vue#L325)
- `.tab-item` —— [`TabItem.vue:446`](frontend/src/components/TabItem.vue#L446)
- `.tab-more-btn` —— [`TabsList.vue:310`](frontend/src/components/TabsList.vue#L310)
- `WindowControls` 里的按钮 —— [`WindowControls.vue:46`](frontend/src/components/WindowControls.vue#L46)

`.tab-add-btn` 是唯一漏掉的。

## 修复

给 `.tab-add-btn` 补上同样的一行 CSS。

## 验证

Windows 下 `wails dev`：修复前快速反复点 `+` 按钮偶发无响应，修复后每次点击都能创建新的 Start 标签。

Closes #234.
