### PR TITLE
fix(overlays): keep drop/loading masks visible with background image

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1723,5 +1723,17 @@ watch(
 .app-container.has-bg .main-content :deep(.el-select__wrapper) {
   backdrop-filter: blur(8px);
 }
+/* 拖拽/等待遮罩：全局透明规则会抹掉底色，这里给几处遮罩恢复颜色，
+   保证背景图下 SFTP 拖入、终端拖文件、分屏落位提示、loading 蒙层仍清晰可见 */
+.app-container.has-bg .main-content :deep(.drop-overlay),
+.app-container.has-bg .main-content :deep(.loading-overlay) {
+  background-color: var(--scrim) !important;
+}
+.app-container.has-bg .main-content :deep(.drop-zone-overlay .dz) {
+  background-color: var(--accent-subtle) !important;
+}
+.app-container.has-bg .main-content :deep(.drop-zone-overlay .dz.active) {
+  background-color: var(--accent-glow) !important;
+}
 
 </style>

--- a/frontend/src/components/BaseTerminal.vue
+++ b/frontend/src/components/BaseTerminal.vue
@@ -1761,14 +1761,14 @@ defineExpose({
   display: flex;
   align-items: center;
   justify-content: center;
-  background: rgba(0, 0, 0, 0.45);
+  background: var(--scrim);
   pointer-events: none;
 }
 .drop-overlay span {
   font-size: 14px;
-  color: #fff;
+  color: var(--text-primary);
   padding: 12px 24px;
-  border: 2px dashed rgba(255, 255, 255, 0.6);
+  border: 2px dashed var(--border-hover);
   border-radius: var(--radius-md);
 }
 </style>

--- a/frontend/src/components/DBQueryEditor.vue
+++ b/frontend/src/components/DBQueryEditor.vue
@@ -624,7 +624,7 @@ function onEditRowCancel() {
 .loading-overlay {
   position: absolute;
   inset: 0;
-  background: rgba(0, 0, 0, 0.3);
+  background: var(--scrim);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -635,10 +635,6 @@ function onEditRowCancel() {
   flex-direction: column;
   align-items: center;
   gap: 12px;
-  padding: 24px 36px;
-  background: var(--bg-elevated);
-  border-radius: var(--radius-md);
-  border: 1px solid var(--border-subtle);
 }
 .spinner {
   width: 28px;
@@ -654,7 +650,7 @@ function onEditRowCancel() {
 .loading-text {
   font-family: var(--font-ui);
   font-size: 13px;
-  color: var(--text-secondary);
+  color: var(--text-primary);
 }
 .editor-top {
   flex-shrink: 0;

--- a/frontend/src/components/DBTableStructure.vue
+++ b/frontend/src/components/DBTableStructure.vue
@@ -533,7 +533,7 @@ async function onAddIndex() {
 .loading-overlay {
   position: absolute;
   inset: 0;
-  background: rgba(0, 0, 0, 0.3);
+  background: var(--scrim);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -544,10 +544,6 @@ async function onAddIndex() {
   flex-direction: column;
   align-items: center;
   gap: 12px;
-  padding: 24px 36px;
-  background: var(--bg-elevated);
-  border-radius: var(--radius-md);
-  border: 1px solid var(--border-subtle);
 }
 .spinner {
   width: 28px;
@@ -563,7 +559,7 @@ async function onAddIndex() {
 .loading-text {
   font-family: var(--font-ui);
   font-size: 13px;
-  color: var(--text-secondary);
+  color: var(--text-primary);
 }
 .section {
   margin-bottom: 16px;

--- a/frontend/src/components/MongoDBTabContent.vue
+++ b/frontend/src/components/MongoDBTabContent.vue
@@ -1387,7 +1387,7 @@ watch(() => props.sessionId, () => {
 .loading-overlay {
   position: absolute;
   inset: 0;
-  background: rgba(0, 0, 0, 0.3);
+  background: var(--scrim);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -1398,10 +1398,6 @@ watch(() => props.sessionId, () => {
   flex-direction: column;
   align-items: center;
   gap: 12px;
-  padding: 24px 36px;
-  background: var(--bg-elevated);
-  border-radius: var(--radius-md);
-  border: 1px solid var(--border-subtle);
 }
 .spinner {
   width: 28px;
@@ -1417,7 +1413,7 @@ watch(() => props.sessionId, () => {
 .loading-text {
   font-family: var(--font-ui);
   font-size: 13px;
-  color: var(--text-secondary);
+  color: var(--text-primary);
 }
 
 /* ── Result grid ── */

--- a/frontend/src/components/SFTPFileList.vue
+++ b/frontend/src/components/SFTPFileList.vue
@@ -496,7 +496,7 @@ function onDragStart(event: DragEvent, row: FileItem) {
   display: flex;
   align-items: center;
   justify-content: center;
-  background: rgba(0, 0, 0, 0.35);
+  background: var(--scrim);
 }
 .loading-content {
   display: flex;
@@ -517,7 +517,7 @@ function onDragStart(event: DragEvent, row: FileItem) {
 }
 .loading-text {
   font-size: 12px;
-  color: var(--text-secondary);
+  color: var(--text-primary);
 }
 
 /* Remove horizontal borders between data rows (keep header border) */

--- a/frontend/src/components/SFTPTabContent.vue
+++ b/frontend/src/components/SFTPTabContent.vue
@@ -1709,14 +1709,14 @@ async function onDropRemote(e: DragEvent) {
   display: flex;
   align-items: center;
   justify-content: center;
-  background: rgba(0, 0, 0, 0.45);
+  background: var(--scrim);
   pointer-events: none;
 }
 .drop-overlay span {
   font-size: 14px;
-  color: var(--on-accent);
+  color: var(--text-primary);
   padding: 12px 24px;
-  border: 2px dashed rgba(255, 255, 255, 0.6);
+  border: 2px dashed var(--border-hover);
   border-radius: var(--radius-md);
 }
 

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -54,6 +54,11 @@
   --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
   --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.5);
 
+  /* Scrim - dim-out mask for loading/drop overlays. Dark themes use a
+     translucent black; light theme overrides to translucent white so the
+     dark text/spinner on top stays legible. */
+  --scrim: rgba(0, 0, 0, 0.35);
+
   /* Fonts */
   --font-ui: -apple-system, 'Microsoft YaHei', 'PingFang SC', 'Noto Sans CJK SC', 'WenQuanYi Micro Hei', sans-serif;
   --font-mono: 'SF Mono', 'Consolas', monospace;
@@ -89,7 +94,7 @@
   --el-border-color-light: rgba(255, 255, 255, 0.1);
   --el-border-color-lighter: rgba(255, 255, 255, 0.08);
   /* Loading mask: uniform dark overlay matching the project's .loading-overlay convention (no white flash on refresh) */
-  --el-mask-color: rgba(0, 0, 0, 0.35);
+  --el-mask-color: var(--scrim);
 
   /* Element Plus sizing */
   --el-input-height: 28px;
@@ -205,6 +210,9 @@
   /* Borders - cool light grays */
   --border-subtle: rgba(0, 0, 0, 0.06);
   --border-hover: rgba(0, 0, 0, 0.12);
+
+  /* Scrim - translucent white so dark loading text stays legible */
+  --scrim: rgba(255, 255, 255, 0.6);
 
   /* Shadows - cleaner, deeper */
   --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.06);


### PR DESCRIPTION
Under background-image mode a global \`background-color: transparent !important\` rule stripped the fill from every drop overlay (BaseTerminal, SFTP panes, panel-drag split zones) and every \`.loading-overlay\`, so the drag mask and the loading dim-out both went invisible. This PR restores them and, while touching those styles, aligns the four overlays into one consistent shape.

**Changes**
- Introduce \`--scrim\` (translucent black in dark themes, translucent white in light) and reroute \`--el-mask-color\` through it. Unifies four \`.loading-overlay\` fills (SFTP / DB / DBQuery / Mongo) that previously hard-coded \`rgba(0,0,0,.3~.35)\`.
- Drop the \`.loading-box\` card chrome (background / border / padding) on DB / DBQuery / Mongo so all four spinners share SFTP's flat layout.
- Recolor drop overlays to match the flat loading style: \`--scrim\` fill, \`--text-primary\` text, \`--border-hover\` dashed border.
- Extend \`.has-bg\` exception rules to restore \`--scrim\` on \`.drop-overlay\` and \`.loading-overlay\`, and \`--accent-subtle\` / \`--accent-glow\` on panel drop zones.

**Verified**
- \`npm run build\` + \`wails dev\`, dark and light themes.
- Drag file to terminal, SFTP local/remote pane; drag tab to workspace split; DB / Mongo / SFTP loading — with and without a background image enabled.

---

后台的通配透明规则（\`.app-container.has-bg\` 下 \`background-color: transparent !important\`）会把所有拖拽遮罩（BaseTerminal、SFTP 面板、面板拖动分屏）和 \`.loading-overlay\` 的底色抹掉，开启背景图后拖拽提示和加载蒙层都看不见。本 PR 修复该问题，并顺手把四处遮罩统一到一套视觉。

**改动**
- 新增 \`--scrim\`（深色主题下半透明黑、浅色主题半透明白），并把 \`--el-mask-color\` 指到它。同时统一 SFTP / DB / DBQuery / Mongo 四处 \`.loading-overlay\` 的底色（原先硬编码 \`rgba(0,0,0,.3~.35)\`）。
- 去掉 DB / DBQuery / Mongo 的 \`.loading-box\` 卡片装饰（background / border / padding），与 SFTP 的扁平布局对齐。
- 拖拽遮罩配色改为与 loading 一致：\`--scrim\` 底色、\`--text-primary\` 文字、\`--border-hover\` 虚线框。
- 在 \`.has-bg\` 例外规则中补上 \`.drop-overlay\` / \`.loading-overlay\` 恢复 \`--scrim\`，面板方向块保留 \`--accent-subtle\` / \`--accent-glow\`。

**验证**
- \`npm run build\` + \`wails dev\`，深色 / 浅色主题各测一次。
- 拖桌面文件到终端、SFTP 本地 / 远端；tab 拖到 workspace 分屏；DB / Mongo / SFTP loading — 均在开启和未开启背景图状态下测过。