### PR TITLE
fix(ai): make FetchModels protocol-aware for Anthropic endpoints

### DIFF
--- a/app.go
+++ b/app.go
@@ -2555,14 +2555,35 @@ type ModelInfo struct {
 	DisplayName string `json:"display_name"`
 }
 
-// FetchModels fetches the available model list from an OpenAI-compatible /v1/models endpoint.
-func (a *App) FetchModels(apiKey, baseURL string) ([]ModelInfo, error) {
-	url := strings.TrimRight(baseURL, "/") + "/models"
+// FetchModels fetches the available model list. openai/responses hit an
+// OpenAI-compatible /models endpoint with a Bearer token; anthropic hits
+// /v1/models with the x-api-key + anthropic-version headers, mirroring
+// chatCompletionAnthropic's URL and auth handling.
+func (a *App) FetchModels(apiKey, baseURL, protocol string) ([]ModelInfo, error) {
+	base := strings.TrimRight(baseURL, "/")
+
+	var url string
+	if protocol == "anthropic" {
+		// Base URL conventionally omits /v1; tolerate legacy configs with it.
+		if strings.HasSuffix(base, "/v1") {
+			url = base + "/models"
+		} else {
+			url = base + "/v1/models"
+		}
+	} else {
+		url = base + "/models"
+	}
+
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("Authorization", "Bearer "+apiKey)
+	if protocol == "anthropic" {
+		req.Header.Set("x-api-key", apiKey)
+		req.Header.Set("anthropic-version", "2023-06-01")
+	} else {
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+	}
 	req.Header.Set("User-Agent", "uniTerm")
 
 	client := &http.Client{Timeout: 10 * time.Second}

--- a/frontend/src/components/SettingsTab.vue
+++ b/frontend/src/components/SettingsTab.vue
@@ -1027,7 +1027,7 @@ async function fetchModelList() {
   modelFetching.value = true
   modelSuggestions.value = []
   try {
-    const models = await FetchModels(modelForm.apiKey, modelForm.baseURL)
+    const models = await FetchModels(modelForm.apiKey, modelForm.baseURL, modelForm.protocol)
     modelSuggestions.value = (models || []).map(m => ({
       value: m.display_name || m.id
     }))

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -101,7 +101,7 @@ export function ExecuteQuery(arg1:string,arg2:string,arg3:string):Promise<databa
 
 export function ExecuteStatement(arg1:string,arg2:string,arg3:string):Promise<database.ExecResult>;
 
-export function FetchModels(arg1:string,arg2:string):Promise<Array<main.ModelInfo>>;
+export function FetchModels(arg1:string,arg2:string,arg3:string):Promise<Array<main.ModelInfo>>;
 
 export function FileSize(arg1:string):Promise<number>;
 

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -186,8 +186,8 @@ export function ExecuteStatement(arg1, arg2, arg3) {
   return window['go']['main']['App']['ExecuteStatement'](arg1, arg2, arg3);
 }
 
-export function FetchModels(arg1, arg2) {
-  return window['go']['main']['App']['FetchModels'](arg1, arg2);
+export function FetchModels(arg1, arg2, arg3) {
+  return window['go']['main']['App']['FetchModels'](arg1, arg2, arg3);
 }
 
 export function FileSize(arg1) {


### PR DESCRIPTION
## Summary

The chat endpoint already tolerates Anthropic base URLs with or without the `/v1` suffix and authenticates with `x-api-key`, but the "fetch model list" path (`FetchModels`) was hardcoded to the OpenAI convention — it appended `/models` (no `/v1`) and sent an `Authorization: Bearer` token. Against an Anthropic-compatible endpoint this fails two ways:

- **Wrong path** → `404` when the base URL omits `/v1` (e.g. `https://api.anthropic.com`).
- **Wrong auth** → `login fail: Please carry the API secret key in the 'X-Api-Key' field` (reported on #349 for `https://api.minimaxi.com/anthropic/v1`).

### Change

`FetchModels` now takes a `protocol` argument and branches on it, mirroring `chatCompletionAnthropic`:

- **anthropic**: `/v1/models` (tolerating a legacy `/v1` suffix) with `x-api-key` + `anthropic-version` headers.
- **openai / responses**: unchanged (`/models` + `Bearer`).

Frontend passes the model's protocol; the wails binding is regenerated to the 3-arg signature.

Closes #349

---

## 概述

聊天接口已经兼容 Anthropic 的 baseURL 带不带 `/v1` 后缀，并用 `x-api-key` 鉴权；但"获取模型列表"的 `FetchModels` 仍写死了 OpenAI 的约定——直接拼 `/models`（不带 `/v1`）并发送 `Authorization: Bearer`。对 Anthropic 兼容端点会有两种失败：

- **路径错误** → baseURL 不带 `/v1` 时返回 `404`（如 `https://api.anthropic.com`）。
- **鉴权错误** → `login fail: Please carry the API secret key in the 'X-Api-Key' field`（#349 中 `https://api.minimaxi.com/anthropic/v1` 的报错）。

### 改动

`FetchModels` 新增 `protocol` 参数并按协议分支，与 `chatCompletionAnthropic` 对齐：

- **anthropic**：`/v1/models`（兼容已带 `/v1` 的旧配置），使用 `x-api-key` + `anthropic-version` 头。
- **openai / responses**：保持不变（`/models` + `Bearer`）。

前端传入模型的协议；wails binding 重新生成为 3 参数签名。

Closes #349