### PR TITLE
fix: correct OpenAI message order when a turn carries both tool_result and text

### DIFF
--- a/app.go
+++ b/app.go
@@ -1759,8 +1759,12 @@ func convertAnthropicMessageToOpenAI(msg map[string]interface{}) []map[string]in
 				}
 			}
 		}
+		// Emit tool messages first, then any text user message. An OpenAI-format
+		// assistant message with tool_calls must be immediately followed by the
+		// matching tool messages; a user text block placed before them triggers a
+		// 400 "insufficient tool messages following tool_calls" error.
 		if _, hasContent := out["content"]; hasContent {
-			results = append([]map[string]interface{}{out}, results...)
+			results = append(results, out)
 		}
 
 	case "assistant":


### PR DESCRIPTION
## Summary

Fixes #347 — OpenAI-compatible providers (e.g. Baidu Qianfan `deepseek-v4-flash`) intermittently returned `400 An assistant message with 'tool_calls' must be followed by tool messages responding to each 'tool_call_id'`, interrupting the conversation.

### Root cause

The frontend can produce a single Anthropic-format `user` message that carries **both** a `tool_result` and a text block — most commonly when a pending command is auto-cancelled because the user starts a new turn (the cancellation `tool_result` and the new user text get merged by the adjacent-user-message merge in `aiStore.ts`). This is valid under the Anthropic protocol.

In the OpenAI converter (`convertAnthropicMessageToOpenAI`), the `user` branch turned each `tool_result` into a `tool` message but **prepended** the text `user` message before them. The resulting sequence was:

```
assistant(tool_calls) -> user(text) -> tool(...)
```

OpenAI-compatible APIs require the `tool` messages to immediately follow the assistant `tool_calls` message, so this triggered the 400. Only OpenAI-protocol providers were affected; the Anthropic path never splits the message this way, which matches the intermittent, provider-specific reports in the issue.

### Fix

Append the text `user` message **after** the `tool` messages, yielding:

```
assistant(tool_calls) -> tool(...) -> user(text)
```

The change is confined to the OpenAI conversion; the Anthropic path and the frontend merge logic are untouched.

---

## 概述

修复 #347 —— 使用 OpenAI 兼容协议的供应商（如百度千帆 `deepseek-v4-flash`）偶发返回 `400 An assistant message with 'tool_calls' must be followed by tool messages...`，导致会话中断。

### 根因

前端可能产生一条同时包含 `tool_result` 和文本块的 Anthropic 格式 `user` 消息 —— 最常见于挂起的命令因用户发起新对话而被自动取消时（取消的 `tool_result` 与用户新输入被 `aiStore.ts` 的相邻 user 消息合并逻辑并成一条）。这在 Anthropic 协议下是合法的。

而在 OpenAI 转换 `convertAnthropicMessageToOpenAI` 的 `user` 分支中，每个 `tool_result` 会被转成 `tool` 消息，但文本 `user` 消息被 **前插** 到了这些 tool 消息之前，得到：

```
assistant(tool_calls) -> user(text) -> tool(...)
```

OpenAI 兼容 API 要求 `tool` 消息紧跟在带 `tool_calls` 的 assistant 消息之后，因此触发 400。只有 OpenAI 协议供应商会命中此问题；Anthropic 路径不会这样拆分消息，这与 issue 中「偶发、特定供应商」的现象一致。

### 修复

将文本 `user` 消息 **追加到** tool 消息之后：

```
assistant(tool_calls) -> tool(...) -> user(text)
```

改动仅限于 OpenAI 转换逻辑，不影响 Anthropic 路径与前端合并逻辑。
