### PR TITLE
fix(shortcut): default openSettings to Ctrl+, so Windows/Linux work

### DIFF
--- a/backend/store/settings_store.go
+++ b/backend/store/settings_store.go
@@ -244,6 +244,6 @@ func defaultKeyboard() map[string]KeyBinding {
 		"closePanel":       {Ctrl: true, Shift: true, Alt: false, Key: "q"},
 		"navigatePrev":     {Ctrl: false, Shift: false, Alt: true, Key: "arrowleft"},
 		"navigateNext":     {Ctrl: false, Shift: false, Alt: true, Key: "arrowright"},
-		"openSettings":     {Ctrl: false, Meta: true, Shift: false, Alt: false, Key: ","},
+		"openSettings":     {Ctrl: true, Shift: false, Alt: false, Key: ","},
 	}
 }

--- a/frontend/src/types/settings.ts
+++ b/frontend/src/types/settings.ts
@@ -128,7 +128,7 @@ export const DEFAULT_KEYBOARD: KeyboardSettings = {
   lockAI: { ctrl: true, shift: true, alt: false, key: 'l' },
   duplicateSession: { ctrl: true, shift: true, alt: false, key: 'd' },
   terminalSearch: { ctrl: true, shift: false, alt: false, key: 'f' },
-  openSettings: { ctrl: false, meta: true, shift: false, alt: false, key: ',' },
+  openSettings: { ctrl: true, shift: false, alt: false, key: ',' },
 }
 
 export interface SFTPBookmarks {


### PR DESCRIPTION
## 摘要
- 修复 `openSettings` 快捷键默认值：由 `Cmd+,`（meta-only）改为 `Ctrl+,`。
- 背景：#271 把默认设成 `meta: true`，导致 Windows/Linux 上没有可用的 `Ctrl+,`（只能按 Win/Meta 键 +,，且常被系统占用）。
- 改回 `ctrl: true` 后：Windows/Linux 走 `Ctrl+,`，macOS 靠既有的 `ctrl → meta` 别名（`useKeyboardShortcuts.ts`）用 `Cmd+,` 触发，两端都可用。
- 仅改前后端两处默认值，不动 meta 建模等其它逻辑。

Closes #270

## 验证
- `npm run build`
- `go build ./...` / `go test ./backend/store`

---

## Summary
- Fix the `openSettings` default binding: change it from `Cmd+,` (meta-only) to `Ctrl+,`.
- Background: #271 defaulted it to `meta: true`, which left Windows/Linux without a working `Ctrl+,` (only Win/Meta key +, worked, and that is often taken by the OS).
- With `ctrl: true`, Windows/Linux use `Ctrl+,` while macOS still triggers via `Cmd+,` through the existing `ctrl → meta` alias in `useKeyboardShortcuts.ts` — both platforms work.
- Only the two default-value sites (frontend + backend) change; the meta modeling and other logic are untouched.

Closes #270

## Validation
- `npm run build`
- `go build ./...` / `go test ./backend/store`
