### PR TITLE
fix(terminal): pass Ctrl+V through to alternate-screen apps

### DIFF
--- a/frontend/src/components/BaseTerminal.vue
+++ b/frontend/src/components/BaseTerminal.vue
@@ -628,6 +628,11 @@ function handleTerminalKey(e: KeyboardEvent): boolean {
 
   // Cmd/Ctrl+V: paste via Wails clipboard (xterm's DOM paste is unreliable in WKWebView).
   if ((e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey && (e.key === 'v' || e.key === 'V') && e.type === 'keydown') {
+    // In alternate-screen apps (vim, k9s, htop, less…) pass Ctrl+V through so
+    // remote apps can use it as a binding (e.g. vim visual block).
+    if (terminalInput?.isInAlternateScreen()) {
+      return true
+    }
     e.preventDefault()
     if (props.mode === 'ssh' || props.mode === 'local') {
       ClipboardGetText().then(text => {


### PR DESCRIPTION
## Summary

BaseTerminal.vue's attachCustomKeyEventHandler hook was unconditionally intercepting Ctrl+V and converting it to a paste, so remote TUI apps in the alternate screen (vim, k9s, htop, less...) could never see ^V. This broke vim visual block and similar bindings.

---

## 变更摘要

ssh链接中使用vim编辑文件，Ctrl-v不能作为列模式工作，仍然是粘贴功能