### PR TITLE
fix(ssh): make keepalive send-only to prevent self-inflicted disconnect

### DIFF
--- a/backend/session/ssh_session.go
+++ b/backend/session/ssh_session.go
@@ -21,10 +21,12 @@ import (
 )
 
 const (
-	// OpenSSH-recommended defaults (ServerAliveInterval=60, CountMax=3):
-	// 180s judgement window rides out `systemctl restart network` / VPN blips.
+	// Keepalive cadence. This is pure keep-alive (no reply awaited): every
+	// interval we send one global request just to keep traffic flowing so a
+	// server/NAT/firewall idle timeout doesn't drop an otherwise-healthy
+	// connection. Dead-connection detection is NOT done here — see readLoop
+	// (EOF) and the OS-level TCP keepalive set in Connect.
 	sshKeepAliveInterval = 60 * time.Second
-	sshKeepAliveMaxFail  = 3
 )
 
 type SSHSession struct {
@@ -43,12 +45,9 @@ type SSHSession struct {
 	decoder        *encoding.Decoder // persistent streaming decoder for output(read)
 	decodeLeftover []byte            // trailing partial multibyte bytes between reads
 
-	// Keepalive diagnostics (see startKeepAlive / disconnect logs).
-	kaFailures   atomic.Int32 // consecutive keepalive failures at last tick
-	kaLastErr    atomic.Value // string: last keepalive error ("" if ok)
-	kaLastOKUnix atomic.Int64 // unix ns of last successful keepalive
-	lastRecv     atomic.Value // []byte: tail of most recent server output (diagnostics)
-	lastSent     atomic.Value // []byte: most recent input sent to server (diagnostics)
+	// Disconnect diagnostics (see readLoop / disconnect logs).
+	lastRecv atomic.Value // []byte: tail of most recent server output (diagnostics)
+	lastSent atomic.Value // []byte: most recent input sent to server (diagnostics)
 }
 
 func NewSSHSession(id string) *SSHSession {
@@ -340,21 +339,12 @@ func tailHex(b []byte, max int) string {
 	return fmt.Sprintf("% x", b)
 }
 
-// kaDiag formats keepalive/idle state for disconnect diagnostics: how long
-// since the last byte from the server, the last-keepalive outcome, and the
-// consecutive-failure count. A long idle with healthy keepalives points to a
-// server-side idle timeout that ignores global keepalive requests.
+// kaDiag formats idle state for disconnect diagnostics: how long since the
+// last byte from the server. Keepalive here is send-only (no reply awaited),
+// so there is no failure/last-OK state to report — a disconnect is detected
+// by readLoop (EOF) or the OS TCP keepalive, not by this loop.
 func (s *SSHSession) kaDiag() string {
-	lastErr, _ := s.kaLastErr.Load().(string)
-	if lastErr == "" {
-		lastErr = "ok"
-	}
-	okAgo := "never"
-	if ns := s.kaLastOKUnix.Load(); ns != 0 {
-		okAgo = time.Since(time.Unix(0, ns)).Truncate(time.Second).String()
-	}
-	return fmt.Sprintf("idle=%v lastKeepalive=%s lastOK=%s ago failures=%d",
-		s.idleSince().Truncate(time.Second), lastErr, okAgo, s.kaFailures.Load())
+	return fmt.Sprintf("idle=%v", s.idleSince().Truncate(time.Second))
 }
 
 func (s *SSHSession) offerExpectOutput(data []byte) {
@@ -430,51 +420,20 @@ func (s *SSHSession) startKeepAlive() {
 	ticker := time.NewTicker(sshKeepAliveInterval)
 	defer ticker.Stop()
 
-	failures := 0
 	for {
 		select {
 		case <-ticker.C:
 			if s.Status() != StatusConnected {
 				return
 			}
-
-			done := make(chan error, 1)
-			go func() {
-				defer func() {
-					if r := recover(); r != nil {
-						done <- fmt.Errorf("panic: %v", r)
-					}
-				}()
-				// Use global request for keepalive, matching standard OpenSSH
-				// ServerAliveInterval behavior. Session channel requests for
-				// keepalive@openssh.com are not recognized by most SSH servers,
-				// causing timeouts that eventually disconnect.
-				_, _, err := s.client.SendRequest("keepalive@openssh.com", true, nil)
-				done <- err
-			}()
-
-			select {
-			case err := <-done:
-				if err != nil {
-					failures++
-					s.kaLastErr.Store(err.Error())
-				} else {
-					failures = 0
-					s.kaLastErr.Store("")
-					s.kaLastOKUnix.Store(time.Now().UnixNano())
-				}
-			case <-time.After(sshKeepAliveInterval):
-				failures++
-				s.kaLastErr.Store("timeout")
-			}
-			s.kaFailures.Store(int32(failures))
-
-			if failures >= sshKeepAliveMaxFail {
-				log.Writef("ssh disconnect: keepalive timeout, %s", s.kaDiag())
-				s.emitData(disconnectNotice("Connection lost."))
-				s.Disconnect()
-				return
-			}
+			// Pure keep-alive: send one global request just to keep traffic
+			// flowing, and do NOT wait for a reply. wantReply=false means
+			// crypto/ssh takes no lock and returns immediately, so a slow or
+			// silent server can never stall this loop (an earlier wantReply=true
+			// version leaked a goroutine holding mux.globalSentMu, which wedged
+			// all later keepalives and let the connection idle out). Detecting a
+			// dead connection is readLoop's job (EOF) plus the OS TCP keepalive.
+			_, _, _ = s.client.SendRequest("keepalive@openssh.com", false, nil)
 
 		case <-s.quit:
 			return

--- a/backend/session/tunnel_service.go
+++ b/backend/session/tunnel_service.go
@@ -8,8 +8,6 @@ import (
 	"time"
 
 	"golang.org/x/crypto/ssh"
-
-	"github.com/ys-ll/uniterm/backend/log"
 )
 
 // tunnelEntry holds the SSH client and listener for a single tunnel.
@@ -140,44 +138,21 @@ func (ts *TunnelService) Start(sessionID string, sshConfig ConnectionConfig, tar
 }
 
 // tunnelKeepAlive periodically pings the tunnel's SSH connection with a
-// global keepalive request (same cadence/threshold as SSHSession's) and
-// closes the connection if the remote stops responding, so a dead jump-host
-// hop doesn't linger silently while the forwarded session on top of it hangs.
+// send-only global keepalive request (same cadence as SSHSession's) purely to
+// keep traffic flowing so an idle jump-host hop isn't dropped by a
+// server/NAT/firewall idle timeout. It does not wait for a reply or tear the
+// connection down: a dead hop surfaces as EOF on the forwarded sessions riding
+// it, and the OS TCP keepalive covers a silently-dropped socket.
 func tunnelKeepAlive(client *ssh.Client, quit chan struct{}, label string) {
 	ticker := time.NewTicker(sshKeepAliveInterval)
 	defer ticker.Stop()
 
-	failures := 0
 	for {
 		select {
 		case <-ticker.C:
-			done := make(chan error, 1)
-			go func() {
-				defer func() {
-					if r := recover(); r != nil {
-						done <- fmt.Errorf("panic: %v", r)
-					}
-				}()
-				_, _, err := client.SendRequest("keepalive@openssh.com", true, nil)
-				done <- err
-			}()
-
-			select {
-			case err := <-done:
-				if err != nil {
-					failures++
-				} else {
-					failures = 0
-				}
-			case <-time.After(sshKeepAliveInterval):
-				failures++
-			}
-
-			if failures >= sshKeepAliveMaxFail {
-				log.Writef("tunnel keepalive: closing jump-host client after %d failures (%s) — sessions riding this tunnel will get EOF", failures, label)
-				client.Close()
-				return
-			}
+			// wantReply=false: crypto/ssh takes no lock and returns
+			// immediately, so a slow/silent jump host can never stall this loop.
+			_, _, _ = client.SendRequest("keepalive@openssh.com", false, nil)
 
 		case <-quit:
 			return


### PR DESCRIPTION
## Problem

The SSH keepalive loop was intended as a **keep-alive** (send periodic
traffic so a server/NAT/firewall idle timeout doesn't drop a healthy
connection), but was implemented as a **disconnect detector**:

- It sent a global request with `wantReply=true` and awaited the reply
  with a timeout, counting a miss as a failure and calling `Disconnect()`
  after `sshKeepAliveMaxFail` misses.
- Worse, the awaiting goroutine **leaked on timeout**: the `SendRequest`
  call stayed blocked inside `crypto/ssh` holding `mux.globalSentMu`. Every
  subsequent keepalive then wedged on that lock, so keepalives stopped
  flowing entirely, the connection went idle, and the server dropped it —
  the exact opposite of the intended behavior.

Diagnostic logs showed this signature repeatedly across days
(`lastKeepalive=timeout lastOK=39s ago failures=1`, matching the old
20s interval + 15s timeout params), with the failure counter stuck at 1
because later ticks could never run.

## Fix

Make keepalive **send-only** (`wantReply=false`): `crypto/ssh` takes no
lock and returns immediately, so a slow or silent server can never stall
the loop, and there is no goroutine/lock to leak. Dead-connection
detection is left to `readLoop` (EOF) and the OS-level TCP keepalive
already set in `Connect`. Removes the now-unused failure/last-OK
diagnostics and the max-failure threshold. Same fix applied to
`tunnelKeepAlive`.

---

## 问题

SSH keepalive 循环的初衷是**保活**（定期发流量，避免健康连接被
服务器/NAT/防火墙的空闲超时掐断），但实现成了**断连检测**：

- 用 `wantReply=true` 的 global request 并等待回复，超时即计为失败，
  累计到 `sshKeepAliveMaxFail` 次就调用 `Disconnect()`。
- 更严重的是超时分支**泄漏了等待中的 goroutine**：`SendRequest` 仍
  阻塞在 `crypto/ssh` 内部并持有 `mux.globalSentMu` 锁，导致后续所有
  keepalive 卡死在该锁上。心跳彻底停发，连接因空闲被服务器断开，与
  保活初衷完全相反。

诊断日志中该特征跨天反复出现（`lastKeepalive=timeout lastOK=39s ago
failures=1`，与旧的 20s 间隔 + 15s 超时参数吻合），失败计数卡在 1，
因为后续 tick 再也无法执行。

## 修复

改为**只发不等**（`wantReply=false`）：`crypto/ssh` 此时不加锁且立即
返回，慢速或无响应的服务器再也无法卡住该循环，也不存在可泄漏的
goroutine/锁。断连检测交给 `readLoop`（EOF）与 `Connect` 中已设置的
系统级 TCP keepalive。同时删除不再使用的失败/上次成功诊断字段及
最大失败阈值。`tunnelKeepAlive` 做相同修复。