### PR TITLE
fix: scope PostgreSQL browser to the connected database

### DIFF
--- a/backend/database/provider_postgres.go
+++ b/backend/database/provider_postgres.go
@@ -132,14 +132,21 @@ func (p *postgresProvider) GetCapabilities() DBCapabilities {
 
 // ── Schema discovery ──
 
+// GetDatabases returns only the currently connected database. A PostgreSQL
+// connection is bound to a single database and cannot query tables across
+// databases, so exposing the whole cluster would let users open other
+// databases and see "no tables". To browse a different database, open a new
+// connection with that database name.
 func (p *postgresProvider) GetDatabases(db *sql.DB) ([]string, error) {
-	results, err := queryStrings(db, "SELECT datname FROM pg_database WHERE datistemplate = false ORDER BY datname")
+	results, err := queryStrings(db, "SELECT current_database() AS datname")
 	if err != nil {
 		return nil, err
 	}
 	names := make([]string, 0, len(results))
 	for _, row := range results {
-		names = append(names, row["datname"])
+		if row["datname"] != "" {
+			names = append(names, row["datname"])
+		}
 	}
 	return names, nil
 }

--- a/frontend/src/components/ConnectionForm.vue
+++ b/frontend/src/components/ConnectionForm.vue
@@ -96,7 +96,7 @@
             <el-form-item v-if="form.authType === 'key' && (form.type === 'ssh' || form.type === 'mosh')" :label="t('conn.keyPassphrase')">
               <el-input v-model="form.password" type="password" show-password :key="passwordInputKey" :placeholder="t('conn.keyPassphrasePlaceholder')" />
             </el-form-item>
-            <el-form-item v-if="form.type === 'database' && form.dbType !== 'rqlite' && form.dbType !== 'redis'" :label="t('db.databases')">
+            <el-form-item v-if="form.type === 'database' && form.dbType !== 'rqlite' && form.dbType !== 'redis'" :label="t('db.databases')" :required="form.dbType === 'postgres'">
               <el-input v-model="form.dbName" :placeholder="t('db.databases')" />
             </el-form-item>
             <el-form-item v-if="form.type === 'database'" :label="t('db.params')">
@@ -840,6 +840,9 @@ function normalizeForm(): ConnectionConfig {
   if (normalized.type === 's3') {
     if (!normalized.user?.trim()) throw new Error('S3: Access Key is required')
     if (!normalized.password?.trim()) throw new Error('S3: Secret Key is required')
+  }
+  if (normalized.type === 'database' && normalized.dbType === 'postgres' && !normalized.dbName?.trim()) {
+    throw new Error(t('db.pgDbNameRequired'))
   }
   if (!normalized.name.trim()) {
     normalized.name = generateUniqueName(

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -607,6 +607,7 @@
   "monitor.net.ipAddrs": "IP-Adressen",
   "db.database": "Datenbank",
   "db.databases": "Datenbanken",
+  "db.pgDbNameRequired": "PostgreSQL erfordert einen Datenbanknamen",
   "db.params": "Zusätzliche Parameter",
   "db.loading": "Laden...",
   "db.selectTableHint": "Doppelklicken Sie auf eine Datenbank oder Tabelle zur Ansicht",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -608,6 +608,7 @@
   "monitor.net.ipAddrs": "IP Addresses",
   "db.database": "Database",
   "db.databases": "Databases",
+  "db.pgDbNameRequired": "PostgreSQL requires a database name",
   "db.params": "Extra Params",
   "db.loading": "Loading...",
   "db.selectTableHint": "Double-click a database or table to view",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -607,6 +607,7 @@
   "monitor.net.ipAddrs": "Direcciones IP",
   "db.database": "Base de Datos",
   "db.databases": "Bases de Datos",
+  "db.pgDbNameRequired": "PostgreSQL requiere un nombre de base de datos",
   "db.params": "Parámetros adicionales",
   "db.loading": "Cargando...",
   "db.selectTableHint": "Haga doble clic en una base de datos o tabla para ver",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -607,6 +607,7 @@
   "monitor.net.ipAddrs": "Adresses IP",
   "db.database": "Base de données",
   "db.databases": "Bases de données",
+  "db.pgDbNameRequired": "PostgreSQL nécessite un nom de base de données",
   "db.params": "Paramètres supplémentaires",
   "db.loading": "Chargement...",
   "db.selectTableHint": "Double-cliquez sur une base de données ou une table pour l'afficher",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -607,6 +607,7 @@
   "monitor.net.ipAddrs": "IP アドレス",
   "db.database": "データベース",
   "db.databases": "データベース",
+  "db.pgDbNameRequired": "PostgreSQL ではデータベース名が必須です",
   "db.params": "追加パラメータ",
   "db.loading": "読み込み中...",
   "db.selectTableHint": "データベースまたはテーブルをダブルクリックして表示",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -607,6 +607,7 @@
   "monitor.net.ipAddrs": "IP 주소",
   "db.database": "데이터베이스",
   "db.databases": "데이터베이스",
+  "db.pgDbNameRequired": "PostgreSQL에는 데이터베이스 이름이 필요합니다",
   "db.params": "추가 매개변수",
   "db.loading": "불러오는 중...",
   "db.selectTableHint": "데이터베이스 또는 테이블을 더블클릭하여 보기",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -607,6 +607,7 @@
   "monitor.net.ipAddrs": "IP-адреса",
   "db.database": "База данных",
   "db.databases": "Базы данных",
+  "db.pgDbNameRequired": "PostgreSQL требует указания имени базы данных",
   "db.params": "Дополнительные параметры",
   "db.loading": "Загрузка...",
   "db.selectTableHint": "Дважды щёлкните по базе данных или таблице для просмотра",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -608,6 +608,7 @@
   "monitor.net.ipAddrs": "IP地址",
   "db.database": "数据库",
   "db.databases": "数据库",
+  "db.pgDbNameRequired": "PostgreSQL 必须填写数据库名",
   "db.params": "额外参数",
   "db.loading": "加载中...",
   "db.selectTableHint": "双击数据库或表查看",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -607,6 +607,7 @@
   "monitor.net.ipAddrs": "IP位址",
   "db.database": "資料庫",
   "db.databases": "資料庫",
+  "db.pgDbNameRequired": "PostgreSQL 必須填寫資料庫名稱",
   "db.params": "額外參數",
   "db.loading": "載入中...",
   "db.selectTableHint": "雙擊資料庫或表查看",


### PR DESCRIPTION
## Summary

Fixes the PostgreSQL bug where the database tree lists every database in the cluster, but clicking any of them shows "no tables".

**Root cause:** A PostgreSQL connection is bound to a single database and cannot query tables across databases (unlike MySQL's `USE` or SQL Server's cross-database `USE`). `GetDatabases` queried the cluster-level `pg_database`, so all databases were listed — but `GetTables` always queried `information_schema.tables` of the *connected* database, ignoring the clicked database. Any database other than the connected one therefore appeared empty (or wrongly showed the connected database's tables).

**Fix:** Keep it honest and simple — pin the browser to the connected database.
- `GetDatabases` now returns only `current_database()`, so the tree shows a single node that `GetTables` can always resolve correctly.
- The connection form requires a database name for PostgreSQL (input marked `required` + validation in `normalizeForm`), preventing the empty-dbName case that lands on the default `postgres` database.

To browse another database, open a new connection with that database name.

## Test
- Connect with dbName `shopdb` → tree shows only `shopdb`, expands to its tables/views. ✅
- Connect with empty dbName → blocked with "PostgreSQL requires a database name". ✅
- Connect with dbName `postgres` → tree shows only `postgres` and its tables. ✅

Closes #368

---

## 中文说明

修复 PostgreSQL「连接后只显示数据库、点击数据库显示无表」的问题。

**根因：** PostgreSQL 一条连接绑定单个数据库，无法跨库查表（不像 MySQL 的 `USE`）。`GetDatabases` 查的是集群级 `pg_database`，列出了所有库；但 `GetTables` 始终查「连接库」的 `information_schema.tables`，忽略了点击的库名——于是点任何非连接库都显示无表（或错显连接库的表）。

**修复：** 采用语义诚实的方案，把浏览范围固定到连接库。
- `GetDatabases` 改为只返回 `current_database()`，树里只有一个节点，`GetTables` 查它必然正确。
- 连接表单对 PostgreSQL 强制要求填写数据库名（输入框 `required` + `normalizeForm` 校验），避免空库名回退到默认 `postgres` 库的情况。

要浏览其它库，请新建一个指定该库名的连接。