### PR TITLE
feat(webdav): use single URL field instead of host+port+SSL

### DIFF
--- a/backend/session/session.go
+++ b/backend/session/session.go
@@ -73,9 +73,6 @@ type ConnectionConfig struct {
 	// SMB-specific fields
 	SmbDomain string `json:"smbDomain,omitempty"`
 	SmbShare  string `json:"smbShare,omitempty"`
-	// WebDAV-specific fields
-	WebdavURL   string `json:"webdavUrl,omitempty"`
-	WebdavUseSSL bool  `json:"webdavUseSSL"` // default true
 	// S3-specific fields
 	S3Region string `json:"s3Region,omitempty"`
 	S3Bucket string `json:"s3Bucket,omitempty"`

--- a/backend/session/webdav_session.go
+++ b/backend/session/webdav_session.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -40,15 +41,7 @@ func NewWebDAVSession(id string) *WebDAVSession {
 func (s *WebDAVSession) Connect(config ConnectionConfig) error {
 	s.setStatus(StatusConnecting)
 
-	port := config.Port
-	if port <= 0 {
-		port = 443
-	}
-	scheme := "https"
-	if !config.WebdavUseSSL {
-		scheme = "http"
-	}
-	url := fmt.Sprintf("%s://%s:%d", scheme, config.Host, port)
+	url := strings.TrimSuffix(config.Host, "/")
 	s.title = fmt.Sprintf("%s@%s", config.User, url)
 
 	client := gowebdav.NewClient(url, config.User, config.Password)

--- a/frontend/src/components/ConnectionForm.vue
+++ b/frontend/src/components/ConnectionForm.vue
@@ -53,10 +53,10 @@
                 </el-button>
               </div>
             </el-form-item>
-            <el-form-item :label="form.type === 's3' ? 'Endpoint' : t('conn.host')" required v-if="form.type !== 'local' && form.type !== 'serial'">
+            <el-form-item :label="form.type === 's3' ? 'Endpoint' : form.type === 'webdav' ? 'URL' : t('conn.host')" required v-if="form.type !== 'local' && form.type !== 'serial'">
               <div class="host-port-row">
-                <el-input v-model="form.host" class="host-input" :placeholder="form.type === 's3' ? 'e.g. s3.amazonaws.com' : t('conn.hostPlaceholder')" />
-                <template v-if="form.type !== 's3'">
+                <el-input v-model="form.host" class="host-input" :placeholder="form.type === 's3' ? 'e.g. s3.amazonaws.com' : form.type === 'webdav' ? 'https://dav.example.com/dav/' : t('conn.hostPlaceholder')" />
+                <template v-if="form.type !== 's3' && form.type !== 'webdav'">
                   <span class="host-port-sep">:</span>
                   <el-input-number v-model="form.port" :min="0" :max="65535" class="port-input" />
                 </template>
@@ -158,11 +158,6 @@
               </el-form-item>
               <el-form-item label="Share">
                 <el-input v-model="form.smbShare" placeholder="Share name (leave empty to browse all)" />
-              </el-form-item>
-            </template>
-            <template v-if="form.type === 'webdav'">
-              <el-form-item label="SSL">
-                <el-switch v-model="form.webdavUseSSL" />
               </el-form-item>
             </template>
             <template v-if="form.type === 's3'">
@@ -590,8 +585,6 @@ const form = reactive<ConnectionConfig>({
   shellPath: '',
   smbDomain: 'WORKGROUP',
   smbShare: '',
-  webdavURL: '',
-  webdavUseSSL: true,
   s3Region: 'us-east-1',
   s3Bucket: '',
   logOnConnect: false,
@@ -696,7 +689,6 @@ watch(() => form.type, (newType) => {
   else if (newType === 'database') form.port = 3306
   else if (newType === 'ftp') form.port = 21
   else if (newType === 'smb') form.port = 445
-  else if (newType === 'webdav') form.port = 443
   if (REMOTE_TYPES.includes(newType) || newType === 'database') {
     form.authType = 'password'
   }

--- a/frontend/src/types/session.ts
+++ b/frontend/src/types/session.ts
@@ -57,9 +57,6 @@ export interface ConnectionConfig {
   // SMB-specific
   smbDomain?: string
   smbShare?: string
-  // WebDAV-specific
-  webdavURL?: string
-  webdavUseSSL?: boolean
   // S3-specific
   s3Region?: string
   s3Bucket?: string

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -303,8 +303,6 @@ export namespace session {
 	    ftpEncoding?: string;
 	    smbDomain?: string;
 	    smbShare?: string;
-	    webdavUrl?: string;
-	    webdavUseSSL: boolean;
 	    s3Region?: string;
 	    s3Bucket?: string;
 	    encoding?: string;
@@ -351,8 +349,6 @@ export namespace session {
 	        this.ftpEncoding = source["ftpEncoding"];
 	        this.smbDomain = source["smbDomain"];
 	        this.smbShare = source["smbShare"];
-	        this.webdavUrl = source["webdavUrl"];
-	        this.webdavUseSSL = source["webdavUseSSL"];
 	        this.s3Region = source["s3Region"];
 	        this.s3Bucket = source["s3Bucket"];
 	        this.encoding = source["encoding"];


### PR DESCRIPTION
Replace the host/port/SSL-toggle form for WebDAV connections with a single URL input, matching the pattern already used for S3. WebDAV service URLs almost always include a path prefix (Nextcloud, Seafile, Jianguoyun, etc.), which the previous scheme+host+port layout could not express — users had no way to reach `/remote.php/dav/files/<user>/`, `/dav/`, etc.

### Changes

- **Form** (`ConnectionForm.vue`): for `webdav`, relabel the host row as **URL**, hide the port input, and drop the SSL switch. Scheme (http/https) is inferred from the URL the user pastes.
- **Backend** (`webdav_session.go`): `Connect` now passes `config.Host` verbatim to `gowebdav.NewClient` (with a trailing-slash trim). No more scheme/port assembly.
- **Types**: drop `WebdavURL` / `WebdavUseSSL` from `ConnectionConfig`, `types/session.ts`, and the generated `wailsjs/go/models.ts`.

Old connections are not preserved (feature is unreleased and had no users).

### Test

- \`go build ./...\` clean.
- \`npm run build\` clean.
- Verified end-to-end with \`docker run -d --name webdav-test -p 8080:80 -e AUTH_TYPE=Basic -e USERNAME=test -e PASSWORD=test bytemark/webdav\`; the form accepts \`http://localhost:8080/\` and lists the root directory.

---

用单个 URL 输入框替换原本 host + port + SSL 开关的 WebDAV 表单，和 S3 的形态保持一致。实际 WebDAV 服务地址几乎都带路径前缀（Nextcloud、Seafile、坚果云等），旧的 scheme+host+port 拼装方式没法表达这些路径，导致连不到真实挂载点。

### 变更

- **表单** (\`ConnectionForm.vue\`)：webdav 类型下把 host 一行的 label 改成 **URL**，隐藏端口输入框，删除 SSL 开关。scheme（http/https）由用户填的 URL 自身决定。
- **后端** (\`webdav_session.go\`)：\`Connect\` 直接把 \`config.Host\` 传给 \`gowebdav.NewClient\`（去掉尾部斜杠），不再拼装 scheme/port。
- **类型**：从 \`ConnectionConfig\`、\`types/session.ts\` 和生成的 \`wailsjs/go/models.ts\` 中移除 \`WebdavURL\` / \`WebdavUseSSL\`。

未做旧连接兼容（功能未发布，无用户）。

### 验证

- \`go build ./...\` 通过。
- \`npm run build\` 通过。
- Docker 起 \`bytemark/webdav\` 实测：\`http://localhost:8080/\` + 用户名密码可正常连接并列目录。