### PR TITLE
fix: cursor and AI-lock styling issues under background image

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1626,10 +1626,15 @@ watch(
   opacity: var(--bg-mask-opacity, 0.6);
 }
 .app-container.has-bg .main-content,
-.app-container.has-bg .main-content :deep(*),
+.app-container.has-bg .main-content :deep(*:not(.xterm-cursor)),
 .app-container.has-bg .app-header,
 .app-container.has-bg :deep(.app-header *) {
   background-color: transparent !important;
+}
+/* 开背景时 AI 输入(IN)标签底色被抹透明，深色文字会糊在图上；
+   改用与输出(OUT)标签一致的白字，保证在背景图上清晰可读 */
+.app-container.has-bg .main-content :deep(.in-box .tool-box-label) {
+  color: var(--on-accent) !important;
 }
 /* 标签栏毛玻璃 */
 .app-container.has-bg :deep(.app-header) {

--- a/frontend/src/components/TabItem.vue
+++ b/frontend/src/components/TabItem.vue
@@ -30,13 +30,6 @@
       />
       <span v-else-if="!isActive && hasNotification && !tab.locked" class="tab-notification-dot" />
     </span>
-    <span
-      v-if="isAILocked"
-      class="tab-ai-lock-indicator"
-      :title="t('terminal.aiLocked')"
-    >
-      <Sparkles :size="14" />
-    </span>
     <span v-if="!editing" class="tab-name" :class="{ 'tab-disconnected': isDisconnected }" @dblclick.stop="startEdit">
       <ArrowDownUp v-if="hasActiveTransfers" class="transfer-indicator" :size="14" title="Transferring..." />
       {{ tab.name }}
@@ -113,7 +106,7 @@ import {
 } from '../../wailsjs/go/main/App'
 import { msg } from '../services/message'
 import type { TerminalTab, SettingsTab, SFTPTab, RDPTab, VNCTab, SPICETab, DBTab, MonitorTab, WorkspaceTab } from '../types/workspace'
-import { SquareTerminal, Laptop, FolderUp, HardDrive, Cloud, Globe, Monitor, MonitorCloud, MonitorSmartphone, Settings, Sparkles, Database, DatabaseZap, Layers, Activity, Terminal, Zap, X, ArrowDownUp, LayoutDashboard, Cable, SquarePlus, Lock, MoreHorizontal } from '@lucide/vue'
+import { SquareTerminal, Laptop, FolderUp, HardDrive, Cloud, Globe, Monitor, MonitorCloud, MonitorSmartphone, Settings, Database, DatabaseZap, Layers, Activity, Terminal, Zap, X, ArrowDownUp, LayoutDashboard, Cable, SquarePlus, Lock, MoreHorizontal } from '@lucide/vue'
 
 const props = defineProps<{
   tab: TerminalTab | SettingsTab | SFTPTab | RDPTab | VNCTab | SPICETab | DBTab | MonitorTab | WorkspaceTab
@@ -534,12 +527,12 @@ onUnmounted(() => {
   box-shadow: inset 0 0 0 1px var(--accent);
 }
 .tab-item.ai-locked {
-  box-shadow: inset 2px 0 0 var(--warning);
+  box-shadow: inset 2px 0 0 var(--warning), inset 0 0 12px var(--warning-subtle);
 }
 .tab-item.active.ai-locked {
   background: var(--bg-hover);
   color: var(--text-primary);
-  box-shadow: inset 0 0 0 1px var(--accent), inset 2px 0 0 var(--warning);
+  box-shadow: inset 0 0 0 1px var(--accent), inset 2px 0 0 var(--warning), inset 0 0 12px var(--warning-subtle);
 }
 .tab-name {
   font-size: 12px;
@@ -610,14 +603,6 @@ onUnmounted(() => {
   padding: 2px 6px;
   width: 120px;
   outline: none;
-}
-.tab-ai-lock-indicator {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-  margin-right: 2px;
-  color: var(--warning);
 }
 .tab-close {
   display: flex;


### PR DESCRIPTION
## Summary

Fixes several UI styling issues introduced by the background-image feature.

- **Blinking cursor invisible under background image**: the global rule that makes all `.main-content` descendants transparent (`background-color: transparent !important`) also killed the terminal's blinking-cursor background, whose visibility relies on a CSS animation (an `!important` declaration overrides `animation`). The non-blinking cursor survived because xterm applies its own `!important` fill. Excludes `.xterm-cursor` from the transparent rule so the blink animation works.
- **AI IN label unreadable under background image**: the IN label used dark text (`--bg-base`) on a green fill; once the fill was forced transparent the dark text smeared over the image. Switches its text to `--on-accent` (white) under background mode, matching the OUT label.
- **AI-locked tab styling**: removes the extra sparkles indicator that appeared on AI-locked tabs, and aligns the tab's locked styling with the panel header (left warning bar + inner warning glow) instead of only a left bar / flat fill. Using `box-shadow` for the glow keeps it visible under background mode without extra overrides.

## Test

- `npm --prefix frontend run build`
- Verified in `wails dev`: blinking cursor visible and AI IN label readable with a background image; AI-locked tabs match the panel header style in both normal and background modes.

---

## 概述

修复背景图功能引入的若干界面样式问题。

- **背景图下闪烁光标不可见**：把 `.main-content` 所有后代背景强制透明的全局规则也抹掉了终端闪烁光标的背景，而闪烁光标依赖 CSS animation 显示（`!important` 声明会覆盖 animation）；非闪烁光标因 xterm 自带 `!important` 填充而幸免。现将 `.xterm-cursor` 从透明规则中排除，让闪烁动画正常生效。
- **背景图下 AI 输入(IN)标签看不清**：IN 标签为绿底 + 深色字(`--bg-base`)，底色被强制透明后深字糊在图上；背景模式下改用白字(`--on-accent`)，与输出(OUT)标签一致。
- **AI 锁定标签样式**：去掉锁定后 tab 上多出的 sparkles 图标，并把 tab 锁定样式统一为与 panel 标题栏一致（左侧警告色竖条 + 内侧警告色发光），不再只是左侧亮条/铺满底色。发光用 `box-shadow` 实现，背景模式下无需额外覆盖也能保留。

## 测试

- `npm --prefix frontend run build`
- `wails dev` 实测：开启背景图后闪烁光标可见、AI IN 标签清晰；AI 锁定 tab 在普通与背景模式下均与 panel 标题栏样式一致。