### PR TITLE
feat(message): add right-click copy/select-all to the log-path toast

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -114,9 +114,9 @@
       :style="{ left: inputMenuPos.x + 'px', top: inputMenuPos.y + 'px' }"
       @click.stop
     >
-      <div class="input-menu-item" @click="inputMenuCut">{{ t('input.cut') }}</div>
+      <div v-if="!inputMenuReadonly" class="input-menu-item" @click="inputMenuCut">{{ t('input.cut') }}</div>
       <div class="input-menu-item" @click="inputMenuCopy">{{ t('input.copy') }}</div>
-      <div class="input-menu-item" @click="inputMenuPaste">{{ t('input.paste') }}</div>
+      <div v-if="!inputMenuReadonly" class="input-menu-item" @click="inputMenuPaste">{{ t('input.paste') }}</div>
       <div class="input-menu-item" @click="inputMenuSelectAll">{{ t('input.selectAll') }}</div>
     </div>
 
@@ -267,6 +267,7 @@ const aiSidebarRef = ref<any>(null)
 // Input context menu state
 const inputMenuVisible = ref(false)
 const inputMenuPos = ref({ x: 0, y: 0 })
+const inputMenuReadonly = ref(false)
 
 // ── Credential prompt ──────────────────────────────────────────
 const credentialVisible = ref(false)
@@ -378,11 +379,12 @@ function closeInputMenu() {
 }
 
 function onInputContextMenu(e: Event) {
-  const { x, y, target } = (e as CustomEvent).detail as {
-    x: number; y: number; target: HTMLElement
+  const { x, y, target, readonly } = (e as CustomEvent).detail as {
+    x: number; y: number; target: HTMLElement; readonly?: boolean
   }
   window.dispatchEvent(new CustomEvent('global:close-context-menus'))
   inputMenuTarget = target
+  inputMenuReadonly.value = !!readonly
   const pos = fitMenuPosition(x, y, 120, 140)
   inputMenuPos.value = { x: parseInt(pos.left), y: parseInt(pos.top) }
   inputMenuVisible.value = true
@@ -413,8 +415,16 @@ function inputMenuCut() {
 
 function inputMenuCopy() {
   const el = inputMenuTarget
+  const readonly = inputMenuReadonly.value
   closeInputMenu()
   if (!el) return
+  // Read-only plain element (log-path toast): copy the live selection if any,
+  // otherwise the whole text.
+  if (readonly) {
+    const sel = window.getSelection()?.toString()
+    navigator.clipboard.writeText(sel || el.textContent || '')
+    return
+  }
   navigator.clipboard.writeText(getInputSelection(el))
 }
 
@@ -434,7 +444,14 @@ function inputMenuPaste() {
 
 function inputMenuSelectAll() {
   const el = inputMenuTarget
-  if (el && 'select' in el) {
+  const readonly = inputMenuReadonly.value
+  if (el && readonly) {
+    const range = document.createRange()
+    range.selectNodeContents(el)
+    const sel = window.getSelection()
+    sel?.removeAllRanges()
+    sel?.addRange(range)
+  } else if (el && 'select' in el) {
     (el as HTMLInputElement | HTMLTextAreaElement).select()
   }
   closeInputMenu()

--- a/frontend/src/composables/useFocusTerminal.ts
+++ b/frontend/src/composables/useFocusTerminal.ts
@@ -54,7 +54,9 @@ export function installTerminalFocusRestore(): () => void {
   // (.el-select__wrapper) and teleports the option list to <body> as
   // .el-popper — neither is a native control, so list them explicitly or the
   // focus guard steals focus back to the terminal and the dropdown never opens.
-  const INTERACTIVE_SEL = 'input, textarea, select, button, a, [role="button"], [role="combobox"], [contenteditable="true"], .xterm-helper-textarea, .el-select__wrapper, .el-input__wrapper, .el-popper'
+  // .msg-copyable is the log-path toast: leaving it alone keeps a text selection
+  // alive so it can be copied instead of being cleared by a terminal refocus.
+  const INTERACTIVE_SEL = 'input, textarea, select, button, a, [role="button"], [role="combobox"], [contenteditable="true"], .xterm-helper-textarea, .el-select__wrapper, .el-input__wrapper, .el-popper, .msg-copyable'
 
   // Walk ancestors looking for the --wails-draggable custom property so we
   // can tell a frameless-window drag region apart from ordinary chrome. Any

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -32,6 +32,16 @@ document.addEventListener('contextmenu', () => {
 
 document.addEventListener('contextmenu', (e) => {
   const target = e.target as HTMLElement
+  // Read-only log-path toast: offer copy/select-all on its plain text.
+  const copyable = target.closest('.msg-copyable') as HTMLElement | null
+  if (copyable) {
+    e.preventDefault()
+    const content = (copyable.querySelector('.el-message__content') as HTMLElement) || copyable
+    window.dispatchEvent(new CustomEvent('input:contextmenu', {
+      detail: { x: e.clientX, y: e.clientY, target: content, readonly: true }
+    }))
+    return
+  }
   const tag = target.tagName
   if (tag === 'INPUT' || tag === 'TEXTAREA' || target.isContentEditable) {
     e.preventDefault()

--- a/frontend/src/services/message.ts
+++ b/frontend/src/services/message.ts
@@ -12,7 +12,8 @@ export const msg = {
   // back to the DOM instead of initiating a window drag on macOS frameless
   // windows. CSS customClass alone isn't enough — the mousedown lands on a
   // text node inside .el-message__content and Wails walks up to find no-drag;
-  // an inline style on the immediate parent is the most reliable target.
+  // an inline style on the immediate parent is the most reliable target. The
+  // msg-copyable class lets the focus guard and right-click menu target it.
   copyable(m: string, type: 'success' | 'info' | 'warning' | 'error' = 'success') {
     const safe = m.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
     ElMessage({
@@ -22,6 +23,7 @@ export const msg = {
       showClose: true,
       duration: 0,
       offset: 56,
+      customClass: 'msg-copyable',
     })
   },
 }

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -838,6 +838,8 @@ body.drag-active .zone {
 .msg-copyable .el-message__content {
   --wails-draggable: no-drag;
   cursor: text;
+  user-select: text;
+  -webkit-user-select: text;
 }
 
 /* Link hover tooltip */


### PR DESCRIPTION
## Summary / 概要

The copyable log-path toast (`msg.copyable`) renders selectable text, but the terminal focus guard steals focus back on `mouseup`, clearing the selection so it can never be copied — and there's no menu affordance for copying.

日志路径提示框（`msg.copyable`）的文字本可选中，但终端焦点守卫在鼠标松开时把焦点抢回终端、清空了选区，导致选了也复制不了，而且没有任何右键菜单入口。

This PR builds on #335: keeps the auto-width selectable span, and makes the path actually copyable — by drag-select **and** by a right-click menu.

本 PR 在 #335 基础上继续：保留自适应宽度、可选中的 span，让路径真正可复制——既能拖选，也能右键菜单复制。

## Changes / 改动

- **useFocusTerminal**: exempt `.msg-copyable` from the focus guard so a selection stays alive instead of being cleared by a terminal refocus. / 将 `.msg-copyable` 排除在焦点守卫外，选区不再被终端重新聚焦清空。
- **main.ts**: route right-clicks on `.msg-copyable` to the existing input context menu with a `readonly` flag. / 把 `.msg-copyable` 上的右键转发到已有的输入右键菜单，带 `readonly` 标记。
- **App.vue**: in readonly mode show only **Copy / Select All** (cut/paste make no sense on a read-only path); both operate on the plain span via the live selection / a `Range`. / 只读模式只显示“复制/全选”（只读路径无需剪切/粘贴），对纯文本 span 生效。
- **message.ts**: tag the toast with `customClass: 'msg-copyable'` so the guard and menu can target it. / 加 `customClass` 供守卫与菜单定位。
- **style.css**: add `user-select:text` to `.msg-copyable`. / 补 `user-select:text`。

## Validation / 验证

- `npm --prefix frontend run build` ✓
- `wails dev` 实测（macOS）：拖选路径 + Cmd+C 可复制；提示框右键出现“复制/全选”，均能拿到完整路径。/ Drag-select + Cmd+C copies; right-click shows Copy/Select All, both yield the full path.