### PR TITLE
fix(ssh): align keepalive with OpenSSH-recommended defaults

### DIFF
--- a/backend/session/ssh_session.go
+++ b/backend/session/ssh_session.go
@@ -21,18 +21,10 @@ import (
 )
 
 const (
-	// Kept well under common corporate firewall/NAT/VPN idle-connection
-	// timeouts (commonly 5-15 minutes, sometimes as low as a few minutes),
-	// which otherwise silently drop the TCP session while the user is
-	// idle-reading in an editor (e.g. vim in normal mode) with no traffic
-	// flowing between keystrokes.
-	sshKeepAliveInterval = 20 * time.Second
-	// Timeout for a single keepalive request. Kept generous: a jump host or
-	// target that is merely slow to answer keepalive@openssh.com under load
-	// must not be mistaken for a dead connection (a too-aggressive 5s value
-	// falsely closed healthy tunnels, see issue #242).
-	sshKeepAliveTimeout = 15 * time.Second
-	sshKeepAliveMaxFail = 4
+	// OpenSSH-recommended defaults (ServerAliveInterval=60, CountMax=3):
+	// 180s judgement window rides out `systemctl restart network` / VPN blips.
+	sshKeepAliveInterval = 60 * time.Second
+	sshKeepAliveMaxFail  = 3
 )
 
 type SSHSession struct {
@@ -471,7 +463,7 @@ func (s *SSHSession) startKeepAlive() {
 					s.kaLastErr.Store("")
 					s.kaLastOKUnix.Store(time.Now().UnixNano())
 				}
-			case <-time.After(sshKeepAliveTimeout):
+			case <-time.After(sshKeepAliveInterval):
 				failures++
 				s.kaLastErr.Store("timeout")
 			}

--- a/backend/session/tunnel_service.go
+++ b/backend/session/tunnel_service.go
@@ -169,7 +169,7 @@ func tunnelKeepAlive(client *ssh.Client, quit chan struct{}, label string) {
 				} else {
 					failures = 0
 				}
-			case <-time.After(sshKeepAliveTimeout):
+			case <-time.After(sshKeepAliveInterval):
 				failures++
 			}
 


### PR DESCRIPTION
## Problem

During a server-side `systemctl restart network` (or brief VPN/Wi-Fi hiccup), uniterm declares the SSH session dead while other clients (Xshell, PuTTY, MobaXterm, OpenSSH) survive. Our ~80s judgement window is the tightest among mainstream terminals.

Log from a real disconnect:

```
ssh disconnect: keepalive timeout, idle=2m51s lastKeepalive=timeout lastOK=1m34s ago failures=4
```

## Fix

Align keepalive with OpenSSH-recommended defaults (`ServerAliveInterval=60`, `ServerAliveCountMax=3`):

- interval: **20s → 60s**
- max failures: **4 → 3**
- drop independent per-request timeout (previously 15s), let it equal the interval — matches OpenSSH's model and removes a select-race where a slightly-late healthy response could be recorded as `timeout`.

Judgement window: **~80s → 180s**. Same constant is reused by `tunnelKeepAlive`, so jump-host tunnels widen too.

---

## 问题

服务端执行 `systemctl restart network`（或 VPN / Wi-Fi 短暂抖动）时，uniterm 会判死会话，而 Xshell / PuTTY / MobaXterm / OpenSSH 都能等到网络恢复。我们的 ~80s 判死窗口是主流终端里最激进的。

实际断线日志：

```
ssh disconnect: keepalive timeout, idle=2m51s lastKeepalive=timeout lastOK=1m34s ago failures=4
```

## 修改

对齐 OpenSSH 官方推荐参数（`ServerAliveInterval=60`, `ServerAliveCountMax=3`）：

- 间隔：**20s → 60s**
- 最大失败次数：**4 → 3**
- 移除独立的单次请求超时（原 15s），让其等于间隔 —— 对齐 OpenSSH 模型，顺便消除一个 select race（16s 才回的健康响应会被 15s 超时先记为失败，随后到达 `done` 通道的成功值被丢弃）。

判死窗口：**~80s → 180s**。跳板机 `tunnelKeepAlive` 复用同一常量，同步生效。