### PR TITLE
fix(workspace): add session log menu and REC dot to panel header

### DIFF
--- a/frontend/src/components/Panel.vue
+++ b/frontend/src/components/Panel.vue
@@ -7,17 +7,27 @@
     @dragstart="emit('dragstart', $event)"
   >
     <div v-if="showHeader" class="panel-header" :class="{ 'ai-locked': isAILocked }" @dblclick.stop>
-      <span v-if="!editing" class="panel-title" @dblclick.stop="startEdit">{{ panel.title }}</span>
-      <input
-        v-else
-        ref="editInputRef"
-        v-model="editName"
-        class="panel-title-input"
-        @keydown.enter="confirmEdit"
-        @keydown.escape="cancelEdit"
-        @blur="confirmEdit"
-        @click.stop
-      />
+      <div class="panel-header-left">
+        <span class="panel-icon-wrapper">
+          <component :is="panelIcon" class="panel-type-icon" />
+          <span
+            v-if="isOutputLogOn"
+            class="panel-log-dot"
+            :title="t('session.recording', { path: outputLogPath })"
+          />
+        </span>
+        <span v-if="!editing" class="panel-title" @dblclick.stop="startEdit">{{ panel.title }}</span>
+        <input
+          v-else
+          ref="editInputRef"
+          v-model="editName"
+          class="panel-title-input"
+          @keydown.enter="confirmEdit"
+          @keydown.escape="cancelEdit"
+          @blur="confirmEdit"
+          @click.stop
+        />
+      </div>
       <div class="panel-header-actions">
         <button
           v-if="(panel.type === 'ssh' || panel.type === 'local') && workspaceId"
@@ -29,7 +39,6 @@
           <Radio :size="14" />
         </button>
         <button
-          v-if="panel.type === 'ssh' || panel.type === 'local'"
           class="panel-ai-lock"
           :class="{ locked: isAILocked }"
           @click.stop="emit('toggleAiLock', panel.id)"
@@ -37,7 +46,7 @@
         >
           <Sparkles :size="14" />
         </button>
-        <div v-if="panel.type === 'ssh' || panel.type === 'local'" class="panel-more-wrapper">
+        <div class="panel-more-wrapper">
           <button
             class="panel-more"
             @click.stop="toggleMoreMenu"
@@ -50,6 +59,12 @@
             <div v-if="panel.type === 'ssh'" class="menu-item" @click="connectSftp(); moreMenuVisible = false">{{ t('sidebar.connectSftp') }}</div>
             <div v-if="panel.type === 'ssh'" class="menu-item" @click="uploadFileRz(); moreMenuVisible = false">{{ t('terminal.uploadFileRz') }}</div>
             <div v-if="panel.type === 'ssh'" class="menu-item" @click="connectMonitor(); moreMenuVisible = false">{{ t('sidebar.connectMonitor') }}</div>
+            <div class="menu-item" @click="toggleOutputLog(); moreMenuVisible = false">
+              {{ isOutputLogOn ? t('session.stopLog') : t('session.startLog') }}
+            </div>
+            <div v-if="isOutputLogOn" class="menu-item" @click="openLogDir(); moreMenuVisible = false">
+              {{ t('session.openLogDir') }}
+            </div>
             <div class="menu-item" @click="triggerSearch(); moreMenuVisible = false">{{ t('terminal.searchText') }}</div>
             <div class="menu-item" @click="triggerExport(); moreMenuVisible = false">{{ t('terminal.export') }}</div>
           </div>
@@ -71,13 +86,20 @@
 
 <script setup lang="ts">
 import { ref, watch, computed, nextTick, onMounted, onUnmounted, inject } from 'vue'
-import { Radio, Sparkles, MoreHorizontal, X } from '@lucide/vue'
+import { Radio, Sparkles, MoreHorizontal, X, SquareTerminal, Laptop, Cable, Terminal, Zap } from '@lucide/vue'
 import BaseTerminal from './BaseTerminal.vue'
 import { useTabStore } from '../stores/tabStore'
 import { usePanelStore } from '../stores/panelStore'
 import { useSessionStore } from '../stores/sessionStore'
 import { useSettingsStore } from '../stores/settingsStore'
-import { CreateSession } from '../../wailsjs/go/main/App'
+import {
+  CreateSession,
+  EnableSessionOutputLog,
+  DisableSessionOutputLog,
+  GetSessionOutputLogInfo,
+  OpenPathInExplorer,
+} from '../../wailsjs/go/main/App'
+import { msg } from '../services/message'
 import { useI18n } from '../i18n'
 import type { Panel } from '../types/workspace'
 import type { ConnectionConfig } from '../types/session'
@@ -146,8 +168,71 @@ const editName = ref('')
 const editInputRef = ref<HTMLInputElement>()
 const moreMenuVisible = ref(false)
 
+// Session output log state — mirrors TabItem so both surfaces stay in sync
+// via panelStore.setOutputLog. Refreshed when the more menu opens and on mount.
+const isOutputLogOn = ref(false)
+const outputLogPath = ref('')
+
+const panelIcon = computed(() => {
+  const t = props.panel.type
+  if (t === 'local') return Laptop
+  if (t === 'serial') return Cable
+  if (t === 'telnet') return Terminal
+  if (t === 'mosh') return Zap
+  return SquareTerminal
+})
+
 function toggleMoreMenu() {
   moreMenuVisible.value = !moreMenuVisible.value
+  if (moreMenuVisible.value) {
+    refreshOutputLogState()
+  }
+}
+
+async function refreshOutputLogState() {
+  try {
+    const info = await GetSessionOutputLogInfo(props.panel.id)
+    isOutputLogOn.value = !!info.enabled
+    outputLogPath.value = info.path || ''
+    panelStore.setOutputLog(props.panel.id, { enabled: isOutputLogOn.value, path: outputLogPath.value })
+  } catch {
+    isOutputLogOn.value = false
+    outputLogPath.value = ''
+  }
+}
+
+async function toggleOutputLog() {
+  try {
+    if (isOutputLogOn.value) {
+      await DisableSessionOutputLog(props.panel.id)
+      const prev = outputLogPath.value
+      isOutputLogOn.value = false
+      outputLogPath.value = ''
+      panelStore.setOutputLog(props.panel.id, { enabled: false, path: '' })
+      msg.info(t('session.logStopped', { path: prev }))
+      return
+    }
+    const path = await EnableSessionOutputLog(props.panel.id, '')
+    if (!path) {
+      msg.error(t('session.logFailed', { error: 'unknown' }))
+      return
+    }
+    isOutputLogOn.value = true
+    outputLogPath.value = path
+    panelStore.setOutputLog(props.panel.id, { enabled: true, path })
+    msg.success(t('session.logStarted', { path }))
+  } catch (e: any) {
+    msg.error(t('session.logFailed', { error: String(e?.message ?? e) }))
+  }
+}
+
+async function openLogDir() {
+  if (!outputLogPath.value) return
+  try {
+    await OpenPathInExplorer(outputLogPath.value)
+  } catch (e: any) {
+    msg.error(String(e?.message ?? e))
+  }
 }
 
 function connectSftp() {
@@ -277,6 +362,7 @@ async function retryConnection(silent = false) {
 
 onMounted(() => {
   document.addEventListener('click', onDocumentClick)
+  refreshOutputLogState()
 })
 
 onUnmounted(() => {
@@ -298,6 +384,18 @@ watch(() => props.isActive, (active) => {
     nextTick(() => baseTerminalRef.value?.focus())
   }
 })
+
+// Keep local log state in sync when TabItem (or anyone else) toggles the log
+// via panelStore.setOutputLog — the header dot updates without reopening the menu.
+watch(() => props.panel.outputLog, (val) => {
+  if (val) {
+    isOutputLogOn.value = !!val.enabled
+    outputLogPath.value = val.path || ''
+  } else {
+    isOutputLogOn.value = false
+    outputLogPath.value = ''
+  }
+}, { deep: true })
 </script>
 
 <style scoped>
@@ -321,6 +419,11 @@ watch(() => props.isActive, (active) => {
 .panel-header:active {
   cursor: grabbing;
 }
+.panel-header-left {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+}
 .panel-active .panel-header {
   background: var(--bg-elevated);
   border-bottom-color: var(--accent);
@@ -336,6 +439,34 @@ watch(() => props.isActive, (active) => {
   text-overflow: ellipsis;
   white-space: nowrap;
   cursor: text;
+}
+.panel-icon-wrapper {
+  position: relative;
+  display: inline-flex;
+  flex-shrink: 0;
+  margin-right: 6px;
+}
+.panel-type-icon {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  color: var(--text-muted);
+}
+.panel-active .panel-type-icon {
+  color: var(--accent);
+}
+.panel-log-dot {
+  position: absolute;
+  right: -2px;
+  bottom: -2px;
+  width: 6px;
+  height: 6px;
+  background: #e5484d;
+  border-radius: 50%;
+  pointer-events: auto;
 }
 .panel-active .panel-title {
   color: var(--text-primary);

--- a/frontend/src/components/TabItem.vue
+++ b/frontend/src/components/TabItem.vue
@@ -525,7 +525,6 @@ onUnmounted(() => {
   height: 6px;
   background: #e5484d;
   border-radius: 50%;
-  border: 1px solid var(--bg-primary, #fff);
   pointer-events: auto;
 }
 .tab-item.active .tab-type-icon {


### PR DESCRIPTION
When the session output log feature (#313) was added, only the terminal tab context menu wired up start/stop recording and the REC indicator. Inside a workspace tab, the panel more menu was not updated and the panel header showed no recording state.

- Panel more menu now includes **Start/Stop recording log** and **Open log folder**, ordered to match the tab context menu (Duplicate → SFTP → rz → Monitor → Log → Search → Export).
- Panel title now shows a terminal-type icon; a small red REC dot overlays the icon while recording, kept in sync with the tab via `panelStore.setOutputLog` (works in both directions).
- The panel more button and AI-lock button were previously gated to \`ssh\` / \`local\`. A workspace panel is always a terminal, so telnet / mosh / serial panels also get the buttons now.
- Both the tab REC dot and the panel REC dot drop their outer border for a consistent flat look.

Single file touched apart from removing the white border on the tab dot: [frontend/src/components/Panel.vue](frontend/src/components/Panel.vue).

---

在会话日志功能（#313）合并后，只有终端 tab 的右键菜单里接入了开始/停止记录日志和 REC 状态指示。工作区 tab 里的 panel more 菜单没有同步添加，panel header 也没有任何录制状态的展示。

- Panel more 菜单里补齐了**开始/停止记录日志**和**打开日志文件夹**两项，顺序与 tab 右键菜单一致（Duplicate → SFTP → rz → Monitor → 日志 → 搜索 → 导出）。
- Panel title 前面补上了终端类型图标，录制中在图标右下角叠加一颗红色小圆点，通过 \`panelStore.setOutputLog\` 与 tab 双向同步。
- Panel 的 more 按钮和 AI Lock 按钮之前被限制为 \`ssh\` / \`local\`。工作区里的 panel 一定是终端，所以 telnet / mosh / serial panel 现在也可以使用这两个按钮。
- Tab 和 panel 的 REC 红点都去掉了外层白色边框，统一为纯色扁平样式。

除了 tab 红点去边框，本次只改动了 [frontend/src/components/Panel.vue](frontend/src/components/Panel.vue)。