### PR TITLE
fix(tabs): keep add-tab button visible when tabs overflow

### DIFF
--- a/frontend/src/components/TabsList.vue
+++ b/frontend/src/components/TabsList.vue
@@ -29,6 +29,7 @@
       class="tab-drop-indicator tab-drop-indicator-end"
     ></div>
     <button
+      v-if="!showMore"
       class="tab-add-btn"
       :title="t('startTab.defaultName')"
       @click="onAddStartTab"
@@ -54,6 +55,13 @@
         </el-dropdown-menu>
       </template>
     </el-dropdown>
+    <button
+      class="tab-add-btn"
+      :title="t('startTab.defaultName')"
+      @click="onAddStartTab"
+    >
+      <Plus :size="14" />
+    </button>
   </div>
 </template>
 


### PR DESCRIPTION
## Summary

When many tabs are open, the tab row overflows and the trailing + (new tab) button scrolls out of view, so it's hard to reach. This pins the + button next to the overflow (…) dropdown — after … and before the AI button — while tabs overflow. When they don't overflow, the + stays at the end of the row as before.

## Changes

- `TabsList.vue`: hide the in-scroll + button when overflowing (`v-if="!showMore"`); add a pinned + inside the `.tab-more` block, after the … dropdown.

## Validation

- `npm --prefix frontend run build` passes.
- `wails dev`: with few tabs the + sits at the row end; opening enough tabs to overflow moves the + to a fixed spot right after … and before the AI button, always visible.

---

## 变更摘要

标签过多时标签栏溢出，末尾的 +（新建标签）按钮会被滚出可视区、难以点到。本 PR 在溢出时把 + 固定到 …（更多）下拉旁边——… 之后、AI 按钮之前。未溢出时 + 仍留在标签行末尾。

## 具体改动

- `TabsList.vue`：溢出时隐藏滚动区内的 +（`v-if="!showMore"`）；在 `.tab-more` 块内、… 下拉之后加一个固定的 +。

## 验证

- `npm --prefix frontend run build` 通过。
- `wails dev`：标签少时 + 在行尾；开到溢出时 + 固定在 … 之后、AI 按钮之前，始终可见。