### PR TITLE
fix(webdav): use ReadDir instead of Stat in ChangeRemoteDir

### DIFF
--- a/backend/session/webdav_session.go
+++ b/backend/session/webdav_session.go
@@ -127,17 +127,32 @@ func (s *WebDAVSession) ChangeRemoteDir(dir string) (FileListResult, error) {
 	if err != nil {
 		return FileListResult{}, err
 	}
-	fi, err := s.client.Stat(target)
+	// ReadDir doubles as an existence + is-dir check, and gowebdav's
+	// internal PROPFIND handles trailing-slash normalization that
+	// Stat() does not (Apache mod_dav returns 301 for /dir without a
+	// slash, which gowebdav treats as an error).
+	entries, err := s.client.ReadDir(target)
 	if err != nil {
-		return FileListResult{}, fmt.Errorf("no such directory: %s", target)
-	}
-	if !fi.IsDir() {
-		return FileListResult{}, fmt.Errorf("not a directory: %s", target)
+		return FileListResult{}, err
 	}
 	s.mu.Lock()
 	s.cwd = target
 	s.mu.Unlock()
-	return s.ListRemote(target)
+	files := make([]FileItem, 0, len(entries))
+	for _, e := range entries {
+		modTime := ""
+		if !e.ModTime().IsZero() {
+			modTime = e.ModTime().Format(time.RFC3339)
+		}
+		files = append(files, FileItem{
+			Name:    e.Name(),
+			Size:    e.Size(),
+			ModTime: modTime,
+			Mode:    e.Mode().String(),
+			IsDir:   e.IsDir(),
+		})
+	}
+	return FileListResult{Files: files, Dir: target}, nil
 }
 
 func (s *WebDAVSession) MakeDir(dir string) error {


### PR DESCRIPTION
### Problem

Double-clicking any directory in a WebDAV session against Apache \`mod_dav\` (including \`bytemark/webdav\`) failed with:

\`\`\`
no such directory: /test
\`\`\`

### Root cause

Apache \`mod_dav\` (and many other WebDAV servers) returns **301 Moved Permanently** for a \`PROPFIND\` on a directory path without a trailing slash — the client is expected to retry against \`/test/\`. \`gowebdav\`'s \`Stat\` does not follow that redirect and surfaces the 301 as an error.

Verified against the local test container:

\`\`\`
PROPFIND /test    → 301 (Location: http://.../test/)
PROPFIND /test/   → 207
\`\`\`

\`WebDAVSession.ChangeRemoteDir\` used \`Stat\` for its existence + is-dir check, so it always tripped on this convention.

### Fix

Drop the \`Stat\` call and use \`ReadDir\` directly:

- \`ReadDir\` doubles as an existence and is-dir check — success means both.
- \`gowebdav\`'s internal PROPFIND does the trailing-slash normalization that \`Stat\` doesn't.
- One fewer round trip (the old code did \`Stat\` then \`ListRemote\` → also a \`ReadDir\`).
- The original \`err\` is propagated instead of the hard-coded \`no such directory\` string, so 403 / timeout / connection reset surface their real cause.

### Test

- \`go build ./...\` clean.
- With \`docker run bytemark/webdav\` on \`http://localhost:8080/\` and a \`test\` directory at the root, double-click now enters it correctly.

---

### 问题

在 Apache \`mod_dav\`（\`bytemark/webdav\` 等）后端的 WebDAV 会话里，双击任意目录都会报：

\`\`\`
no such directory: /test
\`\`\`

### 根因

Apache \`mod_dav\`（以及不少其他 WebDAV 服务）对不带尾斜杠的目录路径的 \`PROPFIND\` 会返 **301 Moved Permanently**，要求客户端改用 \`/test/\` 重试。而 \`gowebdav\` 的 \`Stat\` 不 follow 这个重定向，直接把 301 当错误抛出来。

本地容器验证：

\`\`\`
PROPFIND /test    → 301（Location: http://.../test/）
PROPFIND /test/   → 207
\`\`\`

\`WebDAVSession.ChangeRemoteDir\` 之前拿 \`Stat\` 做"存在 + 是目录"检查，所以每次都会踩到。

### 修复

去掉 \`Stat\`，直接用 \`ReadDir\`：

- \`ReadDir\` 同时充当"存在 + 是目录"的验证 —— 成功即两者都满足。
- \`gowebdav\` 内部的 PROPFIND 会做 \`Stat\` 没做的尾斜杠归一化。
- 少一次网络往返（旧代码是 \`Stat\` + \`ListRemote\`，后者也是 \`ReadDir\`）。
- 原始错误直接透传，不再被 hardcode 的 \`no such directory\` 覆盖，403 / 超时 / 断连能看出真实原因。

### 验证

- \`go build ./...\` 通过。
- \`docker run bytemark/webdav\` 起在 \`http://localhost:8080/\`，根目录建 \`test\` 文件夹，双击可正常进入。