### PR TITLE
style(sidebar): remove divider between search bar and list in Tunnels and QuickCommands panels

### DIFF
--- a/frontend/src/components/QuickCommandsPanel.vue
+++ b/frontend/src/components/QuickCommandsPanel.vue
@@ -575,7 +575,6 @@ watch(searchQuery, (q) => {
   gap: 4px;
   padding: 0 10px 6px;
   flex-shrink: 0;
-  border-bottom: 1px solid var(--border-subtle);
 }
 
 .qc-search-input {

--- a/frontend/src/components/TunnelsPanel.vue
+++ b/frontend/src/components/TunnelsPanel.vue
@@ -295,7 +295,7 @@ function onGroupDrop(groupId: string, e: DragEvent) {
 
 <style scoped>
 .tunnels-panel { display: flex; flex-direction: column; height: 100%; overflow: hidden; }
-.tn-toolbar { display: flex; align-items: center; gap: 4px; padding: 0 10px 6px; flex-shrink: 0; border-bottom: 1px solid var(--border-subtle); }
+.tn-toolbar { display: flex; align-items: center; gap: 4px; padding: 0 10px 6px; flex-shrink: 0; }
 .tn-search-input { flex: 1; min-width: 0; }
 .tn-icon-btn { width: 26px; height: 26px; display: flex; align-items: center; justify-content: center; border: none; border-radius: 4px; background: transparent; color: var(--text-muted); cursor: pointer; flex-shrink: 0; }
 .tn-icon-btn:hover { color: var(--text-primary); background: var(--bg-hover); }


### PR DESCRIPTION
Remove the `border-bottom` on the toolbar of the Tunnels and Quick Commands sidebar panels, which produced a horizontal divider between the search input and the list below it. No other sidebar panel has this divider, so this change brings them in line with the rest.

- `frontend/src/components/TunnelsPanel.vue` — drop `border-bottom` on `.tn-toolbar`
- `frontend/src/components/QuickCommandsPanel.vue` — drop `border-bottom` on `.qc-toolbar`

---

移除侧边栏「隧道」和「快捷命令」两个页面工具栏的 `border-bottom`，即搜索框和下方列表之间的那条分隔横线。其他侧边栏页面都没有这条线，此改动让它们保持一致。

- `frontend/src/components/TunnelsPanel.vue` — 删除 `.tn-toolbar` 的 `border-bottom`
- `frontend/src/components/QuickCommandsPanel.vue` — 删除 `.qc-toolbar` 的 `border-bottom`