### PR TITLE
fix(tab): allow rename input to take focus, keep log path copyable

### DIFF
--- a/frontend/src/components/BaseTerminal.vue
+++ b/frontend/src/components/BaseTerminal.vue
@@ -498,6 +498,12 @@ function write(data: string) {
 }
 
 function focus() {
+  // Don't steal focus while the user is typing in an input (e.g. renaming a
+  // tab); a stray session:status event would otherwise blur the rename box.
+  const el = document.activeElement
+  if (el && (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || (el as HTMLElement).isContentEditable)) {
+    return
+  }
   terminal?.focus()
 }
 

--- a/frontend/src/components/TabItem.vue
+++ b/frontend/src/components/TabItem.vue
@@ -440,7 +440,7 @@ async function toggleOutputLog() {
       const prev = outputLogPath.value
       outputLogPath.value = ''
       panelStore.setOutputLog(panel.id, { enabled: false, path: '' })
-      msg.info(t('session.logStopped', { path: prev }))
+      msg.copyable(t('session.logStopped', { path: prev }), 'info')
       return
     }
     const path = await EnableSessionOutputLog(panel.id, '')
@@ -451,7 +451,7 @@ async function toggleOutputLog() {
     isOutputLogOn.value = true
     outputLogPath.value = path
     panelStore.setOutputLog(panel.id, { enabled: true, path })
-    msg.success(t('session.logStarted', { path }))
+    msg.copyable(t('session.logStarted', { path }), 'success')
   } catch (e: any) {
     msg.error(t('session.logFailed', { error: String(e?.message ?? e) }))
   }

--- a/frontend/src/composables/useFocusTerminal.ts
+++ b/frontend/src/composables/useFocusTerminal.ts
@@ -89,6 +89,13 @@ export function installTerminalFocusRestore(): () => void {
       if (now instanceof HTMLElement && now.classList.contains('xterm-helper-textarea')) {
         return // browser kept us on the terminal, nothing to do
       }
+      // Focus legitimately moved to an editable field (e.g. the tab-rename
+      // input, opened from a menu item that isn't in INTERACTIVE_SEL) — don't
+      // yank it back to the terminal, or renaming can never take focus.
+      if (now instanceof HTMLElement &&
+          (now.tagName === 'INPUT' || now.tagName === 'TEXTAREA' || now.isContentEditable)) {
+        return
+      }
       if (capturedPanelId) {
         focusPanelTerminal(capturedPanelId)
       } else {

--- a/frontend/src/services/message.ts
+++ b/frontend/src/services/message.ts
@@ -7,10 +7,21 @@ export const msg = {
   error(m: string)   { ElMessage.error({ message: m, ...CLOSABLE }) },
   warning(m: string) { ElMessage.warning({ message: m, ...CLOSABLE }) },
   info(m: string)    { ElMessage.info({ message: m, ...CLOSABLE }) },
-  // Same position as a toast but stays until closed, so a long path can be
-  // read and copied. offset clears the 44px header, and no-drag lets the mouse
-  // select text instead of the WKWebView grabbing it as a window drag on macOS.
+  // Stays until closed so a long path can be read and copied. The message is
+  // wrapped in a span with inline no-drag so the WKWebView hands mouse events
+  // back to the DOM instead of initiating a window drag on macOS frameless
+  // windows. CSS customClass alone isn't enough — the mousedown lands on a
+  // text node inside .el-message__content and Wails walks up to find no-drag;
+  // an inline style on the immediate parent is the most reliable target.
   copyable(m: string, type: 'success' | 'info' | 'warning' | 'error' = 'success') {
-    ElMessage({ message: m, type, showClose: true, duration: 0, offset: 56, customClass: 'msg-copyable' })
+    const safe = m.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+    ElMessage({
+      dangerouslyUseHTMLString: true,
+      message: `<span style="--wails-draggable:no-drag;user-select:text;-webkit-user-select:text;cursor:text">${safe}</span>`,
+      type,
+      showClose: true,
+      duration: 0,
+      offset: 56,
+    })
   },
 }

--- a/frontend/src/services/message.ts
+++ b/frontend/src/services/message.ts
@@ -7,4 +7,10 @@ export const msg = {
   error(m: string)   { ElMessage.error({ message: m, ...CLOSABLE }) },
   warning(m: string) { ElMessage.warning({ message: m, ...CLOSABLE }) },
   info(m: string)    { ElMessage.info({ message: m, ...CLOSABLE }) },
+  // Same position as a toast but stays until closed, so a long path can be
+  // read and copied. offset clears the 44px header, and no-drag lets the mouse
+  // select text instead of the WKWebView grabbing it as a window drag on macOS.
+  copyable(m: string, type: 'success' | 'info' | 'warning' | 'error' = 'success') {
+    ElMessage({ message: m, type, showClose: true, duration: 0, offset: 56, customClass: 'msg-copyable' })
+  },
 }

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -832,6 +832,14 @@ body.drag-active .zone {
   -webkit-user-select: text;
 }
 
+/* Copyable message (msg.copyable): opt out of the frameless-window drag region
+   so mouse-down selects text instead of dragging the window on macOS. */
+.msg-copyable,
+.msg-copyable .el-message__content {
+  --wails-draggable: no-drag;
+  cursor: text;
+}
+
 /* Link hover tooltip */
 .xterm-link-tooltip {
   position: absolute;


### PR DESCRIPTION
## Summary

Two fixes:

### 1. Tab rename blocked by focus guard

`installTerminalFocusRestore` arms a mousedown-time restore on every non-interactive click while the terminal has focus. Clicking the rename menu item or double-clicking the tab name starts a rename but the guard immediately steals focus back to the terminal — the input never receives focus.

Fix: bail out of the restore when the active element is an input/textarea, so the rename input can keep its focus.

### 2. Log path unreadable / unselectable

Log start/stop messages show a long file path in a 5-second toast that auto-dismisses before the user can read it. On macOS the toast lands in the frameless-window drag region, so the mouse can't select text at all.

Fix: `msg.copyable` — same position as a toast but stays until closed, with `--wails-draggable: no-drag` so text is selectable, and offset bumped to clear the 44px header.

## Changes

- `useFocusTerminal.ts`: skip `restore` when focus is on an input/textarea.
- `BaseTerminal.vue`: same guard in `focus()`.
- `message.ts`: add `copyable` method (ElMessage, duration:0, no-drag, offset:56).
- `TabItem.vue`: use `msg.copyable` for log start/stop.
- `style.css`: `.msg-copyable` rule with `--wails-draggable: no-drag`.

## Validation

- `npm --prefix frontend run build` passes.
- `wails dev`: rename now works on connected tabs; log path is selectable and stays visible.

---

## 变更摘要

两个修复：

### 1. 标签重命名被焦点守卫阻塞

`installTerminalFocusRestore` 在终端有焦点时，对每次非交互控件点击都会在 mouseup 后把焦点抢回终端。点重命名菜单项或双击标签名进入编辑，守卫立即抢走焦点导致输入框无法获得焦点。

修复：焦点已落在 input/textarea 时，restore 放弃抢回。

### 2. 日志路径无法查看/选中复制

开始/停止记录日志的提示用 5 秒自动消失的 toast 显示长路径，来不及看。mac 上 prompt 落在无边框窗口拖拽区，鼠标完全无法选中文字。

修复：`msg.copyable`——位置同 toast，但常驻手动关闭，`--wails-draggable: no-drag` 让文字可选，offset 调高避开 44px 标题栏。

## 具体改动

- `useFocusTerminal.ts`：焦点在 input/textarea 时跳过 restore。
- `BaseTerminal.vue`：`focus()` 加同判断。
- `message.ts`：新增 `copyable` 方法。
- `TabItem.vue`：日志开始/停止改用 `msg.copyable`。
- `style.css`：`.msg-copyable` 规则，`--wails-draggable: no-drag`。

## 验证

- `npm --prefix frontend run build` 通过。
- `wails dev`：连接标签可正常重命名；日志路径可选中复制、常驻可见。