### PR TITLE
feat(terminal): support macOS Cmd+C to copy selection

### DIFF
--- a/frontend/src/components/BaseTerminal.vue
+++ b/frontend/src/components/BaseTerminal.vue
@@ -653,6 +653,18 @@ function handleTerminalKey(e: KeyboardEvent): boolean {
     return false
   }
 
+  // macOS Cmd+C: copy selection when there is one. With no selection, don't
+  // intercept — let it pass through (Ctrl+C interrupt uses ctrlKey, unaffected).
+  if (isMac && e.metaKey && !e.ctrlKey && !e.shiftKey && !e.altKey && (e.key === 'c' || e.key === 'C') && e.type === 'keydown') {
+    const sel = terminal?.getSelection()
+    if (sel) {
+      e.preventDefault()
+      navigator.clipboard.writeText(sel).catch(() => {})
+      return false
+    }
+    return true
+  }
+
   // Ctrl+Shift+C: copy terminal selection to clipboard
   if ((e.ctrlKey || e.metaKey) && e.shiftKey && (e.key === 'c' || e.key === 'C') && e.type === 'keydown') {
     const sel = terminal?.getSelection()


### PR DESCRIPTION
## Summary / 概述

On macOS, `Cmd+C` now copies the terminal selection to the clipboard, matching the AI window's behavior.

macOS 下,终端选中文本后 `Cmd+C` 复制到剪贴板,与 AI 窗口行为一致。

## Problem / 问题

Previously the terminal only bound `Ctrl+Shift+C` / `Cmd+Shift+C` for copy — plain `Cmd+C` did nothing, while the AI window already supported copy.

此前终端仅绑定 `Ctrl+Shift+C` / `Cmd+Shift+C` 复制,裸 `Cmd+C` 无反应;而 AI 窗口已支持复制。

## Changes / 改动

- `frontend/src/components/BaseTerminal.vue`: add a macOS `Cmd+C` branch in the terminal key handler
  - With selection: copy and intercept / 有选区:复制并拦截
  - No selection: pass through / 无选区:透传,保持原生行为
  - Does not affect `Ctrl+C` interrupt (checks `metaKey`, not `ctrlKey`) or non-mac platforms / 不影响 Ctrl+C 中断信号与非 mac 平台

## Validation / 验证

- `npm --prefix frontend run build` ✅

Closes #381