### PR TITLE
fix: restore dropdown/switch/slider opacity under background image

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1626,13 +1626,15 @@ watch(
   opacity: var(--bg-mask-opacity, 0.6);
 }
 .app-container.has-bg .main-content,
-.app-container.has-bg .main-content :deep(*:not(.xterm-cursor):not([class*="xterm-bg-"]):not(.xterm-selection):not(.xterm-selection *)),
+.app-container.has-bg .main-content :deep(*:not(:where(.xterm-cursor, [class*="xterm-bg-"], .xterm-selection, .xterm-selection *))),
 .app-container.has-bg .app-header,
 .app-container.has-bg :deep(.app-header *) {
   background-color: transparent !important;
 }
 /* 排除 xterm 自身着色的单元格与选区层：否则通配透明规则会抹掉 vim 可视模式
-   (Ctrl-V/Shift-V)、ls 配色、鼠标选区等由终端渲染的背景色 */
+   (Ctrl-V/Shift-V)、ls 配色、鼠标选区等由终端渲染的背景色。
+   用 :where() 包住，避免 :not 提升特异性把下面对话框/下拉/开关/滑杆
+   的不透明例外规则压过去。 */
 /* 开背景时 AI 输入(IN)标签底色被抹透明，深色文字会糊在图上；
    改用与输出(OUT)标签一致的白字，保证在背景图上清晰可读 */
 .app-container.has-bg .main-content :deep(.in-box .tool-box-label) {


### PR DESCRIPTION
## Summary

The previous fix that preserved xterm cell and selection backgrounds under
the app background image (`797b291`) chained four `:not()` clauses on the
wildcard transparency selector, bumping its specificity to `0,7,0`. That
silently overrode the `0,4,0` opaque exception rules for dropdowns,
context menus, dialogs, switches and sliders, so all of those turned
transparent again on top of the background image.

Wrap the excluded selectors in `:where()` so the wildcard rule drops back
to `0,3,0` (below every exception), and the opaque rules win again.

## Affected UI that is restored

- Element Plus dropdowns (`el-select-dropdown`, `el-dropdown-menu`,
  `el-tree-select__popper`)
- All custom right-click / context menus (`context-menu`, `ctx-menu`,
  `conn-context-menu`, `tab-context-menu`, `ai-context-menu`,
  `qc-context-menu`, `sftp-context-menu`, `tn-context-menu`,
  `start-context-menu`, `hash-dropdown`, `drive-dropdown`,
  `bookmark-dropdown`, `type-filter-menu`, `panel-more-menu`,
  `shell-submenu`)
- Dialogs (`el-dialog`, `el-message-box`)
- Switch track / checked accent / white knob
- Slider runway / bar / button
- Settings-category `--accent-subtle` highlight

xterm cell backgrounds, cursor and selection layer keep the previous fix
— only the specificity of the wildcard is lowered.

## Test

- `npm --prefix frontend run build` passes
- Manual: needs `wails dev` with a background image enabled to confirm

---

## 概述

上一次为了在背景图下保住 xterm 单元格背景与选区层的修复（`797b291`），
在通配透明选择器上串了四个 `:not()`，把选择器特异性抬到了 `0,7,0`，
悄悄压过了 `0,4,0` 的下拉/菜单/对话框/开关/滑杆等不透明例外规则，
导致这些控件在背景图上又变回透明。

把被排除的选择器塞进 `:where()`，通配那条降回 `0,3,0`，例外规则重新生效。

## 影响范围

- Element Plus 下拉（`el-select-dropdown` / `el-dropdown-menu` / `el-tree-select__popper`）
- 所有自定义右键/上下文菜单
- 对话框（`el-dialog` / `el-message-box`）
- 开关轨道 / 勾选态强调色 / 白色圆钮
- 滑杆底槽 / 高亮条 / 圆钮
- 设置左侧选中分类的 `--accent-subtle` 高亮

xterm 相关排除项语义未变，vim 可视模式、ls 配色、鼠标选区仍按之前的修复渲染。

## 测试

- `npm --prefix frontend run build` 通过
- 需 `wails dev` 开启背景图实测