### PR TITLE
fix: only auto-dismiss RDP security dialogs from our own process

### DIFF
--- a/backend/session/rdp_session.go
+++ b/backend/session/rdp_session.go
@@ -37,6 +37,10 @@ var (
 	procFindWindowExW      = user32Dll.NewProc("FindWindowExW")
 	procSendMessageW       = user32Dll.NewProc("SendMessageW")
 	procGetSystemMetrics   = user32Dll.NewProc("GetSystemMetrics")
+	procGetWindowThreadPID = user32Dll.NewProc("GetWindowThreadProcessId")
+
+	// kernel32Dll is declared in local_session_windows.go (same package).
+	procGetCurrentProcID = kernel32Dll.NewProc("GetCurrentProcessId")
 )
 
 const (
@@ -143,6 +147,10 @@ func (s *RDPSession) autoDismissSecurityDialogs(stop <-chan struct{}) {
 	}
 	clsName, _ := windows.UTF16PtrFromString("#32770")
 
+	// Our own process ID, used to skip dialogs belonging to the system's mstsc.
+	pid, _, _ := procGetCurrentProcID.Call()
+	selfPID := uint32(pid)
+
 	ticker := time.NewTicker(50 * time.Millisecond)
 	defer ticker.Stop()
 
@@ -158,6 +166,17 @@ func (s *RDPSession) autoDismissSecurityDialogs(stop <-chan struct{}) {
 					uintptr(unsafe.Pointer(tPtr)),
 				)
 				if hwnd == 0 {
+					continue
+				}
+
+				// Only dismiss dialogs owned by our OWN process. The dialog class
+				// (#32770) and titles ("远程桌面连接" / "Windows 安全") are shared
+				// with the system's mstsc; without this filter we would repeatedly
+				// close mstsc's own password/security prompts, causing them to
+				// flicker and re-open. (issue #348)
+				var dlgPID uint32
+				procGetWindowThreadPID.Call(hwnd, uintptr(unsafe.Pointer(&dlgPID)))
+				if dlgPID != selfPID {
 					continue
 				}
 


### PR DESCRIPTION
## Problem

When a uniTerm RDP session is open, opening the system's own Remote Desktop (mstsc) causes its password/security prompts to flicker and repeatedly re-open.

**Root cause:** `autoDismissSecurityDialogs` finds dialogs globally by window class (`#32770`) and title ("远程桌面连接" / "Windows 安全"), then posts close messages / clicks buttons to dismiss them. Those class and titles are shared with the system's mstsc, so the loop also closes mstsc's own prompts — which then re-open, causing the flicker.

## Fix

Filter by owning process: use `GetWindowThreadProcessId` and only dismiss dialogs whose PID matches the current uniTerm process. mstsc runs in a separate process, so its dialogs are left untouched, while uniTerm's own RDP certificate/security prompts are still auto-dismissed.

Refs #348

---

## 问题

打开 uniTerm 的 RDP 会话后，再打开系统自带的远程桌面（mstsc），其密码框/安全提示会不停闪烁、反复弹出。

**根因：** `autoDismissSecurityDialogs` 通过窗口类（`#32770`）和标题（"远程桌面连接" / "Windows 安全"）全局查找对话框，然后发送关闭消息 / 点击按钮将其关闭。这些类名和标题与系统 mstsc 共用，导致该循环也会关闭 mstsc 自己的提示框——随后又被重新弹出，造成闪烁。

## 修复

按所属进程过滤：使用 `GetWindowThreadProcessId`，仅关闭 PID 与当前 uniTerm 进程一致的对话框。mstsc 是独立进程，其对话框不受影响；而 uniTerm 自身 RDP 的证书/安全提示仍会被自动关闭。

关联 #348