### PR TITLE
feat(terminal): add cursorBlink setting (default on)

### DIFF
--- a/frontend/src/components/BaseTerminal.vue
+++ b/frontend/src/components/BaseTerminal.vue
@@ -98,6 +98,7 @@ import {
   bumpOnDataGeneration,
 } from '../services/terminalManager'
 import { getXtermTheme } from '../composables/useTerminal'
+import { stripCursorBlink } from '../utils/cursor'
 import { useTerminalInput } from '../composables/useTerminalInput'
 import { useSuggestions, quickCommandCache } from '../composables/useSuggestions'
 import TerminalSuggestion from './TerminalSuggestion.vue'
@@ -1102,7 +1103,7 @@ onMounted(() => {
     }
 
     // Filter ED3 (erase scrollback).
-    let data = payload.data.replace(/\x1b\[3J/g, '')
+    let data = stripCursorBlink(payload.data, settingsStore.settings.terminal.cursorBlink ?? true).replace(/\x1b\[3J/g, '')
     // For ED2 (clear screen) in the main buffer, replace with scrolling
     // to preserve scrollback history. In alternate screen (vim, less,
     // k9s), pass through unchanged — the app manages its own screen.
@@ -1458,6 +1459,14 @@ watch(() => settingsStore.settings.terminal, (ts) => {
   if (ts.fontFamily) terminal.options.fontFamily = ts.fontFamily
   if (ts.maxHistoryLines) terminal.options.scrollback = ts.maxHistoryLines
   if (ts.theme) terminal.options.theme = getXtermTheme(ts.theme, settingsStore.settings.customTerminalThemes)
+  if (typeof ts.cursorBlink === 'boolean') {
+    terminal.options.cursorBlink = ts.cursorBlink
+    // xterm keeps an internal blink state set by DECSET 12; if the
+    // terminal previously received \x1b[?12h from a remote shell, just
+    // flipping the option may not stop the running blink animation.
+    // Force-reset by feeding the cursor a DECRST 12 sequence.
+    if (!ts.cursorBlink) terminal.write('\x1b[?12l')
+  }
   resize()
 }, { deep: true })
 

--- a/frontend/src/components/SettingsTab.vue
+++ b/frontend/src/components/SettingsTab.vue
@@ -240,6 +240,16 @@
             </div>
           </div>
 
+          <div class="setting-card">
+            <div class="setting-info">
+              <div class="setting-title">{{ t('settings.cursorBlink') }}</div>
+              <div class="setting-desc">{{ t('settings.cursorBlinkDesc') }}</div>
+            </div>
+            <div class="setting-control">
+              <el-switch :model-value="settingsStore.settings.terminal.cursorBlink ?? true" @update:model-value="(v: boolean) => { settingsStore.settings.terminal.cursorBlink = v; settingsStore.save() }" />
+            </div>
+          </div>
+
         </div>
       </div>
 

--- a/frontend/src/composables/useTerminal.ts
+++ b/frontend/src/composables/useTerminal.ts
@@ -10,6 +10,7 @@ import { EventsOn, BrowserOpenURL } from '../../wailsjs/runtime'
 import { useSettingsStore } from '../stores/settingsStore'
 import { useSessionStore } from '../stores/sessionStore'
 import { highlight } from './useHighlight'
+import { stripCursorBlink } from '../utils/cursor'
 import type { CustomTerminalTheme } from '../types/settings'
 
 export interface UseTerminalOptions {
@@ -344,11 +345,16 @@ export function useTerminal(
       fontSize: ts.fontSize || 13,
       fontFamily: ts.fontFamily || 'Consolas, "Courier New", monospace',
       theme: getXtermTheme(themeName, settingsStore.settings.customTerminalThemes),
-      cursorBlink: true,
+      cursorBlink: ts.cursorBlink ?? true,
       rightClickSelectsWord: false,
       scrollback: ts.maxHistoryLines || 2500,
       allowProposedApi: true
     }
+  }
+
+  // Wrap stripCursorBlink with current blink setting for convenience
+  function stripBlink(data: string): string {
+    return stripCursorBlink(data, settingsStore.settings.terminal.cursorBlink ?? true)
   }
 
   function resize() {
@@ -508,7 +514,7 @@ export function useTerminal(
         // Apply syntax highlighting when restoring history so it matches
         // newly arriving lines after a tab switch.
         const hlOn = settingsStore.settings.terminal.highlightEnabled ?? true
-        terminal.write(hlOn ? highlight(history) : history)
+        terminal.write(hlOn ? highlight(stripBlink(history)) : stripBlink(history))
       }
     }
 
@@ -565,7 +571,7 @@ export function useTerminal(
         // Filter ED3 (erase scrollback). For ED2 (clear screen), replace with
         // newline scrolling + home so that current viewport content is pushed
         // into scrollback before clearing, matching standard terminal behavior.
-        let data = payload.data.replace(/\x1b\[3J/g, '')
+        let data = stripBlink(payload.data).replace(/\x1b\[3J/g, '')
         if (data.includes('\x1b[2J')) {
           const rows = terminal.rows
           const scrollClear = '\n'.repeat(rows) + '\x1b[H'
@@ -643,7 +649,7 @@ export function useTerminal(
       // Restore buffered session data that arrived before bindSession
       const history = sessionStore.getData(newId)
       if (history) {
-        terminal.write(history)
+        terminal.write(stripBlink(history))
       }
       // Retry resize multiple times with longer delays to ensure backend Connect is ready
       const delays = [200, 400, 600, 800, 1000, 1500, 2000]
@@ -660,6 +666,10 @@ export function useTerminal(
     if (ts.fontFamily) terminal.options.fontFamily = ts.fontFamily
     if (ts.maxHistoryLines) terminal.options.scrollback = ts.maxHistoryLines
     if (ts.theme) terminal.options.theme = getXtermTheme(ts.theme, settingsStore.settings.customTerminalThemes)
+    if (typeof ts.cursorBlink === 'boolean') {
+      terminal.options.cursorBlink = ts.cursorBlink
+      if (!ts.cursorBlink) terminal.write('\x1b[?12l')
+    }
     resize()
   }, { deep: true })
 

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -305,6 +305,8 @@
   "settings.testFailed": "Verbindung fehlgeschlagen",
   "settings.highlight": "Texthervorhebung",
   "settings.highlightDesc": "Zeitstempel, IPs, Schlüsselwörter, Strings usw. hervorheben",
+  "settings.cursorBlink": "Cursor blinken",
+  "settings.cursorBlinkDesc": "Ob der Terminal-Cursor blinkt",
   "settings.maxTurns": "Max. autonome Runden",
   "settings.maxTurnsDesc": "Maximale Anzahl autonomer Interaktionsrunden pro KI-Anfrage. 0 = unbegrenzt. Standard: 20.",
   "settings.modelList": "Modellliste",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -313,6 +313,8 @@
   "settings.testFailed": "Connection failed",
   "settings.highlight": "Text Highlight",
   "settings.highlightDesc": "Highlight timestamps, IPs, keywords, strings, etc.",
+  "settings.cursorBlink": "Cursor Blink",
+  "settings.cursorBlinkDesc": "Whether the terminal cursor blinks",
   "settings.maxTurns": "Max Autonomous Rounds",
   "settings.maxTurnsDesc": "Maximum autonomous interaction rounds per AI request. Set to 0 for unlimited. Default 20.",
   "settings.modelList": "Model List",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -305,6 +305,8 @@
   "settings.testFailed": "Conexión fallida",
   "settings.highlight": "Resaltado de Texto",
   "settings.highlightDesc": "Resaltar marcas de tiempo, IPs, palabras clave, cadenas, etc.",
+  "settings.cursorBlink": "Parpadeo del cursor",
+  "settings.cursorBlinkDesc": "Si el cursor del terminal parpadea",
   "settings.maxTurns": "Máx. rondas autónomas",
   "settings.maxTurnsDesc": "Rondas máximas de interacción autónoma por solicitud de IA. 0 = ilimitado. Predeterminado: 20.",
   "settings.modelList": "Lista de Modelos",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -305,6 +305,8 @@
   "settings.testFailed": "Échec de la connexion",
   "settings.highlight": "Surlignage du texte",
   "settings.highlightDesc": "Surligner les horodatages, IP, mots-clés, chaînes, etc.",
+  "settings.cursorBlink": "Clignotement du curseur",
+  "settings.cursorBlinkDesc": "Indique si le curseur du terminal clignote",
   "settings.maxTurns": "Max. de tours autonomes",
   "settings.maxTurnsDesc": "Nombre maximum de tours d'interaction autonome par requête IA. 0 = illimité. Défaut : 20.",
   "settings.modelList": "Liste des modèles",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -305,6 +305,8 @@
   "settings.testFailed": "接続失敗",
   "settings.highlight": "テキストハイライト",
   "settings.highlightDesc": "タイムスタンプ、IP、キーワード、文字列などをハイライト",
+  "settings.cursorBlink": "カーソル点滅",
+  "settings.cursorBlinkDesc": "端末カーソルを点滅させるかどうか",
   "settings.maxTurns": "AI自律対話の最大ラウンド数",
   "settings.maxTurnsDesc": "AIリクエストあたりの自律的な対話ラウンドの上限。0は無制限。デフォルト：20。",
   "settings.modelList": "モデル一覧",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -305,6 +305,8 @@
   "settings.testFailed": "연결 실패",
   "settings.highlight": "텍스트 강조",
   "settings.highlightDesc": "타임스탬프, IP, 키워드, 문자열 등을 강조 표시",
+  "settings.cursorBlink": "커서 깜박임",
+  "settings.cursorBlinkDesc": "터미널 커서를 깜박일지 여부",
   "settings.maxTurns": "AI 자율 상호작용 최대 라운드",
   "settings.maxTurnsDesc": "AI 요청당 자율 상호작용 라운드의 최대 횟수. 0은 무제한. 기본값: 20.",
   "settings.modelList": "모델 목록",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -305,6 +305,8 @@
   "settings.testFailed": "Соединение не удалось",
   "settings.highlight": "Подсветка текста",
   "settings.highlightDesc": "Выделять метки времени, IP, ключевые слова, строки и т.д.",
+  "settings.cursorBlink": "Мигание курсора",
+  "settings.cursorBlinkDesc": "Должен ли мигать курсор терминала",
   "settings.maxTurns": "Макс. автономных раундов",
   "settings.maxTurnsDesc": "Максимальное количество автономных раундов взаимодействия на один запрос ИИ. 0 — без ограничений. По умолчанию: 20.",
   "settings.modelList": "Список моделей",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -312,6 +312,8 @@
   "settings.testFailed": "连接失败",
   "settings.highlight": "文本高亮",
   "settings.highlightDesc": "自动高亮时间、IP、关键词、字符串等模式",
+  "settings.cursorBlink": "光标闪烁",
+  "settings.cursorBlinkDesc": "是否启用终端光标闪烁",
   "settings.maxTurns": "AI 自主交互最大轮次",
   "settings.maxTurnsDesc": "AI 自主执行命令与反馈的对话轮数上限。设为 0 表示不限制。默认 20。",
   "settings.modelList": "模型列表",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -305,6 +305,8 @@
   "settings.testFailed": "連線失敗",
   "settings.highlight": "文字高亮",
   "settings.highlightDesc": "自動高亮時間、IP、關鍵詞、字串等模式",
+  "settings.cursorBlink": "游標閃爍",
+  "settings.cursorBlinkDesc": "是否啟用終端游標閃爍",
   "settings.maxTurns": "AI 自主互動最大輪次",
   "settings.maxTurnsDesc": "AI 自主執行命令與回饋的對話輪數上限。設為 0 表示不限制。預設 20。",
   "settings.modelList": "模型列表",

--- a/frontend/src/services/terminalManager.ts
+++ b/frontend/src/services/terminalManager.ts
@@ -3,6 +3,7 @@ import { FitAddon } from '@xterm/addon-fit'
 import { Unicode11Addon } from '@xterm/addon-unicode11'
 import { SearchAddon } from '@xterm/addon-search'
 import { getXtermTheme } from '../composables/useTerminal'
+import { useSettingsStore } from '../stores/settingsStore'
 import type { CustomTerminalTheme } from '../types/settings'
 import { formatFontFamily } from '../utils/formatFontFamily'
 
@@ -64,11 +65,12 @@ export function acquireTerminal(
     }
     managed.isNew = false
   } else {
+    const cursorBlink = useSettingsStore().settings.terminal.cursorBlink ?? true
     const terminal = new Terminal({
       fontSize: options.fontSize ?? 13,
       fontFamily: formatFontFamily(options.fontFamily ?? 'Consolas, "Courier New", monospace'),
       theme: getXtermTheme(options.themeName ?? 'dark', customThemes),
-      cursorBlink: true,
+      cursorBlink,
       rightClickSelectsWord: false,
       scrollback: options.scrollback ?? 2500,
       allowProposedApi: true,

--- a/frontend/src/types/settings.ts
+++ b/frontend/src/types/settings.ts
@@ -51,6 +51,7 @@ export interface TerminalSettings {
   maxHistoryLines: number
   smartCompletion: boolean
   highlightEnabled: boolean
+  cursorBlink: boolean
 }
 
 export interface AIModelConfig {
@@ -161,7 +162,8 @@ export const DEFAULT_SETTINGS: AppSettings = {
     middleClickAction: 'paste',
     maxHistoryLines: 2500,
     smartCompletion: true,
-    highlightEnabled: true
+    highlightEnabled: true,
+    cursorBlink: true
   },
   ai: {
     maxTurns: 20,

--- a/frontend/src/utils/cursor.ts
+++ b/frontend/src/utils/cursor.ts
@@ -1,0 +1,12 @@
+// Strip DEC private mode 12 (cursor blink) from a CSI ? ... h/l sequence
+// when the user has disabled blink. The remote SSH shell sends these to
+// re-enable blinking at runtime, overriding our cursorBlink option.
+// Also accepts and filters intermediate characters (e.g. \x1b[?12;25h → \x1b[?25h).
+export function stripCursorBlink(data: string, enabled: boolean): string {
+  if (enabled) return data
+  return data.replace(/\x1b\[\?(\d+(?:;\d+)*)([hl])/g, (_m, params, suffix) => {
+    const list = (params as string).split(';').filter(p => p !== '12')
+    if (list.length === 0) return ''
+    return `\x1b[?${list.join(';')}${suffix}`
+  })
+}


### PR DESCRIPTION
## Summary

Add a terminal cursor blink toggle in settings (default on). The xterm.js `cursorBlink` option only controls the initial state — remote SSH shells send `\x1b[?12h` (DEC private mode 12) at runtime to re-enable blinking, overriding the option. When the user disables blink we now:

- Strip `\x1b[?12h/l` from incoming data on the shared terminal manager (BaseTerminal + useTerminal), also removing `12` from combined sequences like `\x1b[?12;25h`.
- Feed `\x1b[?12l` to the running terminal on toggle-to-off so xterm's internal blink state resets.

---

## 变更摘要

新增终端光标闪烁开关（默认开启）。xterm.js 的 `cursorBlink` 选项仅控制初始状态，远程 SSH shell 在运行时会发送 `\x1b[?12h`（DEC 私有模式 12）重新启用闪烁，覆盖该选项。当用户关闭闪烁时：

- 剥除传入数据中的 `\x1b[?12h/l`（共享 manager + BaseTerminal + useTerminal），合并形式 `\x1b[?12;25h` 中的 `12` 一并移除
- 用户从开启切到关闭时主动喂一条 `\x1b[?12l` 给终端，重置 xterm 内部闪烁状态

## 验证
本地 wails dev测试可以正常开启关闭