### PR TITLE
fix: sidebar type-filter dropdown rendered behind connection list

### DIFF
--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -25,7 +25,7 @@
           @keydown="onListKeydown"
         >
           <template #suffix>
-            <el-dropdown trigger="click" placement="bottom-end" :teleported="false">
+            <el-dropdown trigger="click" placement="bottom-end" popper-class="type-filter-popper">
               <span class="filter-trigger" :class="{ active: selectedTypeFilter !== 'all' }" @click.stop>
                 <el-icon><Filter :size="14" /></el-icon>
               </span>
@@ -2292,6 +2292,16 @@ defineExpose({ focusSearch, openChangeGroupFor, openChangeGroupForGroup })
 .new-conn-popper {
   margin-top: -8px !important;
   margin-left: 4px !important;
+}
+
+/* Teleported (.type-filter-popper) to body so it floats above everything.
+   The global .el-dropdown-menu provides the surface, but we set a popper
+   background here too as a safety net against any future Teleport removal. */
+.type-filter-popper {
+  background: var(--bg-surface) !important;
+  border: 1px solid var(--border-subtle) !important;
+  border-radius: var(--radius-md) !important;
+  box-shadow: var(--shadow-md) !important;
 }
 
 .theme-select-popper .el-select-group__title {


### PR DESCRIPTION
## Problem

The type-filter dropdown next to the sidebar search box (the funnel icon) was rendered **behind** the connection list, making it unusable — the menu opened but was covered by the list below it.

## Cause

The dropdown used `:teleported="false"`, so its popper rendered inline inside `el-input`'s `suffix` slot. That subtree's stacking context placed the popper below its sibling `.connection-list`, and neither a `z-index` bump nor a `popper-class` background could lift it out of that context.

## Fix

- Remove `:teleported="false"` so the dropdown teleports to `body`, floating above all sidebar content like every other dropdown in the app.
- Add a `type-filter-popper` `popper-class` with background/border/shadow as a safety net.

Verified via `wails dev`: the dropdown now opens correctly above the connection list.

---

## 问题

侧边栏搜索框旁的类型筛选下拉（漏斗图标）被**渲染在连接列表下方**，菜单能展开但被列表盖住，无法使用。

## 原因

该下拉使用了 `:teleported="false"`，浮层内联渲染在 `el-input` 的 `suffix` 插槽内。该子树的层叠上下文使浮层位于兄弟节点 `.connection-list` 之下，且无论提高 `z-index` 还是加 `popper-class` 背景都无法将其提到该上下文之外。

## 修复

- 移除 `:teleported="false"`，让下拉浮层挂载到 `body`，像应用中其他下拉一样悬浮在侧边栏内容之上。
- 补充 `type-filter-popper` 的背景/边框/阴影样式作为兜底。

已通过 `wails dev` 验证：下拉现在能正确悬浮在连接列表之上。