### PR TITLE
fix: hide native RDP window when dialogs open so they aren't covered

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -852,6 +852,8 @@ async function closeTab(tabId: string, opts: { skipConfirm?: boolean } = {}) {
         // skip dialog, proceed to close
       } else {
         const dontShowAgain = ref(false)
+        // Hide the native RDP window so the dialog isn't covered by it (issue #346)
+        RDPHideForOverlay()
         try {
           await ElMessageBox.confirm(
             h('div', { style: 'display:flex;flex-direction:column;gap:10px' }, [
@@ -865,6 +867,8 @@ async function closeTab(tabId: string, opts: { skipConfirm?: boolean } = {}) {
           )
         } catch {
           return
+        } finally {
+          RDPShowForOverlay()
         }
         if (dontShowAgain.value) {
           settingsStore.settings.closeTabPrompt = false

--- a/frontend/src/components/AppHeader.vue
+++ b/frontend/src/components/AppHeader.vue
@@ -179,6 +179,8 @@ async function onClose() {
       // skip dialog, proceed to quit
     } else {
       const dontShowAgain = ref(false)
+      // Hide the native RDP window so the dialog isn't covered by it (issue #346)
+      window.dispatchEvent(new CustomEvent('rdp:overlay-push'))
       try {
         await ElMessageBox.confirm(
           h('div', { style: 'display:flex;flex-direction:column;gap:10px' }, [
@@ -192,6 +194,8 @@ async function onClose() {
         )
       } catch {
         return // user cancelled
+      } finally {
+        window.dispatchEvent(new CustomEvent('rdp:overlay-pop'))
       }
       if (dontShowAgain.value) {
         settingsStore.settings.closeAppPrompt = false

--- a/frontend/src/components/TunnelEditDialog.vue
+++ b/frontend/src/components/TunnelEditDialog.vue
@@ -156,6 +156,8 @@ const form = reactive(blankForm())
 const errorMsg = ref('')
 
 watch(visible, (v) => {
+  // Hide the native RDP window while the dialog is open so it isn't covered (issue #346)
+  window.dispatchEvent(new CustomEvent(v ? 'rdp:overlay-push' : 'rdp:overlay-pop'))
   if (!v) return
   errorMsg.value = ''
   if (props.editingId) {


### PR DESCRIPTION
## Problem

The native RDP window renders above the webview, so modal dialogs are covered by it — users can't see or interact with them. When clicking the tab's X to close an RDP session, the confirmation dialog is hidden behind the RDP window, appearing as a stuck loading spinner.

## Fix

Reuse the existing overlay ref-counting mechanism (`rdp:overlay-push` / `rdp:overlay-pop` → `RDPHideForOverlay` / `RDPShowForOverlay`) to hide the native RDP window while these dialogs are open:

- Tunnel add/edit dialog (`TunnelEditDialog.vue`)
- Close-tab confirmation (`App.vue`)
- Close-app confirmation (`AppHeader.vue`)

Each pairs push/pop correctly (dialog visible watch, or try/finally around the confirm), so the ref count stays balanced. When no RDP session is active, hiding is a no-op.

Closes #346

---

## 问题

RDP 原生窗口渲染在 webview 之上，导致模态弹窗被它遮挡，用户看不到也无法操作。点击标签的 X 关闭 RDP 会话时，确认弹窗被压在 RDP 窗口下面，表现为一直转圈无法关闭。

## 修复

复用现有的 overlay 引用计数机制（`rdp:overlay-push` / `rdp:overlay-pop` → `RDPHideForOverlay` / `RDPShowForOverlay`），在以下弹窗打开时隐藏 RDP 原生窗口：

- 新建/编辑隧道弹窗（`TunnelEditDialog.vue`）
- 关闭标签确认弹窗（`App.vue`）
- 关闭应用确认弹窗（`AppHeader.vue`）

三处均正确配对 push/pop（隧道靠 visible 的 watch，两个确认框靠 try/finally），引用计数保持平衡。无 RDP 会话时隐藏操作为空操作。

关联 #346