### PR TITLE
fix: forward Windows/combo keys to remote in RDP sessions

### DIFF
--- a/backend/session/rdp_session.go
+++ b/backend/session/rdp_session.go
@@ -344,6 +344,21 @@ func (s *RDPSession) Connect(config ConnectionConfig) error {
 		}
 	}
 
+	// Route Windows key and special key combos (Win+E, Win+D, Alt+Tab, etc.)
+	// to the remote machine instead of the local one. KeyboardHookMode=1 means
+	// "apply key combinations at the remote server". (issue #351)
+	// Note: Ctrl+Alt+Del is a Secure Attention Sequence and can never be
+	// forwarded by any RDP client; use Ctrl+Alt+End instead.
+	secObj, _ := dispatch.GetProperty("SecuredSettings2")
+	if secObj != nil {
+		sec := secObj.ToIDispatch()
+		if sec != nil {
+			sec.PutProperty("KeyboardHookMode", 1)
+			sec.Release()
+			log.Writef("[RDP] KeyboardHookMode=1 (forward Win/combo keys to remote)")
+		}
+	}
+
 	// Suppress security prompts on all available AdvancedSettings versions
 	for _, ver := range []int{9, 8, 7, 6, 5, 4, 3} {
 		propName := fmt.Sprintf("AdvancedSettings%d", ver)


### PR DESCRIPTION
## Problem

In RDP sessions, the Windows key and key combinations such as Win+E, Win+D, and Alt+Tab were handled by the local machine instead of being forwarded to the remote host.

## Fix

Set `SecuredSettings2.KeyboardHookMode = 1` on the MsRdpClient ActiveX control, which routes the Windows key and special key combinations to the remote server.

**Note:** `Ctrl+Alt+Del` is a Secure Attention Sequence (SAS) that no RDP client — including the official mstsc — can forward. Users should press **Ctrl+Alt+End** instead, which the remote host receives as Ctrl+Alt+Del.

Closes #351

---

## 问题

RDP 会话中，Windows 键以及 Win+E、Win+D、Alt+Tab 等组合键被本地机器处理，没有转发到远程主机。

## 修复

在 MsRdpClient ActiveX 控件上设置 `SecuredSettings2.KeyboardHookMode = 1`，将 Windows 键和特殊组合键路由到远程服务器。

**说明：** `Ctrl+Alt+Del` 是安全注意序列（SAS），任何 RDP 客户端（包括官方 mstsc）都无法透传。用户应改用 **Ctrl+Alt+End**，远程主机会将其识别为 Ctrl+Alt+Del。

关联 #351