### PR TITLE
fix: preserve xterm cell and selection backgrounds under background image

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1626,11 +1626,13 @@ watch(
   opacity: var(--bg-mask-opacity, 0.6);
 }
 .app-container.has-bg .main-content,
-.app-container.has-bg .main-content :deep(*:not(.xterm-cursor)),
+.app-container.has-bg .main-content :deep(*:not(.xterm-cursor):not([class*="xterm-bg-"]):not(.xterm-selection):not(.xterm-selection *)),
 .app-container.has-bg .app-header,
 .app-container.has-bg :deep(.app-header *) {
   background-color: transparent !important;
 }
+/* 排除 xterm 自身着色的单元格与选区层：否则通配透明规则会抹掉 vim 可视模式
+   (Ctrl-V/Shift-V)、ls 配色、鼠标选区等由终端渲染的背景色 */
 /* 开背景时 AI 输入(IN)标签底色被抹透明，深色文字会糊在图上；
    改用与输出(OUT)标签一致的白字，保证在背景图上清晰可读 */
 .app-container.has-bg .main-content :deep(.in-box .tool-box-label) {


### PR DESCRIPTION
## English

When a background image is enabled, the `has-bg` wildcard rule
(`.main-content *:not(.xterm-cursor) { background-color: transparent !important }`)
strips every element's background so the image can show through. However, it also
cleared xterm's own terminal-rendered backgrounds:

- cell background spans (`xterm-bg-*`) — used by vim visual modes (Ctrl-V/Shift-V), `ls` colors, prompt highlights, etc.
- the selection layer (`.xterm-selection`) — mouse selection highlight

As a result these highlights disappeared under background mode.

This adds `:not([class*="xterm-bg-"])`, `:not(.xterm-selection)` and
`:not(.xterm-selection *)` to the transparency rule so terminal-rendered
backgrounds are preserved, while all other UI still goes transparent to reveal
the image.

## 中文

开启背景图后，`has-bg` 的通配透明规则会把所有元素底色抹成透明以透出背景图，
但同时也抹掉了 xterm 自己渲染的终端底色：

- 带背景色的单元格 span（`xterm-bg-*`）——vim 可视模式（Ctrl-V/Shift-V）、`ls` 配色、prompt 高亮等
- 选区高亮层（`.xterm-selection`）——鼠标选区

导致背景模式下这些高亮消失。本次给透明规则加上对应排除，恢复终端自身的底色渲染，
其余 UI 仍保持透明以显示背景图。