### PR TITLE
fix: preserve default background opacity/blur for older configs

### DIFF
--- a/backend/store/local_state_store.go
+++ b/backend/store/local_state_store.go
@@ -66,7 +66,9 @@ func (s *LocalStateStore) Load() (LocalState, error) {
 		}
 		return LocalState{}, err
 	}
-	var state LocalState
+	// Start from defaults so fields missing in older configs keep their
+	// intended values instead of Go zero values (e.g. opacity/blur = 0).
+	state := defaultLocalState()
 	if err := json.Unmarshal(bytes, &state); err != nil {
 		return defaultLocalState(), nil
 	}


### PR DESCRIPTION
## Problem

When enabling the background image toggle, opacity and blur showed as **0** instead of the intended defaults (opacity 60, blur 3).

**Root cause:** `LocalStateStore.Load()` only used `defaultLocalState()` when the config file was missing or failed to parse. For existing configs created before the background feature (which lack `backgroundOpacity`/`backgroundBlur`), `json.Unmarshal` into a zero-valued struct left those fields at Go's zero value `0`. The frontend's `{ ...DEFAULT, ...s }` merge then overwrote its own defaults (60/3) with the backend's `0`.

## Fix

Start from `defaultLocalState()` before `Unmarshal`, so fields absent in older JSON keep their defaults while present fields are still overridden.

---

## 问题

打开背景图开关后，不透明度和模糊显示为 **0**，而不是设计的默认值（不透明度 60、模糊 3）。

**根因：** `LocalStateStore.Load()` 只在配置文件不存在或解析失败时才使用 `defaultLocalState()`。对于背景图功能上线前就存在的旧配置（缺少 `backgroundOpacity`/`backgroundBlur` 字段），`json.Unmarshal` 到零值结构体时，这些缺失字段保留 Go 零值 `0`。前端 `{ ...DEFAULT, ...s }` 合并又用后端的 `0` 覆盖了自身默认值（60/3）。

## 修复

在 `Unmarshal` 前先用 `defaultLocalState()` 铺底，这样旧 JSON 中缺失的字段保留默认值，已有字段仍正常覆盖。