### PR TITLE
fix(ssh): use standard baud rate 38400 in PTY modes

### DIFF
--- a/backend/session/ssh_session.go
+++ b/backend/session/ssh_session.go
@@ -206,8 +206,8 @@ func (s *SSHSession) Connect(config ConnectionConfig) error {
 
 	modes := ssh.TerminalModes{
 		ssh.ECHO:          1,
-		ssh.TTY_OP_ISPEED: 14400,
-		ssh.TTY_OP_OSPEED: 14400,
+		ssh.TTY_OP_ISPEED: 38400,
+		ssh.TTY_OP_OSPEED: 38400,
 	}
 
 	cols, rows := s.getInitialSize(80, 24)


### PR DESCRIPTION
## Summary

The PTY mode request used a non-standard baud rate `14400` for `TTY_OP_ISPEED`/`TTY_OP_OSPEED` (copied from a widely-circulated `x/crypto/ssh` example). Linux termios has no `B14400` constant, so this value pollutes the remote PTY's termios. When an application later runs `tcgetattr` → modify → `tcsetattr` (e.g. prompt_toolkit switching to raw mode), the kernel rejects the invalid speed field with `EINVAL`.

This is why the `hermes` CLI crashes on Ubuntu Server 26.04 while other SSH clients work — OpenSSH/PuTTY send the standard `38400`.

Fix: use `38400`, matching the OpenSSH default.

Fixes #412

---

## 概述

请求 PTY 时把 `TTY_OP_ISPEED`/`TTY_OP_OSPEED` 设成了非标准波特率 `14400`（抄自广为流传的 `x/crypto/ssh` 示例）。Linux termios 没有 `B14400` 合法常量，这个值会污染远端 PTY 的 termios。之后应用执行 `tcgetattr` → 改标志位 → `tcsetattr`（如 prompt_toolkit 进入 raw mode）时，内核校验速率字段非法 → 返回 `EINVAL`。

这就是 `hermes` CLI 在 Ubuntu Server 26.04 上崩溃、而其它 SSH 工具正常的原因——OpenSSH/PuTTY 发送的是标准值 `38400`。

修复：改用 `38400`，与 OpenSSH 默认一致。

修复 #412