### PR TITLE
fix(rdp): follow keyboard focus on click in multi-monitor setups

### DIFF
--- a/app.go
+++ b/app.go
@@ -1350,22 +1350,6 @@ func (a *App) RDPShow(sessionID string) error {
 	return nil
 }
 
-func (a *App) RDPSetFocus(sessionID string, focused bool) error {
-	if a.sessionManager == nil {
-		return fmt.Errorf("session manager not initialized")
-	}
-	s, ok := a.sessionManager.Get(sessionID)
-	if !ok {
-		return fmt.Errorf("session not found: %s", sessionID)
-	}
-	rdp, ok := s.(*session.RDPSession)
-	if !ok {
-		return fmt.Errorf("session is not RDP")
-	}
-	rdp.SetFocus(focused)
-	return nil
-}
-
 // RDPSetFullScreen toggles the ActiveX control's built-in full-screen mode.
 func (a *App) RDPSetFullScreen(sessionID string, full bool) error {
 	if a.sessionManager == nil {

--- a/backend/session/rdp_session.go
+++ b/backend/session/rdp_session.go
@@ -3,8 +3,8 @@
 package session
 
 import (
-	"runtime"
 	"fmt"
+	"runtime"
 	"sync"
 	"time"
 	"unsafe"
@@ -19,7 +19,6 @@ var (
 	atlDll              = windows.NewLazySystemDLL("atl.dll")
 	procAtlAxWinInit    = atlDll.NewProc("AtlAxWinInit")
 	procAtlAxGetControl = atlDll.NewProc("AtlAxGetControl")
-
 
 	user32Dll              = windows.NewLazySystemDLL("user32.dll")
 	procSetWindowPos       = user32Dll.NewProc("SetWindowPos")
@@ -44,28 +43,27 @@ var (
 )
 
 const (
-	WM_CLOSE       = 0x0010
-	SWP_SHOWWINDOW = 0x0040
-	SWP_HIDEWINDOW = 0x0080
-	SWP_NOMOVE     = 0x0002
-	SWP_NOSIZE     = 0x0001
-	SWP_NOACTIVATE = 0x0010
-	SWP_NOZORDER   = 0x0004
+	WM_CLOSE           = 0x0010
+	SWP_SHOWWINDOW     = 0x0040
+	SWP_HIDEWINDOW     = 0x0080
+	SWP_NOMOVE         = 0x0002
+	SWP_NOSIZE         = 0x0001
+	SWP_NOACTIVATE     = 0x0010
+	SWP_NOZORDER       = 0x0004
 	SWP_ASYNCWINDOWPOS = 0x4000 // non-blocking: avoids freezing RDP COM thread
-	WS_EX_TOOLWINDOW  = 0x00000080
-	WS_EX_NOACTIVATE  = 0x08000000
-	WS_POPUP          = 0x80000000
-	WS_CLIPSIBLINGS   = 0x04000000
-	PM_REMOVE         = 0x0001
-	GWLP_HWNDPARENT   = ^uintptr(7) // -8 represented as uintptr for syscall compatibility
-	SW_HIDE           = 0
-	SW_SHOWNOACTIVATE = 4
-	WM_COMMAND        = 0x0111
-	BM_CLICK          = 0x00F5
-	IDYES             = 6
-	IDOK              = 1
-	SM_CXSCREEN       = 0
-	SM_CYSCREEN       = 1
+	WS_EX_TOOLWINDOW   = 0x00000080
+	WS_POPUP           = 0x80000000
+	WS_CLIPSIBLINGS    = 0x04000000
+	PM_REMOVE          = 0x0001
+	GWLP_HWNDPARENT    = ^uintptr(7) // -8 represented as uintptr for syscall compatibility
+	SW_HIDE            = 0
+	SW_SHOWNOACTIVATE  = 4
+	WM_COMMAND         = 0x0111
+	BM_CLICK           = 0x00F5
+	IDYES              = 6
+	IDOK               = 1
+	SM_CXSCREEN        = 0
+	SM_CYSCREEN        = 1
 )
 
 type RDPSession struct {
@@ -75,7 +73,7 @@ type RDPSession struct {
 	rdp        *ole.IDispatch
 	config     ConnectionConfig
 	mu         sync.Mutex
-	shown     bool
+	shown      bool
 
 	// Last known position, used by Show() after Hide()
 	trackX, trackY int
@@ -83,9 +81,9 @@ type RDPSession struct {
 	// Full-screen toggle request, applied on the COM STA thread by the message
 	// pump. COM (STA) calls must run on the thread that created the object;
 	// calling PutProperty from the Wails binding thread deadlocks.
-	fsRequested bool // a toggle has been requested
-	fsValue     bool // desired FullScreen value
-	fsActive    bool // last observed FullScreen state (for exit detection)
+	fsRequested bool   // a toggle has been requested
+	fsValue     bool   // desired FullScreen value
+	fsActive    bool   // last observed FullScreen state (for exit detection)
 	onFsExit    func() // called (on COM thread) when user leaves full screen via the connection bar
 }
 
@@ -129,8 +127,6 @@ func (s *RDPSession) ClientAreaScreenRect() (x, y, w, h int) {
 func (s *RDPSession) SetParentHwnd(hwnd uintptr) {
 	s.parentHwnd = hwnd
 }
-
-
 
 // autoDismissSecurityDialogs polls for RDP security warning dialogs (e.g.
 // cert prompts or "do you want to connect" dialogs) and dismisses them.
@@ -197,7 +193,6 @@ func (s *RDPSession) autoDismissSecurityDialogs(stop <-chan struct{}) {
 					btnHwnd, _, _ := procFindWindowExW.Call(hwnd, 0, 0, uintptr(unsafe.Pointer(btnPtr)))
 					if btnHwnd != 0 {
 						procSendMessageW.Call(btnHwnd, BM_CLICK, 0, 0)
-						log.Writef("[RDP] clicked button '%s' on dialog hwnd=0x%x", btnText, hwnd)
 						break
 					}
 				}
@@ -207,8 +202,6 @@ func (s *RDPSession) autoDismissSecurityDialogs(stop <-chan struct{}) {
 }
 
 func (s *RDPSession) Connect(config ConnectionConfig) error {
-	log.Writef("[RDP] starting connect to %s:%d as %s", config.Host, config.Port, config.User)
-
 	defer func() {
 		if r := recover(); r != nil {
 			log.Writef("[RDP] PANIC in Connect: %v", r)
@@ -287,7 +280,6 @@ func (s *RDPSession) Connect(config ConnectionConfig) error {
 		sh, _, _ := procGetSystemMetrics.Call(uintptr(SM_CYSCREEN))
 		width = int(sw)
 		height = int(sh)
-		log.Writef("[RDP] fullscreen resolution: using display size %dx%d", width, height)
 	}
 	if width <= 0 {
 		width = 800
@@ -302,7 +294,14 @@ func (s *RDPSession) Connect(config ConnectionConfig) error {
 
 	createWindowEx := windows.NewLazySystemDLL("user32.dll").NewProc("CreateWindowExW")
 	hwnd, _, _ := createWindowEx.Call(
-		uintptr(WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE),
+		// WS_EX_TOOLWINDOW keeps the RDP window off the taskbar. We must NOT add
+		// WS_EX_NOACTIVATE: that flag tells the OS "clicking this window (and its
+		// owner) does not bring them to the foreground", which on multi-monitor
+		// setups leaves the keyboard attached to whatever app was last active on
+		// another screen. Programmatic show/position already use SWP_NOACTIVATE /
+		// SW_SHOWNOACTIVATE, so activation happens only on a real user click —
+		// exactly the behavior we want for keyboard focus. (issue #385)
+		uintptr(WS_EX_TOOLWINDOW),
 		uintptr(unsafe.Pointer(className)),
 		uintptr(unsafe.Pointer(name)),
 		uintptr(WS_POPUP|WS_CLIPSIBLINGS),
@@ -322,7 +321,6 @@ func (s *RDPSession) Connect(config ConnectionConfig) error {
 	// Owned windows naturally stay above their owner but below other top-level windows,
 	// eliminating the need for manual HWND_TOPMOST/HWND_NOTOPMOST z-order management.
 	procSetWindowLongPtr.Call(hwnd, GWLP_HWNDPARENT, s.parentHwnd)
-	log.Writef("[RDP] hwnd=0x%x parentHwnd=0x%x (owned)", hwnd, s.parentHwnd)
 
 	var unk *ole.IUnknown
 	procAtlAxGetControl.Call(hwnd, uintptr(unsafe.Pointer(&unk)))
@@ -406,7 +404,6 @@ func (s *RDPSession) Connect(config ConnectionConfig) error {
 		if sec != nil {
 			sec.PutProperty("KeyboardHookMode", 1)
 			sec.Release()
-			log.Writef("[RDP] KeyboardHookMode=1 (forward Win/combo keys to remote)")
 		}
 	}
 
@@ -420,15 +417,12 @@ func (s *RDPSession) Connect(config ConnectionConfig) error {
 				a.PutProperty("ContainerHandledFullScreen", false)
 				a.PutProperty("WarnOnDirectConnect", false)
 				a.Release()
-				log.Writef("[RDP] AdvancedSettings%d: security prompts suppressed", ver)
 			}
 		}
 	}
 
-
 	// Suppress server certificate warning at OS level
 	setAuthLevelOverride()
-
 
 	// Auto-dismiss any security dialogs that appear during Connect (e.g.
 	// "网站正在尝试启动远程连接"). The goroutine polls for dialog windows
@@ -446,7 +440,6 @@ func (s *RDPSession) Connect(config ConnectionConfig) error {
 		}()
 	}()
 
-	log.Writef("[RDP] calling Connect...")
 	_, err = dispatch.CallMethod("Connect")
 	if err != nil {
 		log.Writef("[RDP] Connect failed: %v", err)
@@ -460,7 +453,6 @@ func (s *RDPSession) Connect(config ConnectionConfig) error {
 		return fmt.Errorf("RDP Connect: %w", err)
 	}
 
-	log.Writef("[RDP] Connect succeeded")
 	// Immediate show-and-position to avoid white/black screen.
 	// Frontend will refine via RDPSetPosition shortly after.
 	s.positionFromMainWindow(width, height)
@@ -469,7 +461,6 @@ func (s *RDPSession) Connect(config ConnectionConfig) error {
 
 	s.runMessagePump()
 
-	log.Writef("[RDP] COM thread exited")
 	return nil
 }
 
@@ -487,7 +478,6 @@ type msg struct {
 }
 
 func (s *RDPSession) runMessagePump() {
-	log.Writef("[RDP] message pump started")
 	var m msg
 	noMsgCount := 0
 	disconnectLogged := false
@@ -509,7 +499,6 @@ func (s *RDPSession) runMessagePump() {
 			s.mu.Unlock()
 			if rdp != nil {
 				rdp.PutProperty("FullScreen", full)
-				log.Writef("[RDP] FullScreen applied on COM thread full=%v", full)
 			}
 		} else {
 			s.mu.Unlock()
@@ -522,7 +511,6 @@ func (s *RDPSession) runMessagePump() {
 		)
 		if ret != 0 {
 			if m.Message == 0x0012 { // WM_QUIT
-				log.Writef("[RDP-pump] WM_QUIT received, exiting")
 				return
 			}
 			procTranslateMessage.Call(uintptr(unsafe.Pointer(&m)))
@@ -554,7 +542,6 @@ func (s *RDPSession) runMessagePump() {
 							s.fsActive = false
 							cb := s.onFsExit
 							s.mu.Unlock()
-							log.Writef("[RDP] full-screen exited via connection bar")
 							if cb != nil {
 								cb()
 							}
@@ -604,9 +591,7 @@ func (s *RDPSession) runMessagePump() {
 			}
 		}
 	}
-	log.Writef("[RDP] message pump exited")
 }
-
 
 func (s *RDPSession) findRdpProgID() string {
 	candidates := []string{
@@ -763,8 +748,6 @@ func elevateRegWrite() {
 	)
 	if ret <= 32 {
 		log.Writef("[RDP] ShellExecute runas failed: %d", ret)
-	} else {
-		log.Writef("[RDP] UAC elevation requested for RedirectionWarningDialogVersion")
 	}
 }
 
@@ -784,7 +767,7 @@ func (s *RDPSession) configureNonScriptable(password string) {
 		return
 	}
 	defer unk.Release()
-	for i, guid := range nsGUIDs {
+	for _, guid := range nsGUIDs {
 		nsGUID := ole.NewGUID(guid)
 		nsUnk, err := unk.QueryInterface(nsGUID)
 		if err != nil || nsUnk == nil {
@@ -794,11 +777,9 @@ func (s *RDPSession) configureNonScriptable(password string) {
 			nsUnk.PutProperty("ClearTextPassword", password)
 		}
 		nsUnk.Release()
-		log.Writef("[RDP] NonScriptable[%d] configured, password=%v", i, password != "")
 		break
 	}
 }
-
 
 type point struct{ X, Y int32 }
 
@@ -837,8 +818,6 @@ func (s *RDPSession) positionFromMainWindow(width, height int) {
 	y := clientTop + topReserve
 	w := clientWidth - sideMargin*2
 	h := clientHeight - topReserve - bottomReserve
-	log.Writef("[RDP] backend positioning: client=(%d,%d %dx%d) rdp=(x=%d y=%d w=%d h=%d)",
-		clientLeft, clientTop, clientWidth, clientHeight, x, y, w, h)
 
 	s.shown = true
 	procSetWindowPos.Call(s.hwnd, 0,
@@ -848,14 +827,12 @@ func (s *RDPSession) positionFromMainWindow(width, height int) {
 
 	s.trackX = x
 	s.trackY = y
-	log.Writef("[RDP] backend position done, shown=%v hwnd=0x%x", s.shown, s.hwnd)
 }
 
 func (s *RDPSession) SetPosition(x, y, w, h int) {
 	s.mu.Lock()
 	hwnd := s.hwnd
 	if hwnd == 0 {
-		log.Writef("[RDP-SetPos] SKIP hwnd=0")
 		s.mu.Unlock()
 		return
 	}
@@ -871,13 +848,6 @@ func (s *RDPSession) SetPosition(x, y, w, h int) {
 		SWP_SHOWWINDOW|SWP_NOACTIVATE|SWP_ASYNCWINDOWPOS)
 }
 
-// SetFocus adjusts the RDP window z-order when uniTerm gains or loses focus.
-// With the owned-window model, z-order is fully automatic — the OS handles it.
-// Kept as a no-op for API compatibility with the frontend.
-func (s *RDPSession) SetFocus(focused bool) {
-	log.Writef("[RDP-focus] SetFocus focused=%v (no-op, owned-window model)", focused)
-}
-
 // SetFullScreen toggles the ActiveX control's built-in full-screen mode.
 // With ContainerHandledFullScreen=false the control renders its own
 // connection bar (with a restore button) to exit full screen.
@@ -890,7 +860,6 @@ func (s *RDPSession) SetFullScreen(full bool) {
 	s.fsRequested = true
 	s.fsValue = full
 	s.mu.Unlock()
-	log.Writef("[RDP] SetFullScreen requested full=%v (deferred to COM thread)", full)
 }
 
 func (s *RDPSession) Show() {

--- a/backend/session/rdp_session_stub.go
+++ b/backend/session/rdp_session_stub.go
@@ -40,8 +40,6 @@ func (s *RDPSession) SetParentHwnd(_ uintptr) {}
 
 func (s *RDPSession) SetPosition(_, _, _, _ int) {}
 
-func (s *RDPSession) SetFocus(_ bool) {}
-
 func (s *RDPSession) Show() {}
 
 func (s *RDPSession) Hide() {}

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -173,7 +173,7 @@ import { loadKeybindings, installGlobalListener, uninstallGlobalListener } from 
 import { focusPanelTerminal, installTerminalFocusRestore } from './composables/useFocusTerminal'
 import type { ShortcutAction } from './types/settings'
 import { useI18n } from './i18n'
-import { CreateSession, CloseSession, RDPHide, RDPShow, RDPSetPosition, RDPSetFocus, RecordRecentConnection, GetPlatform, GetBackgroundImage } from '../wailsjs/go/main/App'
+import { CreateSession, CloseSession, RDPHide, RDPShow, RDPSetPosition, RecordRecentConnection, GetPlatform, GetBackgroundImage } from '../wailsjs/go/main/App'
 import { EventsOn, ClipboardGetText, Quit } from '../wailsjs/runtime'
 import { msg } from './services/message'
 import type { ConnectionConfig } from './types/session'
@@ -659,15 +659,6 @@ onMounted(async () => {
   // (issue #285) — see composables/useFocusTerminal.ts for the policy.
   uninstallFocusRestore = installTerminalFocusRestore()
 
-  // RDP blur/focus: notify Go side so it can manage focus on the native RDP window
-  window.addEventListener('blur', () => {
-    const sid = getActiveRdpSessionId()
-    if (sid) RDPSetFocus(sid, false)
-  })
-  window.addEventListener('focus', () => {
-    const sid = getActiveRdpSessionId()
-    if (sid) RDPSetFocus(sid, true)
-  })
   // RDP overlay tracking
   window.addEventListener('rdp:overlay-push', RDPHideForOverlay)
   window.addEventListener('rdp:overlay-pop', RDPShowForOverlay)

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -183,8 +183,6 @@ export function OpenPathInExplorer(arg1:string):Promise<void>;
 
 export function RDPHide(arg1:string):Promise<void>;
 
-export function RDPSetFocus(arg1:string,arg2:boolean):Promise<void>;
-
 export function RDPSetFullScreen(arg1:string,arg2:boolean):Promise<void>;
 
 export function RDPSetPosition(arg1:string,arg2:number,arg3:number,arg4:number,arg5:number):Promise<void>;

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -354,10 +354,6 @@ export function RDPHide(arg1) {
   return window['go']['main']['App']['RDPHide'](arg1);
 }
 
-export function RDPSetFocus(arg1, arg2) {
-  return window['go']['main']['App']['RDPSetFocus'](arg1, arg2);
-}
-
 export function RDPSetFullScreen(arg1, arg2) {
   return window['go']['main']['App']['RDPSetFullScreen'](arg1, arg2);
 }


### PR DESCRIPTION
Closes #385

## Problem

On a multi-monitor setup, after interacting with an app on another screen, clicking into the RDP window did not move keyboard focus to it. Typing and paste kept going to the previously active app until the user clicked the uniTerm title bar.

## Root cause

The RDP window is created with `WS_EX_NOACTIVATE`. That flag tells the OS *not* to bring the window (and its owner, the uniTerm main window) to the foreground on click. Since Windows routes keyboard input to the foreground window, clicking the RDP window never took focus.

## Fix

- Remove `WS_EX_NOACTIVATE` from the RDP window's extended style. Programmatic show/position already use `SWP_NOACTIVATE` / `SW_SHOWNOACTIVATE`, so activation now happens only on a real user click — exactly the desired behavior.
- Trim RDP logging down to error/anomaly paths only.
- Remove the now-dead `SetFocus` chain (`RDPSession.SetFocus`, the `App.RDPSetFocus` binding, and the frontend blur/focus listeners) that the owned-window model had already reduced to a no-op.

## Testing

Verified on a dual-monitor Windows setup: click another app on the primary screen, then click the RDP window on the secondary screen — keyboard input now goes to RDP immediately.

---

## 问题

双屏下，先操作了另一屏幕的程序后，点击 RDP 窗口不会把键盘焦点切过去。键盘输入和粘贴仍然进入之前激活的程序，只有点了 uniTerm 标题栏焦点才会回到 RDP。

## 根因

RDP 窗口创建时带了 `WS_EX_NOACTIVATE` 扩展样式。该标志告诉系统点击此窗口时**不要**把它(及其 owner —— uniTerm 主窗口)提到前台。而 Windows 的键盘输入路由给前台窗口，所以点击 RDP 窗口始终拿不到焦点。

## 修复

- 移除 RDP 窗口的 `WS_EX_NOACTIVATE`。程序化的显示/定位本就使用 `SWP_NOACTIVATE` / `SW_SHOWNOACTIVATE`，因此现在只有真实鼠标点击才会激活窗口 —— 正是期望行为。
- 将 RDP 日志精简为仅保留错误/异常路径。
- 删除已成死代码的 `SetFocus` 调用链(`RDPSession.SetFocus`、`App.RDPSetFocus` 绑定、前端 blur/focus 监听器）—— owned-window 模型下它早已是空操作。

## 测试

双屏 Windows 环境实测:主屏点击其他程序，再点副屏 RDP 窗口 —— 键盘输入立即进入 RDP。