### PR TITLE
feat(broadcast): per-panel selection with Ctrl+Click

### DIFF
--- a/frontend/src/components/BaseTerminal.vue
+++ b/frontend/src/components/BaseTerminal.vue
@@ -417,14 +417,12 @@ async function applySuggestion(item: ReturnType<typeof suggestions.getSelectedIt
     // replacement is exactly the currentToken; for multi-token input (e.g.
     // "git che" → "git checkout") backspaces leave the earlier text behind.
     if (props.broadcastActive && props.workspaceId) {
-      const tab = tabStore.tabs.find(t => t.id === props.workspaceId)
-      if (tab && tab.type === 'workspace') {
-        for (const pid of tab.panelIds) {
-          const p = panelStore.getPanel(pid)
-          if (p?.sessionId && (p.type === 'ssh' || p.type === 'local')) {
-            SessionWrite(p.sessionId, '\x15')
-            SessionWrite(p.sessionId, item.value)
-          }
+      const targets = tabStore.getBroadcastPanelIdsInWorkspace(props.workspaceId)
+      for (const pid of targets) {
+        const p = panelStore.getPanel(pid)
+        if (p?.sessionId && (p.type === 'ssh' || p.type === 'local')) {
+          SessionWrite(p.sessionId, '\x15')
+          SessionWrite(p.sessionId, item.value)
         }
       }
     } else if (sid) {
@@ -609,9 +607,9 @@ function writeTerminalInput(data: string, inAlternateScreen: boolean) {
   if (!sid || !filtered) return
 
   if (props.broadcastActive && props.workspaceId) {
-    const tab = tabStore.tabs.find(t => t.id === props.workspaceId)
-    if (tab && tab.type === 'workspace') {
-      for (const pid of tab.panelIds) {
+    const targets = tabStore.getBroadcastPanelIdsInWorkspace(props.workspaceId)
+    if (targets.length > 0) {
+      for (const pid of targets) {
         const p = panelStore.getPanel(pid)
         if (p?.sessionId && (p.type === 'ssh' || p.type === 'local')) {
           SessionWrite(p.sessionId, filtered)
@@ -1560,10 +1558,10 @@ const menu = useTerminalMenu({
   onPaste: async (text) => {
     if (props.mode === 'ssh' || props.mode === 'local') {
       if (props.broadcastActive && props.workspaceId) {
-        const tab = tabStore.tabs.find(t => t.id === props.workspaceId)
-        if (tab && tab.type === 'workspace') {
+        const targets = tabStore.getBroadcastPanelIdsInWorkspace(props.workspaceId)
+        if (targets.length > 0) {
           const filtered = filterTerminalInput(text, false)
-          for (const pid of tab.panelIds) {
+          for (const pid of targets) {
             const p = panelStore.getPanel(pid)
             if (p?.sessionId && (p.type === 'ssh' || p.type === 'local')) {
               // Bracket per target session — each has its own paste mode.
@@ -1571,6 +1569,8 @@ const menu = useTerminalMenu({
               SessionWrite(p.sessionId, wrap ? '\x1b[200~' + filtered + '\x1b[201~' : filtered)
             }
           }
+        } else {
+          await pasteToSession(text)
         }
       } else {
         await pasteToSession(text)

--- a/frontend/src/components/HistoryPanel.vue
+++ b/frontend/src/components/HistoryPanel.vue
@@ -195,7 +195,7 @@ function getTargetSessionIds(): string[] {
   if (!tab) return []
   if (tab.type === 'workspace' && tabStore.isBroadcasting(tab.id)) {
     const ids: string[] = []
-    for (const pid of tab.panelIds) {
+    for (const pid of tabStore.getBroadcastPanelIdsInWorkspace(tab.id)) {
       const p = panelStore.getPanel(pid)
       if (p?.sessionId && (p.type === 'ssh' || p.type === 'local')) {
         ids.push(p.sessionId)

--- a/frontend/src/components/Panel.vue
+++ b/frontend/src/components/Panel.vue
@@ -22,9 +22,9 @@
         <button
           v-if="(panel.type === 'ssh' || panel.type === 'local') && workspaceId"
           class="panel-broadcast"
-          :class="{ active: broadcastActive }"
-          @click.stop="tabStore.toggleBroadcast(workspaceId)"
-          :title="t('terminal.broadcastInput')"
+          :class="{ active: panelBroadcastActive }"
+          @click.stop="onBroadcastClick"
+          :title="broadcastTitle"
         >
           <Radio :size="14" />
         </button>
@@ -62,7 +62,7 @@
       :mode="panel.type === 'local' ? 'local' : 'ssh'"
       :session-id="panel.sessionId"
       :on-session-status="onSessionStatus"
-      :broadcast-active="broadcastActive"
+      :broadcast-active="panelBroadcastActive"
       :workspace-id="workspaceId"
       :panel-id="panel.id"
     />
@@ -98,7 +98,6 @@ const props = defineProps<{
   panel: Panel
   showHeader: boolean
   isActive: boolean
-  broadcastActive?: boolean
   workspaceId?: string
 }>()
 
@@ -122,6 +121,23 @@ const showCredentialDialog = inject<(title: string, subtitle: string, fields: ('
 const isAILocked = computed(() =>
   tabStore.isPanelAILocked(props.panel.id)
 )
+
+const panelBroadcastActive = computed(() =>
+  tabStore.isPanelBroadcasting(props.panel.id)
+)
+
+const broadcastTitle = computed(() =>
+  `${t('terminal.broadcastInput')}\n${t('terminal.broadcastCtrlHint')}`
+)
+
+function onBroadcastClick(e: MouseEvent) {
+  if (!props.workspaceId) return
+  if (e.ctrlKey || e.metaKey) {
+    tabStore.toggleBroadcastPanel(props.panel.id)
+  } else {
+    tabStore.toggleBroadcast(props.workspaceId)
+  }
+}
 
 const baseTerminalRef = ref<InstanceType<typeof BaseTerminal> | null>(null)
 

--- a/frontend/src/components/PanelGrid.vue
+++ b/frontend/src/components/PanelGrid.vue
@@ -5,7 +5,6 @@
       :panel-ids="panelIds"
       :active-panel-id="activePanelId"
       :tab-id="tabId"
-      :broadcast-active="broadcastActive"
       @close-panel="$emit('closePanel', $event)"
       @toggle-ai-lock="$emit('toggleAiLock', $event)"
       @duplicate="$emit('duplicate', $event)"
@@ -26,7 +25,6 @@ defineProps<{
   panelIds: string[]
   activePanelId: string | null
   tabId: string
-  broadcastActive: boolean
 }>()
 
 defineEmits<{

--- a/frontend/src/components/QuickCommandsPanel.vue
+++ b/frontend/src/components/QuickCommandsPanel.vue
@@ -380,10 +380,10 @@ function getTargetSessionIds(): string[] {
   const tab = tabStore.tabs.find(t => t.id === activeTabId)
   if (!tab) return []
 
-  // Broadcast mode: send to all SSH/local panels in the workspace
+  // Broadcast mode: send to broadcasting SSH/local panels in the workspace
   if (tab.type === 'workspace' && tabStore.isBroadcasting(tab.id)) {
     const ids: string[] = []
-    for (const pid of tab.panelIds) {
+    for (const pid of tabStore.getBroadcastPanelIdsInWorkspace(tab.id)) {
       const p = panelStore.getPanel(pid)
       if (p?.sessionId && (p.type === 'ssh' || p.type === 'local')) {
         ids.push(p.sessionId)

--- a/frontend/src/components/RenderNode.vue
+++ b/frontend/src/components/RenderNode.vue
@@ -13,7 +13,6 @@
         :panel="panel"
         :show-header="isMultiPanel"
         :is-active="activePanelId === panel.id"
-        :broadcast-active="broadcastActive"
         :workspace-id="tabId"
         :key="`${panel.id}-${tabId}`"
         @close="handleClosePanel(panel.id)"
@@ -38,7 +37,6 @@
         :panel-ids="panelIds"
         :active-panel-id="activePanelId"
         :tab-id="tabId"
-        :broadcast-active="broadcastActive"
         @close-panel="(id) => $emit('closePanel', id)"
         @toggle-ai-lock="(id) => $emit('toggleAiLock', id)"
         @duplicate="(id) => $emit('duplicate', id)"
@@ -70,7 +68,6 @@ const props = defineProps<{
   panelIds: string[]
   activePanelId: string | null
   tabId: string
-  broadcastActive: boolean
 }>()
 
 const emit = defineEmits<{

--- a/frontend/src/components/WorkspaceContent.vue
+++ b/frontend/src/components/WorkspaceContent.vue
@@ -8,7 +8,6 @@
       :panel-ids="tab.panelIds"
       :active-panel-id="tab.activePanelId"
       :tab-id="tab.id"
-      :broadcast-active="tabStore.isBroadcasting(tab.id)"
       @close-panel="closePanel"
       @toggle-ai-lock="onToggleAiLock"
       @duplicate="onDuplicatePanel"

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -107,6 +107,7 @@
   "terminal.aiLockedToPanel": "KI an dieses Panel gebunden",
   "terminal.lockAIToPanel": "KI an dieses Panel binden",
   "terminal.broadcastInput": "Eingabe an alle Panels senden",
+  "terminal.broadcastCtrlHint": "Strg+Klick: nur dieses Terminal umschalten",
   "terminal.searchPlaceholder": "Suchen...",
   "terminal.searchPrev": "Vorheriges",
   "terminal.searchNext": "Nächstes",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -110,6 +110,7 @@
   "terminal.aiLockedToPanel": "AI locked to this panel",
   "terminal.lockAIToPanel": "Lock AI to this panel",
   "terminal.broadcastInput": "Broadcast input to all panels",
+  "terminal.broadcastCtrlHint": "Ctrl+Click: toggle this terminal only",
   "terminal.searchPlaceholder": "Search...",
   "terminal.searchPrev": "Previous",
   "terminal.searchNext": "Next",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -107,6 +107,7 @@
   "terminal.aiLockedToPanel": "IA bloqueada en este panel",
   "terminal.lockAIToPanel": "Bloquear IA en este panel",
   "terminal.broadcastInput": "Difundir entrada a todos los paneles",
+  "terminal.broadcastCtrlHint": "Ctrl+Clic: alternar solo esta terminal",
   "terminal.searchPlaceholder": "Buscar...",
   "terminal.searchPrev": "Anterior",
   "terminal.searchNext": "Siguiente",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -107,6 +107,7 @@
   "terminal.aiLockedToPanel": "IA verrouillée sur ce panneau",
   "terminal.lockAIToPanel": "Verrouiller l'IA sur ce panneau",
   "terminal.broadcastInput": "Diffuser la saisie vers tous les panneaux",
+  "terminal.broadcastCtrlHint": "Ctrl+Clic : basculer uniquement ce terminal",
   "terminal.searchPlaceholder": "Rechercher...",
   "terminal.searchPrev": "Précédent",
   "terminal.searchNext": "Suivant",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -107,6 +107,7 @@
   "terminal.aiLockedToPanel": "AI をこのパネルにロック中",
   "terminal.lockAIToPanel": "AI をこのパネルにロック",
   "terminal.broadcastInput": "すべてのパネルに入力をブロードキャスト",
+  "terminal.broadcastCtrlHint": "Ctrl+クリック：このターミナルのみ切り替え",
   "terminal.searchPlaceholder": "検索...",
   "terminal.searchPrev": "前へ",
   "terminal.searchNext": "次へ",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -107,6 +107,7 @@
   "terminal.aiLockedToPanel": "AI가 이 패널에 잠김",
   "terminal.lockAIToPanel": "AI를 이 패널에 잠그기",
   "terminal.broadcastInput": "모든 패널에 입력 브로드캐스트",
+  "terminal.broadcastCtrlHint": "Ctrl+클릭: 이 터미널만 전환",
   "terminal.searchPlaceholder": "검색...",
   "terminal.searchPrev": "이전",
   "terminal.searchNext": "다음",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -107,6 +107,7 @@
   "terminal.aiLockedToPanel": "ИИ закреплен за этой панелью",
   "terminal.lockAIToPanel": "Закрепить ИИ за этой панелью",
   "terminal.broadcastInput": "Транслировать ввод на все панели",
+  "terminal.broadcastCtrlHint": "Ctrl+клик: переключить только этот терминал",
   "terminal.searchPlaceholder": "Поиск...",
   "terminal.searchPrev": "Назад",
   "terminal.searchNext": "Вперед",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -109,6 +109,7 @@
   "terminal.aiLockedToPanel": "AI 已锁定到此面板",
   "terminal.lockAIToPanel": "锁定 AI 到此面板",
   "terminal.broadcastInput": "广播输入到所有面板",
+  "terminal.broadcastCtrlHint": "Ctrl+点击：单独切换此终端",
   "terminal.searchPlaceholder": "搜索...",
   "terminal.searchPrev": "上一个",
   "terminal.searchNext": "下一个",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -107,6 +107,7 @@
   "terminal.aiLockedToPanel": "AI 已鎖定到此面板",
   "terminal.lockAIToPanel": "鎖定 AI 到此面板",
   "terminal.broadcastInput": "廣播輸入到所有面板",
+  "terminal.broadcastCtrlHint": "Ctrl+點擊：單獨切換此終端",
   "terminal.searchPlaceholder": "搜尋...",
   "terminal.searchPrev": "上一個",
   "terminal.searchNext": "下一個",

--- a/frontend/src/stores/tabStore.ts
+++ b/frontend/src/stores/tabStore.ts
@@ -8,13 +8,13 @@ const tabState = reactive<{
   tabs: Tab[]
   activeTabId: string | null
   aiLockedPanelIds: Set<string>
-  broadcastWorkspaceId: string | null
+  broadcastPanelIds: Set<string>
   tabNotifications: Record<string, boolean>
 }>({
   tabs: [],
   activeTabId: null,
   aiLockedPanelIds: new Set<string>(),
-  broadcastWorkspaceId: null,
+  broadcastPanelIds: new Set<string>(),
   tabNotifications: {}
 })
 
@@ -43,18 +43,55 @@ export const useTabStore = defineStore('tab', () => {
     return ids.length > 0 ? ids[0] : null
   })
   const aiLockedPanelIds = computed(() => tabState.aiLockedPanelIds)
-  const broadcastWorkspaceId = computed(() => tabState.broadcastWorkspaceId)
+  const broadcastPanelIds = computed(() => tabState.broadcastPanelIds)
 
+  // Panel-level: whether a specific panel is participating in broadcast.
+  function isPanelBroadcasting(panelId: string): boolean {
+    return tabState.broadcastPanelIds.has(panelId)
+  }
+
+  // Workspace-level: any panel in the workspace is participating.
+  // Used for the button's active-highlight fallback and for legacy
+  // "if broadcasting, send to all" call sites (history / quick commands).
+  function isBroadcasting(workspaceId: string): boolean {
+    const tab = tabState.tabs.find(t => t.id === workspaceId)
+    if (!tab || tab.type !== 'workspace') return false
+    return tab.panelIds.some(id => tabState.broadcastPanelIds.has(id))
+  }
+
+  // Return the set of panels broadcasting within a given workspace.
+  function getBroadcastPanelIdsInWorkspace(workspaceId: string): string[] {
+    const tab = tabState.tabs.find(t => t.id === workspaceId)
+    if (!tab || tab.type !== 'workspace') return []
+    return tab.panelIds.filter(id => tabState.broadcastPanelIds.has(id))
+  }
+
+  // Plain click: if any panel in this workspace broadcasts, turn all off;
+  // otherwise turn all ssh/local panels on.
   function toggleBroadcast(workspaceId: string) {
-    if (tabState.broadcastWorkspaceId === workspaceId) {
-      tabState.broadcastWorkspaceId = null
+    const tab = tabState.tabs.find(t => t.id === workspaceId)
+    if (!tab || tab.type !== 'workspace') return
+    const panelStore = usePanelStore()
+    const anyOn = tab.panelIds.some(id => tabState.broadcastPanelIds.has(id))
+    if (anyOn) {
+      for (const id of tab.panelIds) tabState.broadcastPanelIds.delete(id)
     } else {
-      tabState.broadcastWorkspaceId = workspaceId
+      for (const id of tab.panelIds) {
+        const p = panelStore.getPanel(id)
+        if (p && (p.type === 'ssh' || p.type === 'local')) {
+          tabState.broadcastPanelIds.add(id)
+        }
+      }
     }
   }
 
-  function isBroadcasting(workspaceId: string): boolean {
-    return tabState.broadcastWorkspaceId === workspaceId
+  // Ctrl+click: toggle just this panel's participation.
+  function toggleBroadcastPanel(panelId: string) {
+    if (tabState.broadcastPanelIds.has(panelId)) {
+      tabState.broadcastPanelIds.delete(panelId)
+    } else {
+      tabState.broadcastPanelIds.add(panelId)
+    }
   }
 
   // ── Create tabs ──
@@ -283,6 +320,7 @@ export const useTabStore = defineStore('tab', () => {
 
     for (const pid of removedPanelIds) {
       tabState.aiLockedPanelIds.delete(pid)
+      tabState.broadcastPanelIds.delete(pid)
     }
 
     return removedPanelIds
@@ -471,6 +509,7 @@ export const useTabStore = defineStore('tab', () => {
 
     // Remove panel from workspace
     wsTab.panelIds = wsTab.panelIds.filter(id => id !== panelId)
+    tabState.broadcastPanelIds.delete(panelId)
     if (wsTab.activePanelId === panelId) {
       wsTab.activePanelId = wsTab.panelIds[0] || null
     }
@@ -679,9 +718,12 @@ export const useTabStore = defineStore('tab', () => {
     removeAILockedPanel,
     clearAILockedPanels,
     toggleTabLock,
-    broadcastWorkspaceId,
+    broadcastPanelIds,
     toggleBroadcast,
+    toggleBroadcastPanel,
     isBroadcasting,
+    isPanelBroadcasting,
+    getBroadcastPanelIdsInWorkspace,
     markTabNotification,
     clearTabNotification,
     hasTabNotification,


### PR DESCRIPTION
Closes #310.

The broadcast button used to be all-or-nothing per workspace, so users
could not exclude a specific terminal from the broadcast group. This
adds a Ctrl/Cmd+Click modifier that toggles a single panel's
participation, while a plain click keeps the existing "toggle the whole
workspace" behaviour.

## Behaviour
- **Plain click** on the broadcast icon: if any panel in the workspace is
  broadcasting, turn all off; otherwise turn every ssh/local panel on.
  (Same as before.)
- **Ctrl/⌘ + Click**: toggle only the current panel — lets the user
  hand-pick a subset that broadcasts between themselves.
- The icon now lights up per-panel, so the broadcast group is visible at
  a glance.
- Tooltip is a two-liner: the original label plus a `Ctrl+Click` hint.
  All 9 locales updated.

## Implementation
- Replace `tabStore.broadcastWorkspaceId: string | null` with
  `broadcastPanelIds: Set<string>`.
- New store API: `isPanelBroadcasting`, `toggleBroadcastPanel`,
  `getBroadcastPanelIdsInWorkspace`. `isBroadcasting(workspaceId)` is
  now derived from the set.
- All dispatch call sites (typing, suggestions, right-click paste,
  history run, quick commands) filter by the broadcast set instead of
  the whole workspace.
- Clean up `broadcastPanelIds` on `closeTab` / `removePanelFromWorkspaceTab`.

## Verified
- `npm run build` clean.
- `wails dev` manual test: plain click / Ctrl+click toggle correctly,
  tooltip shows both lines, typing / paste / history / quick command
  all respect the selected subset.

---

关联 #310。

原来广播按钮是「一个工作区整体开/关」，无法排除个别终端。本 PR 增加 Ctrl/⌘+点击 修饰键：普通点击维持原「工作区全开/全关」行为，Ctrl+点击 则只切换当前面板的广播开关，用户可以自由挑选参与广播的终端子集。

## 交互
- **普通左键点击** 广播按钮：工作区里有任一面板广播中 → 全灭；否则把所有 ssh/local 面板全部加入广播组。（同原来）
- **Ctrl/⌘ + 左键点击**：只切换当前面板 —— 用户可以手动挑选一个子集互相广播。
- 按钮高亮改成「本面板是否在广播中」，广播组一眼看清。
- Tooltip 双行显示：原文案 + `Ctrl+点击：单独切换此终端`，9 种语言都补上。

## 实现
- `tabStore.broadcastWorkspaceId: string | null` → `broadcastPanelIds: Set<string>`。
- 新增 API：`isPanelBroadcasting`、`toggleBroadcastPanel`、`getBroadcastPanelIdsInWorkspace`；`isBroadcasting(workspaceId)` 改为从集合派生。
- 所有分发点（输入、建议、右键粘贴、历史命令、快捷命令）改为按广播集合过滤，而不是遍历整个工作区。
- `closeTab` / `removePanelFromWorkspaceTab` 里同步清理 `broadcastPanelIds`。

## 验证
- `npm run build` 通过。
- `wails dev` 实测：普通点击 / Ctrl+点击 切换正确，tooltip 显示两行，输入 / 粘贴 / 历史 / 快捷命令都按选定子集广播。