### PR TITLE
fix(terminal): bind paste to platform shortcut, pass Ctrl+V through

### DIFF
--- a/frontend/src/components/BaseTerminal.vue
+++ b/frontend/src/components/BaseTerminal.vue
@@ -116,6 +116,8 @@ const props = defineProps<{
   panelId?: string
 }>()
 
+const isMac = /Mac|iPhone|iPad/.test(navigator.userAgent)
+
 const settingsStore = useSettingsStore()
 const sessionStore = useSessionStore()
 const tabStore = useTabStore()
@@ -626,13 +628,14 @@ function handleTerminalKey(e: KeyboardEvent): boolean {
   // Check global shortcuts first (Ctrl+Shift+/Alt+ combos)
   if (e.type === 'keydown' && !onTerminalKey(e)) return false
 
-  // Cmd/Ctrl+V: paste via Wails clipboard (xterm's DOM paste is unreliable in WKWebView).
-  if ((e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey && (e.key === 'v' || e.key === 'V') && e.type === 'keydown') {
-    // In alternate-screen apps (vim, k9s, htop, less…) pass Ctrl+V through so
-    // remote apps can use it as a binding (e.g. vim visual block).
-    if (terminalInput?.isInAlternateScreen()) {
-      return true
-    }
+  // Paste via Wails clipboard (xterm's DOM paste is unreliable in WKWebView).
+  // Bind to the platform's paste shortcut only — Cmd+V on macOS, Ctrl+Shift+V
+  // elsewhere. Plain Ctrl+V is never intercepted, so it passes through to the
+  // terminal app (vim visual block, bash literal-next…) on every platform.
+  const pasteCombo = isMac
+    ? (e.metaKey && !e.ctrlKey && !e.shiftKey && !e.altKey)
+    : (e.ctrlKey && e.shiftKey && !e.metaKey && !e.altKey)
+  if (pasteCombo && (e.key === 'v' || e.key === 'V') && e.type === 'keydown') {
     e.preventDefault()
     if (props.mode === 'ssh' || props.mode === 'local') {
       ClipboardGetText().then(text => {


### PR DESCRIPTION
## Summary

Paste was bound to any `Cmd/Ctrl+V` keydown, so it swallowed `Ctrl+V` inside terminal apps — breaking vim visual block and bash literal-next (`Ctrl+V Tab`). #327 only passed `Ctrl+V` through on the alternate screen, which left two gaps: `Ctrl+V` was still swallowed at the shell prompt, and its `metaKey || ctrlKey` guard also disabled `Cmd+V` paste inside vim.

This binds paste to the platform's paste shortcut only:

- **macOS**: `Cmd+V`
- **Windows / Linux**: `Ctrl+Shift+V` (mirrors the existing `Ctrl+Shift+C` copy)

Plain `Ctrl+V` is never intercepted, so it always reaches the terminal app on every platform and every screen (main + alternate). The alternate-screen special-case from #327 is no longer needed and is removed.

## Changes

- `BaseTerminal.vue`: detect macOS once (`isMac`), and gate the paste handler on the platform-specific combo instead of any `Cmd/Ctrl+V`. Drop the `isInAlternateScreen()` passthrough branch — paste no longer depends on screen state.

## Validation

- `npm --prefix frontend run build` passes.
- `wails dev` (macOS): `Ctrl+V` enters visual block in vim; `Cmd+V` pastes at the shell prompt and inside vim insert mode; multi-line paste keeps bracketed-paste (no re-indent). Right-click / middle-click paste unaffected (they go through `onPaste`, never bound to a shortcut).

---

## 变更摘要

之前粘贴绑定在任意 `Cmd/Ctrl+V` 上，导致终端应用里的 `Ctrl+V` 被吞——vim 列选（visual block）、bash literal-next（`Ctrl+V Tab`）都失效。#327 只在 alternate-screen 放行 `Ctrl+V`，仍有两处没解决：shell 提示符下 `Ctrl+V` 依然被吞；且其 `metaKey || ctrlKey` 判断连 vim 里的 `Cmd+V` 粘贴也一并禁掉了。

本次把粘贴只绑到平台标准粘贴键：

- **macOS**：`Cmd+V`
- **Windows / Linux**：`Ctrl+Shift+V`（与已有的 `Ctrl+Shift+C` 复制对称）

纯 `Ctrl+V` 不再被拦截，在所有平台、所有屏幕（主屏 + alternate）都透传给终端应用。#327 的 alternate-screen 特判不再需要，一并移除。

## 具体改动

- `BaseTerminal.vue`：一次性检测 macOS（`isMac`），粘贴处理改用平台专属组合键判断，去掉 `isInAlternateScreen()` 透传分支——粘贴不再依赖屏幕状态。

## 验证

- `npm --prefix frontend run build` 通过。
- `wails dev`（macOS）：vim 里 `Ctrl+V` 进入列选；shell 提示符与 vim 插入模式下 `Cmd+V` 正常粘贴；多行粘贴保留 bracketed-paste（不重复缩进）。右键/中键粘贴不受影响（走 `onPaste`，本就未绑快捷键）。