### PR TITLE
fix(ui): let el-select dropdowns open when a terminal is focused

### DIFF
--- a/frontend/src/composables/useFocusTerminal.ts
+++ b/frontend/src/composables/useFocusTerminal.ts
@@ -50,7 +50,11 @@ export function focusActivePanelTerminal() {
  * Returns a teardown function.
  */
 export function installTerminalFocusRestore(): () => void {
-  const INTERACTIVE_SEL = 'input, textarea, select, button, a, [role="button"], [contenteditable="true"], .xterm-helper-textarea'
+  // Element Plus renders its select/dropdown trigger as a plain <div>
+  // (.el-select__wrapper) and teleports the option list to <body> as
+  // .el-popper — neither is a native control, so list them explicitly or the
+  // focus guard steals focus back to the terminal and the dropdown never opens.
+  const INTERACTIVE_SEL = 'input, textarea, select, button, a, [role="button"], [role="combobox"], [contenteditable="true"], .xterm-helper-textarea, .el-select__wrapper, .el-input__wrapper, .el-popper'
 
   // Walk ancestors looking for the --wails-draggable custom property so we
   // can tell a frameless-window drag region apart from ordinary chrome. Any


### PR DESCRIPTION
## 摘要
- 修复：终端聚焦后，侧边栏「个性化」里的下拉（主题 / 语言 / 配色 / 字体）第二次点击打不开，只把终端重新聚焦。
- 根因：终端焦点守卫（#304，`useFocusTerminal.ts`）把「未落在已知交互控件上的 mousedown」当成会抢焦点的手势并强行把焦点拉回终端。而 Element Plus 的下拉触发器是普通 `<div class="el-select__wrapper">`，选项列表又 teleport 到 `<body>` 成为 `.el-popper`，两者都不在守卫的白名单里。于是终端聚焦后再点下拉，焦点被拽回终端，下拉当场失焦、无法展开。
- 修复：把 `.el-select__wrapper`、`.el-input__wrapper`、`[role="combobox"]`、`.el-popper` 加入交互白名单。



## 验证
- `npm run build`
- `wails dev` 实测：连接终端并点击终端聚焦后，反复点击侧边栏个性化下拉，均可正常展开并选择。

---

## Summary
- Fix: after a terminal is focused, the sidebar Personalization dropdowns (theme / language / color scheme / font) fail to open on the second click — focus is just yanked back to the terminal.
- Root cause: the terminal focus-restore guard (#304, `useFocusTerminal.ts`) treats any mousedown that does not land on a known interactive control as a focus-stealing gesture and pulls focus back to the terminal. Element Plus renders its select trigger as a plain `<div class="el-select__wrapper">` and teleports the option list to `<body>` as `.el-popper`, neither of which matched the whitelist. So once the terminal had focus, clicking a dropdown had focus reclaimed and the dropdown never opened.
- Fix: add `.el-select__wrapper`, `.el-input__wrapper`, `[role="combobox"]` and `.el-popper` to the interactive whitelist.

## Validation
- `npm run build`
- `wails dev`: with a connected, focused terminal, sidebar Personalization dropdowns now open and select reliably on repeated clicks.
