### PR TITLE
fix(rdp): add missing button text to auto-dismiss security dialog

### DIFF
--- a/backend/session/rdp_session.go
+++ b/backend/session/rdp_session.go
@@ -184,7 +184,7 @@ func (s *RDPSession) autoDismissSecurityDialogs(stop <-chan struct{}) {
 				// Also try clicking buttons directly (Windows 11 may use different labels)
 				for _, btnText := range []string{
 					"是(&Y)", "是", "Yes", "&Yes",
-					"连接(&C)", "连接", "Connect", "&Connect",
+					"连接(&C)", "连接(&N)", "连接", "Connect", "&Connect",
 					"确认", "确认(&Y)", "确认(&O)",
 					"确定", "确定(&O)", "OK", "&OK",
 					"继续", "继续(&C)", "Continue", "&Continue",


### PR DESCRIPTION
Closes #296

## Problem

On Windows 11 25H2, the RDP security dialog's "连接" button uses `&N` as the accelerator key, making the actual window text `"连接(&N)"`. The auto-dismiss loop in `autoDismissSecurityDialogs` only matched `"连接(&C)"` and `"连接"`, so it failed to find and click the button, causing the dialog to stay visible and flicker.

## Fix

Add `"连接(&N)"` to the button text lookup list. `FindWindowExW` does exact-string matching, so all variants must be listed.

---

## 问题

Windows 11 25H2 下，RDP 安全对话框的"连接"按钮使用 `&N` 作为助记符，实际窗口文本为 `"连接(&N)"`。`autoDismissSecurityDialogs` 的按钮文本列表只匹配了 `"连接(&C)"` 和 `"连接"`，未找到该按钮，导致对话框无法关闭并持续闪烁。

## 修复

在按钮文本列表中加入 `"连接(&N)"`。`FindWindowExW` 是精确字符串匹配，因此需要列出所有变体。