### PR TITLE
style(tab): min width, hover-only close/more/ai-lock, dedup local terminal names

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1029,8 +1029,8 @@ async function createLocalTerminal(shellPath?: string, keepOpen?: boolean) {
     // Create tab AFTER session is bound so BaseTerminal mounts with valid sessionId
     const prev = tabStore.activeTab
     const tab = prev?.type === 'start' && !keepOpen
-      ? tabStore.replaceStartTab(prev.id, shellName, panel.id)
-      : tabStore.createTerminalTab(shellName, panel.id)
+      ? tabStore.replaceStartTab(prev.id, panel.title, panel.id)
+      : tabStore.createTerminalTab(panel.title, panel.id)
     panelStore.movePanelToTab(panel.id, tab.id)
   } catch (e) {
     console.error('Failed to create local terminal:', e)

--- a/frontend/src/components/TabItem.vue
+++ b/frontend/src/components/TabItem.vue
@@ -11,7 +11,7 @@
     @contextmenu="onContextMenu"
   >
     <button
-      v-if="(isActive || hovered) && !tab.locked"
+      v-if="hovered && !tab.locked"
       class="tab-close"
       @click.stop="$emit('close', tab.id)"
     ><X /></button>
@@ -30,20 +30,6 @@
       />
       <span v-else-if="!isActive && hasNotification && !tab.locked" class="tab-notification-dot" />
     </span>
-    <span v-if="!editing" class="tab-name" :class="{ 'tab-disconnected': isDisconnected }" @dblclick.stop="startEdit">
-      <ArrowDownUp v-if="hasActiveTransfers" class="transfer-indicator" :size="14" title="Transferring..." />
-      {{ tab.name }}
-    </span> 
-    <input
-      v-else
-      ref="editInputRef"
-      v-model="editName"
-      class="tab-name-input"
-      @keydown.enter="confirmEdit"
-      @keydown.escape="cancelEdit"
-      @blur="confirmEdit"
-      @click.stop
-    />
     <button
       v-if="tab.type === 'terminal'"
       class="tab-ai-lock"
@@ -60,6 +46,27 @@
     >
       <Sparkles :size="14" />
     </span>
+    <span v-if="!editing" class="tab-name" :class="{ 'tab-disconnected': isDisconnected }" @dblclick.stop="startEdit">
+      <ArrowDownUp v-if="hasActiveTransfers" class="transfer-indicator" :size="14" title="Transferring..." />
+      {{ tab.name }}
+    </span>
+    <input
+      v-else
+      ref="editInputRef"
+      v-model="editName"
+      class="tab-name-input"
+      @keydown.enter="confirmEdit"
+      @keydown.escape="cancelEdit"
+      @blur="confirmEdit"
+      @click.stop
+    />
+    <button
+      class="tab-more"
+      @click.stop="onMoreClick"
+      :title="t('terminal.more')"
+    >
+      <MoreHorizontal :size="14" />
+    </button>
 
     <Teleport to="body">
       <div
@@ -110,7 +117,7 @@ import {
 } from '../../wailsjs/go/main/App'
 import { msg } from '../services/message'
 import type { TerminalTab, SettingsTab, SFTPTab, RDPTab, VNCTab, SPICETab, DBTab, MonitorTab, WorkspaceTab } from '../types/workspace'
-import { SquareTerminal, Laptop, FolderUp, HardDrive, Cloud, Globe, Monitor, MonitorCloud, MonitorSmartphone, Settings, Sparkles, Database, DatabaseZap, Layers, Activity, Terminal, Zap, X, ArrowDownUp, LayoutDashboard, Cable, SquarePlus, Lock } from '@lucide/vue'
+import { SquareTerminal, Laptop, FolderUp, HardDrive, Cloud, Globe, Monitor, MonitorCloud, MonitorSmartphone, Settings, Sparkles, Database, DatabaseZap, Layers, Activity, Terminal, Zap, X, ArrowDownUp, LayoutDashboard, Cable, SquarePlus, Lock, MoreHorizontal } from '@lucide/vue'
 
 const props = defineProps<{
   tab: TerminalTab | SettingsTab | SFTPTab | RDPTab | VNCTab | SPICETab | DBTab | MonitorTab | WorkspaceTab
@@ -235,6 +242,18 @@ function onContextMenu(e: MouseEvent) {
   e.stopPropagation()
   window.dispatchEvent(new CustomEvent('global:close-context-menus'))
   contextMenuStyle.value = { left: e.clientX + 'px', top: e.clientY + 'px' }
+  contextMenuVisible.value = true
+  if (supportsOutputLog.value) {
+    refreshOutputLogState()
+  }
+}
+
+function onMoreClick(e: MouseEvent) {
+  e.stopPropagation()
+  const btn = e.currentTarget as HTMLElement
+  const rect = btn.getBoundingClientRect()
+  window.dispatchEvent(new CustomEvent('global:close-context-menus'))
+  contextMenuStyle.value = { left: rect.left + 'px', top: rect.bottom + 4 + 'px' }
   contextMenuVisible.value = true
   if (supportsOutputLog.value) {
     refreshOutputLogState()
@@ -429,6 +448,7 @@ onUnmounted(() => {
   align-items: center;
   gap: 2px;
   height: 28px;
+  min-width: 120px;
   padding: 0 12px;
   margin: 0 1px;
   cursor: pointer;
@@ -437,7 +457,7 @@ onUnmounted(() => {
   position: relative;
   color: var(--text-secondary);
   font-size: 12px;
-  transition: all 0.15s ease;
+  transition: background 0.15s ease, color 0.15s ease;
   flex-shrink: 0;
   --wails-draggable: no-drag;
 }
@@ -528,7 +548,11 @@ onUnmounted(() => {
   outline: none;
 }
 .tab-ai-lock {
-  background: none;
+  position: absolute;
+  left: 30px;
+  top: 50%;
+  transform: translateY(-50%);
+  background: var(--bg-hover);
   border: none;
   color: var(--text-muted);
   cursor: pointer;
@@ -536,18 +560,26 @@ onUnmounted(() => {
   height: 18px;
   padding: 0;
   border-radius: 3px;
-  display: inline-flex;
+  display: none;
   align-items: center;
   justify-content: center;
+  flex-shrink: 0;
 }
-.tab-ai-lock .ai-lock-icon {
-  display: block;
+.tab-item:hover .tab-ai-lock {
+  display: inline-flex;
+}
+.tab-ai-lock.locked {
+  position: static;
+  transform: none;
+  display: inline-flex;
+  background: transparent;
+  color: var(--warning);
+  margin-right: 2px;
 }
 .tab-ai-lock:hover {
   color: var(--text-primary);
-  background: var(--bg-hover);
 }
-.tab-ai-lock.locked {
+.tab-ai-lock.locked:hover {
   color: var(--warning);
 }
 .tab-close {
@@ -568,6 +600,30 @@ onUnmounted(() => {
 }
 .tab-close:hover {
   background: var(--bg-hover);
+  color: var(--text-primary);
+}
+.tab-more {
+  position: absolute;
+  right: 6px;
+  top: 50%;
+  transform: translateY(-50%);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  background: var(--bg-hover);
+  border: none;
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
+  cursor: pointer;
+  flex-shrink: 0;
+}
+.tab-item:hover .tab-more {
+  display: inline-flex;
+}
+.tab-more:hover {
   color: var(--text-primary);
 }
 </style>


### PR DESCRIPTION
## Summary

Tab bar UX polish.

- **Min width**: give each tab a `min-width: 120px` so short labels ("Local", "Settings") no longer collapse to a tiny width.
- **Close button on active tab**: previously the active tab always replaced its type icon with a close button. Now the active tab behaves like inactive tabs — the icon is only replaced by the close button on hover.
- **More (`...`) button**: appears on hover at the far right of a tab. Clicking it opens the same context menu as right-click, positioned just under the button. Uses `position: absolute` so it doesn't affect tab width — no layout jitter.
- **AI lock button**:
  - Not locked: hidden by default; on hover it floats next to the icon as an overlay (over the tab name).
  - Locked: stays inline right after the icon (occupies space, pushes the tab name right, tab widens) — acts as a persistent status indicator, click again to unlock.
- **Local terminal tab names**: `App.vue` was passing the raw shell name (e.g. `Local Windows`) to `createTerminalTab`, bypassing the existing `makeTitleUnique` dedup in `panelStore`. All other connection types use `panel.title` (already deduped). Fixed by using `panel.title` here too, so repeated local terminals become `Local Windows`, `Local Windows (2)`, `Local Windows (3)`, matching the behavior of SSH / SFTP / Serial / etc.

---

## 概要

标签栏交互优化。

- **最小宽度**：给每个标签设置 `min-width: 120px`，短名称的标签（如"Local"、"设置"）不再被挤成极窄的一小块。
- **激活标签的关闭按钮**：之前激活标签的类型图标默认就被关闭按钮替代，与非激活标签行为不一致。现在统一为：只有 hover 时才用关闭按钮替换图标。
- **更多（`...`）按钮**：hover 时在标签最右侧出现，点击后弹出的菜单和右键菜单一致，位置在按钮正下方。使用 `position: absolute`，不影响标签宽度，不会导致抖动。
- **AI 锁定按钮**：
  - 未锁定：默认隐藏；hover 时以浮层形式出现在图标右侧，遮住文本，不改变布局。
  - 已锁定：常驻显示在图标右侧（占位、把文本推到右边、标签自然变宽），作为状态提示；再次点击可解锁。
- **本地终端标签重名**：`App.vue` 中本地终端创建 tab 时直接使用 shell 名称，绕过了 `panelStore` 里的 `makeTitleUnique` 去重逻辑。其他所有连接类型（SSH / SFTP / Serial 等）都用 `panel.title`（已去重）。改为使用 `panel.title` 后，多次打开本地终端会得到 `Local Windows`、`Local Windows (2)`、`Local Windows (3)`，行为与其他连接一致。