### PR TITLE
feat: hide skills feature entries (not released this cycle)

### DIFF
--- a/frontend/src/components/AISidebar.vue
+++ b/frontend/src/components/AISidebar.vue
@@ -612,15 +612,9 @@ function detectSlashQuery(): string | null {
 }
 
 function refreshSkillDropdown() {
-  const query = detectSlashQuery()
-  if (query !== null) {
-    skillDropdownVisible.value = true
-    skillQuery.value = query
-    skillHighlightIndex.value = 0
-  } else {
-    skillDropdownVisible.value = false
-    skillQuery.value = ''
-  }
+  // Skills 功能本期暂不开放，禁用 / 斜杠命令下拉
+  skillDropdownVisible.value = false
+  skillQuery.value = ''
 }
 
 function onSelectSkill(name: string) {

--- a/frontend/src/components/SettingsTab.vue
+++ b/frontend/src/components/SettingsTab.vue
@@ -932,7 +932,8 @@ const categories = computed(() => {
     { key: 'terminal', label: t('settings.terminal'), icon: Monitor },
     { key: 'keyboard', label: t('shortcut.title'), icon: Keyboard },
     { key: 'ai', label: t('settings.ai'), icon: MessageCircleMore },
-    { key: 'skills', label: t('settings.skills'), icon: Wrench },
+    // Skills 功能本期暂不开放，隐藏入口
+    // { key: 'skills', label: t('settings.skills'), icon: Wrench },
     { key: 'sync', label: t('settings.sync'), icon: RefreshCw },
     { key: 'about', label: t('settings.about'), icon: Info },
   ]


### PR DESCRIPTION
## Summary

Hide the Skills feature entries since it is not shipping this cycle. The implementation is kept intact so it can be re-enabled later.

- **Settings → Skills category**: commented out in the category list, so the Skills management panel (`SkillsManager`) is no longer reachable.
- **AI sidebar `/` slash command**: the skill dropdown is disabled, so typing `/` no longer surfaces skills and no skill chip can be attached.

No implementation code was removed — restoring the two edits brings the feature back.

## Test

- `npm --prefix frontend run build` passes.

---

## 概要

Skills 功能本期暂不开放，隐藏其入口。实现代码保留，方便后续版本恢复。

- **设置页 → Skills 分类**：在分类列表中注释掉，Skills 管理面板（`SkillsManager`）不再可达。
- **AI 侧边栏 `/` 斜杠命令**：禁用 skill 下拉，输入 `/` 不再弹出 skill，也无法挂载 skill chip。

未删除任何实现代码——还原这两处改动即可恢复功能。

## 测试

- `npm --prefix frontend run build` 通过。
