### PR TITLE
feat(tabs): extend duplicate to sftp and database tabs

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1290,9 +1290,9 @@ async function onConnectDB(config: ConnectionConfig, prevStart?: any) {
   const tab = tabStore.createDBTab(displayTitle, panel.id)
   if (reposition) reposition(tab.id)
   if (config.dbType === 'redis') {
-    tab.type = 'redis' as any
+    tab.type = 'redis'
   } else if (config.dbType === 'mongodb') {
-    tab.type = 'mongodb' as any
+    tab.type = 'mongodb'
   }
   panelStore.movePanelToTab(panel.id, tab.id)
   RecordRecentConnection(config.id)

--- a/frontend/src/components/TabItem.vue
+++ b/frontend/src/components/TabItem.vue
@@ -76,7 +76,7 @@
         :style="contextMenuStyle"
         @click.stop
       >
-        <div v-if="tab.type === 'terminal'" class="menu-item" @click="duplicateTab">{{ t('tab.duplicate') }}</div>
+        <div v-if="canDuplicate" class="menu-item" @click="duplicateTab">{{ t('tab.duplicate') }}</div>
         <div v-if="tab.type === 'terminal' && panelStore.getPanel(tab.panelId)?.type === 'ssh'" class="menu-item" @click="openSftp">{{ t('sidebar.connectSftp') }}</div>
         <div v-if="tab.type === 'terminal' && panelStore.getPanel(tab.panelId)?.type === 'ssh'" class="menu-item" @click="uploadFileRz">{{ t('terminal.uploadFileRz') }}</div>
         <div v-if="tab.type === 'terminal' && panelStore.getPanel(tab.panelId)?.type === 'ssh'" class="menu-item" @click="openMonitor">{{ t('sidebar.connectMonitor') }}</div>
@@ -217,6 +217,13 @@ const supportsOutputLog = computed(() => {
   return !!p && ['ssh', 'telnet', 'serial', 'mosh', 'local'].includes(p.type)
 })
 
+// Duplicate is supported for tabs backed by a reproducible connection:
+// terminals, file transfer, and database (incl. mongodb/redis variants).
+const canDuplicate = computed(() => {
+  const type = props.tab.type
+  return type === 'terminal' || type === 'sftp' || type === 'database' || type === 'mongodb' || type === 'redis'
+})
+
 function onDragStart(e: DragEvent) {
   e.dataTransfer?.setData('application/tab-id', props.tab.id)
   e.dataTransfer?.setData('application/tab-type', props.tab.type)
@@ -342,21 +349,49 @@ function closeLeft() {
 }
 
 async function duplicateTab() {
-  const panel = panelStore.getPanel((props.tab as TerminalTab).panelId)
+  closeContextMenu()
+  const tab = props.tab
+  if (!('panelId' in tab)) return
+  const panel = panelStore.getPanel(tab.panelId)
   if (!panel) return
+
   const newPanel = panelStore.createPanel(panel.config, panel.type)
   panelStore.updateTitle(newPanel.id, panel.title)
+
+  let newTab
+  if (tab.type === 'terminal') {
+    newTab = tabStore.createTerminalTab(newPanel.title, newPanel.id)
+  } else if (tab.type === 'sftp') {
+    newTab = tabStore.createFtpTab(newPanel.title, newPanel.id)
+  } else if (tab.type === 'database' || tab.type === 'mongodb' || tab.type === 'redis') {
+    newTab = tabStore.createDBTab(newPanel.title, newPanel.id)
+    newTab.type = tab.type
+  } else {
+    return
+  }
+  panelStore.movePanelToTab(newPanel.id, newTab.id)
+
   if (panel.config) {
     try {
-      const info = await CreateSession(panel.config.type, panel.config)
+      const sessionType = resolveSessionType(tab.type, panel.config)
+      const info = await CreateSession(sessionType, panel.config)
       panelStore.bindSession(newPanel.id, info.id)
+      if (tab.type !== 'terminal') sessionStore.initSession(info.id)
     } catch (e) {
       console.error('Failed to duplicate session:', e)
     }
   }
-  const newTab = tabStore.createTerminalTab(newPanel.title, newPanel.id)
-  panelStore.movePanelToTab(newPanel.id, newTab.id)
-  closeContextMenu()
+}
+
+// The session-type argument to CreateSession isn't always panel.config.type:
+// database panels split into mysql/postgres/redis/mongodb by dbType.
+function resolveSessionType(tabType: string, config: any): string {
+  if (tabType === 'database' || tabType === 'mongodb' || tabType === 'redis') {
+    if (config?.dbType === 'redis') return 'redis'
+    if (config?.dbType === 'mongodb') return 'mongodb'
+    return 'database'
+  }
+  return config?.type
 }
 
 function openSftp() {

--- a/frontend/src/stores/tabStore.ts
+++ b/frontend/src/stores/tabStore.ts
@@ -1,6 +1,6 @@
 import { defineStore } from 'pinia'
 import { reactive, computed } from 'vue'
-import type { Tab, TerminalTab, SettingsTab, WorkspaceTab, SFTPTab, RDPTab, VNCTab, SPICETab, DBTab, MongoDBTab, MonitorTab, StartTab, PanelLayout, LayoutNode } from '../types/workspace'
+import type { Tab, TerminalTab, SettingsTab, WorkspaceTab, SFTPTab, RDPTab, VNCTab, SPICETab, DBTab, MonitorTab, StartTab, PanelLayout, LayoutNode } from '../types/workspace'
 import { usePanelStore } from './panelStore'
 import { t } from '../i18n'
 
@@ -236,18 +236,6 @@ export const useTabStore = defineStore('tab', () => {
     const tab: DBTab = {
       type: 'database',
       id: genId('db-tab'),
-      panelId,
-      name
-    }
-    tabState.tabs.push(tab)
-    tabState.activeTabId = tab.id
-    return tab
-  }
-
-  function createMongoDBTab(name: string, panelId: string): MongoDBTab {
-    const tab: MongoDBTab = {
-      type: 'mongodb',
-      id: genId('mongo-tab'),
       panelId,
       name
     }
@@ -693,7 +681,6 @@ export const useTabStore = defineStore('tab', () => {
     createVNCTab,
     createSPICETab,
     createDBTab,
-    createMongoDBTab,
     createMonitorTab,
     createStartTab,
     createWorkspaceTab,

--- a/frontend/src/types/workspace.ts
+++ b/frontend/src/types/workspace.ts
@@ -25,7 +25,7 @@ export type LayoutNode =
 
 // ── Tab types ──
 
-export type Tab = TerminalTab | SettingsTab | WorkspaceTab | SFTPTab | RDPTab | VNCTab | SPICETab | DBTab | MongoDBTab | MonitorTab | StartTab
+export type Tab = TerminalTab | SettingsTab | WorkspaceTab | SFTPTab | RDPTab | VNCTab | SPICETab | DBTab | MonitorTab | StartTab
 
 export interface TerminalTab {
   type: 'terminal'
@@ -78,7 +78,7 @@ export interface VNCTab {
 }
 
 export interface DBTab {
-  type: 'database'
+  type: 'database' | 'mongodb' | 'redis'
   id: string
   panelId: string
   name: string
@@ -87,14 +87,6 @@ export interface DBTab {
 
 export interface SPICETab {
   type: 'spice'
-  id: string
-  panelId: string
-  name: string
-  locked?: boolean
-}
-
-export interface MongoDBTab {
-  type: 'mongodb'
   id: string
   panelId: string
   name: string


### PR DESCRIPTION
Duplicate was previously wired for terminal tabs only. This PR extends it to file-transfer (sftp/ftp/smb/webdav/s3) and database (mysql/postgres/redis/mongodb) tabs, and cleans up the redis/mongodb tab-type inconsistency along the way.

## Changes

**Unify database tab types**
- Drop the unused `MongoDBTab` interface and `createMongoDBTab` factory. They were never called — `onConnectDB` always went through `createDBTab` and then overwrote `tab.type = 'mongodb' as any`.
- Widen `DBTab.type` to `'database' | 'mongodb' | 'redis'` so the override is type-safe and the `as any` casts in `App.vue` can go away.
- Redis and MongoDB now share the same code path: build a DBTab, then set its `type` from `config.dbType`.

**Extend duplicate**
- `TabItem.vue` menu item now shows for `terminal | sftp | database | mongodb | redis`.
- `duplicateTab()` dispatches on `tab.type` to pick the right factory (`createTerminalTab` / `createFtpTab` / `createDBTab`).
- Session type passed to `CreateSession` is resolved from `config.type` for terminals and file transfer, and from `config.dbType` for database variants — matching the existing `onConnect*` handlers.
- Non-terminal duplicates call `sessionStore.initSession` for consistency with `onConnectDB`/`onConnectRDP`.

---

之前 duplicate 只对终端类型的 tab 生效。本 PR 将其扩展到文件传输（sftp/ftp/smb/webdav/s3）和数据库（mysql/postgres/redis/mongodb）类型的 tab，并顺手统一 redis/mongodb tab 类型不一致的问题。

## 改动

**统一数据库 tab 类型**
- 删除从未被调用的 `MongoDBTab` 接口和 `createMongoDBTab` 工厂。原本 \`onConnectDB\` 走的是 \`createDBTab\` 再 \`tab.type = 'mongodb' as any\` 覆盖，两条路完全没对齐。
- 把 \`DBTab.type\` 拓宽为 \`'database' | 'mongodb' | 'redis'\`，覆盖操作类型安全，同时移除 \`App.vue\` 里的 \`as any\`。
- Redis 与 MongoDB 现在走同一条路径：先建 DBTab，再按 \`config.dbType\` 设置 \`type\`。

**扩展 duplicate**
- \`TabItem.vue\` 菜单项现对 \`terminal | sftp | database | mongodb | redis\` 显示。
- \`duplicateTab()\` 按 \`tab.type\` 选对应的工厂函数（\`createTerminalTab\` / \`createFtpTab\` / \`createDBTab\`）。
- 传给 \`CreateSession\` 的 sessionType：终端和文件传输取自 \`config.type\`，数据库根据 \`config.dbType\` 决定 —— 与已有的 \`onConnect*\` 处理保持一致。
- 非终端 duplicate 补调 \`sessionStore.initSession\`，与 \`onConnectDB\`/\`onConnectRDP\` 一致。