### PR TITLE
fix(ci): use Fedora package names for rpm dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -194,6 +194,11 @@ jobs:
           depends:
             - libgtk-3-0
             - libwebkit2gtk-4.1-0
+          overrides:
+            rpm:
+              depends:
+                - gtk3
+                - webkit2gtk4.1
           contents:
             - src: build/bin/uniTerm
               dst: /usr/bin/uniterm


### PR DESCRIPTION
## Summary

The CI packaging step generated both `.deb` and `.rpm` from a single nfpm config that shared one `depends` list using Debian/Ubuntu package names (`libgtk-3-0`, `libwebkit2gtk-4.1-0`). Those names do not exist on Fedora/RHEL, so `dnf install ./uniterm-*.rpm` failed with "nothing provides libgtk-3-0 / libwebkit2gtk-4.1-0".

This adds an `overrides.rpm.depends` block mapping the dependencies to their Fedora names:

| Purpose | deb | rpm |
|---------|-----|-----|
| GTK3 runtime | `libgtk-3-0` | `gtk3` |
| WebKit2GTK 4.1 | `libwebkit2gtk-4.1-0` | `webkit2gtk4.1` |

The deb package is unchanged; the override only applies when packaging the rpm.

Fixes #374

---

## 概述

CI 打包时 deb 和 rpm 共用同一份 nfpm 的 `depends` 列表，里面写的是 Debian/Ubuntu 包名（`libgtk-3-0`、`libwebkit2gtk-4.1-0`）。这些名字在 Fedora/RHEL 上不存在，导致 `dnf install ./uniterm-*.rpm` 报 "nothing provides libgtk-3-0 / libwebkit2gtk-4.1-0" 安装失败。

本 PR 增加 `overrides.rpm.depends`，把 rpm 的依赖映射为 Fedora 包名：`gtk3`、`webkit2gtk4.1`。deb 包不受影响，override 仅在打 rpm 时生效。

修复 #374
