### PR TITLE
feat: drag-and-drop reordering for groups and connections

### DIFF
--- a/frontend/src/components/GroupTreeItem.vue
+++ b/frontend/src/components/GroupTreeItem.vue
@@ -2,7 +2,11 @@
   <!-- Group header -->
   <div
     class="group-header"
-    :class="{ 'drag-over': dragOverId === node.group.id }"
+    :class="{
+      'drag-over': dragOverId === node.group.id,
+      'drop-before': dropIndicator?.id === node.group.id && dropIndicator?.position === 'before',
+      'drop-after': dropIndicator?.id === node.group.id && dropIndicator?.position === 'after',
+    }"
     :style="{ paddingLeft: (6 + depth * 16) + 'px' }"
     draggable="true"
     @click="onToggle"
@@ -35,11 +39,17 @@
       v-for="conn in node.connections"
       :key="conn.id"
       class="connection-item indented"
-      :class="{ active: selected.has(conn.id) }"
+      :class="{
+        active: selected.has(conn.id),
+        'drop-before': dropIndicator?.id === conn.id && dropIndicator?.position === 'before',
+        'drop-after': dropIndicator?.id === conn.id && dropIndicator?.position === 'after',
+      }"
       :style="{ paddingLeft: (24 + depth * 16) + 'px' }"
       draggable="true"
       @dragstart="onConnDragStart($event, conn)"
       @dragend="onConnDragEnd"
+      @dragover.prevent="onConnDragOver($event, conn)"
+      @drop.prevent="onConnDrop($event, conn)"
       @click="onItemClick($event, conn)"
       @dblclick="onItemDblClick(conn)"
       @contextmenu.prevent="onConnCtxMenu($event, conn)"
@@ -82,6 +92,7 @@ const totalCount = computed(() => {
 const expanded = inject<Set<string>>('expandedGroups')!
 const selected = inject<Set<string>>('selectedIds')!
 const dragOverId = inject<any>('dragOverGroupId')!
+const dropIndicator = inject<any>('dropIndicator')!
 const handlers = inject<any>('groupHandlers')!
 const utils = inject<any>('utils')!
 
@@ -100,8 +111,8 @@ function onGrpDragStart(e: DragEvent) {
   e.dataTransfer!.effectAllowed = 'move'
 }
 
-function onGrpDragOver() {
-  handlers.onGroupDragOver(props.node.group.id)
+function onGrpDragOver(e: DragEvent) {
+  handlers.onGroupDragOver(props.node.group.id, e)
 }
 
 function onGrpDragLeave() {
@@ -118,6 +129,14 @@ function onConnDragStart(e: DragEvent, conn: ConnectionConfig) {
 
 function onConnDragEnd() {
   handlers.onDragEnd()
+}
+
+function onConnDragOver(e: DragEvent, conn: ConnectionConfig) {
+  handlers.onConnDragOver(e, conn)
+}
+
+function onConnDrop(e: DragEvent, conn: ConnectionConfig) {
+  handlers.onConnDrop(e, conn)
 }
 
 function onItemClick(e: MouseEvent, conn: ConnectionConfig) {
@@ -157,6 +176,33 @@ function onMoreClick(e: MouseEvent, conn: ConnectionConfig) {
 .group-header.drag-over {
   background: var(--accent-subtle);
   box-shadow: inset 0 0 0 1px var(--accent);
+}
+/* Insertion line for reordering (siblings) */
+.group-header,
+.connection-item {
+  position: relative;
+}
+.group-header.drop-before::before,
+.connection-item.drop-before::before,
+.group-header.drop-after::after,
+.connection-item.drop-after::after {
+  content: '';
+  position: absolute;
+  left: 6px;
+  right: 6px;
+  height: 2px;
+  background: var(--accent);
+  border-radius: 1px;
+  z-index: 2;
+  pointer-events: none;
+}
+.group-header.drop-before::before,
+.connection-item.drop-before::before {
+  top: -1px;
+}
+.group-header.drop-after::after,
+.connection-item.drop-after::after {
+  bottom: -1px;
 }
 .group-arrow {
   display: inline-flex;

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -105,7 +105,7 @@
           :class="{ 'drag-over': dragOverGroupId === '__ungrouped__' }"
           @click="toggleGroup('__ungrouped__')"
           @contextmenu.prevent="onVirtualGroupContextMenu($event)"
-          @dragover.prevent="onGroupDragOver('__ungrouped__')"
+          @dragover.prevent="onGroupDragOver('__ungrouped__', $event)"
           @dragleave="onGroupDragLeave('__ungrouped__')"
           @drop.prevent="onGroupDrop('__ungrouped__', $event)"
         >
@@ -121,11 +121,15 @@
             :key="conn.id"
             class="connection-item indented"
             :class="{
-              active: selectedIds.has(conn.id)
+              active: selectedIds.has(conn.id),
+              'drop-before': dropIndicator?.id === conn.id && dropIndicator?.position === 'before',
+              'drop-after': dropIndicator?.id === conn.id && dropIndicator?.position === 'after',
             }"
             draggable="true"
             @dragstart="onDragStart($event, conn)"
             @dragend="onDragEnd"
+            @dragover.prevent="onConnDragOver($event, conn)"
+            @drop.prevent="onConnDrop($event, conn)"
             @click="onItemClick($event, conn)"
             @dblclick="onItemDblClick(conn)"
             @contextmenu.prevent="onContextMenu($event, conn)"
@@ -149,11 +153,15 @@
           :key="conn.id"
           class="connection-item"
           :class="{
-            active: selectedIds.has(conn.id)
+            active: selectedIds.has(conn.id),
+            'drop-before': dropIndicator?.id === conn.id && dropIndicator?.position === 'before',
+            'drop-after': dropIndicator?.id === conn.id && dropIndicator?.position === 'after',
           }"
           draggable="true"
           @dragstart="onDragStart($event, conn)"
           @dragend="onDragEnd"
+          @dragover.prevent="onConnDragOver($event, conn)"
+          @drop.prevent="onConnDrop($event, conn)"
           @click="onItemClick($event, conn)"
           @dblclick="onItemDblClick(conn)"
           @contextmenu.prevent="onContextMenu($event, conn)"
@@ -880,6 +888,12 @@ function findConnById(id: string | null): ConnectionConfig | undefined {
 
 // ── Drag & drop ──
 const dragOverGroupId = ref<string | null>(null)
+// Insertion indicator for manual reordering. `id` is a connection id or a
+// group id (or '__ungrouped__'); position drives before/after/inside visuals.
+const dropIndicator = ref<{ id: string; position: 'before' | 'after' | 'inside' } | null>(null)
+
+// Reordering is only meaningful against the full, unfiltered list.
+const reorderEnabled = computed(() => !searchQuery.value.trim() && selectedTypeFilter.value === 'all')
 
 function onDragStart(e: DragEvent, conn: ConnectionConfig) {
   const ids = getSelectedConnectionIds()
@@ -895,9 +909,70 @@ function onDragStart(e: DragEvent, conn: ConnectionConfig) {
 
 function onDragEnd() {
   dragOverGroupId.value = null
+  dropIndicator.value = null
 }
 
-function onGroupDragOver(groupId: string) {
+// Ordered connection ids within a group, matching connections array order.
+function connSiblingIds(groupId: string | undefined): string[] {
+  return connectionStore.connections
+    .filter(c => (c.groupId || undefined) === (groupId || undefined))
+    .map(c => c.id)
+}
+
+// ── Connection item drag (reorder within / across groups) ──
+function onConnDragOver(e: DragEvent, conn: ConnectionConfig) {
+  if (!reorderEnabled.value) return
+  const el = e.currentTarget as HTMLElement
+  const rect = el.getBoundingClientRect()
+  const position = (e.clientY - rect.top) < rect.height / 2 ? 'before' : 'after'
+  dropIndicator.value = { id: conn.id, position }
+  dragOverGroupId.value = null
+}
+
+async function onConnDrop(e: DragEvent, conn: ConnectionConfig) {
+  const indicator = dropIndicator.value
+  dropIndicator.value = null
+  const raw = e.dataTransfer?.getData('text/plain')
+  if (!raw || !indicator) return
+  try {
+    const data = JSON.parse(raw)
+    if (!Array.isArray(data) || data.length === 0) return
+    const targetGroupId = conn.groupId || undefined
+    let beforeId: string | undefined
+    if (indicator.position === 'before') {
+      beforeId = conn.id
+    } else {
+      const siblings = connSiblingIds(targetGroupId)
+      const idx = siblings.indexOf(conn.id)
+      beforeId = idx >= 0 ? siblings[idx + 1] : undefined
+    }
+    await connectionStore.moveConnections(data, targetGroupId, beforeId)
+    selectedIds.value = new Set()
+  } catch {
+    // ignore parse errors
+  }
+}
+
+// ── Group header drag (reorder siblings vs reparent/move-in) ──
+function onGroupDragOver(groupId: string, e?: DragEvent) {
+  if (reorderEnabled.value && e && groupId !== '__ungrouped__') {
+    const el = e.currentTarget as HTMLElement
+    const rect = el.getBoundingClientRect()
+    const offset = e.clientY - rect.top
+    const edge = rect.height * 0.28
+    if (offset < edge) {
+      dropIndicator.value = { id: groupId, position: 'before' }
+      dragOverGroupId.value = null
+      return
+    }
+    if (offset > rect.height - edge) {
+      dropIndicator.value = { id: groupId, position: 'after' }
+      dragOverGroupId.value = null
+      return
+    }
+  }
+  // Middle region (or reorder disabled / ungrouped): move-in / reparent
+  dropIndicator.value = null
   dragOverGroupId.value = groupId
 }
 
@@ -905,31 +980,63 @@ function onGroupDragLeave(groupId: string) {
   if (dragOverGroupId.value === groupId) {
     dragOverGroupId.value = null
   }
+  if (dropIndicator.value?.id === groupId) {
+    dropIndicator.value = null
+  }
 }
 
 async function onGroupDrop(groupId: string, e: DragEvent) {
+  const indicator = dropIndicator.value
+  dragOverGroupId.value = null
+  dropIndicator.value = null
   const raw = e.dataTransfer?.getData('text/plain')
-  if (raw) {
-    try {
-      const data = JSON.parse(raw)
-      // Check if dropping a group (to reparent)
-      if (data && data.type === 'group') {
-        const targetParentId = groupId === '__ungrouped__' ? undefined : groupId
-        await connectionStore.reparentGroup(data.id, targetParentId)
-        dragOverGroupId.value = null
+  if (!raw) return
+  try {
+    const data = JSON.parse(raw)
+    // Dropping a group
+    if (data && data.type === 'group') {
+      if (indicator && indicator.id === groupId && indicator.position !== 'inside') {
+        // Reorder as sibling of the target group
+        const target = connectionStore.groups.find(g => g.id === groupId)
+        const newParentId = target?.parentId
+        let beforeId: string | undefined
+        if (indicator.position === 'before') {
+          beforeId = groupId
+        } else {
+          const siblings = connectionStore.groups
+            .filter(g => (g.parentId || undefined) === (newParentId || undefined))
+            .map(g => g.id)
+          const idx = siblings.indexOf(groupId)
+          beforeId = idx >= 0 ? siblings[idx + 1] : undefined
+        }
+        await connectionStore.moveGroup(data.id, newParentId, beforeId)
         return
       }
-      // Otherwise, dropping connections (plain array of IDs)
-      if (Array.isArray(data) && data.length > 0) {
-        const targetGroupId = groupId === '__ungrouped__' ? undefined : groupId
-        await connectionStore.setConnectionsGroup(data, targetGroupId)
-        selectedIds.value = new Set()
-      }
-    } catch {
-      // ignore parse errors
+      // Middle: move into this group as a child
+      const targetParentId = groupId === '__ungrouped__' ? undefined : groupId
+      await connectionStore.reparentGroup(data.id, targetParentId)
+      return
     }
+    // Dropping connections
+    if (Array.isArray(data) && data.length > 0) {
+      const targetGroupId = groupId === '__ungrouped__' ? undefined : groupId
+      if (indicator && indicator.id === groupId && indicator.position !== 'inside') {
+        // Reorder relative to the group header: before = group's first slot
+        let beforeId: string | undefined
+        if (indicator.position === 'before') {
+          beforeId = connSiblingIds(targetGroupId)[0]
+        } else {
+          beforeId = undefined // after header: append to group end
+        }
+        await connectionStore.moveConnections(data, targetGroupId, beforeId)
+      } else {
+        await connectionStore.moveConnections(data, targetGroupId)
+      }
+      selectedIds.value = new Set()
+    }
+  } catch {
+    // ignore parse errors
   }
-  dragOverGroupId.value = null
 }
 
 // ── Connection click / multi-select ──
@@ -1648,6 +1755,7 @@ onUnmounted(() => {
 provide('expandedGroups', expandedGroups)
 provide('selectedIds', selectedIds)
 provide('dragOverGroupId', dragOverGroupId)
+provide('dropIndicator', dropIndicator)
 provide('groupHandlers', {
   onToggleGroup: toggleGroup,
   onGroupContextMenu,
@@ -1658,6 +1766,8 @@ provide('groupHandlers', {
   onItemDblClick,
   onDragStart,
   onDragEnd,
+  onConnDragOver,
+  onConnDrop,
   onContextMenu,
   onConnMoreClick,
 })
@@ -1878,7 +1988,23 @@ defineExpose({ focusSearch, openChangeGroupFor, openChangeGroupForGroup })
   transition: all 0.12s ease;
   margin-bottom: 2px;
   user-select: none;
+  position: relative;
 }
+
+.connection-item.drop-before::before,
+.connection-item.drop-after::after {
+  content: '';
+  position: absolute;
+  left: 6px;
+  right: 6px;
+  height: 2px;
+  background: var(--accent);
+  border-radius: 1px;
+  z-index: 2;
+  pointer-events: none;
+}
+.connection-item.drop-before::before { top: -1px; }
+.connection-item.drop-after::after { bottom: -1px; }
 
 .connection-item.indented {
   padding-left: 24px;

--- a/frontend/src/stores/connectionStore.ts
+++ b/frontend/src/stores/connectionStore.ts
@@ -197,6 +197,67 @@ export const useConnectionStore = defineStore('connection', () => {
     await save()
   }
 
+  // Move connections into targetGroupId and reorder within the connections
+  // array so they land right before beforeId (or at the group's end when
+  // beforeId is omitted). Preserves the relative order of the moved ids.
+  async function moveConnections(connectionIds: string[], targetGroupId: string | undefined, beforeId?: string) {
+    const moveSet = new Set(connectionIds)
+    // Grab moved items in their current array order, apply the new group
+    const moved = connections.value.filter(c => moveSet.has(c.id))
+    if (moved.length === 0) return
+    for (const c of moved) c.groupId = targetGroupId
+
+    const rest = connections.value.filter(c => !moveSet.has(c.id))
+
+    let insertAt: number
+    if (beforeId && !moveSet.has(beforeId)) {
+      const idx = rest.findIndex(c => c.id === beforeId)
+      insertAt = idx >= 0 ? idx : rest.length
+    } else {
+      // Append after the last connection already in the target group
+      let lastIdx = -1
+      for (let i = 0; i < rest.length; i++) {
+        if (rest[i].groupId === targetGroupId) lastIdx = i
+      }
+      insertAt = lastIdx >= 0 ? lastIdx + 1 : rest.length
+    }
+
+    rest.splice(insertAt, 0, ...moved)
+    connections.value = rest
+    await save()
+  }
+
+  // Reparent a group (reusing reparentGroup's cycle/name guards) and reorder
+  // it within the groups array so it lands right before beforeId sibling
+  // (or at the end of its new parent when beforeId is omitted).
+  async function moveGroup(groupId: string, newParentId: string | undefined, beforeId?: string) {
+    if (newParentId === groupId) return
+    if (newParentId && isDescendantOf(groupId, newParentId)) return
+
+    const g = groups.value.find(g => g.id === groupId)
+    if (!g) return
+
+    const newName = uniqueGroupName(g.name, newParentId, groupId)
+    g.parentId = newParentId
+    g.name = newName
+
+    const rest = groups.value.filter(x => x.id !== groupId)
+    let insertAt: number
+    if (beforeId && beforeId !== groupId) {
+      const idx = rest.findIndex(x => x.id === beforeId)
+      insertAt = idx >= 0 ? idx : rest.length
+    } else {
+      let lastIdx = -1
+      for (let i = 0; i < rest.length; i++) {
+        if (rest[i].parentId === newParentId) lastIdx = i
+      }
+      insertAt = lastIdx >= 0 ? lastIdx + 1 : rest.length
+    }
+    rest.splice(insertAt, 0, g)
+    groups.value = rest
+    await save()
+  }
+
   // ── Derived: tree structure ──
 
   const groupedConnections = computed<GroupedConnections>(() => {
@@ -226,16 +287,8 @@ export const useConnectionStore = defineStore('connection', () => {
       }
     }
 
-    // Recursive sort
-    function sortNode(node: GroupTreeNode) {
-      node.connections.sort((a, b) => a.name.localeCompare(b.name))
-      node.children.sort((a, b) => a.group.name.localeCompare(b.group.name))
-      node.children.forEach(sortNode)
-    }
-    roots.forEach(sortNode)
-    roots.sort((a, b) => a.group.name.localeCompare(b.group.name))
-    ungrouped.sort((a, b) => a.name.localeCompare(b.name))
-
+    // Display order follows the underlying array order (manual sort).
+    // No name-based sorting: drag & drop reorders the arrays directly.
     return { roots, ungrouped }
   })
 
@@ -278,6 +331,8 @@ export const useConnectionStore = defineStore('connection', () => {
     getChildGroups,
     setConnectionGroup,
     setConnectionsGroup,
+    moveConnections,
+    moveGroup,
     groupedConnections,
     allGroupIds,
   }


### PR DESCRIPTION
## Summary

Closes #379. Adds drag-and-drop reordering for both groups and connections in the sidebar.

- Display order now follows the underlying array order instead of name-based auto-sorting. Dragging reorders the `groups` / `connections` arrays directly and persists through the existing `save()`, so no data-model change is needed and old configs stay ordered.
- **Connection reorder**: dropping onto a connection's upper/lower half inserts it before/after that item (works within a group and across groups). Multi-selected connections move together, preserving their relative order.
- **Group reorder**: dropping onto a group header's top/bottom edge (~28%) reorders it as a sibling; the middle region keeps the existing move-in / reparent behavior.
- An accent insertion line indicates the drop position; the middle region keeps the existing full-row highlight.
- Reordering is disabled while a search query or type filter is active (only move-into-group remains), to avoid ambiguous positioning against a filtered list.

## Test

- `npm --prefix frontend run build` passes.
- Verified in `wails dev`: intra-group reorder, cross-group move, group sibling reorder, move-in/reparent, multi-select drag, and order persistence after restart.

---

## 概要

关闭 #379。为侧边栏的分组和连接增加拖拽排序。

- 显示顺序改为跟随底层数组顺序，不再按名字自动排序。拖拽直接重排 `groups` / `connections` 数组并通过既有 `save()` 持久化，无需改动数据模型，旧配置天然有序。
- **连接排序**：拖到某连接的上/下半区即插入到其前/后（组内、跨组均可）。多选连接一起移动并保留相对顺序。
- **分组排序**：拖到分组头的上/下边缘（约 28%）作为同级重新排序；中间区域保留原有的移进/重挂父级行为。
- 用 accent 色插入线指示落点；中间区域沿用原有整行高亮。
- 搜索或类型过滤激活时禁用重排（仅保留移进分组），避免在过滤后的列表上定位歧义。

## 测试

- `npm --prefix frontend run build` 通过。
- `wails dev` 实测：组内排序、跨组移动、分组同级排序、移进/重挂父级、多选拖动、重启后顺序持久化。
