### PR TITLE
feat: show timestamp on disconnect and reconnect notices

### DIFF
--- a/backend/session/serial_session.go
+++ b/backend/session/serial_session.go
@@ -127,7 +127,7 @@ func (s *SerialSession) readLoop() {
 			if err != io.EOF {
 				s.emitData([]byte(fmt.Sprintf("\r\n\x1b[31m[Serial read error: %v]\x1b[0m\r\n", err)))
 			} else {
-				s.emitData([]byte("\r\n\x1b[31mSerial device disconnected. Press Enter to reconnect.\x1b[0m\r\n"))
+				s.emitData(disconnectNotice("Serial device disconnected."))
 			}
 			s.Disconnect()
 			return

--- a/backend/session/session.go
+++ b/backend/session/session.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -16,6 +17,13 @@ const (
 	StatusDisconnected SessionStatus = "disconnected"
 	StatusError        SessionStatus = "error"
 )
+
+// disconnectNotice formats a red disconnect prompt with the local time it
+// happened, so users can tell when a remote host dropped them. See issue #367.
+func disconnectNotice(msg string) []byte {
+	ts := time.Now().Format("2006-01-02 15:04:05")
+	return []byte(fmt.Sprintf("\r\n\x1b[31m%s (%s) Press Enter to reconnect.\x1b[0m\r\n", msg, ts))
+}
 
 type ConnectionGroup struct {
 	ID       string  `json:"id"`

--- a/backend/session/ssh_session.go
+++ b/backend/session/ssh_session.go
@@ -331,7 +331,7 @@ func (s *SSHSession) readLoop() {
 				last, _ := s.lastRecv.Load().([]byte)
 				sent, _ := s.lastSent.Load().([]byte)
 				log.Writef("ssh disconnect: remote closed (EOF), %s lastRecv=%s lastSent=%s", s.kaDiag(), tailHex(last, 64), tailHex(sent, 32))
-				s.emitData([]byte("\r\n\x1b[31mConnection closed by remote host. Press Enter to reconnect.\x1b[0m\r\n"))
+				s.emitData(disconnectNotice("Connection closed by remote host."))
 			}
 			s.Disconnect()
 			return
@@ -479,7 +479,7 @@ func (s *SSHSession) startKeepAlive() {
 
 			if failures >= sshKeepAliveMaxFail {
 				log.Writef("ssh disconnect: keepalive timeout, %s", s.kaDiag())
-				s.emitData([]byte("\r\n\x1b[31mConnection lost. Press Enter to reconnect.\x1b[0m\r\n"))
+				s.emitData(disconnectNotice("Connection lost."))
 				s.Disconnect()
 				return
 			}

--- a/backend/session/telnet_session.go
+++ b/backend/session/telnet_session.go
@@ -116,7 +116,7 @@ func (s *TelnetSession) readLoop(ctx context.Context) {
 			if err != io.EOF {
 				s.emitData([]byte(fmt.Sprintf("\r\n\x1b[31m[read error: %v]\x1b[0m\r\n", err)))
 			} else {
-				s.emitData([]byte("\r\n\x1b[31mConnection closed by remote host. Press Enter to reconnect.\x1b[0m\r\n"))
+				s.emitData(disconnectNotice("Connection closed by remote host."))
 			}
 			s.Disconnect()
 			return

--- a/frontend/src/components/Panel.vue
+++ b/frontend/src/components/Panel.vue
@@ -349,7 +349,10 @@ async function retryConnection(silent = false) {
     props.panel.config.password = result.password
   }
 
-  baseTerminalRef.value?.write(RESET_MOUSE_MODES + '\r\n\x1b[33mReconnecting...\x1b[0m\r\n')
+  const now = new Date()
+  const pad = (n: number) => String(n).padStart(2, '0')
+  const reconnectAt = `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())} ${pad(now.getHours())}:${pad(now.getMinutes())}:${pad(now.getSeconds())}`
+  baseTerminalRef.value?.write(RESET_MOUSE_MODES + `\r\n\x1b[33mReconnecting... (${reconnectAt})\x1b[0m\r\n`)
   try {
     const info = await CreateSession(props.panel.config.type, props.panel.config)
     panelStore.bindSession(props.panel.id, info.id)


### PR DESCRIPTION
## English

When a remote host drops the connection, the terminal now shows the local time it happened, so users can tell when they were disconnected. The reconnecting notice also carries a timestamp. Both use a unified `YYYY-MM-DD HH:mm:ss` format.

Covered paths:
- SSH: remote close (EOF) and keepalive timeout
- Telnet: remote close
- Serial: device disconnected
- Reconnecting notice (frontend)

Example:
\`\`\`
Connection closed by remote host. (2026-07-22 14:30:15) Press Enter to reconnect.
Reconnecting... (2026-07-22 14:30:20)
\`\`\`

Closes #367

## 中文

被远程主机断开连接时，终端会显示断开发生的本地时间，方便判断是何时掉线的；重连提示也带上时间戳。前后端统一使用 `YYYY-MM-DD HH:mm:ss` 格式。

涵盖：SSH（远端关闭 / keepalive 超时）、Telnet（远端关闭）、Serial（设备断开）、重连提示（前端）。

Closes #367