### PR TITLE
feat(shortcut): support macOS Cmd+Q / Cmd+W (#339)

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -170,8 +170,8 @@ import { loadKeybindings, installGlobalListener, uninstallGlobalListener } from 
 import { focusPanelTerminal, installTerminalFocusRestore } from './composables/useFocusTerminal'
 import type { ShortcutAction } from './types/settings'
 import { useI18n } from './i18n'
-import { CreateSession, CloseSession, RDPHide, RDPShow, RDPSetPosition, RDPSetFocus, LoadLocalState, SaveLocalState, RecordRecentConnection } from '../wailsjs/go/main/App'
-import { EventsOn, ClipboardGetText } from '../wailsjs/runtime'
+import { CreateSession, CloseSession, RDPHide, RDPShow, RDPSetPosition, RDPSetFocus, LoadLocalState, SaveLocalState, RecordRecentConnection, GetPlatform } from '../wailsjs/go/main/App'
+import { EventsOn, ClipboardGetText, Quit } from '../wailsjs/runtime'
 import { msg } from './services/message'
 import type { ConnectionConfig } from './types/session'
 import { parseQuickConnect } from './utils/quickConnect'
@@ -547,6 +547,24 @@ function onEditShortcut(e: KeyboardEvent) {
   }
 }
 
+// macOS-only system shortcuts (issue #339): Cmd+Q quits, Cmd+W closes the
+// active tab. Guarded by isMac so Windows/Linux never see this behaviour —
+// there Ctrl+Q/W stay free for the terminal and the existing keybindings.
+let isMac = false
+function onMacSystemShortcut(e: KeyboardEvent) {
+  if (!isMac || e.defaultPrevented) return
+  if (!e.metaKey || e.ctrlKey || e.altKey || e.shiftKey) return
+  const key = e.key.toLowerCase()
+  if (key === 'q') {
+    e.preventDefault()
+    Quit()
+  } else if (key === 'w') {
+    e.preventDefault()
+    const t = tabStore.activeTab
+    if (t) closeTab(t.id)
+  }
+}
+
 onMounted(async () => {
   connectionStore.load()
   aiStore.init()
@@ -577,6 +595,9 @@ onMounted(async () => {
   document.addEventListener('wheel', onWheel, { passive: false })
   // WKWebView doesn't forward Cmd+A/C/V on input/textarea/contenteditable — handle globally.
   document.addEventListener('keydown', onEditShortcut)
+  // macOS system shortcuts (Cmd+Q / Cmd+W) — only armed on darwin.
+  try { isMac = (await GetPlatform()) === 'darwin' } catch { isMac = false }
+  if (isMac) document.addEventListener('keydown', onMacSystemShortcut, true)
   // Keyboard shortcuts — load once on mount, watch for settings changes
   applyKeybindings()
   installGlobalListener()
@@ -741,6 +762,7 @@ onUnmounted(() => {
   window.removeEventListener('global:close-context-menus', closeInputMenu)
   document.removeEventListener('click', closeInputMenu)
   document.removeEventListener('wheel', onWheel)
+  document.removeEventListener('keydown', onMacSystemShortcut, true)
   // RDP overlay tracking
   window.removeEventListener('rdp:overlay-push', RDPHideForOverlay)
   window.removeEventListener('rdp:overlay-pop', RDPShowForOverlay)


### PR DESCRIPTION
Closes #339

## Summary / 概要

macOS users expect **Cmd+Q** to quit the app and **Cmd+W** to close the current tab, but pressing them did nothing. On darwin the app installs an empty native menu to hide Wails' default Edit/Window menus, so these system accelerators had no owner.

macOS 用户习惯 **Cmd+Q** 退出、**Cmd+W** 关闭当前标签，但此前按了没反应。应用在 darwin 上装了个空的原生菜单来隐藏 Wails 默认菜单，导致这些系统快捷键无人接管。

> Note: the issue mentions Cmd+W as "minimise", but the macOS convention is close-window; here it closes the active tab (Cmd+M remains the system minimise). / 备注：issue 把 Cmd+W 写作“最小化”，但 mac 惯例是关闭窗口，这里实现为关闭当前标签（Cmd+M 仍是系统最小化）。

## Changes / 改动

- Add a **darwin-only** `keydown` listener in `App.vue`:
  - **Cmd+Q** → `Quit()`
  - **Cmd+W** → close the active tab via the existing `closeTab()` (confirm dialog + session cleanup still apply). / 复用 `closeTab()`，确认弹窗与会话清理照旧。
- Guarded by `GetPlatform()==='darwin'` **and** an `isMac` check; the listener is only registered on macOS. / 以 `GetPlatform()==='darwin'` 与 `isMac` 双重判断，仅在 macOS 注册。

## Windows/Linux 不引入 / no impact

The listener is never registered off darwin, and the handler returns immediately when `!isMac`. `Ctrl+Q` / `Ctrl+W` stay free for the terminal and existing keybindings. / 非 darwin 不注册监听，handler 首行 `!isMac` 直接返回，`Ctrl+Q/W` 仍留给终端与现有快捷键。

## Validation / 验证

- `npm --prefix frontend run build` ✓
- `wails dev`（macOS）：Cmd+W 关闭当前标签（含确认弹窗）、Cmd+Q 退出应用。