### PR TITLE
fix: preserve group when creating a second connection in the same group

### DIFF
--- a/frontend/src/components/ConnectionForm.vue
+++ b/frontend/src/components/ConnectionForm.vue
@@ -517,6 +517,13 @@ const visible = computed({
 watch(visible, (val) => {
   if (val) {
     passwordInputKey.value++
+    // Apply group on open: the defaultGroupId watch won't fire when the value
+    // is unchanged, so restore it here to avoid losing the group on the second
+    // consecutive create within the same group.
+    if (!props.editConfig) {
+      selectedGroupId.value = props.defaultGroupId
+      form.groupId = props.defaultGroupId
+    }
   }
 })
 


### PR DESCRIPTION
## Summary

Fixes #337 — creating a second connection under the same sidebar group loses the group info (only reliably reproducible on macOS).

### Root cause

The new-connection form (`ConnectionForm.vue`) only wrote `defaultGroupId` into `form.groupId` through a value-change `watch`:

1. Right-click group A → new connection: `defaultGroupId` goes `undefined → A`, the watch fires, group is set. First create works.
2. On save, `resetForm()` clears `form.groupId`, but the sidebar's `newConnGroupId` (the `defaultGroupId` prop) stays `A`.
3. Second create under the same group A: `defaultGroupId` is `A → A` (unchanged), so the watch never fires and `form.groupId` stays cleared. Group is lost.

### Fix

Apply the group when the form opens (in the existing `watch(visible)`), instead of relying on the prop value changing. This reliably restores the group even when it matches the previous value.

---

## 概要

修复 #337 —— 在侧边栏同一分组下创建第二个连接时分组信息丢失（仅在 macOS 上稳定复现）。

### 根本原因

新建连接表单（`ConnectionForm.vue`）只通过监听值变化的 `watch` 把 `defaultGroupId` 写入 `form.groupId`：

1. 右键分组 A → 新建连接：`defaultGroupId` 从 `undefined → A`，watch 触发，分组设置成功，第一次正常。
2. 保存时 `resetForm()` 清空 `form.groupId`，但侧边栏的 `newConnGroupId`（即 `defaultGroupId`）仍是 `A`。
3. 第二次在同一分组 A 下新建：`defaultGroupId` 为 `A → A`（值未变），watch 不触发，`form.groupId` 保持清空状态，分组丢失。

### 修复

改为在表单打开时（现有的 `watch(visible)` 中）主动应用分组，而不依赖 prop 值变化，这样即使与上次值相同也能可靠恢复分组。