### PR TITLE
fix(ai): hide current-terminal tag on settings tab

### DIFF
--- a/frontend/src/components/AISidebar.vue
+++ b/frontend/src/components/AISidebar.vue
@@ -445,14 +445,19 @@ const lockedPanels = computed(() => [...tabStore.aiLockedPanelIds])
 
 const currentIsTerminal = computed(() => {
   const tab = tabStore.activeTab
-  return tab?.type === 'terminal' || tab?.type === 'settings'
+  if (tab?.type === 'terminal') return true
+  if (tab?.type === 'workspace') {
+    const pid = (tab as any).activePanelId
+    return !!(pid && panelStore.getPanel(pid))
+  }
+  return false
 })
 
 const currentTerminalLabel = computed(() => {
   const tab = tabStore.activeTab
   if (!tab) return t('ai.currentTerminal')
   let panelId: string | undefined
-  if (tab.type === 'terminal' || tab.type === 'settings') {
+  if (tab.type === 'terminal') {
     panelId = (tab as any).panelId
   } else if (tab.type === 'workspace') {
     panelId = (tab as any).activePanelId


### PR DESCRIPTION
## Summary
The "current terminal" chip above the AI input was also showing on the Settings tab as `Current terminal: Settings`. That chip is meant only for terminal-type tabs.

`currentIsTerminal` treated `tab.type === 'settings'` as a terminal, and `currentTerminalLabel` then read the settings tab's `panelId` to produce the label.

## Changes
- `AISidebar.vue`: drop the `settings` branch in both `currentIsTerminal` and `currentTerminalLabel`. For `workspace` tabs, only show the chip when an active panel actually exists.

## Verification
- `npm --prefix frontend run build` passes.

---

## 摘要
AI 输入框上方的「当前终端」标签在打开设置页时也会出现，显示为「当前终端: 设置」。这个标签应仅在终端类标签上出现。

之前 `currentIsTerminal` 把 `settings` 也当作终端，`currentTerminalLabel` 又读取了设置标签的 `panelId`，导致误显示。

## 修改
- `AISidebar.vue`：`currentIsTerminal` 与 `currentTerminalLabel` 都去掉 `settings` 分支；`workspace` 标签仅在存在活动 panel 时才显示。

## 验证
- 前端构建通过。
