### PR TITLE
fix(tabs): fix duplicate for terminal, sftp and database tabs

### DIFF
--- a/frontend/src/components/TabItem.vue
+++ b/frontend/src/components/TabItem.vue
@@ -358,6 +358,24 @@ async function duplicateTab() {
   const newPanel = panelStore.createPanel(panel.config, panel.type)
   panelStore.updateTitle(newPanel.id, panel.title)
 
+  // Create + bind the session BEFORE mounting the tab, so the terminal has a
+  // sessionId on first mount. Mounting first (empty sessionId) leaves the
+  // shared terminal keyed by '' and bindSession's later id change can't
+  // transfer it (the watch skips when oldId is falsy), so server output is
+  // dropped until an incidental resize rebuilds the reference.
+  let info
+  if (panel.config) {
+    try {
+      const sessionType = resolveSessionType(tab.type, panel.config)
+      info = await CreateSession(sessionType, panel.config)
+      panelStore.bindSession(newPanel.id, info.id)
+      if (tab.type !== 'terminal') sessionStore.initSession(info.id)
+    } catch (e) {
+      console.error('Failed to duplicate session:', e)
+      return
+    }
+  }
+
   let newTab
   if (tab.type === 'terminal') {
     newTab = tabStore.createTerminalTab(newPanel.title, newPanel.id)
@@ -370,17 +388,6 @@ async function duplicateTab() {
     return
   }
   panelStore.movePanelToTab(newPanel.id, newTab.id)
-
-  if (panel.config) {
-    try {
-      const sessionType = resolveSessionType(tab.type, panel.config)
-      const info = await CreateSession(sessionType, panel.config)
-      panelStore.bindSession(newPanel.id, info.id)
-      if (tab.type !== 'terminal') sessionStore.initSession(info.id)
-    } catch (e) {
-      console.error('Failed to duplicate session:', e)
-    }
-  }
 }
 
 // The session-type argument to CreateSession isn't always panel.config.type:

--- a/frontend/src/components/TabItem.vue
+++ b/frontend/src/components/TabItem.vue
@@ -391,12 +391,18 @@ async function duplicateTab() {
 }
 
 // The session-type argument to CreateSession isn't always panel.config.type:
-// database panels split into mysql/postgres/redis/mongodb by dbType.
+// - database panels split into mysql/postgres/redis/mongodb by dbType;
+// - a file-transfer (sftp) tab shares the SSH connection, so its config.type
+//   is 'ssh' but the session must be created as 'sftp' (ftp/smb/webdav/s3
+//   already carry a matching config.type).
 function resolveSessionType(tabType: string, config: any): string {
   if (tabType === 'database' || tabType === 'mongodb' || tabType === 'redis') {
     if (config?.dbType === 'redis') return 'redis'
     if (config?.dbType === 'mongodb') return 'mongodb'
     return 'database'
+  }
+  if (tabType === 'sftp') {
+    return config?.type === 'ssh' ? 'sftp' : config?.type
   }
   return config?.type
 }


### PR DESCRIPTION
## Summary

Duplicating a tab (right-click → Duplicate) was broken on `main` in two ways after #320. This fixes both.

### 1. Terminal: multi-minute black screen before connect

#320 reordered `duplicateTab` to mount the tab (`createTerminalTab` + `movePanelToTab`) **before** `CreateSession` / `bindSession`, so the terminal mounted while `sessionId` was still empty:

- `acquireTerminal('')` keyed the shared terminal by the empty string.
- `bindSession` then changed `sessionId` from `''` to the real id, firing the `sessionId` watch — but that watch only transfers the terminal when `oldId` is truthy (`if (oldId && oldId !== newId)`). With `oldId === ''` (falsy), the transfer was skipped.
- `terminal` stayed `null`, so the `session:data` handler dropped every byte of server output until an incidental resize rebuilt the reference — hence the long, random black screen.

Fix: restore the order already used by App.vue's keyboard-shortcut `duplicateSession` — create and bind the session first, then mount the tab.

### 2. SFTP: "not a file transfer session"

An SFTP tab shares the SSH connection, so its `config.type` is `'ssh'`. `resolveSessionType` returned `config.type` verbatim, so duplicating an SFTP tab created an **SSH** session and every file op failed with `not a file transfer session`. (ftp/smb/webdav/s3 already carry a matching `config.type`, and database splits by `dbType`, so only sftp was affected.)

Fix: map an sftp tab's `'ssh'` config to an `'sftp'` session.

## Changes

- `TabItem.vue` `duplicateTab`: create + bind the session before mounting the tab; bail out on connect failure.
- `TabItem.vue` `resolveSessionType`: return `'sftp'` for an sftp tab whose config.type is `'ssh'`.

## Validation

- `npm --prefix frontend run build` passes.
- `wails dev` launches. Please confirm in a real connection: right-click → Duplicate connects instantly for terminal tabs, and duplicated SFTP / database tabs open their file/query view without error.

---

## 变更摘要

复制标签（右键 → 复制）在 #320 之后于 `main` 上有两处损坏，本 PR 一并修复。

### 1. 终端：连接前长时间黑屏

#320 把 `duplicateTab` 改成先挂载标签（`createTerminalTab` + `movePanelToTab`）**再** `CreateSession` / `bindSession`，终端在 `sessionId` 还是空时就挂载：

- `acquireTerminal('')` 用空串作 key。
- 随后 `bindSession` 把 `sessionId` 从 `''` 改成真实 id，触发 watch——但 watch 只在 `oldId` 为真值时 transfer（`if (oldId && oldId !== newId)`）。`oldId === ''`（falsy），transfer 被跳过。
- `terminal` 一直为 `null`，`session:data` 处理器把服务器输出整个丢弃，直到某次 resize 侥幸重建引用——于是长时间随机黑屏。

修复：恢复 App.vue 键盘快捷键版 `duplicateSession` 的正确顺序——先创建并绑定 session，再挂载标签。

### 2. SFTP：提示 "not a file transfer session"

SFTP 与 SSH 共用连接，其 `config.type` 是 `'ssh'`。`resolveSessionType` 原样返回 `config.type`，导致复制 SFTP 标签建成了 **SSH** 会话，所有文件操作报 `not a file transfer session`。（ftp/smb/webdav/s3 的 config.type 恰好等于 session type，数据库按 dbType 分流，故只有 sftp 受影响。）

修复：把 sftp 标签的 `'ssh'` config 映射为 `'sftp'` 会话。

## 具体改动

- `TabItem.vue` `duplicateTab`：先创建并绑定 session，再挂载标签；连接失败提前返回。
- `TabItem.vue` `resolveSessionType`：sftp 标签且 config.type 为 `'ssh'` 时返回 `'sftp'`。

## 验证

- `npm --prefix frontend run build` 通过。
- `wails dev` 正常启动。请在真实连接下确认：终端标签右键→复制可秒连；复制的 SFTP / 数据库标签能正常打开文件/查询视图、无报错。