### PR TITLE
fix(ssh): support passphrase-protected private keys (closes #197)

### DIFF
--- a/backend/session/ssh_auth.go
+++ b/backend/session/ssh_auth.go
@@ -13,23 +13,10 @@ func makeSSHAuthMethods(config ConnectionConfig, kbCallback ssh.KeyboardInteract
 	case "password":
 		methods = append(methods, ssh.Password(config.Password))
 	case "key":
-		key, err := os.ReadFile(config.KeyPath)
-		if err != nil {
-			methods = append(methods, ssh.Password(config.Password))
-			break
+		if signer, ok := parsePrivateKeyFile(config.KeyPath, config.Password); ok {
+			methods = append(methods, ssh.PublicKeys(signer))
 		}
-		signer, err := ssh.ParsePrivateKey(key)
-		if err != nil {
-			methods = append(methods, ssh.Password(config.Password))
-			break
-		}
-		methods = append(methods, ssh.PublicKeys(signer))
-	case "agent":
-		methods = append(methods, ssh.Password(config.Password))
-	default:
-		methods = append(methods, ssh.Password(config.Password))
 	}
-
 
 	// Keyboard-interactive as fallback for password-less or failed-password scenarios.
 	if kbCallback != nil {
@@ -37,4 +24,27 @@ func makeSSHAuthMethods(config ConnectionConfig, kbCallback ssh.KeyboardInteract
 	}
 
 	return methods
+}
+
+// parsePrivateKeyFile reads the private key at path and parses it, using
+// passphrase when the key is encrypted. Returns (nil, false) on any error;
+// the caller is expected to fall back to other auth methods so the SSH
+// handshake surfaces a meaningful error to the user.
+func parsePrivateKeyFile(path, passphrase string) (ssh.Signer, bool) {
+	key, err := os.ReadFile(path)
+	if err != nil {
+		return nil, false
+	}
+	if passphrase != "" {
+		signer, err := ssh.ParsePrivateKeyWithPassphrase(key, []byte(passphrase))
+		if err != nil {
+			return nil, false
+		}
+		return signer, true
+	}
+	signer, err := ssh.ParsePrivateKey(key)
+	if err != nil {
+		return nil, false
+	}
+	return signer, true
 }

--- a/frontend/src/components/ConnectionForm.vue
+++ b/frontend/src/components/ConnectionForm.vue
@@ -79,7 +79,7 @@
                 </div>
               </el-form-item>
             </template>
-            <el-form-item v-if="form.type !== 'local' && form.type !== 'serial' && ((form.authType === 'password' && form.type !== 'rdp') || (form.type === 'rdp' && !form.rdpEnableNLA) || form.type === 'vnc' || form.type === 'spice' || form.type === 'database' || form.type === 'mosh' || form.type === 'telnet' || form.type === 'ftp' || form.type === 'smb' || form.type === 'webdav' || form.type === 's3') && !(form.type === 'database' && form.dbType === 'rqlite')" :label="form.type === 's3' ? 'Secret Key' : t('conn.password')">
+            <el-form-item v-if="form.type !== 'local' && form.type !== 'serial' && ((form.authType === 'password' && form.type !== 'rdp') || (form.type === 'rdp' && !form.rdpEnableNLA) || form.type === 'vnc' || form.type === 'spice' || form.type === 'database' || form.type === 'telnet' || form.type === 'ftp' || form.type === 'smb' || form.type === 'webdav' || form.type === 's3') && !(form.type === 'database' && form.dbType === 'rqlite')" :label="form.type === 's3' ? 'Secret Key' : t('conn.password')">
               <el-input v-model="form.password" type="password" show-password :key="passwordInputKey" :placeholder="form.type === 's3' ? 'Secret Access Key' : ''" />
             </el-form-item>
             <el-form-item v-if="form.authType === 'key' && (form.type === 'ssh' || form.type === 'mosh')" :label="t('conn.keyPath')">
@@ -92,6 +92,9 @@
                   </el-tooltip>
                 </template>
               </el-input>
+            </el-form-item>
+            <el-form-item v-if="form.authType === 'key' && (form.type === 'ssh' || form.type === 'mosh')" :label="t('conn.keyPassphrase')">
+              <el-input v-model="form.password" type="password" show-password :key="passwordInputKey" :placeholder="t('conn.keyPassphrasePlaceholder')" />
             </el-form-item>
             <el-form-item v-if="form.type === 'database' && form.dbType !== 'rqlite' && form.dbType !== 'redis'" :label="t('db.databases')">
               <el-input v-model="form.dbName" :placeholder="t('db.databases')" />

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -39,6 +39,8 @@
   "conn.password": "Passwort",
   "conn.keyPath": "Schlüsselpfad",
   "conn.keyPathPlaceholder": "z. B. ~/.ssh/id_rsa",
+  "conn.keyPassphrase": "Schlüsselpasswort",
+  "conn.keyPassphrasePlaceholder": "Leer lassen, wenn der Schlüssel nicht verschlüsselt ist",
   "conn.selectKeyFile": "Schlüsseldatei auswählen",
   "conn.cancel": "Abbrechen",
   "conn.saveConnect": "Speichern & Verbinden",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -42,6 +42,8 @@
   "conn.password": "Password",
   "conn.keyPath": "Key Path",
   "conn.keyPathPlaceholder": "e.g. ~/.ssh/id_rsa",
+  "conn.keyPassphrase": "Key passphrase",
+  "conn.keyPassphrasePlaceholder": "Leave empty if the key is not encrypted",
   "conn.selectKeyFile": "Select key file",
   "conn.cancel": "Cancel",
   "conn.saveConnect": "Save & Connect",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -39,6 +39,8 @@
   "conn.password": "Contraseña",
   "conn.keyPath": "Ruta de la Clave",
   "conn.keyPathPlaceholder": "p. ej. ~/.ssh/id_rsa",
+  "conn.keyPassphrase": "Contraseña de la clave",
+  "conn.keyPassphrasePlaceholder": "Dejar vacío si la clave no está cifrada",
   "conn.selectKeyFile": "Seleccionar archivo de clave",
   "conn.cancel": "Cancelar",
   "conn.saveConnect": "Guardar y Conectar",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -39,6 +39,8 @@
   "conn.password": "Mot de passe",
   "conn.keyPath": "Chemin de la clé",
   "conn.keyPathPlaceholder": "ex. ~/.ssh/id_rsa",
+  "conn.keyPassphrase": "Phrase secrète de la clé",
+  "conn.keyPassphrasePlaceholder": "Laisser vide si la clé n'est pas chiffrée",
   "conn.selectKeyFile": "Sélectionner le fichier de clé",
   "conn.cancel": "Annuler",
   "conn.saveConnect": "Enregistrer et connecter",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -39,6 +39,8 @@
   "conn.password": "パスワード",
   "conn.keyPath": "鍵のパス",
   "conn.keyPathPlaceholder": "例: ~/.ssh/id_rsa",
+  "conn.keyPassphrase": "鍵のパスフレーズ",
+  "conn.keyPassphrasePlaceholder": "秘密鍵にパスワードがない場合は空欄",
   "conn.selectKeyFile": "鍵ファイルを選択",
   "conn.cancel": "キャンセル",
   "conn.saveConnect": "保存して接続",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -39,6 +39,8 @@
   "conn.password": "비밀번호",
   "conn.keyPath": "키 경로",
   "conn.keyPathPlaceholder": "예: ~/.ssh/id_rsa",
+  "conn.keyPassphrase": "키 암호",
+  "conn.keyPassphrasePlaceholder": "개인 키에 암호가 없으면 비워 두세요",
   "conn.selectKeyFile": "키 파일 선택",
   "conn.cancel": "취소",
   "conn.saveConnect": "저장 후 연결",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -39,6 +39,8 @@
   "conn.password": "Пароль",
   "conn.keyPath": "Путь к ключу",
   "conn.keyPathPlaceholder": "например, ~/.ssh/id_rsa",
+  "conn.keyPassphrase": "Пароль ключа",
+  "conn.keyPassphrasePlaceholder": "Оставьте пустым, если ключ не зашифрован",
   "conn.selectKeyFile": "Выбрать файл ключа",
   "conn.cancel": "Отмена",
   "conn.saveConnect": "Сохранить и подключиться",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -41,6 +41,8 @@
   "conn.password": "密码",
   "conn.keyPath": "密钥路径",
   "conn.keyPathPlaceholder": "例如 ~/.ssh/id_rsa",
+  "conn.keyPassphrase": "密钥密码",
+  "conn.keyPassphrasePlaceholder": "私钥无密码可留空",
   "conn.selectKeyFile": "选择密钥文件",
   "conn.cancel": "取消",
   "conn.saveConnect": "保存并连接",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -39,6 +39,8 @@
   "conn.password": "密碼",
   "conn.keyPath": "金鑰路徑",
   "conn.keyPathPlaceholder": "例如 ~/.ssh/id_rsa",
+  "conn.keyPassphrase": "金鑰密碼",
+  "conn.keyPassphrasePlaceholder": "私鑰無密碼可留空",
   "conn.selectKeyFile": "選擇金鑰檔案",
   "conn.cancel": "取消",
   "conn.saveConnect": "儲存並連線",


### PR DESCRIPTION
## Summary

When authenticating with a private key that has its own passphrase, the SSH handshake used to fail with `attempted methods [none password], no supported methods remain` because `ssh.ParsePrivateKey` returned a `PassphraseMissingError` and the code silently fell back to sending the (unset) password — the key itself was never actually offered.

This PR lets the user store the key passphrase in the existing `password` field of the connection config (the field is otherwise unused when `authType=key`) and uses it when parsing the key.

## Changes

- **[backend/session/ssh_auth.go](../blob/fix/ssh-key-passphrase-197/backend/session/ssh_auth.go)**: extract `parsePrivateKeyFile`; call `ssh.ParsePrivateKeyWithPassphrase` when passphrase is non-empty, fall back to `ssh.ParsePrivateKey` otherwise. Drop the dead `ssh.Password` fallback that ran on parse failure — it was never a valid substitute for a public-key method. `mosh` / `tunnel_service` / `tunnel_forward` share this helper and benefit automatically.
- **[frontend/src/components/ConnectionForm.vue](../blob/fix/ssh-key-passphrase-197/frontend/src/components/ConnectionForm.vue)**: when `authType=key`, show a dedicated *Key passphrase* input right under *Key path*, bound to the same `form.password`. Also fix a pre-existing bug where mosh unconditionally showed the *Password* field regardless of `authType`.
- 9 locales: add `conn.keyPassphrase` and `conn.keyPassphrasePlaceholder`.

No schema change — `connections.json` is fully forward/backward compatible.

## Test

- unencrypted key → login OK (regression)
- ed25519 with passphrase, correct passphrase → login OK
- ed25519 with passphrase, wrong passphrase → auth failure with meaningful error
- RSA with passphrase → login OK
- mosh + password / mosh + key → correct single field shown in each

Closes #197

---

## 摘要

用带 passphrase（私钥自身的加密密码）的密钥登录 SSH 时，握手会失败并报 `attempted methods [none password], no supported methods remain`。原因是 `ssh.ParsePrivateKey` 抛出 `PassphraseMissingError`，旧代码默默 fallback 到 password 认证，公钥根本没被上抛，服务端只看到 none / password 都不匹配。

本 PR 复用 `password` 字段承载密钥密码（`authType=key` 时该字段原本无实际用途），解析时按 passphrase 走。

## 改动

- **[backend/session/ssh_auth.go](../blob/fix/ssh-key-passphrase-197/backend/session/ssh_auth.go)**：抽出 `parsePrivateKeyFile`，`passphrase` 非空时走 `ssh.ParsePrivateKeyWithPassphrase`，否则 `ssh.ParsePrivateKey`。删掉了解析失败时 fallback 到 password 的死代码——那从来不是公钥认证的合理替代。`mosh` / `tunnel_service` / `tunnel_forward` 共用同一 helper，自动受益。
- **[frontend/src/components/ConnectionForm.vue](../blob/fix/ssh-key-passphrase-197/frontend/src/components/ConnectionForm.vue)**：`authType=key` 时在"密钥路径"下方显示"密钥密码"输入框，绑定到同一个 `form.password`。顺手修了一个已存在的 bug：mosh 无论 authType 是什么都会显示"密码"框。
- 9 种语言各加 `conn.keyPassphrase` / `conn.keyPassphrasePlaceholder`。

不改数据结构，`connections.json` 完全兼容。

## 测试

- 无 passphrase 密钥 → 正常登录（回归）
- ed25519 + passphrase，密码正确 → 正常登录
- ed25519 + passphrase，密码错误 → auth 失败，错误信息可读
- RSA + passphrase → 正常登录
- mosh 切换 password / key，各自只显示对应输入框

Closes #197