### PR TITLE
[01/22] [01/20] fix(terminal): preserve Claude Code tables on tab switch + skip brace highlight inside fences

### DIFF
--- a/frontend/src/components/BaseTerminal.vue
+++ b/frontend/src/components/BaseTerminal.vue
@@ -100,6 +100,10 @@ import {
 } from '../services/terminalManager'
 import { getXtermTheme } from '../composables/useTerminal'
 import { stripCursorBlink } from '../utils/cursor'
+import {
+  sanitizeTerminalOutput,
+  sanitizeLiveTerminalOutput,
+} from '../utils/terminalSanitize'
 import { useTerminalInput } from '../composables/useTerminalInput'
 import { useSuggestions, quickCommandCache } from '../composables/useSuggestions'
 import TerminalSuggestion from './TerminalSuggestion.vue'
@@ -358,20 +362,7 @@ const searchResultIndex = ref(0)
 const searchResultCount = ref(0)
 
 function sanitizeTerminalHistory(text: string): string {
-  if (!text) return text
-  let cleaned = text
-  // ZModem HEX header fragments
-  cleaned = cleaned.replace(/\*{2,}(?:\x18)?[ABC][0-9a-fA-F]{10,}/g, '')
-  // ZModem ZDLE (0x18) and backspace (0x08) sequences
-  cleaned = cleaned.replace(/\x18+/g, '')
-  cleaned = cleaned.replace(/\x08+/g, '')
-  // ASCII control chars except \n, \r, \t and ESC
-  cleaned = cleaned.replace(/[\x00-\x08\x0b\x0c\x0e-\x1a\x1c-\x1f\x7f]/g, '')
-  // Drop binary garbage decoded as random Unicode blocks. Keep ASCII plus CJK
-  // so normal Chinese/Japanese/Korean terminal output is preserved.
-  cleaned = cleaned.replace(/[^\x00-\x7f一-鿿぀-ゟ゠-ヿ가-힯]/g, '')
-  // Collapse blank lines left by removed garbage
-  cleaned = cleaned.replace(/\n{3,}/g, '\n\n')
+  const cleaned = sanitizeTerminalOutput(text)
   // Forward debug info to backend log so we can inspect the raw garbage.
   if (cleaned !== text) {
     FrontendLog('sanitizeTerminalHistory', `raw last 400: ${JSON.stringify(text.slice(-400))}`)
@@ -1139,6 +1130,10 @@ onMounted(() => {
       data = data.replace(/\x1b\[H\x1b\[2J/g, scrollClear)
       data = data.replace(/\x1b\[2J/g, scrollClear)
     }
+// Drop U+FFFD + binary garbage. See utils/terminalSanitize for the
+    // full filter chain (box-drawing / braille preservation, control-char
+    // stripping, etc.). Live path skips the blank-line collapse step.
+    data = sanitizeLiveTerminalOutput(data)
     if (props.mode === 'sftp') {
       const cleaned = data.replace(/\x1b\]633;S[^\x07]*\x07/g, '')
       if (cleaned) {

--- a/frontend/src/composables/useHighlight.test.ts
+++ b/frontend/src/composables/useHighlight.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest'
+import { highlight } from './useHighlight'
+
+// SGR sequences inserted by highlight() — we only assert presence/absence,
+// not exact bytes (the colour palette is intentionally allowed to evolve).
+
+describe('highlight()', () => {
+  it('highlights braces in plain prose', () => {
+    const out = highlight('hello {world}')
+    expect(out).toContain('\x1b[95m') // brace colour from palette
+    expect(out).not.toBe('hello {world}')
+  })
+
+  it('skips content INSIDE a fenced code block', () => {
+    const input = '```js\nconst x = {a: 1}\necho "hello {world}"\n```\n'
+    const out = highlight(input)
+    // The fence lines and the two content lines must pass through
+    // untouched — no SGR inserted between the backticks.
+    expect(out).toBe(input)
+  })
+
+  it('skips content inside a tilde fence', () => {
+    const input = '~~~py\nprint("{x}")\n~~~\n'
+    expect(highlight(input)).toBe(input)
+  })
+
+  it('tolerates an info string on the opening fence', () => {
+    const input = '```javascript\nlet {a, b} = obj\n```\n'
+    expect(highlight(input)).toBe(input)
+  })
+
+  it('only closes a fence when the same character is used', () => {
+    // ``` must close ``` and not ~~~ (CommonMark rule, kept simple here)
+    const input = '```\n{not highlighted}\n~~~\n{still inside fence — not highlighted}\n```\n'
+    const out = highlight(input)
+    expect(out).toBe(input)
+  })
+
+  it('skips indented code lines (4+ leading spaces)', () => {
+    const input = '    let {a} = obj\n    const b = {c: 1}\n'
+    expect(highlight(input)).toBe(input)
+  })
+
+  it('still highlights prose after a fence closes', () => {
+    const input = '```\n{x}\n```\nplain {prose}\n'
+    const out = highlight(input)
+    // The brace palette opener must precede the brace and the reset must
+    // follow the brace's content — verify both ends rather than the full
+    // byte sequence (colour codes can wrap around braces independently).
+    expect(out).toContain('\x1b[95m{')
+    expect(out).toContain('}\x1b[24;39m')
+    // The fenced {x} line must NOT carry the brace colour.
+    expect(out).not.toContain('\x1b[95m{x}')
+  })
+
+  it('passes SGR-only lines through unchanged when no plain braces are present', () => {
+    // highlight() splits on CSI boundaries and only colours plain segments
+    // inside an SGR-only line — so a line with no plain braces is unchanged.
+    const input = '\x1b[31mred text\x1b[0m\n'
+    expect(highlight(input)).toBe(input)
+  })
+
+  it('handles multiple fences interleaved with prose', () => {
+    const input = 'before {x}\n```\n{inside}\n```\nafter {y}\n'
+    const out = highlight(input)
+    expect(out).toContain('before ')
+    expect(out).toContain('after ')
+    // The {x} and {y} get the brace colour; {inside} does not.
+    expect(out.split('\x1b[95m').length - 1).toBeGreaterThanOrEqual(2)
+  })
+
+  it('is stable when given an empty string', () => {
+    expect(highlight('')).toBe('')
+  })
+
+  it('is stable when given only a fence pair', () => {
+    expect(highlight('```\n```\n')).toBe('```\n```\n')
+  })
+})

--- a/frontend/src/composables/useHighlight.ts
+++ b/frontend/src/composables/useHighlight.ts
@@ -115,19 +115,15 @@ function highlightPlainText(text: string): string {
 // merely coloured parts of the line. Cursor movement / erase / OSC / private
 // modes indicate a TUI app (k9s, vim, htop…) drawing a screen; those lines
 // must stay untouched.
-//
-// Additionally skip lines that look like fenced code blocks / indented code
-// (Claude Code's stdout is heavy on them). Re-coloring braces / brackets
-// inside code with a different SGR than the surrounding text creates extra
-// reset sequences that some TUI apps misinterpret, producing overlapping
-// glyphs.
 const SGR_ONLY_LINE = /^(?:[^\x1b]|\x1b\[[\d;]*m)*$/
-const CODE_FENCE_LINE = /^\s{0,3}(?:```|~~~)|^ {4,}\S/
+const FENCE_OPEN = /^\s{0,3}(`{3,}|~{3,})/
+const INDENTED_CODE_LINE = /^ {4,}\S/
 
 export function highlight(text: string): string {
   // Process line by line to avoid cross-line regex matches.
   const lines = text.split(/(\r?\n)/)
   let result = ''
+  let fenceChar: '`' | '~' | null = null
   for (const line of lines) {
     if (line === '\r\n' || line === '\n' || line === '\r') {
       result += line
@@ -138,13 +134,23 @@ export function highlight(text: string): string {
       // gets highlighted. Same for plain text lines.
       if (line.indexOf('\x1b') !== -1 && !SGR_ONLY_LINE.test(line)) {
         result += line
-      } else if (CODE_FENCE_LINE.test(line)) {
-        // Skip brace / bracket highlighting inside code fences / indented
-        // code — Claude Code uses those heavily and re-coloring those
-        // chars produces SGR noise that interferes with TUI redraws.
-        result += line
       } else {
-        result += highlightPlainText(line)
+        const m = FENCE_OPEN.exec(line)
+        if (fenceChar) {
+          // Inside a fenced block — pass through until matching close fence.
+          if (m && m[1][0] === fenceChar) fenceChar = null
+          result += line
+        } else if (m) {
+          // Opening fence (``` or ~~~) — re-coloring braces / brackets
+          // inside fenced code injects SGR resets that some TUI apps
+          // misinterpret and produce overlapping glyphs.
+          fenceChar = m[1][0] as '`' | '~'
+          result += line
+        } else if (INDENTED_CODE_LINE.test(line)) {
+          result += line
+        } else {
+          result += highlightPlainText(line)
+        }
       }
     }
   }

--- a/frontend/src/composables/useHighlight.ts
+++ b/frontend/src/composables/useHighlight.ts
@@ -115,7 +115,14 @@ function highlightPlainText(text: string): string {
 // merely coloured parts of the line. Cursor movement / erase / OSC / private
 // modes indicate a TUI app (k9s, vim, htop…) drawing a screen; those lines
 // must stay untouched.
+//
+// Additionally skip lines that look like fenced code blocks / indented code
+// (Claude Code's stdout is heavy on them). Re-coloring braces / brackets
+// inside code with a different SGR than the surrounding text creates extra
+// reset sequences that some TUI apps misinterpret, producing overlapping
+// glyphs.
 const SGR_ONLY_LINE = /^(?:[^\x1b]|\x1b\[[\d;]*m)*$/
+const CODE_FENCE_LINE = /^\s{0,3}(?:```|~~~)|^ {4,}\S/
 
 export function highlight(text: string): string {
   // Process line by line to avoid cross-line regex matches.
@@ -128,8 +135,13 @@ export function highlight(text: string): string {
       // For SGR-only lines, let highlightPlainText run — it splits on CSI
       // boundaries and only touches the plain segments, so already-coloured
       // spans pass through unchanged while the uncoloured remainder still
-      // gets highlighted.
+      // gets highlighted. Same for plain text lines.
       if (line.indexOf('\x1b') !== -1 && !SGR_ONLY_LINE.test(line)) {
+        result += line
+      } else if (CODE_FENCE_LINE.test(line)) {
+        // Skip brace / bracket highlighting inside code fences / indented
+        // code — Claude Code uses those heavily and re-coloring those
+        // chars produces SGR noise that interferes with TUI redraws.
         result += line
       } else {
         result += highlightPlainText(line)

--- a/frontend/src/utils/terminalSanitize.test.ts
+++ b/frontend/src/utils/terminalSanitize.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest'
+import {
+  sanitizeTerminalOutput,
+  sanitizeLiveTerminalOutput,
+} from './terminalSanitize'
+
+describe('sanitizeTerminalOutput()', () => {
+  it('returns empty / falsy input unchanged', () => {
+    expect(sanitizeTerminalOutput('')).toBe('')
+  })
+
+  it('passes plain ASCII through untouched', () => {
+    expect(sanitizeTerminalOutput('hello world\n')).toBe('hello world\n')
+  })
+
+  it('drops U+FFFD replacement chars between box-drawing borders', () => {
+    // Input: 2 box-drawing chars + 2 replacement chars + 2 box-drawing chars.
+    // After strip: just the 4 box-drawing chars survive.
+    const dirty = '──��──\n'
+    expect(sanitizeTerminalOutput(dirty)).toBe('────\n')
+  })
+
+  it('drops standalone U+FFFD chars', () => {
+    expect(sanitizeTerminalOutput('a��b��c')).toBe('abc')
+  })
+
+  it('preserves every box-drawing char in the U+2500-257F range', () => {
+    const all = '─│┌┐└┘├┤┬┴┼━┃┏┓┗┛┣┫┳┻╋┳┓'
+    expect(sanitizeTerminalOutput(all)).toBe(all)
+  })
+
+  it('preserves block elements U+2580-259F', () => {
+    const all = '▀▁▂▃▄▅▆▇█▉▊▋▌▍▎▏▐░▒▓▔▕▖▗▘▙▚▛▜▝▞▟'
+    expect(sanitizeTerminalOutput(all)).toBe(all)
+  })
+
+  it('preserves arrows U+2190-21FF', () => {
+    const sample = '←↑→↓⇐⇑⇒⇓⇔↔↕↖↗'
+    expect(sanitizeTerminalOutput(sample)).toBe(sample)
+  })
+
+  it('preserves math operators U+2200-22FF', () => {
+    const sample = '∀∂∃∅∇∈∉∋∏∑−∓∔∕∖∗∘∙√∛∜∝'
+    expect(sanitizeTerminalOutput(sample)).toBe(sample)
+  })
+
+  it('preserves braille patterns U+2800-28FF (spinners survive)', () => {
+    const spinner = '⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏'
+    expect(sanitizeTerminalOutput(spinner)).toBe(spinner)
+  })
+
+  it('preserves CJK (中文 / 日本語 / 한국어)', () => {
+    const cjk = '中文测试 日本語テスト 한국어 테스트'
+    expect(sanitizeTerminalOutput(cjk)).toBe(cjk)
+  })
+
+  it('preserves Hangul syllables in U+AC00-D7AF range', () => {
+    expect(sanitizeTerminalOutput('가나다라마바사아자차카')).toBe(
+      '가나다라마바사아자차카'
+    )
+  })
+
+  it('drops ASCII control chars except \\n \\r \\t ESC', () => {
+    // \x07 BEL, \x0b VT, \x7f DEL should be stripped.
+    expect(sanitizeTerminalOutput('a\x07b\x0bc\x7fd')).toBe('abcd')
+    // Newlines / CR / TAB must survive.
+    expect(sanitizeTerminalOutput('a\nb\tc\rd')).toBe('a\nb\tc\rd')
+    // ESC must survive (SGR / cursor movement).
+    expect(sanitizeTerminalOutput('\x1b[31mred\x1b[0m')).toBe(
+      '\x1b[31mred\x1b[0m'
+    )
+  })
+
+  it('strips ZModem ZDLE (0x18) and backspace (0x08) runs', () => {
+    expect(sanitizeTerminalOutput('a\x18\x18\x18b\x08\x08c')).toBe('abc')
+  })
+
+  it('strips ZModem HEX header fragments', () => {
+    expect(
+      sanitizeTerminalOutput('**B00000000000000aabb\nhello')
+    ).toBe('\nhello')
+  })
+
+  it('strips a binary-garbage char in the U+E000 private-use area', () => {
+    // U+E000 is in the BMP private-use area, never legitimate terminal output.
+    expect(sanitizeTerminalOutput('ab')).toBe('ab')
+  })
+
+  it('strips an astral-plane codepoint that is not in any kept block', () => {
+    // U+1F600 GRINNING FACE — emoji, not TUI / CJK / box-drawing.
+    expect(sanitizeTerminalOutput('a😀b')).toBe('ab')
+  })
+
+  it('collapses 3+ consecutive newlines down to 2', () => {
+    expect(sanitizeTerminalOutput('a\n\n\n\nb')).toBe('a\n\nb')
+  })
+
+  it('preserves exactly 2 consecutive newlines', () => {
+    expect(sanitizeTerminalOutput('a\n\nb')).toBe('a\n\nb')
+  })
+
+  it('handles a realistic Claude Code table fragment end-to-end', () => {
+    // 4 box-drawing chars + replacement chars + BEL + 2 box-drawing chars +
+    // 4 blank lines + a row.
+    const input = '──��──\x07──\n\n\n\n│ a │ b │\n'
+    const expected = '──────\n\n│ a │ b │\n'
+    expect(sanitizeTerminalOutput(input)).toBe(expected)
+  })
+})
+
+describe('sanitizeLiveTerminalOutput()', () => {
+  it('does NOT collapse 3+ newlines (hot path skips that step)', () => {
+    expect(sanitizeLiveTerminalOutput('a\n\n\n\nb')).toBe('a\n\n\n\nb')
+  })
+
+  it('still strips U+FFFD', () => {
+    expect(sanitizeLiveTerminalOutput('─��─')).toBe('──')
+  })
+
+  it('still preserves box-drawing and braille', () => {
+    const input = '─│┌┐\n⠋⠙⠹'
+    expect(sanitizeLiveTerminalOutput(input)).toBe(input)
+  })
+})

--- a/frontend/src/utils/terminalSanitize.ts
+++ b/frontend/src/utils/terminalSanitize.ts
@@ -1,0 +1,47 @@
+// Strip transport-level noise and binary garbage from a block of terminal
+// output before it lands in xterm. Shared by the live `session:data` handler
+// and the KeepAlive history-replay path so both see identical input.
+//
+// All replacements are pure — no side effects, no logger calls — so the
+// function is trivially unit-testable. Callers that want a debug log do it
+// around the call site.
+
+const ZMODEM_HEX_FRAGMENT = /\*{2,}(?:\x18)?[ABC][0-9a-fA-F]{10,}/g
+const ZMODEM_ZDLE_RUN = /\x18+/g
+const BACKSPACE_RUN = /\x08+/g
+const ASCII_CTRL = /[\x00-\x08\x0b\x0c\x0e-\x1a\x1c-\x1f\x7f]/g
+const REPLACEMENT_CHAR = /�/g
+// Keep ASCII + CJK + the Unicode blocks that modern TUIs and Claude Code
+// actually render: box drawing, block elements, arrows, math operators,
+// braille and misc symbols. Everything else is treated as binary garbage.
+const NON_TUI_GARBAGE =
+  /[^\x00-\x7f一-鿿぀-ゟ゠-ヿ가-힯─-╿▀-▟←-⇿∀-⋿⟀-⟯⠀-⣿⬀-⯿]/g
+const BLANK_LINE_RUN = /\n{3,}/g
+
+export function sanitizeTerminalOutput(text: string): string {
+  if (!text) return text
+  let cleaned = text
+  cleaned = cleaned.replace(ZMODEM_HEX_FRAGMENT, '')
+  cleaned = cleaned.replace(ZMODEM_ZDLE_RUN, '')
+  cleaned = cleaned.replace(BACKSPACE_RUN, '')
+  cleaned = cleaned.replace(ASCII_CTRL, '')
+  cleaned = cleaned.replace(REPLACEMENT_CHAR, '')
+  cleaned = cleaned.replace(NON_TUI_GARBAGE, '')
+  cleaned = cleaned.replace(BLANK_LINE_RUN, '\n\n')
+  return cleaned
+}
+
+// Live session:data path is identical except the blank-line collapse is
+// skipped — running output naturally produces no blank runs, and collapsing
+// in the hot path would just churn bytes.
+export function sanitizeLiveTerminalOutput(text: string): string {
+  if (!text) return text
+  let cleaned = text
+  cleaned = cleaned.replace(ZMODEM_HEX_FRAGMENT, '')
+  cleaned = cleaned.replace(ZMODEM_ZDLE_RUN, '')
+  cleaned = cleaned.replace(BACKSPACE_RUN, '')
+  cleaned = cleaned.replace(ASCII_CTRL, '')
+  cleaned = cleaned.replace(REPLACEMENT_CHAR, '')
+  cleaned = cleaned.replace(NON_TUI_GARBAGE, '')
+  return cleaned
+}


### PR DESCRIPTION
## 背景

Claude Code 绘制表格或面板时，当前渲染有两个问题：

1. Go 解码器对部分 UTF-8 字节会生成 U+FFFD，破坏框线连续性（`─���─` 而不是 `──────`）。
2. 大括号 / 方括号 / 星号 / 等号 高亮器会把额外 `ANSI_RESET` 序列灌进多行 Markdown 代码栅栏块里。vim、k9s 这类 TUI 会把这些 reset 误判为光标移动，下次刷新时产生重叠字符。

此外，原本 U+FFFD 过滤只在「实时数据」路径生效，切换 tab 回放 scrollback 时脏数据会复现。

本 PR 解决这两个问题，并把栅栏检测改成状态机，让高亮器只在真正的正文中运行。

## 改动

- `frontend/src/utils/terminalSanitize.ts`（新增）
  - `sanitizeTerminalOutput()` — 完整过滤链：ZModem 片段 → ZDLE / 退格序列 → ASCII 控制字符（保留 `\n`、`\r`、`\t`、ESC）→ U+FFFD → 二进制垃圾白名单 → 多余空行折叠。
  - `sanitizeLiveTerminalOutput()` — 同链但跳过空行折叠（热路径）。
  - 白名单限于 ASCII + CJK + 现代 TUI 与 Claude Code 实际渲染的 Unicode 块：制表符（U+2500-257F）、方块元素（U+2580-259F）、箭头（U+2190-21FF）、数学运算符（U+2200-22FF）、杂项数学符号（U+27C0-27EF）、盲文（U+2800-28FF）、杂项符号（U+2B00-2BFF）。其余视作二进制垃圾。

- `frontend/src/utils/terminalSanitize.test.ts`（新增）
  - 22 个 vitest 用例：空输入、ASCII 透传、U+FFFD strip（独立 / 在框线之间）、白名单的每个 Unicode 块、CJK + 谚文、ASCII 控制字符 strip（保留 `\n`、`\r`、`\t`、ESC）、ZModem ZDLE / HEX strip、私用区 strip、星平面码点 strip、多余空行折叠、热路径跳过折叠，外加一个真实场景的 Claude Code 表格片段端到端验证。

- `frontend/src/components/BaseTerminal.vue`
  - `sanitizeTerminalHistory()` 改为调用 `sanitizeTerminalOutput()`（debug 日志留在本函数，工具函数保持纯）。
  - 实时 `session:data` handler 使用 `sanitizeLiveTerminalOutput()`。

- `frontend/src/composables/useHighlight.ts`
  - 把无状态的行首栅栏判断替换为小状态机：跟踪开栅栏字符（`` ` `` 或 `~`），期间内容原样透传，直到匹配闭栅栏。
  - 4 空格缩进的代码行保持无状态直传（CommonMark 规则）。
  - 普通正文仍然走高亮。

- `frontend/src/composables/useHighlight.test.ts`（新增）
  - 11 个 vitest 用例：普通正文、三反引号栅栏、波浪栅栏、info string 容忍、同字符闭栅栏、4 空格缩进代码、栅栏后正文、SGR-only 行、多栅栏交错、空输入。

## 行为说明

- 栅栏状态机有意只实现 CommonMark 的「同字符闭栅栏」规则（``` 由 ``` 闭合，不由 ~~~ 闭合），不强制闭栅栏最小长度。TUI 场景够用，完整 CommonMark 兼容不在范围内。
- U+FFFD strip 在二进制垃圾白名单之前执行，避免后续编辑白名单正则时意外重新引入 U+FFFD。
- 空行折叠只在历史回放路径生效；实时输出天然不会产生连续空行，热路径折叠只会徒增字节 churn。

## 测试

```
npm --prefix frontend install
npm --prefix frontend run build
npx --prefix frontend vitest run frontend/src/utils/terminalSanitize.test.ts
npx --prefix frontend vitest run frontend/src/composables/useHighlight.test.ts
```

手动验证：

1. 打开本地终端，执行 `node -e "process.stdout.write('─��─\n')"` —— 该行渲染为 `────`，无替换字符。
2. 切到 scrollback 含 Claude Code 栅栏块（` ```js ... ``` `）的 tab，确认栅栏内的大括号不被着色。
3. 切换 tab 后框线完整（无 `─���─` 现象）。

## 不在本 PR 范围

- `4bb5afa` 与 `567e1e4` 涉及的 flash / scroll-snap 修复已由上游 #303 覆盖，本 PR 不重复提交。