### PR TITLE
feat(tab): limit tab title max width with ellipsis and tooltip

### DIFF
--- a/frontend/src/components/TabItem.vue
+++ b/frontend/src/components/TabItem.vue
@@ -30,9 +30,9 @@
       />
       <span v-else-if="!isActive && hasNotification && !tab.locked" class="tab-notification-dot" />
     </span>
-    <span v-if="!editing" class="tab-name" :class="{ 'tab-disconnected': isDisconnected }" @dblclick.stop="startEdit">
+    <span v-if="!editing" class="tab-name" :class="{ 'tab-disconnected': isDisconnected }" :title="tab.name" @dblclick.stop="startEdit">
       <ArrowDownUp v-if="hasActiveTransfers" class="transfer-indicator" :size="14" title="Transferring..." />
-      {{ tab.name }}
+      <span class="tab-name-text">{{ tab.name }}</span>
     </span>
     <input
       v-else
@@ -538,7 +538,8 @@ onUnmounted(() => {
   font-size: 12px;
   white-space: nowrap;
   overflow: hidden;
-  text-overflow: ellipsis;
+  /* 约 25 个字符后省略，避免过长主机名撑大标题栏；完整名见 title 悬停 */
+  max-width: 200px;
   display: flex;
   align-items: center;
   gap: 6px;
@@ -546,6 +547,11 @@ onUnmounted(() => {
      widens the tab (no layout shift) and the button never covers the name. */
   margin-right: 20px;
   font-weight: 500;
+}
+.tab-name-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .tab-disconnected {
   opacity: 0.5;


### PR DESCRIPTION
## Summary / 概述

Long host names in tab titles are now truncated with an ellipsis, and hovering shows the full name — so an overly long title no longer takes up excessive space.

主机名过长时,标题栏标签以省略号截断,悬停显示完整名称,避免过长标题占用过大空间。

## Changes / 改动

- `frontend/src/components/TabItem.vue`:
  - `.tab-name` gains `max-width: 200px` (~25 chars) / 加最大宽度约 25 字符
  - Name wrapped in `.tab-name-text` span for the ellipsis to take effect (a flex container's direct text node does not honor `text-overflow: ellipsis`) / 名字包一层 span 使省略号生效(flex 容器直下文本节点 ellipsis 不生效)
  - `:title="tab.name"` shows the full name on hover / 悬停显示完整名称

## Validation / 验证

- `npm --prefix frontend run build` ✅

Closes #376