### PR TITLE
fix(ai): include shell prompt in execute_command/collect_output result

### DIFF
--- a/frontend/src/services/terminalAgent.ts
+++ b/frontend/src/services/terminalAgent.ts
@@ -108,15 +108,8 @@ export function watchOutput(
         resolve({ output: '', timedOut: false, cancelled: true })
         return
       }
-      if (timedOut) {
-        resolve({ output: stripAnsi(output).trim(), timedOut: true })
-        return
-      }
-      const lastInfo = getLastDisplayLine(output)
-      const result = lastInfo
-        ? toDisplayLines(stripAnsi(output)).slice(0, lastInfo.index).join('\n').trim()
-        : stripAnsi(output).trim()
-      resolve({ output: result, timedOut: false })
+      const normalized = toDisplayLines(stripAnsi(output)).join('\n').trim()
+      resolve({ output: normalized, timedOut })
     }
 
     const checkIdle = () => {
@@ -487,7 +480,7 @@ function buildCommand(command: string, shellPath?: string): string {
 function stripAnsi(str: string): string {
   return str
     .replace(/\x1B\[[0-9;?]*[A-Za-z]/g, '')
-    .replace(/\x1B][0-9;]*(?:\x07|\x1B\\)/g, '')
+    .replace(/\x1B\][\s\S]*?(?:\x07|\x1B\\)/g, '')
     .replace(/\x1B[()[\]#\^%@>=]/g, '')
     .replace(/\x1B[/!_]./g, '')
     .replace(/\x1B./g, '')


### PR DESCRIPTION
`execute_command` / `collect_output` used to slice off the final line
(the reappeared shell prompt) before returning the output to the AI, so
the AI could only rely on the outer `[COMMAND COMPLETED]` marker and had
no visibility into the current shell state (cwd change, user switch,
REPL entry, prompt theme change, etc.).

- Return the full watched output including the final prompt line. The
  timeout and completed branches now share the same normalization
  (`toDisplayLines(stripAnsi(output))`), so progress-bar `\r` redraws
  collapse to their final state in both branches.
- Widen the OSC stripper to `\x1B\][\s\S]*?(?:\x07|\x1B\)` so window
  title sequences like `\x1b]0;user@host:~\x07` are removed cleanly.
  Previously the regex only allowed `[0-9;]*` and would leave text like
  `0;user@host:~` in the stripped output, which became visible now that
  the prompt line is included.

Other tools (`start_command`, `capture_terminal`, `send_terminal_key`)
are unaffected.

---

修复 `execute_command` / `collect_output` 返回给 AI 的结果不包含 shell
提示符行的问题。之前 `watchOutput` 判定命令完成后，主动 `slice` 掉了末尾
的 prompt 行，AI 只能靠外层的 `[COMMAND COMPLETED]` 状态推断命令结束，
无法感知当前 shell 状态（cwd 变化、切用户、进入 REPL、prompt 主题变化等）。

- 保留完整 watched output（含末尾 prompt 行）。超时分支和完成分支统一使用
  `toDisplayLines(stripAnsi(output))` 规范化,进度条 `\r` 覆写在两条分支中
  都会收敛到最终显示态。
- 放宽 ANSI 剥离中 OSC 序列的匹配范围为 `\x1B\][\s\S]*?(?:\x07|\x1B\)`,
  让像 `\x1b]0;user@host:~\x07` 这样的窗口标题序列被干净剥掉。此前正则只
  允许 `[0-9;]*`,会把 `0;user@host:~` 这样的文本残留下来——之前因为末尾
  prompt 行被截掉这段隐藏了,现在保留 prompt 后就暴露出来。

其他工具(`start_command`、`capture_terminal`、`send_terminal_key`)不受影响。