### PR TITLE
fix: auto-append /v1 for Anthropic base URL

### DIFF
--- a/app.go
+++ b/app.go
@@ -1475,7 +1475,15 @@ func (a *App) chatCompletionAnthropic(apiKey, baseURL, model string, reqBody map
 		return "", fmt.Errorf("marshal modified request: %w", err)
 	}
 
-	url := strings.TrimRight(baseURL, "/") + "/messages"
+	// Anthropic base URL conventionally omits /v1 (client appends /v1/messages).
+	// Tolerate legacy configs that already include the /v1 suffix.
+	base := strings.TrimRight(baseURL, "/")
+	var url string
+	if strings.HasSuffix(base, "/v1") {
+		url = base + "/messages"
+	} else {
+		url = base + "/v1/messages"
+	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 600*time.Second)
 	defer cancel()

--- a/docs/guide/en/features/ai-assistant.md
+++ b/docs/guide/en/features/ai-assistant.md
@@ -27,7 +27,7 @@ Supports Anthropic and OpenAI-compatible APIs. You can add multiple models and s
 |------|------|
 | Name | Custom display name used to distinguish configurations in the model list |
 | Protocol | Choose **Anthropic** or **OpenAI** protocol, determining the request format |
-| Base URL | API endpoint address. OpenAI defaults to `https://api.openai.com/v1`, Anthropic defaults to `https://api.anthropic.com/v1` |
+| Base URL | API endpoint address. OpenAI defaults to `https://api.openai.com/v1`, Anthropic defaults to `https://api.anthropic.com` |
 | User-Agent | Optional. Custom User-Agent header identifier. Presets include uniTerm, Claude Code, Cursor, and manual input is also supported |
 | API Key | API authentication key, stored as a password |
 | Model | Model name (e.g. `gpt-4o`, `claude-sonnet-4-20250514`). Use the "Fetch Model List" button to pull available models from the API |

--- a/docs/guide/zh/features/ai-assistant.md
+++ b/docs/guide/zh/features/ai-assistant.md
@@ -27,7 +27,7 @@ AI Agent 会：
 |------|------|
 | 名称 | 自定义显示名称，用于在模型列表中区分不同配置 |
 | 协议 | 选择 **Anthropic** 或 **OpenAI** 协议，决定请求格式 |
-| Base URL | API 端点地址，OpenAI 默认为 `https://api.openai.com/v1`，Anthropic 默认为 `https://api.anthropic.com/v1` |
+| Base URL | API 端点地址，OpenAI 默认为 `https://api.openai.com/v1`，Anthropic 默认为 `https://api.anthropic.com` |
 | User-Agent | 可选，自定义请求头中的 User-Agent 标识，提供 uniTerm、Claude Code、Cursor 等预设，也支持手动输入 |
 | API Key | API 认证密钥，以密码形式存储 |
 | 模型 | 模型名称（如 `gpt-4o`、`claude-sonnet-4-20250514`），可通过「获取模型列表」按钮从 API 自动拉取可选模型 |

--- a/frontend/src/components/SettingsTab.vue
+++ b/frontend/src/components/SettingsTab.vue
@@ -621,7 +621,7 @@
           </div>
         </el-form-item>
         <el-form-item :label="t('settings.modelBaseURL')">
-          <el-input v-model="modelForm.baseURL" :placeholder="modelForm.protocol === 'openai' ? 'https://api.openai.com/v1' : 'https://api.anthropic.com/v1'" />
+          <el-input v-model="modelForm.baseURL" :placeholder="modelForm.protocol === 'openai' ? 'https://api.openai.com/v1' : 'https://api.anthropic.com'" />
         </el-form-item>
         <el-form-item :label="t('settings.modelUserAgent')">
           <el-select v-model="modelForm.userAgent" style="width: 100%" filterable allow-create>


### PR DESCRIPTION
## Summary

The Anthropic protocol conventionally uses a base URL **without** the `/v1` suffix — clients append `/v1/messages` themselves (e.g. `https://api.anthropic.com`, `https://api.minimaxi.com/anthropic`). The backend, however, only appended `/messages`, so a URL like `https://api.minimaxi.com/anthropic` became `.../anthropic/messages` and returned **404**.

This is the root cause of #349.

## Changes

- **app.go**: the Anthropic branch now appends `/v1/messages`, while tolerating legacy configs that already end with `/v1` (avoids `/v1/v1/messages`). All four forms now work:
  - `https://api.anthropic.com`
  - `https://api.anthropic.com/v1` (legacy)
  - `https://api.minimaxi.com/anthropic`
  - `https://api.minimaxi.com/anthropic/v1`
- **SettingsTab.vue**: Anthropic placeholder changed to the suffix-free `https://api.anthropic.com`.
- **docs**: updated the Anthropic default Base URL in the zh/en guides.

OpenAI protocol is unchanged — its compatible endpoints use varying version segments (`/v1`, `/api/paas/v4`, `/api/v3`, ...) that cannot be auto-completed.

Closes #349

---

## 概述

Anthropic 协议的 Base URL 惯例是**不带** `/v1` 后缀的——由客户端自己拼 `/v1/messages`（如 `https://api.anthropic.com`、`https://api.minimaxi.com/anthropic`）。但后端只拼了 `/messages`，导致 `https://api.minimaxi.com/anthropic` 变成 `.../anthropic/messages`，返回 **404**。

这就是 #349 的根本原因。

## 改动

- **app.go**：Anthropic 分支改为拼 `/v1/messages`，同时兼容已带 `/v1` 的存量配置（避免拼成 `/v1/v1/messages`）。四种写法均可用：
  - `https://api.anthropic.com`
  - `https://api.anthropic.com/v1`（存量）
  - `https://api.minimaxi.com/anthropic`
  - `https://api.minimaxi.com/anthropic/v1`
- **SettingsTab.vue**：Anthropic 占位符改为不带后缀的 `https://api.anthropic.com`。
- **docs**：更新中英文档中 Anthropic 的默认 Base URL。

OpenAI 协议维持原样——其兼容端点的版本段五花八门（`/v1`、`/api/paas/v4`、`/api/v3` 等），无法自动补全。

Closes #349