### PR TITLE
fix(ai): hide "copy as markdown" when assistant text is blank

### DIFF
--- a/frontend/src/components/AIMessage.vue
+++ b/frontend/src/components/AIMessage.vue
@@ -3,7 +3,7 @@
     <div class="content">
       <div class="text" v-html="renderedContent" @click="onTextClick" />
 
-      <div v-if="message.role === 'assistant' && message.content" class="copy-action">
+      <div v-if="message.role === 'assistant' && message.content?.trim()" class="copy-action">
         <button class="copy-md-btn" @click="copyAsMarkdown" :title="t('ai.copyMarkdown')">
           <el-icon><Copy :size="14" /></el-icon>
           <span class="copy-md-label">{{ copyMdLabel }}</span>


### PR DESCRIPTION
Refs #306.

**Symptom**
The "Copy as Markdown" button appeared under assistant messages that contained only tool calls. Clicking it flashed a "Copied" toast, but the clipboard remained empty.

**Root cause**
The button was gated on `message.role === 'assistant' && message.content`. For turns that carry only `tool_calls`, `message.content` is typically a whitespace-only string (for example a single `"\n"` produced by the streaming layer), which is truthy in JS. So the button was rendered, and `navigator.clipboard.writeText(message.content)` wrote whitespace.

**Fix**
Gate the button on `message.content?.trim()` in `frontend/src/components/AIMessage.vue`. When the assistant produced no standalone text (only tools), the button now stays hidden. Pure-text answers behave the same as before.

Note: this PR does not address the "copy AI-generated tables as Markdown" ask from the same issue. That is a follow-up — the tables live inside tool outputs, which have their own copy buttons. Happy to look at that in a separate change if you want.

**Verification**
- `npm --prefix frontend run build` ✓
- Manual `wails dev`: asking a tool-only question no longer shows the button; a pure-text answer still shows it and copies actual content.

---

关联 #306。

**问题现象**
只包含工具调用的 assistant 消息下方会显示「复制为 Markdown」按钮，点击后弹出「已复制」，但剪贴板里其实是空的。

**根因**
按钮显示条件是 `message.role === 'assistant' && message.content`。当那一轮仅有 `tool_calls` 时，`message.content` 常常是纯空白字符串（比如流式输出层给出的一个 `"\n"`），在 JS 里仍为真值，按钮就渲染出来了，`navigator.clipboard.writeText(message.content)` 写入的也就只有空白。

**修复**
将 `frontend/src/components/AIMessage.vue` 中的判断改为 `message.content?.trim()`。当 assistant 没有独立文本（只有工具调用）时按钮不再显示，纯文本回答的行为不变。

说明：本次不处理 issue 中「AI 生成的表格复制为 Markdown」的诉求。那些表格通常出现在工具输出块内，工具块本身有自己的复制按钮，需要另外做，可以单独提 PR 实现。

**验证**
- `npm --prefix frontend run build` ✓
- 手动 `wails dev` 实测：仅工具调用的问答不再出现按钮；纯文本回答按钮仍然存在且复制内容正常。
