### PR TITLE
fix(macos): restore native Edit menu so Cmd+C/V/A/X/Z work app-wide

### DIFF
--- a/main.go
+++ b/main.go
@@ -53,14 +53,21 @@ func main() {
 		maxW, maxH = 9999, 9999
 	}
 
-	// Only set an (empty) app menu on macOS — this is the trick that hides
-	// Wails' default Edit/Window menus there. On Linux (GTK) a non-nil Menu
-	// makes the backend create an empty GtkMenuBar at the top of the window,
-	// which shows up as a thin white line in the Frameless window. Leaving
-	// Menu as nil elsewhere avoids that. See issue #291.
+	// On macOS, install the standard App + Edit menus. The Edit menu is what
+	// routes the native Cmd+C/V/X/A/Z shortcuts to the first responder — every
+	// WKWebView text field (input/textarea/contenteditable) relies on it. An
+	// empty menu here used to suppress Wails' defaults but also killed those
+	// shortcuts app-wide, forcing per-component JS reimplementations. The menu
+	// lives in the top system menu bar, so it doesn't affect the frameless
+	// window. On Linux (GTK) a non-nil Menu creates an empty GtkMenuBar that
+	// shows as a thin white line in the frameless window, so leave it nil
+	// there. See issue #291.
 	var appMenu *menu.Menu
 	if runtime.GOOS == "darwin" {
-		appMenu = &menu.Menu{}
+		appMenu = menu.NewMenuFromItems(
+			menu.AppMenu(),
+			menu.EditMenu(),
+		)
 	}
 
 	// Read the persisted window-frame preference before wails.Run — the frame


### PR DESCRIPTION
## Summary / 摘要

从根上修复 macOS 下 Cmd+C/V/X/A/Z 编辑快捷键在文本框失效的问题：恢复原生 Edit 菜单，一次性让所有 WKWebView 文本框的 Cmd 编辑键可用，替代此前各组件逐个 JS 补丁的做法。

Root-cause fix for macOS edit shortcuts (Cmd+C/V/X/A/Z) not working in text fields: restore the native Edit menu so all WKWebView text fields get Cmd editing at once, instead of the previous per-component JS patches.

## Problem / 问题

`main.go` 在 macOS 上用空的 `&menu.Menu{}` 隐藏 Wails 默认菜单，但这连带删掉了原生 Edit 菜单。而 macOS 的 Cmd+C/V/X/A/Z 正是靠 Edit 菜单把快捷键路由到第一响应者（`copy:`/`paste:`/`selectAll:`），所有 WKWebView 文本框都依赖它。结果这些编辑键全平台失效，只能各组件单独用 JS 补实现（历史 PR #301/#388）。

An empty `&menu.Menu{}` on macOS hid Wails' defaults but also removed the native Edit menu, which routes Cmd+C/V/X/A/Z to the first responder that every WKWebView text field relies on. Those shortcuts broke app-wide, forcing per-component JS reimplementations.

## Changes / 改动

- `main.go`：macOS 分支改用 `menu.NewMenuFromItems(menu.AppMenu(), menu.EditMenu())`，恢复标准 App + Edit 菜单。
  - 菜单位于顶部系统菜单栏，不影响 frameless 窗口外观。
  - 改动仅限 `darwin` 分支；Linux/Windows 仍保持 `Menu=nil`，不会重现 #291 的 Linux 顶端白线。

## Notes / 说明

- **终端的 Cmd+C/粘贴自定义处理保留**（`BaseTerminal.vue`）：xterm 选区渲染在 canvas 上，原生 `copy:` 抓不到，终端粘贴需写入 PTY，属终端固有特性，不在本次移除范围。
- AppMenu 自带 Cmd+Q(Quit)，与既有 JS 的 Cmd+Q 处理同为「退出」，行为一致、无冲突，保持现状。

## Validation / 验证

- `go build ./...` 通过。
- 本地 macOS 实测：新建连接表单、AI 助理输入框的 Cmd+C/V/A 直接生效；终端 Cmd+C 复制选区、粘贴正常。

Closes #413