### PR TITLE
feat(ai): AI skill save & import, path display, and queued-skill fix

### DIFF
--- a/backend/store/skills_store.go
+++ b/backend/store/skills_store.go
@@ -37,6 +37,7 @@ type SkillMeta struct {
 	Enabled        bool   `json:"enabled"`        // 是否进 L1/补全/识别（源:prefs）
 	SortOrder      int    `json:"sortOrder"`      // 列表排序（源:prefs）
 	Dir            string `json:"dir"`            // 存储目录名，可 ≠ name（源:目录）
+	Path           string `json:"path"`           // skill 目录的绝对路径（源:目录）
 	HasReferences  bool   `json:"hasReferences"`  // 是否文件夹型（有 references/）（源:目录）
 	ScriptCount    int    `json:"scriptCount"`    // scripts/ 文件数（源:目录）
 	ModelInvocable bool   `json:"modelInvocable"` // = !disable-model-invocation（源:目录）
@@ -207,6 +208,7 @@ func scanDir(root string, isSystem bool) []SkillMeta {
 			Description:    fm.description,
 			IsSystem:       isSystem,
 			Dir:            dir,
+			Path:           skillDir,
 			ModelInvocable: !fm.disableInv,
 			CreatedModel:   fm.createdModel,
 			HasReferences:  dirHasFiles(filepath.Join(skillDir, referencesDir)),

--- a/frontend/src/components/AISidebar.vue
+++ b/frontend/src/components/AISidebar.vue
@@ -160,13 +160,6 @@
           </div>
         </div>
 
-        <div v-if="activeSkillChip" class="skill-chip-area">
-          <span class="skill-chip">
-            ⚡ {{ activeSkillChip }}
-            <button class="skill-chip-close" @click="activeSkillChip = null">&times;</button>
-          </span>
-        </div>
-
         <div v-if="aiStore.queuedMessages.length" class="queued-area">
           <div v-for="q in aiStore.queuedMessages" :key="q.id" class="queued-chip">
             <span class="queued-text">{{ q.content }}</span>
@@ -257,7 +250,7 @@
 
 <script setup lang="ts">
 import { ref, nextTick, computed, watch, onMounted, onUnmounted } from 'vue'
-import { X, Trash2, Expand, Shrink, History, MessageSquarePlus, Search, ChevronDown, ChevronUp, ArrowUp, Square, Plus } from '@lucide/vue'
+import { X, Trash2, Expand, Shrink, History, MessageSquarePlus, Search, ChevronDown, ChevronUp, ArrowUp, Square, Plus, Zap } from '@lucide/vue'
 import { useAIStore } from '../stores/aiStore'
 import { useSettingsStore } from '../stores/settingsStore'
 import { useSkillStore } from '../stores/skillStore'
@@ -287,6 +280,10 @@ function getEditableText(): string {
     if (node.nodeType === Node.TEXT_NODE) {
       text += node.textContent || ''
     } else if (node instanceof HTMLElement) {
+      if (node.classList.contains('skill-tag')) {
+        // skill tag 不贡献文本(skill 正文单独注入,不发给终端)
+        return
+      }
       if (node.classList.contains('hash-tag')) {
         text += node.getAttribute('data-ref') || node.textContent || ''
       } else {
@@ -296,6 +293,33 @@ function getEditableText(): string {
   }
   el.childNodes.forEach(walk)
   return text
+}
+
+// 从输入框里提取已插入的 skill 名(取第一个 skill-tag)
+function extractSkillFromInput(): string | null {
+  const el = editableRef.value
+  if (!el) return null
+  const tag = el.querySelector('.skill-tag')
+  return tag?.getAttribute('data-skill') || null
+}
+
+// Create a skill inline tag span (⚡ name), non-editable, carries data-skill
+function createSkillTagSpan(name: string): HTMLSpanElement {
+  const span = document.createElement('span')
+  span.className = 'skill-tag'
+  span.setAttribute('data-skill', name)
+  span.contentEditable = 'false'
+  span.textContent = '⚡ ' + name
+  const el = editableRef.value
+  if (el) {
+    for (const attr of el.attributes) {
+      if (attr.name.startsWith('data-v-')) {
+        span.setAttribute(attr.name, '')
+        break
+      }
+    }
+  }
+  return span
 }
 
 // Create a hash-tag span with scoped CSS attribute so styles apply
@@ -656,7 +680,27 @@ function onSelectSkill(name: string) {
       }
     }
   }
-  activeSkillChip.value = name
+  // 移除已有的 skill tag（只允许一个），再在光标处插入新的
+  if (el) {
+    el.querySelectorAll('.skill-tag').forEach(n => n.remove())
+    const tagSpan = createSkillTagSpan(name)
+    const sel = window.getSelection()
+    if (sel && sel.rangeCount > 0 && el.contains(sel.anchorNode)) {
+      const range = sel.getRangeAt(0)
+      range.collapse(false)
+      range.insertNode(tagSpan)
+      const trailing = document.createTextNode(' ')
+      tagSpan.after(trailing)
+      range.setStart(trailing, 1)
+      range.collapse(true)
+      sel.removeAllRanges()
+      sel.addRange(range)
+    } else {
+      // 光标不在输入框（按钮触发）：插到开头
+      el.insertBefore(tagSpan, el.firstChild)
+      el.insertBefore(document.createTextNode(' '), tagSpan.nextSibling)
+    }
+  }
   skillDropdownVisible.value = false
   skillQuery.value = ''
   syncInputText()
@@ -1051,8 +1095,8 @@ async function onSend() {
   const text = getEditableText().trim()
   if (!text) return
 
-  // F5: 显式调用 skill —— 如果挂了 chip，注入 L2 正文到用户消息
-  const skillName = activeSkillChip.value
+  // F5: 显式调用 skill —— 输入框里挂了 skill tag 则注入其 L2 正文
+  const skillName = extractSkillFromInput()
   let skillBody = ''
   if (skillName) {
     try {
@@ -1060,11 +1104,10 @@ async function onSend() {
     } catch (e) {
       console.error('Failed to get skill body:', e)
     }
-    activeSkillChip.value = null
   }
 
   if (busy.value) {
-    aiStore.enqueueMessage(text)
+    aiStore.enqueueMessage(text, skillName || undefined, skillBody || undefined)
     clearInput()
     return
   }
@@ -1658,6 +1701,9 @@ defineExpose({ focusInput })
   color: var(--text-muted);
   border-color: var(--border-subtle);
 }
+.panel-tag-skill-icon {
+  flex-shrink: 0;
+}
 .panel-tag-close {
   background: none;
   border: none;
@@ -1795,34 +1841,6 @@ defineExpose({ focusInput })
   white-space: nowrap;
 }
 /* Skill chip */
-.skill-chip-area {
-  padding: 4px 8px 0;
-}
-.skill-chip {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  padding: 2px 8px;
-  background: var(--accent-subtle);
-  border: 1px solid var(--accent-glow);
-  border-radius: 10px;
-  font-size: 11px;
-  color: var(--accent);
-  font-weight: 500;
-}
-.skill-chip-close {
-  background: none;
-  border: none;
-  color: var(--accent);
-  cursor: pointer;
-  padding: 0;
-  font-size: 14px;
-  line-height: 1;
-  opacity: 0.7;
-}
-.skill-chip-close:hover {
-  opacity: 1;
-}
 .queued-area {
   display: flex;
   flex-direction: column;

--- a/frontend/src/components/AISidebar.vue
+++ b/frontend/src/components/AISidebar.vue
@@ -1165,6 +1165,7 @@ onMounted(() => {
   window.addEventListener('ai:ask', onAskAI)
   window.addEventListener('global:close-context-menus', closeAIMenu)
   document.addEventListener('click', closeAIMenu)
+  skillStore.load()
 
   if (messagesRef.value) {
     messagesRef.value.addEventListener('scroll', onMessagesScroll)

--- a/frontend/src/components/SkillCreateDialog.vue
+++ b/frontend/src/components/SkillCreateDialog.vue
@@ -36,6 +36,12 @@
         </template>
       </div>
 
+      <div class="import-actions">
+        <el-button size="small" @click="importZip">{{ t('settings.skillsImportZip') }}</el-button>
+        <el-button size="small" @click="importDir">{{ t('settings.skillsImportDir') }}</el-button>
+        <span class="import-hint">{{ t('settings.skillsImportFolderHint') }}</span>
+      </div>
+
       <el-form label-position="right" label-width="72px" size="small">
         <el-form-item required :label="t('settings.skillsName')">
           <el-input
@@ -79,6 +85,7 @@ import { ElMessage } from 'element-plus'
 import { FileUp, CircleCheck } from '@lucide/vue'
 import { useI18n } from '../i18n'
 import { useSkillStore } from '../stores/skillStore'
+import { OpenFileDialogFiltered, OpenDirectoryDialog, ImportSkillFromZip, ImportSkillFromDir } from '../../wailsjs/go/main/App'
 
 const { t } = useI18n()
 const store = useSkillStore()
@@ -168,7 +175,7 @@ async function handleFile(file: File) {
       parseError.value = e?.message || t('settings.skillsParseFail')
     }
   } else if (lower.endsWith('.zip') || lower.endsWith('.skill')) {
-    // zip 导入需后端解压：提示用户改用 .md，或后续通过文件对话框路径导入
+    // 拖入的 zip 拿不到磁盘路径，引导用下方「导入 Zip」按钮走原生对话框
     parseState.value = 'fail'
     parseError.value = t('settings.skillsZipHint')
   } else {
@@ -190,6 +197,33 @@ async function onCreate() {
     ElMessage.error(e?.message || 'Creation failed')
   }
 }
+
+// 通过 Wails 原生对话框选 zip / 文件夹，走后端导入（支持文件夹型 skill）
+async function importZip() {
+  try {
+    const path = await OpenFileDialogFiltered(t('settings.skillsImportZip'), 'Skill', '*.zip;*.skill')
+    if (!path) return
+    const name = await ImportSkillFromZip(path)
+    await store.reload()
+    ElMessage.success(t('settings.skillsImportOk', { name }))
+    emit('created')
+  } catch (e: any) {
+    ElMessage.error(e?.message || 'Import failed')
+  }
+}
+
+async function importDir() {
+  try {
+    const path = await OpenDirectoryDialog()
+    if (!path) return
+    const name = await ImportSkillFromDir(path)
+    await store.reload()
+    ElMessage.success(t('settings.skillsImportOk', { name }))
+    emit('created')
+  } catch (e: any) {
+    ElMessage.error(e?.message || 'Import failed')
+  }
+}
 </script>
 
 <style scoped>
@@ -209,6 +243,15 @@ async function onCreate() {
   text-align: center;
   cursor: pointer;
   transition: border-color 0.15s;
+}
+.import-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.import-hint {
+  font-size: 11px;
+  color: var(--el-text-color-secondary);
 }
 .upload-zone:hover {
   border-color: var(--el-color-primary);

--- a/frontend/src/components/SkillsManager.vue
+++ b/frontend/src/components/SkillsManager.vue
@@ -31,6 +31,10 @@
           <span class="skill-card-name">{{ skill.name }}</span>
         </div>
         <div class="skill-card-desc">{{ skill.description }}</div>
+        <div v-if="skill.path" class="skill-card-path" @click.stop="openFolder(skill)" :title="t('settings.skillsOpenFolder')">
+          <FolderOpen :size="12" class="skill-card-path-icon" />
+          <span class="skill-card-path-text">{{ skill.path }}</span>
+        </div>
       </div>
       <div class="skill-card-actions" @click.stop>
         <el-switch
@@ -117,7 +121,7 @@
 
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue'
-import { Plus, Lock, LockOpen, Settings2, Search, BookOpen } from '@lucide/vue'
+import { Plus, Lock, LockOpen, Settings2, Search, BookOpen, FolderOpen } from '@lucide/vue'
 import { ElMessage, ElMessageBox } from 'element-plus'
 import { useI18n } from '../i18n'
 import { useSkillStore } from '../stores/skillStore'
@@ -164,6 +168,10 @@ async function onSaveEdit() {
 function handleCmd(cmd: string, skill: SkillMeta) {
   if (cmd === 'delete') onDelete(skill)
   else if (cmd === 'edit') openEdit(skill)
+}
+
+function openFolder(skill: SkillMeta) {
+  store.openFolder(skill.path)
 }
 
 async function onDelete(skill: SkillMeta) {
@@ -255,5 +263,29 @@ onMounted(() => {
   align-items: center;
   gap: 6px;
   flex-shrink: 0;
+}
+.skill-card-path {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-top: 4px;
+  font-size: 11px;
+  color: var(--el-text-color-placeholder);
+  cursor: pointer;
+  width: fit-content;
+  max-width: 100%;
+}
+.skill-card-path:hover {
+  color: var(--el-color-primary);
+}
+.skill-card-path-icon {
+  flex-shrink: 0;
+}
+.skill-card-path-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  direction: rtl;
+  text-align: left;
 }
 </style>

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -925,5 +925,9 @@
   "ai.skillExplicit": "Explicit",
   "ai.skillAuto": "Auto",
   "settings.skillsEdit": "Edit",
-  "settings.skillsEditLocked": "Skill is locked (view only). Unlock it in the list to edit."
+  "settings.skillsEditLocked": "Skill is locked (view only). Unlock it in the list to edit.",
+  "settings.skillsImportZip": "Import Zip",
+  "settings.skillsImportDir": "Import Folder",
+  "settings.skillsImportFolderHint": "Supports folder skills with references/ and scripts/",
+  "settings.skillsImportOk": "Imported skill \"{name}\""
 }

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -925,6 +925,7 @@
   "ai.skillExplicit": "Explicit",
   "ai.skillAuto": "Auto",
   "settings.skillsEdit": "Edit",
+  "settings.skillsOpenFolder": "Reveal in file manager",
   "settings.skillsEditLocked": "Skill is locked (view only). Unlock it in the list to edit.",
   "settings.skillsImportZip": "Import Zip",
   "settings.skillsImportDir": "Import Folder",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -925,6 +925,7 @@
   "ai.skillExplicit": "显式调用",
   "ai.skillAuto": "自动识别",
   "settings.skillsEdit": "编辑",
+  "settings.skillsOpenFolder": "在文件管理器中打开",
   "settings.skillsEditLocked": "技能已锁定，仅可查看。如需修改请先在列表中解锁。",
   "settings.skillsImportZip": "导入 Zip",
   "settings.skillsImportDir": "导入文件夹",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -925,5 +925,9 @@
   "ai.skillExplicit": "显式调用",
   "ai.skillAuto": "自动识别",
   "settings.skillsEdit": "编辑",
-  "settings.skillsEditLocked": "技能已锁定，仅可查看。如需修改请先在列表中解锁。"
+  "settings.skillsEditLocked": "技能已锁定，仅可查看。如需修改请先在列表中解锁。",
+  "settings.skillsImportZip": "导入 Zip",
+  "settings.skillsImportDir": "导入文件夹",
+  "settings.skillsImportFolderHint": "支持含 references/、scripts/ 的文件夹型 skill",
+  "settings.skillsImportOk": "已导入技能「{name}」"
 }

--- a/frontend/src/services/agent.ts
+++ b/frontend/src/services/agent.ts
@@ -317,10 +317,16 @@ export async function runAgent(userInput: string, skillName?: string, skillBody?
     if (store.queuedMessages.length > 0) {
       const drained = store.queuedMessages.splice(0)
       drained.forEach((q, i) => {
+        let header = ''
+        if (q.skillName && q.skillBody) {
+          header = `[Skill: ${q.skillName}]\n${q.skillBody}`
+          store.addSkillCard(q.skillName, 'explicit')
+        }
         store.addMessage({
           id: `msg-${Date.now()}-${i}`,
           role: 'user',
           content: q.content,
+          _contextHeader: header || undefined,
         })
       })
       turnCount = 0

--- a/frontend/src/services/agent.ts
+++ b/frontend/src/services/agent.ts
@@ -4,6 +4,7 @@ import { useAIStore } from '../stores/aiStore'
 import { useSettingsStore } from '../stores/settingsStore'
 import { useTabStore } from '../stores/tabStore'
 import { usePanelStore } from '../stores/panelStore'
+import { useSkillStore } from '../stores/skillStore'
 import { EventsOn } from '../../wailsjs/runtime'
 import type { AIMessage } from '../types/ai'
 
@@ -188,7 +189,19 @@ function buildSystemPrompt(): string {
     shellPath.toLowerCase().includes('pwsh') ||
     shellPath.toLowerCase().includes('cmd')
   )
-  return store.systemPrompt + getShellGuidance(shellPath, isWindowsShell)
+  return store.systemPrompt + getShellGuidance(shellPath, isWindowsShell) + buildSkillIndex()
+}
+
+/**
+ * L1 skill index: name + description of enabled skills, appended to the system
+ * prompt so the model knows which skills exist (to invoke or avoid duplicating).
+ */
+function buildSkillIndex(): string {
+  const skillStore = useSkillStore()
+  const list = skillStore.enabledSkills
+  if (list.length === 0) return ''
+  const lines = list.map(s => `- /${s.name}: ${s.description}`).join('\n')
+  return `\n\nAVAILABLE SKILLS (invoke a matching one instead of reinventing it; do NOT duplicate an existing one with save_skill):\n${lines}`
 }
 
 export async function runAgent(userInput: string, skillName?: string, skillBody?: string) {
@@ -663,6 +676,28 @@ export async function runAgent(userInput: string, skillName?: string, skillBody?
       store.isRunning = false
       cleanupStreamListeners()
       return
+    } else if (tu.name === 'save_skill') {
+      const name = tu.input.name as string
+      const description = tu.input.description as string
+      const body = tu.input.body as string
+      try {
+        store.status = 'executing'
+        const skillStore = useSkillStore()
+        await skillStore.saveByAgent(name, description, body)
+        store.addMessage({
+          id: `msg-${Date.now()}`,
+          role: 'tool',
+          content: `[Skill saved: ${name}] The user can now invoke it with /${name}.`,
+          tool_call_id: tu.id
+        })
+      } catch (e: any) {
+        store.addMessage({
+          id: `msg-${Date.now()}`,
+          role: 'tool',
+          content: `[Error saving skill: ${e.message ?? e}]`,
+          tool_call_id: tu.id
+        })
+      }
     }
   }
 

--- a/frontend/src/services/llm.ts
+++ b/frontend/src/services/llm.ts
@@ -307,5 +307,27 @@ export const AVAILABLE_TOOLS = [
       },
       required: ['question', 'options']
     }
+  },
+  {
+    name: 'save_skill',
+    description: 'Create or update a reusable skill (a command-line workflow / SOP) so it can be invoked later via /name. Use this when the user asks to save the current approach as a skill, or when you and the user just worked out a repeatable command-line procedure worth keeping. Write a thin skill: only include steps the model would NOT do by default, use imperative steps, state clearly in the description what it does AND when to use it. Locked skills cannot be overwritten.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        name: {
+          type: 'string',
+          description: 'Skill identifier in kebab-case (lowercase letters, digits, hyphens), e.g. "git-clean-branches". This becomes the /trigger.'
+        },
+        description: {
+          type: 'string',
+          description: 'One line: what the skill does AND when to use it (drives matching). E.g. "Clean up merged local git branches. Use when the user wants to delete/tidy git branches."'
+        },
+        body: {
+          type: 'string',
+          description: 'The skill instructions as markdown (imperative steps). Do NOT include YAML frontmatter — name/description are passed separately.'
+        }
+      },
+      required: ['name', 'description', 'body']
+    }
   }
 ]

--- a/frontend/src/stores/aiStore.ts
+++ b/frontend/src/stores/aiStore.ts
@@ -177,18 +177,20 @@ export const useAIStore = defineStore('ai', () => {
     multiSelect: boolean
   } | null>(null)
   const lastPanelContext = ref<{ panelId: string; shellPath: string } | null>(null)
-  const queuedMessages = ref<{ id: string; content: string }[]>([])
+  const queuedMessages = ref<{ id: string; content: string; skillName?: string; skillBody?: string }[]>([])
 
   function setLastPanelContext(panelId: string, shellPath: string) {
     lastPanelContext.value = { panelId, shellPath }
   }
 
-  function enqueueMessage(content: string) {
+  function enqueueMessage(content: string, skillName?: string, skillBody?: string) {
     const trimmed = content.trim()
     if (!trimmed) return
     queuedMessages.value.push({
       id: `q-${Date.now()}-${queuedMessages.value.length}`,
       content: trimmed,
+      skillName,
+      skillBody,
     })
   }
 

--- a/frontend/src/stores/aiStore.ts
+++ b/frontend/src/stores/aiStore.ts
@@ -55,6 +55,13 @@ AVAILABLE TOOLS:
 4. collect_output — Wait and collect new terminal output. Pure passive listening — does NOT send anything to the terminal. Use when a command is still running and you want to see progress.
 5. send_terminal_key — Send text or control keys to the terminal. Use ONLY when you can SEE an interactive prompt (password, y/n, confirmation). By default, send_enter=true automatically appends Enter after your input, so "y" becomes "y" + Enter. Set send_enter=false only when you need to type raw characters without submitting.
 6. interrupt_command — Send Ctrl+C to cancel the running command.
+7. save_skill — Create or update a reusable skill (a command-line workflow / SOP) invokable later via /name. Use when the user asks to save the current approach as a skill, or when you just worked out a repeatable command-line procedure worth keeping.
+
+SKILL AUTHORING (when using save_skill):
+- name: kebab-case (lowercase letters, digits, hyphens), e.g. "git-clean-branches". Becomes the /trigger.
+- description: one line stating BOTH what it does AND when to use it — this drives future matching. E.g. "Clean up merged local git branches. Use when the user wants to delete/tidy git branches."
+- body: imperative markdown steps. Write a THIN skill — only include steps you would NOT do by default. Do NOT include YAML frontmatter (name/description are passed separately).
+- Locked skills are rejected by the backend when overwriting.
 
 CRITICAL RULES:
 - You can only send ONE tool call at a time. Never send multiple tool calls in a single response.

--- a/frontend/src/stores/skillStore.ts
+++ b/frontend/src/stores/skillStore.ts
@@ -1,6 +1,6 @@
 import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
-import { ListSkills, GetSkillBody, SetSkillEnabled, SetSkillLocked, DeleteSkill, CreateSkill, SaveSkill } from '../../wailsjs/go/main/App'
+import { ListSkills, GetSkillBody, SetSkillEnabled, SetSkillLocked, DeleteSkill, CreateSkill, SaveSkill, OpenPathInExplorer } from '../../wailsjs/go/main/App'
 import type { SkillMeta } from '../types/skill'
 
 export const useSkillStore = defineStore('skills', () => {
@@ -102,9 +102,18 @@ export const useSkillStore = defineStore('skills', () => {
     }
   }
 
+  async function openFolder(path: string): Promise<void> {
+    if (!path) return
+    try {
+      await OpenPathInExplorer(path)
+    } catch (e) {
+      console.error('Failed to open skill folder:', e)
+    }
+  }
+
   return {
     skills, loaded, enabledSkills,
     load, reload,
-    toggleEnabled, toggleLocked, remove, create, save, saveByAgent, getBody,
+    toggleEnabled, toggleLocked, remove, create, save, saveByAgent, getBody, openFolder,
   }
 })

--- a/frontend/src/stores/skillStore.ts
+++ b/frontend/src/stores/skillStore.ts
@@ -81,6 +81,18 @@ export const useSkillStore = defineStore('skills', () => {
     }
   }
 
+  // AI 侧保存：已存在则覆写（后端拒绝 locked），不存在则新建。
+  async function saveByAgent(name: string, description: string, body: string) {
+    await load()
+    const exists = skills.value.some(s => s.name === name)
+    if (exists) {
+      await SaveSkill(name, description, body)
+    } else {
+      await CreateSkill(name, description, body)
+    }
+    await reload()
+  }
+
   async function getBody(name: string): Promise<string> {
     try {
       return await GetSkillBody(name)
@@ -93,6 +105,6 @@ export const useSkillStore = defineStore('skills', () => {
   return {
     skills, loaded, enabledSkills,
     load, reload,
-    toggleEnabled, toggleLocked, remove, create, save, getBody,
+    toggleEnabled, toggleLocked, remove, create, save, saveByAgent, getBody,
   }
 })

--- a/frontend/src/types/skill.ts
+++ b/frontend/src/types/skill.ts
@@ -7,6 +7,7 @@ export interface SkillMeta {
   enabled: boolean
   sortOrder: number
   dir: string
+  path: string
   hasReferences: boolean
   scriptCount: number
   modelInvocable: boolean

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -1335,6 +1335,7 @@ export namespace store {
 	    enabled: boolean;
 	    sortOrder: number;
 	    dir: string;
+	    path: string;
 	    hasReferences: boolean;
 	    scriptCount: number;
 	    modelInvocable: boolean;
@@ -1356,6 +1357,7 @@ export namespace store {
 	        this.enabled = source["enabled"];
 	        this.sortOrder = source["sortOrder"];
 	        this.dir = source["dir"];
+	        this.path = source["path"];
 	        this.hasReferences = source["hasReferences"];
 	        this.scriptCount = source["scriptCount"];
 	        this.modelInvocable = source["modelInvocable"];


### PR DESCRIPTION
## Summary / 摘要

围绕 AI 助理的 Skill 机制补齐三块能力：AI 通过 `save_skill` 固化技能并接入 zip/文件夹导入；技能管理页展示 skill 存储路径并可在文件管理器中打开；修复排队消息丢失已挂载 skill 的问题。

Rounds out the AI skill mechanism: let the AI persist skills via `save_skill` and wire up zip/folder import; surface each skill's storage path in the manager with reveal-in-file-manager; and fix queued messages silently dropping an attached skill.

## Changes / 改动

**Skill save & import**
- AI 可通过 `save_skill` 工具固化技能，并接入 zip / 文件夹导入（`ImportFromDir` / `ImportFromZip`，递归拷贝 `SKILL.md` + `references/` + `scripts/`）。

**技能页路径显示 / Skill path display** (Closes #403)
- `SkillMeta` 新增 `path` 字段，扫描时填入 skill 目录绝对路径。
- 技能卡片描述下方显示存储路径，点击复用现有 `OpenPathInExplorer` 在 Finder / 资源管理器中定位。

**排队 skill 修复 / Queued-skill fix** (Closes #404)
- 队列项一并保存 `skillName` / `skillBody`；drain 时与即时发送路径一致地注入 `_contextHeader` 并添加 skill card，两条发送路径语义对齐。

## Validation / 验证

- `go build ./...` 通过。
- `npm --prefix frontend run build` 通过。


Closes #386
Closes #403
Closes #404