### PR TITLE
fix(tabs): consolidate batch-close confirm and persist close prompt settings

### DIFF
--- a/backend/store/settings_store.go
+++ b/backend/store/settings_store.go
@@ -99,6 +99,8 @@ type AppSettings struct {
 	AI                   AISettings            `json:"ai"`
 	Keyboard             map[string]KeyBinding `json:"keyboard"`
 	AutoCheckUpdate      *bool                 `json:"autoCheckUpdate"`
+	CloseTabPrompt       *bool                 `json:"closeTabPrompt"`
+	CloseAppPrompt       *bool                 `json:"closeAppPrompt"`
 	SFTPBookmarks        SFTPBookmarks         `json:"sftpBookmarks"`
 	CustomTerminalThemes []CustomTerminalTheme `json:"customTerminalThemes"`
 	DefaultLocalShell    string                `json:"defaultLocalShell"`
@@ -191,6 +193,14 @@ func (s *SettingsStore) Load() (AppSettings, error) {
 		settings.AutoCheckUpdate = boolPtr(true)
 		needsSave = true
 	}
+	if settings.CloseTabPrompt == nil {
+		settings.CloseTabPrompt = boolPtr(true)
+		needsSave = true
+	}
+	if settings.CloseAppPrompt == nil {
+		settings.CloseAppPrompt = boolPtr(true)
+		needsSave = true
+	}
 	if needsSave {
 		jsonData, _ := json.MarshalIndent(settings, "", "  ")
 		_ = os.WriteFile(s.filePath(), jsonData, 0600)
@@ -227,6 +237,8 @@ func defaultSettings() AppSettings {
 		},
 		Keyboard:        defaultKeyboard(),
 		AutoCheckUpdate: boolPtr(true),
+		CloseTabPrompt:  boolPtr(true),
+		CloseAppPrompt:  boolPtr(true),
 		SFTPBookmarks: SFTPBookmarks{
 			LocalPaths:  []string{},
 			RemotePaths: []string{},

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -6,6 +6,7 @@
       @toggle-sidebar="sidebarVisible = !sidebarVisible"
       @open-settings="openSettings"
       @close-tab="closeTab"
+      @close-tab-batch="closeTabBatch"
       @toggle-ai-lock="onToggleAiLock"
       @tab-dragstart="onTabDragStart"
     />
@@ -764,7 +765,7 @@ function openSettings() {
   panelStore.movePanelToTab(panel.id, tab.id)
 }
 
-async function closeTab(tabId: string) {
+async function closeTab(tabId: string, opts: { skipConfirm?: boolean } = {}) {
   // Close session before removing panel to clean up Go-side resources
   const tab = tabStore.tabs.find(t => t.id === tabId)
   if (tab?.locked) return
@@ -778,7 +779,7 @@ async function closeTab(tabId: string) {
     return
   }
   // Confirm before closing connected sessions to prevent accidental disconnect
-  if (tab && tab.type !== 'settings') {
+  if (tab && tab.type !== 'settings' && !opts.skipConfirm) {
     const panelIds = tab.type === 'workspace' ? tab.panelIds : 'panelId' in tab ? [tab.panelId] : []
     const hasConnected = panelIds.some(pid => {
       const p = panelStore.getPanel(pid)
@@ -870,6 +871,54 @@ async function closeTab(tabId: string) {
       tabStore.createStartTab()
     }
   })
+}
+
+// Batch close (close left/right/others). Consolidate the "has connected
+// sessions" confirmation into a single dialog so users don't get one prompt
+// per tab, and honor "don't show again" for the current batch too.
+async function closeTabBatch(tabIds: string[]) {
+  if (!tabIds.length) return
+  const targets = tabIds
+    .map(id => tabStore.tabs.find(t => t.id === id))
+    .filter((t): t is NonNullable<typeof t> => !!t && !t.locked)
+  if (!targets.length) return
+
+  const connectedCount = targets.reduce((n, tab) => {
+    if (tab.type === 'settings' || tab.type === 'start') return n
+    const panelIds = tab.type === 'workspace' ? tab.panelIds : 'panelId' in tab ? [tab.panelId] : []
+    const hit = panelIds.some(pid => {
+      const p = panelStore.getPanel(pid)
+      if (!p?.sessionId) return false
+      return sessionStore.getStatus(p.sessionId) === 'connected'
+    })
+    return hit ? n + 1 : n
+  }, 0)
+
+  if (connectedCount > 0 && settingsStore.settings.closeTabPrompt) {
+    const dontShowAgain = ref(false)
+    try {
+      await ElMessageBox.confirm(
+        h('div', { style: 'display:flex;flex-direction:column;gap:10px' }, [
+          h('span', t('tab.closeConnectedBatchConfirm', { count: connectedCount })),
+          h(ElCheckbox, {
+            'onUpdate:modelValue': (v: boolean) => { dontShowAgain.value = v }
+          }, () => t('tab.dontShowAgain'))
+        ]),
+        t('tab.closeConfirmTitle'),
+        { confirmButtonText: t('tab.close'), cancelButtonText: t('conn.cancel'), type: 'warning' }
+      )
+    } catch {
+      return
+    }
+    if (dontShowAgain.value) {
+      settingsStore.settings.closeTabPrompt = false
+      settingsStore.save()
+    }
+  }
+
+  for (const tab of targets) {
+    await closeTab(tab.id, { skipConfirm: true })
+  }
 }
 
 function getPanelConfig(panelId: string): ConnectionConfig | null {

--- a/frontend/src/components/AppHeader.vue
+++ b/frontend/src/components/AppHeader.vue
@@ -17,6 +17,7 @@
     <div class="header-tabs" :class="{ 'tabs-centered': platform === 'darwin' }">
       <TabsList
         @close-tab="(id: string) => emit('close-tab', id)"
+        @close-tab-batch="(ids: string[]) => emit('close-tab-batch', ids)"
         @toggle-ai-lock="(panelId: string) => emit('toggle-ai-lock', panelId)"
         @tab-dragstart="(e: DragEvent, tabId: string) => emit('tab-dragstart', e, tabId)"
       />
@@ -93,6 +94,7 @@ const emit = defineEmits<{
   'toggle-sidebar': []
   'open-settings': []
   'close-tab': [id: string]
+  'close-tab-batch': [ids: string[]]
   'toggle-ai-lock': [panelId: string]
   'tab-dragstart': [e: DragEvent, tabId: string]
 }>()

--- a/frontend/src/components/TabItem.vue
+++ b/frontend/src/components/TabItem.vue
@@ -123,6 +123,7 @@ const props = defineProps<{
 const emit = defineEmits<{
   activate: [id: string]
   close: [id: string]
+  closeBatch: [ids: string[]]
   toggleAiLock: [panelId: string]
 }>()
 
@@ -330,22 +331,24 @@ function closeTab() {
 function closeOther() {
   const allTabs = tabStore.tabs
   const currentIdx = allTabs.findIndex(t => t.id === props.tab.id)
-  const others = allTabs.filter((t, i) => i !== currentIdx && !t.locked)
-  others.forEach(t => emit('close', t.id))
+  const ids = allTabs.filter((t, i) => i !== currentIdx && !t.locked).map(t => t.id)
+  if (ids.length) emit('closeBatch', ids)
   closeContextMenu()
 }
 
 function closeRight() {
   const allTabs = tabStore.tabs
   const currentIdx = allTabs.findIndex(t => t.id === props.tab.id)
-  allTabs.slice(currentIdx + 1).filter(t => !t.locked).forEach(t => emit('close', t.id))
+  const ids = allTabs.slice(currentIdx + 1).filter(t => !t.locked).map(t => t.id)
+  if (ids.length) emit('closeBatch', ids)
   closeContextMenu()
 }
 
 function closeLeft() {
   const allTabs = tabStore.tabs
   const currentIdx = allTabs.findIndex(t => t.id === props.tab.id)
-  allTabs.slice(0, currentIdx).filter(t => !t.locked).forEach(t => emit('close', t.id))
+  const ids = allTabs.slice(0, currentIdx).filter(t => !t.locked).map(t => t.id)
+  if (ids.length) emit('closeBatch', ids)
   closeContextMenu()
 }
 

--- a/frontend/src/components/TabsList.vue
+++ b/frontend/src/components/TabsList.vue
@@ -12,6 +12,7 @@
         :has-notification="tabStore.hasTabNotification(tab.id)"
         @activate="setActiveTab"
         @close="(id: string) => $emit('close-tab', id)"
+        @close-batch="(ids: string[]) => $emit('close-tab-batch', ids)"
         @toggle-ai-lock="(panelId: string) => $emit('toggle-ai-lock', panelId)"
         @dragstart="(e: DragEvent, tabId: string) => $emit('tab-dragstart', e, tabId)"
         @dragover.prevent="(e: DragEvent) => onTabDragOver(e, index)"
@@ -115,6 +116,7 @@ onUnmounted(() => {
 
 defineEmits<{
   'close-tab': [id: string]
+  'close-tab-batch': [ids: string[]]
   'toggle-ai-lock': [panelId: string]
   'tab-dragstart': [e: DragEvent, tabId: string]
 }>()

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -94,6 +94,7 @@
   "tab.unlock": "Tab entsperren",
   "tab.closeConfirmTitle": "Schließen bestätigen",
   "tab.closeConnectedConfirm": "Dieser Tab hat eine aktive Verbindung. Beim Schließen wird die Verbindung getrennt. Wirklich schließen?",
+  "tab.closeConnectedBatchConfirm": "{count} verbundene Sitzungen werden getrennt. Wirklich schließen?",
   "tab.more": "Weitere Tabs",
   "tab.dontShowAgain": "Nicht mehr anzeigen (in Einstellungen wieder aktivierbar)",
   "terminal.duplicate": "Duplizieren",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -97,6 +97,7 @@
   "tab.unlock": "Unlock Tab",
   "tab.closeConfirmTitle": "Close Confirmation",
   "tab.closeConnectedConfirm": "This tab has an active connection. Closing it will disconnect. Are you sure?",
+  "tab.closeConnectedBatchConfirm": "{count} connected sessions will be disconnected. Are you sure you want to close them?",
   "tab.more": "More Tabs",
   "tab.dontShowAgain": "Don't show again (can be re-enabled in settings)",
   "terminal.duplicate": "Duplicate",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -94,6 +94,7 @@
   "tab.unlock": "Desbloquear pestaña",
   "tab.closeConfirmTitle": "Confirmar Cierre",
   "tab.closeConnectedConfirm": "Esta pestaña está conectada. Al cerrarla se desconectará. ¿Continuar?",
+  "tab.closeConnectedBatchConfirm": "Se desconectarán {count} sesiones activas. ¿Cerrarlas?",
   "tab.more": "Más pestañas",
   "tab.dontShowAgain": "No mostrar de nuevo (se puede reactivar en ajustes)",
   "terminal.duplicate": "Duplicar",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -94,6 +94,7 @@
   "tab.unlock": "Déverrouiller l'onglet",
   "tab.closeConfirmTitle": "Confirmer la fermeture",
   "tab.closeConnectedConfirm": "Cet onglet est connecté. Le fermer déconnectera la session. Continuer ?",
+  "tab.closeConnectedBatchConfirm": "{count} sessions connectées seront déconnectées. Confirmer la fermeture ?",
   "tab.more": "Plus d'onglets",
   "tab.dontShowAgain": "Ne plus afficher (réactivable dans les paramètres)",
   "terminal.duplicate": "Dupliquer",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -94,6 +94,7 @@
   "tab.unlock": "ロック解除",
   "tab.closeConfirmTitle": "閉じる確認",
   "tab.closeConnectedConfirm": "このタブは接続中です。閉じると切断されます。本当に閉じますか？",
+  "tab.closeConnectedBatchConfirm": "接続中の {count} 個のセッションを閉じて切断します。よろしいですか？",
   "tab.more": "他のタブ",
   "tab.dontShowAgain": "今後表示しない（設定で再開可能）",
   "terminal.duplicate": "複製",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -94,6 +94,7 @@
   "tab.unlock": "탭 잠금 해제",
   "tab.closeConfirmTitle": "닫기 확인",
   "tab.closeConnectedConfirm": "이 탭은 연결되어 있습니다. 닫으면 연결이 끊어집니다. 계속하시겠습니까?",
+  "tab.closeConnectedBatchConfirm": "연결된 세션 {count}개가 끊깁니다. 계속하시겠습니까?",
   "tab.more": "더 많은 탭",
   "tab.dontShowAgain": "다시 표시하지 않음 (설정에서 다시 활성화 가능)",
   "terminal.duplicate": "복제",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -94,6 +94,7 @@
   "tab.unlock": "Открепить вкладку",
   "tab.closeConfirmTitle": "Подтверждение закрытия",
   "tab.closeConnectedConfirm": "Эта вкладка подключена. Закрытие приведёт к разрыву соединения. Продолжить?",
+  "tab.closeConnectedBatchConfirm": "Будут отключены {count} активных сеансов. Закрыть их?",
   "tab.more": "Еще вкладки",
   "tab.dontShowAgain": "Больше не показывать (можно включить в настройках)",
   "terminal.duplicate": "Дублировать",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -96,6 +96,7 @@
   "tab.unlock": "解锁标签",
   "tab.closeConfirmTitle": "关闭确认",
   "tab.closeConnectedConfirm": "该窗口已连接，关闭将断开连接。确定要关闭吗？",
+  "tab.closeConnectedBatchConfirm": "本次将关闭 {count} 个已连接的会话，全部断开连接。确定要关闭吗？",
   "tab.more": "更多标签",
   "tab.dontShowAgain": "不再提示（可在设置中开启）",
   "terminal.duplicate": "复制连接",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -94,6 +94,7 @@
   "tab.unlock": "解鎖標籤",
   "tab.closeConfirmTitle": "關閉確認",
   "tab.closeConnectedConfirm": "該視窗已連線，關閉將中斷連線。確定要關閉嗎？",
+  "tab.closeConnectedBatchConfirm": "本次將關閉 {count} 個已連線的工作階段，全部中斷連線。確定要關閉嗎？",
   "tab.more": "更多分頁",
   "tab.dontShowAgain": "不再提示（可在設定中開啟）",
   "terminal.duplicate": "複製連接",

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -1157,6 +1157,8 @@ export namespace store {
 	    ai: AISettings;
 	    keyboard: Record<string, KeyBinding>;
 	    autoCheckUpdate?: boolean;
+	    closeTabPrompt?: boolean;
+	    closeAppPrompt?: boolean;
 	    sftpBookmarks: SFTPBookmarks;
 	    customTerminalThemes: CustomTerminalTheme[];
 	    defaultLocalShell: string;
@@ -1173,6 +1175,8 @@ export namespace store {
 	        this.ai = this.convertValues(source["ai"], AISettings);
 	        this.keyboard = this.convertValues(source["keyboard"], KeyBinding, true);
 	        this.autoCheckUpdate = source["autoCheckUpdate"];
+	        this.closeTabPrompt = source["closeTabPrompt"];
+	        this.closeAppPrompt = source["closeAppPrompt"];
 	        this.sftpBookmarks = this.convertValues(source["sftpBookmarks"], SFTPBookmarks);
 	        this.customTerminalThemes = this.convertValues(source["customTerminalThemes"], CustomTerminalTheme);
 	        this.defaultLocalShell = source["defaultLocalShell"];


### PR DESCRIPTION
Fixes #338.

**Symptoms**
1. When batch-closing tabs (close right / close others / close left), one confirmation dialog was shown per connected tab. Ticking "don't show again" in one dialog only took effect **after** that batch finished — the remaining dialogs were already open and had to be dismissed one by one.
2. Turning off "close tab prompt" (either through the checkbox or the settings toggle) did not survive an app restart.

**Root causes**
1. `closeRight` / `closeOther` / `closeLeft` in `TabItem.vue` synchronously emitted N separate `close` events, each of which read `settingsStore.settings.closeTabPrompt` and opened its own `ElMessageBox`. The flag was only flipped after the first dialog resolved, by which point the rest were already on screen.
2. The backend `AppSettings` struct in `backend/store/settings_store.go` did not declare `CloseTabPrompt` / `CloseAppPrompt`. Go's `json.Unmarshal` silently dropped the fields on load and `json.Marshal` never wrote them back, so every restart returned the frontend default (`true`).

**Fix**
- Backend: added `CloseTabPrompt *bool` and `CloseAppPrompt *bool` to `AppSettings`, with `defaultSettings()` and `Load()` backfill to `true` (same pattern as `AutoCheckUpdate`).
- Frontend: introduced a `close-tab-batch` event that carries all target tab IDs. `closeTabBatch` in `App.vue` counts connected sessions once, shows a single consolidated confirm dialog (`tab.closeConnectedBatchConfirm`, translated in 9 locales), and then serially calls `closeTab(id, { skipConfirm: true })`. `closeTab` gained an optional `skipConfirm` param for this path.

**Verification**
- `npm --prefix frontend run build` ✓
- `go build ./...` ✓
- Local `wails dev`: right-click → close right on multiple connected local shells now shows one dialog; ticking "don't show again" closes the rest silently and the setting stays off after restart.

---

修复 #338。

**问题现象**
1. 右键「关闭右侧 / 关闭其他 / 关闭左侧」时，每个已连接标签都会弹出一次确认框。在其中一个里勾「不再提示」点确定后，剩余弹窗已经全部渲染出来，无法回滚，只能一个个手动点。
2. 关闭「关闭标签页提示」开关后，重启应用又变回开启。

**根因**
1. `TabItem.vue` 中的 `closeRight` / `closeOther` / `closeLeft` 同步地 `forEach` emit 了 N 个 `close` 事件，每个都同时进入 `closeTab` 并读到当时仍为 `true` 的 `closeTabPrompt`，各自弹出一个 `ElMessageBox`。第一次确认后 flag 才被翻成 `false`，但其余弹窗已经开出来了。
2. 后端 `backend/store/settings_store.go` 里的 `AppSettings` 结构体没有声明 `CloseTabPrompt` / `CloseAppPrompt`。Go 的 `json.Unmarshal` 静默丢弃了这两个字段，`json.Marshal` 也不会写回，所以每次重启前端拿到的都是缺字段的对象，回退到默认值 `true`。

**修复**
- 后端：`AppSettings` 增加 `CloseTabPrompt *bool` / `CloseAppPrompt *bool`，`defaultSettings()` 和 `Load()` 里做 nil 兜底并回写（与 `AutoCheckUpdate` 保持一致）。
- 前端：新增 `close-tab-batch` 事件，携带全部待关闭 tab id。`App.vue` 里的 `closeTabBatch` 先统计已连接会话总数，只弹**一次**合并的确认框（`tab.closeConnectedBatchConfirm`，已翻译 9 种语言），然后串行调用 `closeTab(id, { skipConfirm: true })`。`closeTab` 增加可选 `skipConfirm` 参数供批量路径使用。

**验证**
- `npm --prefix frontend run build` ✓
- `go build ./...` ✓
- `wails dev` 手动实测：右键关闭右侧多个已连接会话时只弹一次确认框；勾「不再提示」点确定后剩余会话直接关闭，重启后开关仍保持关闭。
