### PR TITLE
feat: add RDP full-screen support and fullscreen resolution

### DIFF
--- a/app.go
+++ b/app.go
@@ -949,6 +949,11 @@ func (a *App) CreateSession(sessionType string, config session.ConnectionConfig)
 	// Set parent HWND for RDP sessions
 	if rdp, ok := s.(*session.RDPSession); ok {
 		rdp.SetParentHwnd(a.mainHwnd)
+		// Notify the frontend when the user exits native full screen so it can
+		// resume position sync.
+		rdp.SetOnFullScreenExit(func() {
+			runtime.EventsEmit(a.ctx, "rdp:fullscreen-exit", s.ID())
+		})
 	}
 
 	s.SetOnDataCallback(func(data []byte) {
@@ -1277,6 +1282,23 @@ func (a *App) RDPSetFocus(sessionID string, focused bool) error {
 		return fmt.Errorf("session is not RDP")
 	}
 	rdp.SetFocus(focused)
+	return nil
+}
+
+// RDPSetFullScreen toggles the ActiveX control's built-in full-screen mode.
+func (a *App) RDPSetFullScreen(sessionID string, full bool) error {
+	if a.sessionManager == nil {
+		return fmt.Errorf("session manager not initialized")
+	}
+	s, ok := a.sessionManager.Get(sessionID)
+	if !ok {
+		return fmt.Errorf("session not found: %s", sessionID)
+	}
+	rdp, ok := s.(*session.RDPSession)
+	if !ok {
+		return fmt.Errorf("session is not RDP")
+	}
+	rdp.SetFullScreen(full)
 	return nil
 }
 

--- a/backend/session/rdp_session.go
+++ b/backend/session/rdp_session.go
@@ -36,6 +36,7 @@ var (
 	procPostMessageW       = user32Dll.NewProc("PostMessageW")
 	procFindWindowExW      = user32Dll.NewProc("FindWindowExW")
 	procSendMessageW       = user32Dll.NewProc("SendMessageW")
+	procGetSystemMetrics   = user32Dll.NewProc("GetSystemMetrics")
 )
 
 const (
@@ -59,6 +60,8 @@ const (
 	BM_CLICK          = 0x00F5
 	IDYES             = 6
 	IDOK              = 1
+	SM_CXSCREEN       = 0
+	SM_CYSCREEN       = 1
 )
 
 type RDPSession struct {
@@ -72,6 +75,22 @@ type RDPSession struct {
 
 	// Last known position, used by Show() after Hide()
 	trackX, trackY int
+
+	// Full-screen toggle request, applied on the COM STA thread by the message
+	// pump. COM (STA) calls must run on the thread that created the object;
+	// calling PutProperty from the Wails binding thread deadlocks.
+	fsRequested bool // a toggle has been requested
+	fsValue     bool // desired FullScreen value
+	fsActive    bool // last observed FullScreen state (for exit detection)
+	onFsExit    func() // called (on COM thread) when user leaves full screen via the connection bar
+}
+
+// SetOnFullScreenExit registers a callback fired when the user exits the
+// ActiveX full screen via its built-in connection bar.
+func (s *RDPSession) SetOnFullScreenExit(cb func()) {
+	s.mu.Lock()
+	s.onFsExit = cb
+	s.mu.Unlock()
 }
 
 func NewRDPSession(id string) *RDPSession {
@@ -244,6 +263,15 @@ func (s *RDPSession) Connect(config ConnectionConfig) error {
 
 	width := config.RdpFixedWidth
 	height := config.RdpFixedHeight
+	// Sentinel -1 means "follow the display": use the primary monitor's
+	// physical resolution as the remote desktop size. (issue: fullscreen option)
+	if width == -1 || height == -1 {
+		sw, _, _ := procGetSystemMetrics.Call(uintptr(SM_CXSCREEN))
+		sh, _, _ := procGetSystemMetrics.Call(uintptr(SM_CYSCREEN))
+		width = int(sw)
+		height = int(sh)
+		log.Writef("[RDP] fullscreen resolution: using display size %dx%d", width, height)
+	}
 	if width <= 0 {
 		width = 800
 	}
@@ -323,7 +351,10 @@ func (s *RDPSession) Connect(config ConnectionConfig) error {
 			adv.PutProperty("RDPPort", port)
 			adv.PutProperty("RedirectClipboard", true)
 			adv.PutProperty("RedirectDrives", true)
-			adv.PutProperty("DisplayConnectionBar", false)
+			// Let the ActiveX control handle full screen
+			// itself and show its built-in connection bar (which carries the
+			// restore/exit button). Requires ContainerHandledFullScreen=false.
+			adv.PutProperty("DisplayConnectionBar", true)
 			adv.PutProperty("EnableAutoReconnect", true)
 			if config.RdpEnableNLA {
 				adv.PutProperty("EnableCredSspSupport", true)
@@ -333,7 +364,10 @@ func (s *RDPSession) Connect(config ConnectionConfig) error {
 				adv.PutProperty("AuthenticationLevel", 0)
 			}
 			adv.PutProperty("WarnOnDirectConnect", false)
-			adv.PutProperty("ContainerHandledFullScreen", true)
+			// false = ActiveX manages full screen itself
+			// (renders its own connection bar with an exit button), instead of
+			// delegating to the host container.
+			adv.PutProperty("ContainerHandledFullScreen", false)
 			if config.RdpSmartSizing {
 				adv.PutProperty("SmartSizing", true)
 			}
@@ -351,7 +385,7 @@ func (s *RDPSession) Connect(config ConnectionConfig) error {
 		if advHigh != nil {
 			a := advHigh.ToIDispatch()
 			if a != nil {
-				a.PutProperty("ContainerHandledFullScreen", true)
+				a.PutProperty("ContainerHandledFullScreen", false)
 				a.PutProperty("WarnOnDirectConnect", false)
 				a.Release()
 				log.Writef("[RDP] AdvancedSettings%d: security prompts suppressed", ver)
@@ -434,6 +468,22 @@ func (s *RDPSession) runMessagePump() {
 			break
 		}
 
+		// Apply any pending full-screen toggle on THIS (COM STA) thread.
+		s.mu.Lock()
+		if s.fsRequested {
+			s.fsRequested = false
+			full := s.fsValue
+			rdp := s.rdp
+			s.fsActive = full
+			s.mu.Unlock()
+			if rdp != nil {
+				rdp.PutProperty("FullScreen", full)
+				log.Writef("[RDP] FullScreen applied on COM thread full=%v", full)
+			}
+		} else {
+			s.mu.Unlock()
+		}
+
 		ret, _, _ := procPeekMessage.Call(
 			uintptr(unsafe.Pointer(&m)),
 			0, 0, 0,
@@ -453,6 +503,36 @@ func (s *RDPSession) runMessagePump() {
 			// Check hwnd every ~1 second via heartbeat counter.
 			time.Sleep(50 * time.Millisecond)
 			noMsgCount++
+
+			// Detect full-screen exit via the built-in connection bar: the
+			// control flips FullScreen back to false. Poll on THIS COM thread
+			// every ~250ms while full screen is active.
+			if noMsgCount%5 == 0 {
+				s.mu.Lock()
+				active := s.fsActive
+				rdp := s.rdp
+				s.mu.Unlock()
+				if active && rdp != nil {
+					fs, err := rdp.GetProperty("FullScreen")
+					if err == nil && fs != nil {
+						stillFull := false
+						if b, ok := fs.Value().(bool); ok {
+							stillFull = b
+						}
+						if !stillFull {
+							s.mu.Lock()
+							s.fsActive = false
+							cb := s.onFsExit
+							s.mu.Unlock()
+							log.Writef("[RDP] full-screen exited via connection bar")
+							if cb != nil {
+								cb()
+							}
+						}
+					}
+				}
+			}
+
 			if noMsgCount%20 == 0 {
 				log.Writef("[RDP-pump] heartbeat idle=%d, pumpMsgs=%d, hwnd=0x%x", noMsgCount, pumpTick, s.hwnd)
 				// Check if RDP connection is still alive via ActiveX Connected property.
@@ -768,6 +848,21 @@ func (s *RDPSession) SetPosition(x, y, w, h int) {
 // Kept as a no-op for API compatibility with the frontend.
 func (s *RDPSession) SetFocus(focused bool) {
 	log.Writef("[RDP-focus] SetFocus focused=%v (no-op, owned-window model)", focused)
+}
+
+// SetFullScreen toggles the ActiveX control's built-in full-screen mode.
+// With ContainerHandledFullScreen=false the control renders its own
+// connection bar (with a restore button) to exit full screen.
+//
+// The actual COM PutProperty runs on the message-pump (STA) thread — see
+// runMessagePump — because STA COM objects must be called on their owning
+// thread; calling from the Wails binding thread deadlocks.
+func (s *RDPSession) SetFullScreen(full bool) {
+	s.mu.Lock()
+	s.fsRequested = true
+	s.fsValue = full
+	s.mu.Unlock()
+	log.Writef("[RDP] SetFullScreen requested full=%v (deferred to COM thread)", full)
 }
 
 func (s *RDPSession) Show() {

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -244,6 +244,8 @@ function getActiveRdpSessionId(): string | null {
 
 function rdpSyncPosition() {
   if (rdpOverlayCount.value > 0) return
+  // While in native ActiveX full screen, don't fight it with SetPosition.
+  if (rdpFullScreen.value) return
   const area = document.querySelector('.rdp-area') as HTMLElement | null
   if (!area) return
   const sid = getActiveRdpSessionId()
@@ -265,12 +267,23 @@ function rdpResetTracking() {
   nextTick(() => rdpSyncPosition())
 }
 
+// Native ActiveX full-screen: pause position sync while active, restore on exit.
+function onRdpFullScreenEnter() {
+  rdpFullScreen.value = true
+}
+function onRdpFullScreenExit() {
+  rdpFullScreen.value = false
+  nextTick(() => rdpSyncPosition())
+}
+
 
 // ── RDP overlay tracking: unified show/hide entry points ──
 // ALL triggers (context menus, dialogs, drag, resize, external events)
 // MUST call RDPHideForOverlay() to hide and RDPShowForOverlay() to restore.
 // Reference-counted: nesting works correctly across multiple concurrent triggers.
 const rdpOverlayCount = ref(0)
+// Set while a native ActiveX full-screen session is active.
+const rdpFullScreen = ref(false)
 let rdpRestoreTimer: ReturnType<typeof setTimeout> | null = null
 
 function RDPHideForOverlay() {
@@ -661,6 +674,10 @@ onMounted(async () => {
   window.addEventListener('split:resize-start', RDPHideForOverlay)
   window.addEventListener('split:resize-end', RDPShowForOverlay)
   window.addEventListener('rdp:sync-position', rdpResetTracking)
+  // RDP native full-screen enter/exit
+  window.addEventListener('rdp:fullscreen-enter', onRdpFullScreenEnter)
+  // Exit is emitted from Go when the user uses the connection bar's restore button.
+  EventsOn('rdp:fullscreen-exit', () => onRdpFullScreenExit())
   // Go-side WndProc events: window move/resize start/end
   EventsOn('rdp:move-resize-start', () => RDPHideForOverlay())
   EventsOn('rdp:move-resize-end', () => RDPShowForOverlay())
@@ -809,6 +826,7 @@ onUnmounted(() => {
   window.removeEventListener('split:resize-start', RDPHideForOverlay)
   window.removeEventListener('split:resize-end', RDPShowForOverlay)
   window.removeEventListener('rdp:sync-position', rdpResetTracking)
+  window.removeEventListener('rdp:fullscreen-enter', onRdpFullScreenEnter)
 
 })
 

--- a/frontend/src/components/ConnectionForm.vue
+++ b/frontend/src/components/ConnectionForm.vue
@@ -591,6 +591,7 @@ const form = reactive<ConnectionConfig>({
 })
 
 const rdpResolutions = [
+  { label: t('rdp.fullscreen'), w: -1, h: -1 },
   { label: '800 × 600 (SVGA)', w: 800, h: 600 },
   { label: '1024 × 768 (XGA)', w: 1024, h: 768 },
   { label: '1280 × 720 (HD)', w: 1280, h: 720 },

--- a/frontend/src/components/RDPTabContent.vue
+++ b/frontend/src/components/RDPTabContent.vue
@@ -33,6 +33,8 @@
       <span>{{ config?.host }}:{{ config?.port || 3389 }}</span>
       <span class="rdp-status-sep">|</span>
       <span>{{ t('rdp.resolution') }}: {{ statusResolution }}</span>
+      <span class="rdp-status-spacer" />
+      <button class="rdp-fullscreen-btn" @click="enterFullScreen">{{ t('rdp.fullscreen') }}</button>
     </div>
   </div>
 </template>
@@ -42,7 +44,7 @@ import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
 import { Loader } from '@lucide/vue'
 import { useI18n } from '../i18n'
 import type { ConnectionConfig } from '../types/session'
-import { CreateSession, CloseSession, RDPHide } from '../../wailsjs/go/main/App'
+import { CreateSession, CloseSession, RDPHide, RDPSetFullScreen } from '../../wailsjs/go/main/App'
 import { EventsOn } from '../../wailsjs/runtime'
 import { usePanelStore } from '../stores/panelStore'
 
@@ -59,6 +61,9 @@ const status = ref<'connecting' | 'connected' | 'disconnected' | 'error'>('conne
 const currentSessionId = ref<string | null>(props.sessionId)
 const errorMessage = ref<string>('')
 const statusResolution = computed(() => {
+  if (props.config?.rdpFixedWidth === -1 || props.config?.rdpFixedHeight === -1) {
+    return t('rdp.fullscreen')
+  }
   if (props.config?.rdpFixedWidth && props.config?.rdpFixedHeight) {
     return `${props.config.rdpFixedWidth}×${props.config.rdpFixedHeight}`
   }
@@ -114,6 +119,14 @@ async function reconnect() {
     currentSessionId.value = null
   }
   await connect()
+}
+
+// Enter the ActiveX control's built-in full screen. The control renders its
+// own connection bar with a restore button to exit.
+async function enterFullScreen() {
+  if (!currentSessionId.value) return
+  window.dispatchEvent(new CustomEvent('rdp:fullscreen-enter'))
+  try { await RDPSetFullScreen(currentSessionId.value, true) } catch (e) { console.error('RDP fullscreen error:', e) }
 }
 
 // --- Events (lifecycle-scoped to avoid listener accumulation) ---
@@ -215,4 +228,18 @@ watch(() => props.sessionId, (newId) => {
   background: var(--success);
 }
 .rdp-status-sep { color: var(--text-disabled); }
+.rdp-status-spacer { flex: 1; }
+.rdp-fullscreen-btn {
+  border: 1px solid var(--border-default);
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 12px;
+  padding: 1px 10px;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+.rdp-fullscreen-btn:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
 </style>

--- a/frontend/src/components/TabItem.vue
+++ b/frontend/src/components/TabItem.vue
@@ -68,6 +68,7 @@
         @click.stop
       >
         <div v-if="canDuplicate" class="menu-item" @click="duplicateTab">{{ t('tab.duplicate') }}</div>
+        <div v-if="tab.type === 'rdp'" class="menu-item" @click="enterRdpFullScreen">{{ t('rdp.fullscreen') }}</div>
         <div v-if="tab.type === 'terminal'" class="menu-item" @click="toggleAiLock">
           {{ isAILocked ? t('terminal.aiLocked') : t('terminal.lockAI') }}
         </div>
@@ -108,6 +109,7 @@ import {
   DisableSessionOutputLog,
   GetSessionOutputLogInfo,
   OpenPathInExplorer,
+  RDPSetFullScreen,
 } from '../../wailsjs/go/main/App'
 import { msg } from '../services/message'
 import type { TerminalTab, SettingsTab, SFTPTab, RDPTab, VNCTab, SPICETab, DBTab, MonitorTab, WorkspaceTab } from '../types/workspace'
@@ -430,6 +432,15 @@ function openMonitor() {
     window.dispatchEvent(new CustomEvent('app:connect-monitor', { detail: panel }))
   }
   closeContextMenu()
+}
+
+async function enterRdpFullScreen() {
+  closeContextMenu()
+  const panel = panelStore.getPanel((props.tab as RDPTab).panelId)
+  const sid = panel?.sessionId
+  if (!sid) return
+  window.dispatchEvent(new CustomEvent('rdp:fullscreen-enter'))
+  try { await RDPSetFullScreen(sid, true) } catch (e) { console.error('RDP fullscreen error:', e) }
 }
 
 async function toggleOutputLog() {

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -457,6 +457,7 @@
   "rdp.retry": "Retry",
   "rdp.timeout": "Connection timed out. Please check the host address and network connectivity.",
   "rdp.resolution": "Resolution",
+  "rdp.fullscreen": "Fullscreen",
   "vnc.connecting": "Connecting to {host}...",
   "vnc.connected": "Connected",
   "vnc.disconnected": "Disconnected",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -457,6 +457,7 @@
   "rdp.retry": "重试",
   "rdp.timeout": "连接超时，请检查主机地址和网络连接。",
   "rdp.resolution": "分辨率",
+  "rdp.fullscreen": "全屏",
   "vnc.connecting": "正在连接到 {host}...",
   "vnc.connected": "已连接",
   "vnc.disconnected": "已断开",

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -171,6 +171,8 @@ export function RDPHide(arg1:string):Promise<void>;
 
 export function RDPSetFocus(arg1:string,arg2:boolean):Promise<void>;
 
+export function RDPSetFullScreen(arg1:string,arg2:boolean):Promise<void>;
+
 export function RDPSetPosition(arg1:string,arg2:number,arg3:number,arg4:number,arg5:number):Promise<void>;
 
 export function RDPShow(arg1:string):Promise<void>;

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -330,6 +330,10 @@ export function RDPSetFocus(arg1, arg2) {
   return window['go']['main']['App']['RDPSetFocus'](arg1, arg2);
 }
 
+export function RDPSetFullScreen(arg1, arg2) {
+  return window['go']['main']['App']['RDPSetFullScreen'](arg1, arg2);
+}
+
 export function RDPSetPosition(arg1, arg2, arg3, arg4, arg5) {
   return window['go']['main']['App']['RDPSetPosition'](arg1, arg2, arg3, arg4, arg5);
 }


### PR DESCRIPTION
## Summary

Adds full-screen support for RDP sessions, plus a "Fullscreen" resolution option.

## Details

Uses the MsRdpClient ActiveX control's built-in full-screen mode (which renders its own connection bar with a restore button to exit):

- **Enter full screen** from the status bar button or the tab's right-click menu.
- The COM `PutProperty("FullScreen")` call runs on the message-pump (STA) thread rather than the Wails binding thread — calling a single-threaded-apartment COM object from another thread would deadlock (this was the cause of a hang in early testing).
- **Exit detection**: the message pump polls the `FullScreen` property (~250ms) and, when the user restores via the connection bar, emits an event so the frontend resumes overlay position sync.
- **Fullscreen resolution option**: a new entry in the resolution dropdown that follows the primary display's physical resolution. Stored as a sentinel `-1`, resolved via `GetSystemMetrics` at connect time so it adapts to whatever machine the connection runs on.

## Notes

- `Ctrl+Alt+Del` and multi-monitor mode are out of scope for this PR. Multi-monitor (mentioned in #196) would require substantially more work given the embedded-window architecture.

Refs #196

---

## 概述

为 RDP 会话添加全屏支持，并在分辨率中新增"全屏"选项。

## 细节

使用 MsRdpClient ActiveX 控件自带的全屏模式（控件自身会渲染带还原按钮的连接条用于退出）：

- **进入全屏**：通过状态栏按钮或标签右键菜单触发。
- COM 的 `PutProperty("FullScreen")` 调用在消息泵（STA）线程执行，而非 Wails 绑定线程——从其它线程调用单线程套间（STA）的 COM 对象会死锁（这是早期测试中卡死的根因）。
- **退出检测**：消息泵轮询 `FullScreen` 属性（约 250ms），当用户通过连接条还原时发出事件，前端据此恢复覆盖窗口的位置同步。
- **全屏分辨率选项**：分辨率下拉新增一项，跟随主显示器的物理分辨率。以哨兵值 `-1` 存储，连接时通过 `GetSystemMetrics` 解析，从而适配实际运行的机器。

## 说明

- `Ctrl+Alt+Del` 与多屏模式不在本 PR 范围内。多屏（#196 中提及）在当前嵌入式窗口架构下改动量较大。

关联 #196