### PR TITLE
refactor(tab): declutter hovered tab — AI lock into menu, no layout shift

### DIFF
--- a/frontend/src/components/TabItem.vue
+++ b/frontend/src/components/TabItem.vue
@@ -68,6 +68,9 @@
         @click.stop
       >
         <div v-if="canDuplicate" class="menu-item" @click="duplicateTab">{{ t('tab.duplicate') }}</div>
+        <div v-if="tab.type === 'terminal'" class="menu-item" @click="toggleAiLock">
+          {{ isAILocked ? t('terminal.aiLocked') : t('terminal.lockAI') }}
+        </div>
         <div v-if="tab.type === 'terminal' && panelStore.getPanel(tab.panelId)?.type === 'ssh'" class="menu-item" @click="openSftp">{{ t('sidebar.connectSftp') }}</div>
         <div v-if="tab.type === 'terminal' && panelStore.getPanel(tab.panelId)?.type === 'ssh'" class="menu-item" @click="uploadFileRz">{{ t('terminal.uploadFileRz') }}</div>
         <div v-if="tab.type === 'terminal' && panelStore.getPanel(tab.panelId)?.type === 'ssh'" class="menu-item" @click="openMonitor">{{ t('sidebar.connectMonitor') }}</div>
@@ -80,9 +83,6 @@
         <div v-if="tab.type === 'terminal'" class="menu-item" @click="triggerSearch">{{ t('terminal.searchText') }}</div>
         <div v-if="tab.type === 'terminal'" class="menu-item" @click="triggerExport">{{ t('terminal.export') }}</div>
         <div v-if="tab.type === 'terminal'" class="menu-item" @click="startEdit">{{ t('tab.rename') }}</div>
-        <div v-if="tab.type === 'terminal'" class="menu-item" @click="toggleAiLock">
-          {{ isAILocked ? t('terminal.aiLocked') : t('terminal.lockAI') }}
-        </div>
         <div v-if="tab.type === 'terminal'" class="menu-divider" />
         <div v-if="tab.type !== 'start' && tab.type !== 'settings'" class="menu-item" @click="toggleLock">
           {{ tab.locked ? t('tab.unlock') : t('tab.lock') }}

--- a/frontend/src/components/TabItem.vue
+++ b/frontend/src/components/TabItem.vue
@@ -523,6 +523,12 @@ onUnmounted(() => {
   gap: 6px;
   margin-right: 4px;
   font-weight: 500;
+  transition: margin-right 0.12s ease;
+}
+/* On hover the floating more (…) button overlays the name's tail; reserve
+   room so the label stays fully visible instead of being covered. */
+.tab-item:hover .tab-name {
+  margin-right: 24px;
 }
 .tab-disconnected {
   opacity: 0.5;

--- a/frontend/src/components/TabItem.vue
+++ b/frontend/src/components/TabItem.vue
@@ -30,19 +30,10 @@
       />
       <span v-else-if="!isActive && hasNotification && !tab.locked" class="tab-notification-dot" />
     </span>
-    <button
-      v-if="tab.type === 'terminal'"
-      class="tab-ai-lock"
-      :class="{ locked: isAILocked }"
-      @click.stop="$emit('toggleAiLock', tab.panelId)"
-      :title="isAILocked ? t('terminal.aiLocked') : t('terminal.lockAI')"
-    >
-      <Sparkles :size="14" />
-    </button>
     <span
-      v-else-if="tab.type === 'workspace' && isAILocked"
-      class="tab-ai-lock locked"
-      title="AI locked to a panel in this workspace"
+      v-if="isAILocked"
+      class="tab-ai-lock-indicator"
+      :title="t('terminal.aiLocked')"
     >
       <Sparkles :size="14" />
     </span>
@@ -89,6 +80,9 @@
         <div v-if="tab.type === 'terminal'" class="menu-item" @click="triggerSearch">{{ t('terminal.searchText') }}</div>
         <div v-if="tab.type === 'terminal'" class="menu-item" @click="triggerExport">{{ t('terminal.export') }}</div>
         <div v-if="tab.type === 'terminal'" class="menu-item" @click="startEdit">{{ t('tab.rename') }}</div>
+        <div v-if="tab.type === 'terminal'" class="menu-item" @click="toggleAiLock">
+          {{ isAILocked ? t('terminal.aiLocked') : t('terminal.lockAI') }}
+        </div>
         <div v-if="tab.type === 'terminal'" class="menu-divider" />
         <div v-if="tab.type !== 'start' && tab.type !== 'settings'" class="menu-item" @click="toggleLock">
           {{ tab.locked ? t('tab.unlock') : t('tab.lock') }}
@@ -321,6 +315,13 @@ function toggleLock() {
   closeContextMenu()
 }
 
+function toggleAiLock() {
+  if (props.tab.type === 'terminal') {
+    emit('toggleAiLock', props.tab.panelId)
+  }
+  closeContextMenu()
+}
+
 function closeTab() {
   emit('close', props.tab.id)
   closeContextMenu()
@@ -521,14 +522,10 @@ onUnmounted(() => {
   display: flex;
   align-items: center;
   gap: 6px;
-  margin-right: 4px;
+  /* Always reserve room for the floating more (…) button so hovering never
+     widens the tab (no layout shift) and the button never covers the name. */
+  margin-right: 20px;
   font-weight: 500;
-  transition: margin-right 0.12s ease;
-}
-/* On hover the floating more (…) button overlays the name's tail; reserve
-   room so the label stays fully visible instead of being covered. */
-.tab-item:hover .tab-name {
-  margin-right: 24px;
 }
 .tab-disconnected {
   opacity: 0.5;
@@ -587,39 +584,12 @@ onUnmounted(() => {
   width: 120px;
   outline: none;
 }
-.tab-ai-lock {
-  position: absolute;
-  left: 30px;
-  top: 50%;
-  transform: translateY(-50%);
-  background: var(--bg-hover);
-  border: none;
-  color: var(--text-muted);
-  cursor: pointer;
-  width: 18px;
-  height: 18px;
-  padding: 0;
-  border-radius: 3px;
-  display: none;
+.tab-ai-lock-indicator {
+  display: inline-flex;
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
-}
-.tab-item:hover .tab-ai-lock {
-  display: inline-flex;
-}
-.tab-ai-lock.locked {
-  position: static;
-  transform: none;
-  display: inline-flex;
-  background: transparent;
-  color: var(--warning);
   margin-right: 2px;
-}
-.tab-ai-lock:hover {
-  color: var(--text-primary);
-}
-.tab-ai-lock.locked:hover {
   color: var(--warning);
 }
 .tab-close {


### PR DESCRIPTION
Closes #325

## Summary

A hovered tab showed three buttons (close, AI lock, more) over a name that the floating more (…) button half-covered — cluttered, as reported in #325. This simplifies the hovered tab:

1. **AI lock → menu.** Remove the hover AI-lock button; add a lock/unlock AI item to the more (…) / right-click menu. AI-locked tabs still show a static (non-clickable) sparkles indicator so the state is visible at a glance.
2. **No layout shift on hover.** The name now reserves fixed room for the floating more button (constant right margin), so hovering never widens the tab and the button never overlaps the name — no jitter.

## Changes

- `TabItem.vue`:
  - Remove the `.tab-ai-lock` hover button; replace with a static `.tab-ai-lock-indicator` shown only when AI-locked.
  - Add a `toggleAiLock` menu item (terminal tabs) that emits the existing `toggleAiLock` event.
  - Give `.tab-name` a constant `margin-right` sized for the more button; drop the hover-only margin change and its transition.

## Validation

- `npm --prefix frontend run build` passes.
- `wails dev`: hovered tab shows only close + more; the name no longer shifts or gets covered on hover; AI lock/unlock works from the menu; locked tabs show the sparkles indicator.

---

## 变更摘要

悬停标签时会同时出现三个按钮（关闭、AI 锁、菜单），且浮动的 more（…）按钮遮住名称一半，显得杂乱（见 #325）。本 PR 精简悬停标签：

1. **AI 锁移入菜单。** 移除悬停时的 AI 锁按钮；在 more（…）/ 右键菜单中加「锁定/解锁 AI」项。被 AI 锁定的标签仍显示一个静态（不可点）的 sparkles 图标，锁定状态一眼可见。
2. **悬停不再抖动。** 名称常驻预留 more 按钮的空间（固定右边距），悬停时标签宽度不变、按钮不遮名称，无抖动。

## 具体改动

- `TabItem.vue`：
  - 移除 `.tab-ai-lock` 悬停按钮，改为仅锁定时显示的静态 `.tab-ai-lock-indicator`。
  - 菜单加 `toggleAiLock` 项（终端标签），沿用原有 `toggleAiLock` 事件。
  - `.tab-name` 改为常驻 `margin-right`，去掉 hover 时的边距变化与过渡。

## 验证

- `npm --prefix frontend run build` 通过。
- `wails dev`：悬停标签只剩关闭 + 菜单；名称不再位移或被遮；菜单可锁定/解锁 AI；锁定的标签显示 sparkles 图标。