### PR TITLE
fix(connections): persist edits when using Save & Connect for non-terminal types

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -889,6 +889,15 @@ function closeStartAndReposition(prevTab: any): (newTabId: string) => void {
 async function onConnect(config: ConnectionConfig, keepOpen?: boolean, wasEdit?: boolean) {
   const prev = tabStore.activeTab
   const prevStart = (prev?.type === 'start' && !keepOpen) ? prev : undefined
+  // Persist form changes BEFORE dispatching by type. The type-specific
+  // handlers below only call connectionStore.add(), which is a silent
+  // no-op for existing ids and would otherwise drop edits made in the
+  // "Save & Connect" flow.
+  if (wasEdit) {
+    connectionStore.update(config.id, config)
+  } else {
+    connectionStore.add(config)
+  }
   if (config.type === 'ftp') { await onConnectFtp(config, prevStart); return }
   if (config.type === 'smb') { await onConnectSmb(config, prevStart); return }
   if (config.type === 'webdav') { await onConnectWebdav(config, prevStart); return }
@@ -897,11 +906,6 @@ async function onConnect(config: ConnectionConfig, keepOpen?: boolean, wasEdit?:
   if (config.type === 'vnc') { await onConnectVNC(config, prevStart); return }
   if (config.type === 'spice') { await onConnectSPICE(config, prevStart); return }
   if (config.type === 'database') { await onConnectDB(config, prevStart); return }
-  if (wasEdit) {
-    connectionStore.update(config.id, config)
-  } else {
-    connectionStore.add(config)
-  }
 
   // Credential check
   const resolved = await ensureCredentials(config)


### PR DESCRIPTION
### Problem

From the start-tab card grid, right-click a connection → **Edit**, tweak any field, then hit **Save & Connect**. For FTP, SMB, WebDAV, S3, RDP, VNC, SPICE, and Database connections, the edits were silently dropped — the session used the new form values, but the saved connection kept its old state, so the next click launched the old config again.

### Root cause

\`ConnectionForm\`'s **Save & Connect** button emits \`@connect\` with \`wasEdit=true\`. \`App.vue::onConnect()\` honored that flag only in its default branch (SSH/Telnet/Mosh/Local/Serial):

\`\`\`ts
if (config.type === 'ftp')     { await onConnectFtp(config, prevStart); return }
if (config.type === 'smb')     { ... return }
// ... six more early returns
if (wasEdit) { connectionStore.update(config.id, config) }   // never reached
else         { connectionStore.add(config) }
\`\`\`

Each early-return handler (\`onConnectFtp\`, \`onConnectWebdav\`, etc.) called \`connectionStore.add(config)\` unconditionally, but the store's \`add\` is a silent no-op when the id already exists — so edits were dropped.

### Fix

Move the \`wasEdit ? update : add\` call to the top of \`onConnect\`, before dispatching by type. The subsequent \`add()\` calls inside each handler stay put and remain idempotent no-ops for existing ids.

### Test

Repro (WebDAV, before): edit → change URL → Save & Connect → new session opens with new URL, but reopening the saved card still shows the old URL.
After: reopening the saved card shows the new URL.

---

### 问题

在开始页卡片网格上右键点某个连接 → **编辑**，改任意字段，点 **保存并连接**。对于 FTP、SMB、WebDAV、S3、RDP、VNC、SPICE、Database 类型，改动会被静默丢弃 —— 会话确实用新值起来了，但保存下来的连接还是旧的，下次再点还是旧配置。

### 根因

\`ConnectionForm\` 的 **保存并连接** 按钮 emit \`@connect\` 时会带上 \`wasEdit=true\`。而 \`App.vue::onConnect()\` 只在默认分支（SSH/Telnet/Mosh/Local/Serial）里读了这个标志：

\`\`\`ts
if (config.type === 'ftp')     { await onConnectFtp(config, prevStart); return }
if (config.type === 'smb')     { ... return }
// ... 还有六个提前 return
if (wasEdit) { connectionStore.update(config.id, config) }   // 走不到
else         { connectionStore.add(config) }
\`\`\`

每个提前 return 的 handler（\`onConnectFtp\`、\`onConnectWebdav\` 等）内部都无条件调用 \`connectionStore.add(config)\`，而 store 的 \`add\` 遇到已存在的 id 会静默 return —— 编辑就丢了。

### 修复

把 \`wasEdit ? update : add\` 挪到 \`onConnect\` 顶部、按类型分发之前执行。各 handler 内部的 \`add()\` 保持不动，它对已有 id 是幂等空操作，不会有副作用。

### 验证

复现（WebDAV，修复前）：编辑 → 改 URL → 保存并连接 → 新会话确实用新 URL，但再次打开这张卡片仍显示旧 URL。
修复后：再次打开这张卡片显示新 URL。