### PR TITLE
chore(log): drop high-frequency debug logs to reduce noise

### DIFF
--- a/app.go
+++ b/app.go
@@ -3216,23 +3216,18 @@ func (a *App) MongoDropIndex(sessionID string, dbName string, collection string,
 }
 
 func (a *App) GetDatabases(sessionID string) ([]string, error) {
-	log.Writef("[GetDatabases] sessionID=%s", sessionID)
 	ds, p, err := a.dbProvider(sessionID)
 	if err != nil {
 		return nil, err
 	}
-	log.Writef("[GetDatabases] dbType=%s, fetching databases...", ds.DBType())
 	dbs, err := p.GetDatabases(ds.DB())
 	if err != nil {
 		log.Writef("[GetDatabases] failed: %v", err)
-	} else {
-		log.Writef("[GetDatabases] got %d databases: %v", len(dbs), dbs)
 	}
 	return dbs, err
 }
 
 func (a *App) GetTables(sessionID string, dbName string) ([]database.TableInfo, error) {
-	log.Writef("[GetTables] sessionID=%s, dbName=%s", sessionID, dbName)
 	ds, p, err := a.dbProvider(sessionID)
 	if err != nil {
 		return nil, err
@@ -3245,11 +3240,6 @@ func (a *App) GetTables(sessionID string, dbName string) ([]database.TableInfo, 
 	sort.Slice(tables, func(i, j int) bool {
 		return tables[i].Name < tables[j].Name
 	})
-	names := make([]string, len(tables))
-	for i, t := range tables {
-		names[i] = t.Name
-	}
-	log.Writef("[GetTables] got %d tables: %v", len(tables), names)
 	return tables, nil
 }
 

--- a/backend/session/rdp_session.go
+++ b/backend/session/rdp_session.go
@@ -180,8 +180,6 @@ func (s *RDPSession) autoDismissSecurityDialogs(stop <-chan struct{}) {
 					continue
 				}
 
-				log.Writef("[RDP] found security dialog: %s hwnd=0x%x", title, hwnd)
-
 				// Dismiss via standard dialog button IDs
 				procPostMessageW.Call(hwnd, WM_COMMAND, IDYES, 0)
 				procPostMessageW.Call(hwnd, WM_COMMAND, IDOK, 0)
@@ -491,7 +489,6 @@ type msg struct {
 func (s *RDPSession) runMessagePump() {
 	log.Writef("[RDP] message pump started")
 	var m msg
-	pumpTick := 0
 	noMsgCount := 0
 	disconnectLogged := false
 	for {
@@ -530,7 +527,6 @@ func (s *RDPSession) runMessagePump() {
 			}
 			procTranslateMessage.Call(uintptr(unsafe.Pointer(&m)))
 			procDispatchMessage.Call(uintptr(unsafe.Pointer(&m)))
-			pumpTick++
 			noMsgCount = 0
 		} else {
 			// No message available; sleep briefly to avoid busy-wait.
@@ -568,7 +564,6 @@ func (s *RDPSession) runMessagePump() {
 			}
 
 			if noMsgCount%20 == 0 {
-				log.Writef("[RDP-pump] heartbeat idle=%d, pumpMsgs=%d, hwnd=0x%x", noMsgCount, pumpTick, s.hwnd)
 				// Check if RDP connection is still alive via ActiveX Connected property.
 				// When the remote side drops or the connection is lost, this transitions
 				// to 0 while the ActiveX window is still alive.
@@ -867,7 +862,6 @@ func (s *RDPSession) SetPosition(x, y, w, h int) {
 	s.shown = true
 	s.trackX = x
 	s.trackY = y
-	log.Writef("[RDP-SetPos] FROM FRONTEND x=%d y=%d w=%d h=%d", x, y, w, h)
 	s.mu.Unlock()
 
 	// Owned window: z-order is automatic. SWP_SHOWWINDOW handles tab-switch restore.
@@ -910,7 +904,6 @@ func (s *RDPSession) Show() {
 	tY := s.trackY
 	s.shown = true
 	s.mu.Unlock()
-	log.Writef("[RDP-Show] trackX=%d trackY=%d hwnd=0x%x", tX, tY, hwnd)
 	if hwnd != 0 {
 		procShowWindow.Call(hwnd, SW_SHOWNOACTIVATE)
 		procSetWindowPos.Call(hwnd, 0,
@@ -921,7 +914,6 @@ func (s *RDPSession) Show() {
 }
 
 func (s *RDPSession) Hide() {
-	log.Writef("[RDP-Hide] called")
 	s.mu.Lock()
 	if !s.shown {
 		s.mu.Unlock()

--- a/backend/session/ssh_session.go
+++ b/backend/session/ssh_session.go
@@ -480,7 +480,6 @@ func (s *SSHSession) Disconnect() error {
 func (s *SSHSession) Resize(cols, rows int) error {
 	// Always save the desired size so it can be applied after Connect finishes.
 	s.SetPendingSize(cols, rows)
-	log.Writef("ssh resize: cols=%d rows=%d", cols, rows)
 	if s.session == nil {
 		return fmt.Errorf("session not connected")
 	}


### PR DESCRIPTION
## What

Several log lines fired on every UI operation or on a polling loop,
flooding `uniterm.log` and burying the diagnostics that matter. This
removes the noisiest ones:

| Location | Log | Fired |
|---|---|---|
| `ssh_session.go` | `ssh resize` | every frame while dragging a window/panel |
| `rdp_session.go` | `[RDP-SetPos] FROM FRONTEND` | every RDP window move/resize |
| `rdp_session.go` | `[RDP-Show]` / `[RDP-Hide]` | every window show/hide (tab switch) |
| `rdp_session.go` | `[RDP-pump] heartbeat` | RDP message pump, every 20 idle ticks |
| `rdp_session.go` | `[RDP] found security dialog` | every dialog-scan hit |
| `app.go` | `[GetDatabases]` / `[GetTables]` info | dumped every table name (1000+ per refresh) |

Only the log statements were removed. Connection setup, disconnect
detection (the RDP `Connected`-property check inside the pump loop is
kept), errors, and panics all remain. The now-unused `pumpTick` counter,
which only fed the heartbeat log, was dropped too.

Net: 19 deletions, 0 additions.

---

## 说明

多处日志在每次 UI 操作或轮询循环中触发，刷爆 `uniterm.log` 并淹没真正
有用的诊断信息。本次删除其中最吵的几条：

| 位置 | 日志 | 触发时机 |
|---|---|---|
| `ssh_session.go` | `ssh resize` | 拖动窗口/面板时每帧打印 |
| `rdp_session.go` | `[RDP-SetPos] FROM FRONTEND` | 每次 RDP 窗口移动/缩放 |
| `rdp_session.go` | `[RDP-Show]` / `[RDP-Hide]` | 每次窗口显示/隐藏（tab 切换） |
| `rdp_session.go` | `[RDP-pump] heartbeat` | RDP 消息泵，每 20 个 idle tick |
| `rdp_session.go` | `[RDP] found security dialog` | 每次扫描到对话框 |
| `app.go` | `[GetDatabases]` / `[GetTables]` 信息日志 | 会打全部表名，一次刷新上千条 |

仅删除日志语句。连接建立、断连检测（消息泵内的 RDP `Connected` 属性
检查予以保留）、错误与 panic 全部保留。同时删除仅为 heartbeat 日志
服务的 `pumpTick` 计数器。

净变更：删除 19 行，新增 0 行。