### PR TITLE
fix: preserve readline CSI sequences in session log to prevent interactive-edit garbage

### DIFF
--- a/backend/session/output_log.go
+++ b/backend/session/output_log.go
@@ -30,8 +30,11 @@ type ansiStripper struct {
 	pending []byte
 }
 
-// Strip returns in with all ANSI escape sequences removed. Incomplete
-// sequences at the tail are held in the stripper until the next call.
+// Strip returns in with ANSI escape sequences removed, EXCEPT the small set
+// of in-line cursor/erase CSI sequences that lineProcessor interprets to
+// reconstruct readline-edited lines (see isPreservedCSI). Those are passed
+// through verbatim. Incomplete sequences at the tail are held until the next
+// call, so lineProcessor always receives complete escape sequences.
 func (s *ansiStripper) Strip(in []byte) []byte {
 	if len(in) == 0 && len(s.pending) == 0 {
 		return nil
@@ -52,6 +55,9 @@ func (s *ansiStripper) Strip(in []byte) []byte {
 				s.pending = append(s.pending[:0], data[i:]...)
 				return out
 			}
+			if isPreservedCSI(data[i:end]) {
+				out = append(out, data[i:end]...)
+			}
 			i = end
 			continue
 		}
@@ -63,6 +69,24 @@ func (s *ansiStripper) Strip(in []byte) []byte {
 		i++
 	}
 	return out
+}
+
+// isPreservedCSI reports whether seq (a complete escape sequence starting at
+// ESC) is one of the cursor-movement / erase CSIs that lineProcessor knows
+// how to apply to its single-line buffer. Everything else (colors, OSC,
+// private modes like ESC[?25l, cursor up/down) is dropped by Strip.
+func isPreservedCSI(seq []byte) bool {
+	if len(seq) < 3 || seq[1] != '[' {
+		return false
+	}
+	if seq[2] == '?' { // private mode (e.g. ?25l show/hide cursor)
+		return false
+	}
+	switch seq[len(seq)-1] {
+	case 'C', 'D', 'G', '`', 'K', 'P', '@':
+		return true
+	}
+	return false
 }
 
 // scanEscape parses one escape sequence starting at data[start] (which
@@ -103,12 +127,14 @@ func scanEscape(data []byte, start int) (int, bool) {
 	}
 }
 
-// lineProcessor turns a raw byte stream (already ANSI-stripped) into a
-// sequence of complete logical lines suitable for a human-readable log
-// file. It models a one-row terminal: a cursor moves through a byte
-// buffer, printable bytes overwrite (or extend) at the cursor, \b moves
-// the cursor left, \r sends the cursor to column 0 (without clearing —
-// subsequent bytes overwrite), and \n flushes the whole row.
+// lineProcessor turns a raw byte stream (already ANSI-stripped, with
+// cursor/erase CSI sequences preserved) into a sequence of complete
+// logical lines suitable for a human-readable log file. It models a
+// one-row terminal: a cursor moves through a byte buffer, printable bytes
+// overwrite (or extend) at the cursor, \b moves the cursor left, \r sends
+// the cursor to column 0, \n flushes the whole row, and preserved CSI
+// sequences (ESC [ ... C/D/G/`/K/P/@) perform cursor movement, erase, or
+// delete/insert on the buffer.
 //
 // This is what SecureCRT / Xshell / PuTTY do in "Printable text" mode:
 // the log ends up containing the text the user actually saw on screen,
@@ -127,6 +153,12 @@ func scanEscape(data []byte, start int) (int, bool) {
 //   - \n (0x0A) → append \n and flush the whole buffer; buffer + cursor
 //     reset.
 //   - \t (0x09) → treated as a printable byte and preserved.
+//   - CSI C (CUF) → cursor right n columns.
+//   - CSI D (CUB) → cursor left n columns.
+//   - CSI G / ` (CHA) → cursor to column n (1-indexed).
+//   - CSI K (EL) → erase in line: 0=to end, 1=from start, 2=entire.
+//   - CSI P (DCH) → delete n chars at cursor.
+//   - CSI @ (ICH) → insert n blanks at cursor.
 //   - After flushTimeout of inactivity, the next Feed call flushes the
 //     partial line (without appending \n) so long-running commands
 //     without newline output — top, less, monitoring shells — still
@@ -135,6 +167,7 @@ func scanEscape(data []byte, start int) (int, bool) {
 type lineProcessor struct {
 	line         []byte
 	pos          int
+	emitted      int // high-water mark: bytes of line already written to output
 	lastActivity time.Time
 	flushTimeout time.Duration
 }
@@ -153,22 +186,44 @@ func (p *lineProcessor) Feed(in []byte) []byte {
 	}
 	now := time.Now()
 	var out []byte
-	// If we have been idle long enough and there is a partial line,
-	// emit it before we start appending new bytes so timestamps in the
-	// log roughly track the wall clock. The partial line stays in the
-	// buffer — this is a flush, not a discard.
-	if !p.lastActivity.IsZero() && len(p.line) > 0 && now.Sub(p.lastActivity) >= p.flushTimeout {
-		out = append(out, p.line...)
+	// If we have been idle long enough and there is un-emitted content in
+	// the buffer, flush only the new tail (bytes past the high-water mark)
+	// so timestamps in the log roughly track the wall clock. The partial
+	// line stays in the buffer — this is a flush, not a discard. Emitting
+	// only line[emitted:] avoids re-writing bytes already logged, which is
+	// what caused slow char-by-char echo (e.g. switch CLIs) to duplicate a
+	// growing line prefix on every keystroke.
+	if !p.lastActivity.IsZero() && len(p.line) > p.emitted && now.Sub(p.lastActivity) >= p.flushTimeout {
+		out = append(out, p.line[p.emitted:]...)
+		p.emitted = len(p.line)
 	}
-	for _, b := range in {
+
+	i := 0
+	for i < len(in) {
+		b := in[i]
+		if b == 0x1b && i+2 < len(in) && in[i+1] == '[' {
+			// Complete CSI sequence, guaranteed by ansiStripper.
+			// Find the final byte (0x40-0x7E).
+			end := i + 2
+			for end < len(in) {
+				c := in[end]
+				end++
+				if c >= 0x40 && c <= 0x7E {
+					break
+				}
+			}
+			p.applyCSI(in[i+2 : end]) // params + final byte
+			i = end
+			continue
+		}
+		// Non-CSI byte: standard line-processor logic.
 		switch b {
 		case '\n':
-			// The cursor may be somewhere in the middle of the line
-			// (e.g. mid-\r overwrite); flush the whole buffer regardless.
-			p.line = append(p.line, '\n')
-			out = append(out, p.line...)
+			out = append(out, p.line[p.emitted:]...)
+			out = append(out, '\n')
 			p.line = p.line[:0]
 			p.pos = 0
+			p.emitted = 0
 		case '\r':
 			p.pos = 0
 		case '\b':
@@ -182,23 +237,147 @@ func (p *lineProcessor) Feed(in []byte) []byte {
 				p.line = append(p.line, b)
 			}
 			p.pos++
+			// A write at or before the high-water mark rewrote already-emitted
+			// bytes (\r or \b repaint); pull the mark back so the change is
+			// re-flushed rather than silently lost.
+			if p.pos <= p.emitted {
+				p.emitted = p.pos - 1
+			}
 		}
+		i++
 	}
 	p.lastActivity = now
 	return out
 }
 
-// FlushPartial returns the current partial line (without appending \n)
-// and empties the buffer. Called on Disable so the last-written line
-// is not lost when the session ends without a trailing newline.
+// applyCSI applies a cursor/erase CSI command to the line buffer. csi is the
+// parameter + final byte portion of the sequence (without "ESC [").
+// Supported commands: C (CUF), D (CUB), G/` (CHA), K (EL), P (DCH), @ (ICH).
+func (p *lineProcessor) applyCSI(csi []byte) {
+	if len(csi) == 0 {
+		return
+	}
+	cmd := csi[len(csi)-1]
+	params := csi[:len(csi)-1]
+
+	switch cmd {
+	case 'C': // CUF — cursor right
+		n := parseCSIParam(params, 0, 1)
+		p.pos += n
+		if p.pos > len(p.line) {
+			p.pos = len(p.line)
+		}
+	case 'D': // CUB — cursor left
+		n := parseCSIParam(params, 0, 1)
+		if n > p.pos {
+			p.pos = 0
+		} else {
+			p.pos -= n
+		}
+	case 'G', '`': // CHA — cursor to column n (1-indexed)
+		n := parseCSIParam(params, 0, 1)
+		if n < 1 {
+			n = 1
+		}
+		col := n - 1
+		if col > len(p.line) {
+			col = len(p.line)
+		}
+		p.pos = col
+	case 'K': // EL — erase in line (default param 0)
+		switch parseCSIParam(params, 0, 0) {
+		case 0: // erase to end of line
+			p.line = p.line[:p.pos]
+		case 1: // erase from beginning to cursor
+			suffix := make([]byte, len(p.line)-p.pos)
+			copy(suffix, p.line[p.pos:])
+			p.line = suffix
+			p.pos = 0
+			p.emitted = 0
+			return
+		case 2: // erase entire line
+			p.line = p.line[:0]
+			p.pos = 0
+			p.emitted = 0
+			return
+		}
+	case 'P': // DCH — delete n characters at cursor
+		n := parseCSIParam(params, 0, 1)
+		if p.pos >= len(p.line) {
+			return
+		}
+		if n > len(p.line)-p.pos {
+			p.line = p.line[:p.pos]
+		} else {
+			copy(p.line[p.pos:], p.line[p.pos+n:])
+			p.line = p.line[:len(p.line)-n]
+		}
+	case '@': // ICH — insert n blank characters at cursor
+		n := parseCSIParam(params, 0, 1)
+		if p.pos >= len(p.line) {
+			return
+		}
+		ins := make([]byte, n)
+		p.line = append(p.line[:p.pos], append(ins, p.line[p.pos:]...)...)
+	}
+	// If the buffer was shortened past the emitted mark, pull it back so
+	// we don't silently lose bytes that were already flushed.
+	if p.emitted > len(p.line) {
+		p.emitted = len(p.line)
+	}
+}
+
+// parseCSIParam extracts the idx-th semicolon-separated numeric parameter
+// from params. Returns defaultVal if the parameter is missing or empty.
+func parseCSIParam(params []byte, idx, defaultVal int) int {
+	start := 0
+	for i := 0; i < idx; i++ {
+		semi := -1
+		for j := start; j < len(params); j++ {
+			if params[j] == ';' {
+				semi = j
+				break
+			}
+		}
+		if semi == -1 {
+			return defaultVal
+		}
+		start = semi + 1
+	}
+	if start >= len(params) {
+		return defaultVal
+	}
+	end := start
+	for end < len(params) && params[end] != ';' {
+		end++
+	}
+	if start == end {
+		return defaultVal
+	}
+	n := 0
+	for _, b := range params[start:end] {
+		n = n*10 + int(b-'0')
+	}
+	return n
+}
+
+// FlushPartial returns the not-yet-emitted tail of the current line
+// (without appending \n) and empties the buffer. Called on Disable so the
+// last-written line is not lost when the session ends without a trailing
+// newline. Bytes already flushed on a timeout are not repeated.
 func (p *lineProcessor) FlushPartial() []byte {
-	if len(p.line) == 0 {
+	if len(p.line) <= p.emitted {
+		p.line = p.line[:0]
+		p.pos = 0
+		p.emitted = 0
+		p.lastActivity = time.Time{}
 		return nil
 	}
-	out := make([]byte, len(p.line))
-	copy(out, p.line)
+	out := make([]byte, len(p.line)-p.emitted)
+	copy(out, p.line[p.emitted:])
 	p.line = p.line[:0]
 	p.pos = 0
+	p.emitted = 0
 	p.lastActivity = time.Time{}
 	return out
 }
@@ -207,6 +386,7 @@ func (p *lineProcessor) FlushPartial() []byte {
 func (p *lineProcessor) Reset() {
 	p.line = p.line[:0]
 	p.pos = 0
+	p.emitted = 0
 	p.lastActivity = time.Time{}
 }
 

--- a/backend/session/output_log_test.go
+++ b/backend/session/output_log_test.go
@@ -85,6 +85,98 @@ func TestSanitizeLogName(t *testing.T) {
 	}
 }
 
+func TestLineProcessorSlowCharEchoNoDuplication(t *testing.T) {
+	// Regression for issue #358: a switch CLI echoes one char per keystroke.
+	// When the user types slower than flushTimeout, each Feed triggers a
+	// timeout flush. The buffer must only emit the NEW tail each time, not
+	// re-emit the growing prefix, or the log fills with duplicated lines
+	// like "port acc[prompt]port accv[prompt]port access v...".
+	p := lineProcessor{flushTimeout: 1 * time.Millisecond}
+	var out []byte
+	for _, ch := range []string{"v", "l", "a", "n", " ", "2", "4"} {
+		time.Sleep(2 * time.Millisecond)
+		out = append(out, p.Feed([]byte(ch))...)
+	}
+	out = append(out, p.Feed([]byte("\r\n"))...)
+	got := string(out)
+	want := "vlan 24\n"
+	if got != want {
+		t.Errorf("slow char echo = %q, want %q", got, want)
+	}
+}
+
+func TestLineProcessorRepaintAfterTimeoutFlush(t *testing.T) {
+	// After a timeout flush emits a prefix, a \r-repaint that overwrites
+	// already-emitted bytes must re-flush the corrected tail rather than
+	// silently drop it.
+	p := lineProcessor{flushTimeout: 1 * time.Millisecond}
+	out := string(p.Feed([]byte("abc")))
+	if out != "" {
+		t.Errorf("first Feed emitted %q, want empty", out)
+	}
+	time.Sleep(2 * time.Millisecond)
+	// Timeout flush emits "abc"; then \r rewrites to "aXY". "abc" is already
+	// committed to the log (can't be unwritten), so the corrected tail is
+	// appended: the second Feed yields "abc" (flush) + "aXY\n" (repaint).
+	out2 := string(p.Feed([]byte("\raXY\n")))
+	want := "abcaXY\n"
+	if out2 != want {
+		t.Errorf("repaint after flush = %q, want %q", out2, want)
+	}
+}
+
+func TestLineProcessorReadlineRecallEraseToEnd(t *testing.T) {
+	// Regression: readline history recall repaints the prompt line. Recalling
+	// a SHORTER command over a longer one uses ESC[K to erase the leftover
+	// tail. Without interpreting ESC[K the log kept the old tail, e.g.
+	// "cat trace_fip_flows.sh er01.cloud.local...". \r returns to col 0, the
+	// new command overwrites, ESC[K erases the rest.
+	var p lineProcessor
+	// First command echoed, then Enter.
+	got1 := string(p.Feed([]byte("[root@m ~]# cat test.txt\r\n")))
+	if got1 != "[root@m ~]# cat test.txt\n" {
+		t.Errorf("first line = %q", got1)
+	}
+	// Prompt reprints; user recalls a longer line then a shorter one. The
+	// shorter recall overwrites from col 0 and erases the tail with ESC[K.
+	in := []byte("[root@m ~]# cat a_very_long_old_command.txt\r" +
+		"[root@m ~]# cat short.sh\x1b[K\r\n")
+	got2 := string(p.Feed(in))
+	want2 := "[root@m ~]# cat short.sh\n"
+	if got2 != want2 {
+		t.Errorf("recall erase-to-end = %q, want %q", got2, want2)
+	}
+}
+
+func TestLineProcessorCursorMoveAndDelete(t *testing.T) {
+	// readline mid-line edit: type "helo", move cursor left with ESC[D,
+	// insert 'l' — verify cursor-left (D) and the resulting text.
+	var p lineProcessor
+	// "helo" then cursor left 2 (before 'l'... actually before 'o'): ESC[2D
+	// puts cursor between 'e' and 'l'; insert 'l' → "hello".
+	got := string(p.Feed([]byte("helo\x1b[2Dl\r\n")))
+	// helo, pos=4. ESC[2D → pos=2 (between 'e' and 'l'). write 'l' overwrites
+	// 'l' at pos2, pos=3. \n flushes "hello"? -> overwrite makes "hello"? no:
+	// "helo"[2]='l' overwritten with 'l' = "helo", pos3. So result "helo".
+	// This asserts cursor-left works without corrupting the buffer.
+	if got != "helo\n" {
+		t.Errorf("cursor move = %q, want %q", got, "helo\n")
+	}
+}
+
+func TestLineProcessorDeleteChar(t *testing.T) {
+	// ESC[P (DCH) deletes n chars at cursor — used by readline Ctrl+D / edit.
+	var p lineProcessor
+	// "hello", cursor to col 1 (ESC[2G → 1-indexed col 2 = pos 1, on 'e'),
+	// delete 1 char → "hllo".
+	got := string(p.Feed([]byte("hello\x1b[2G\x1b[Px\r\n")))
+	// hello pos5. ESC[2G → pos1. ESC[P deletes 'e' → "hllo" pos1. 'x' writes
+	// at pos1 over 'l' → "hxlo" pos2. \n → "hxlo".
+	if got != "hxlo\n" {
+		t.Errorf("delete char = %q, want %q", got, "hxlo\n")
+	}
+}
+
 func TestOutputLoggerBasic(t *testing.T) {
 	var l OutputLogger
 	dir := t.TempDir()


### PR DESCRIPTION
## Summary

Session logs became garbled when the user edited the command line interactively over SSH — recalling shell history, moving the cursor, or overwriting a longer command with a shorter one produced interleaved prompt/command fragments in the log file (issue #358), even though the terminal displayed correctly.

## Root cause

The log pipeline was: `ansiStripper` removes **all** ANSI escape sequences → `lineProcessor` reconstructs lines using only `\r`, `\b`, `\n`. readline repaints the command line with cursor-movement and erase CSIs (`ESC[K`, cursor left/right, column position, etc.). Those were stripped before reaching `lineProcessor`, so when a shorter command was recalled over a longer one, the old tail was never erased and leaked into the log.

## Fix

- `ansiStripper` now passes through the subset of CSI sequences `lineProcessor` understands: cursor left/right (`C`/`D`), column position (`G`/`` ` ``), erase in line (`K`), delete char (`P`), insert blank (`@`). Colors, OSC, and private modes are still dropped.
- `lineProcessor` applies those CSIs to its single-line buffer, updating the cursor and truncating/rearranging bytes as a terminal would.
- The timeout-flush `emitted` high-water mark is preserved; a CSI that truncates the buffer past the mark pulls the mark back so nothing already logged is lost or duplicated.

## Known limitation

The processor still models a single line. Command lines that wrap across the terminal width, or edits that move the cursor between wrapped rows, cannot be perfectly reconstructed — this is inherent to the single-line model.

## Tests

Existing `lineProcessor` / `ansiStripper` / `OutputLogger` tests pass. Three new regression tests cover readline recall erase-to-end, cursor-left edit, and delete-char.

---

## 概述

通过 SSH 交互式编辑命令行时（调用历史命令、移动光标、用较短命令覆盖较长命令），会话日志文件出现提示符与命令片段交错的乱码（issue #358），而终端显示本身是正常的。

## 根因

日志管线为：`ansiStripper` 剥掉**所有** ANSI 转义序列 → `lineProcessor` 仅用 `\r`、`\b`、`\n` 重建行。readline 使用光标移动和擦除类 CSI（`ESC[K`、光标左右、列定位等）重绘命令行，这些序列在到达 `lineProcessor` 前就被剥掉、未执行。于是调用一条较短的历史命令覆盖较长命令时，旧命令的尾巴没有被擦除，残留进日志。

## 修复

- `ansiStripper` 放行 `lineProcessor` 能解释的那部分 CSI：光标左右（`C`/`D`）、列定位（`G`/`` ` ``）、行内擦除（`K`）、删除字符（`P`）、插入空白（`@`）；颜色、OSC、私有模式仍照旧剥掉。
- `lineProcessor` 把这些 CSI 作用到单行缓冲，像终端一样更新光标、截断/重排字节。
- 保留超时刷新的 `emitted` 高水位标记；若 CSI 截断缓冲越过该标记，则回退标记，确保已写入的内容不丢失也不重复。

## 已知局限

处理器仍是单行模型。命令行超出终端宽度折行、或在折行的多行间移动光标编辑时，无法完美还原——这是单行模型的固有限制。

## 测试

原有 `lineProcessor` / `ansiStripper` / `OutputLogger` 测试全部通过。新增三个回归测试，覆盖历史命令 recall 擦尾、光标左移编辑、删除字符。
