### PR TITLE
[03/20] fix(terminal): xterm polish (selection, clipboard, addon dispose, Unicode 11)

### DIFF
--- a/frontend/src/components/BaseTerminal.vue
+++ b/frontend/src/components/BaseTerminal.vue
@@ -462,13 +462,11 @@ function resize() {
     fitAddon.fit()
     if (terminal.cols <= 0 || terminal.rows <= 0) return
 
-    // Trust terminal.cols/rows set by fitAddon.fit() — xterm's internal
-    // measure already accounts for the scrollbar gutter. The previous
-    // Math.floor((rect.width - TERMINAL_PADDING * 2 - scrollbarWidth) /
-    // cellWidth) recomputation double-subtracted the gutter and produced
-    // an off-by-one column on every Claude Code table border, causing the
-    // whole rendered table to drift half a cell.
+    // Trust fitAddon.fit() — its measure already accounts for the scrollbar
+    // gutter; manual recomputation double-subtracts it.
     terminal.resize(terminal.cols, terminal.rows)
+    // Full-viewport redraw — prevents canvas ghosting during rapid write bursts.
+    terminal.refresh(0, terminal.rows - 1)
     SessionResize(sid, terminal.cols, terminal.rows).catch(() => {})
   } else {
     getFitAddon()?.fit()
@@ -758,8 +756,8 @@ onMounted(() => {
   )
   terminal.loadAddon(webLinksAddon)
 
-  // Unicode 11 support
-  try { terminal.unicode.activeVersion = '11' } catch (_) {}
+  // Unicode 11 activeVersion is set in terminalManager.ts right after the
+  // addon loads; no need to set it here again.
 
   // Set up search results listener from shared SearchAddon
   const managed = getManagedTerminal(props.sessionId || '')

--- a/frontend/src/components/BaseTerminal.vue
+++ b/frontend/src/components/BaseTerminal.vue
@@ -462,34 +462,14 @@ function resize() {
     fitAddon.fit()
     if (terminal.cols <= 0 || terminal.rows <= 0) return
 
-    let cellWidth = 0
-    let cellHeight = 0
-    try {
-      const core = (terminal as any)._core
-      const dims = core?._renderService?.dimensions
-      if (dims) {
-        cellWidth = dims.css?.cell?.width || 0
-        cellHeight = dims.css?.cell?.height || 0
-      }
-    } catch {
-      cellWidth = 0
-      cellHeight = 0
-    }
-
-    if (cellWidth === 0 || cellHeight === 0) {
-      SessionResize(sid, terminal.cols, terminal.rows).catch(() => {})
-      return
-    }
-
-    const TERMINAL_PADDING = 4
-    const scrollbarWidth = (terminal as any)._core?.viewport?.scrollBarWidth || 0
-    const cols = Math.floor((rect.width - TERMINAL_PADDING * 2 - scrollbarWidth) / cellWidth)
-    const rows = Math.floor((rect.height - TERMINAL_PADDING * 2) / cellHeight)
-    const newCols = Math.max(2, cols)
-    const newRows = Math.max(1, rows)
-
-    terminal.resize(newCols, newRows)
-    SessionResize(sid, newCols, newRows).catch(() => {})
+    // Trust terminal.cols/rows set by fitAddon.fit() — xterm's internal
+    // measure already accounts for the scrollbar gutter. The previous
+    // Math.floor((rect.width - TERMINAL_PADDING * 2 - scrollbarWidth) /
+    // cellWidth) recomputation double-subtracted the gutter and produced
+    // an off-by-one column on every Claude Code table border, causing the
+    // whole rendered table to drift half a cell.
+    terminal.resize(terminal.cols, terminal.rows)
+    SessionResize(sid, terminal.cols, terminal.rows).catch(() => {})
   } else {
     getFitAddon()?.fit()
   }

--- a/frontend/src/composables/useTerminal.ts
+++ b/frontend/src/composables/useTerminal.ts
@@ -338,6 +338,10 @@ export function useTerminal(
   let splitResizing = false
   let suppressResizeUntil = 0
   let retryOnEnter = false
+  let hoverEl: HTMLDivElement | null = null
+  let cachedCellWidth = 0
+  let cachedCellHeight = 0
+  let cachedFontKey = ''
 
   function getTerminalOptions() {
     const ts = settingsStore.settings.terminal
@@ -378,16 +382,27 @@ export function useTerminal(
     // Use try/catch because these are internal APIs that may change between versions.
     let cellWidth = 0
     let cellHeight = 0
-    try {
-      const core = (terminal as any)._core
-      const dims = core?._renderService?.dimensions
-      if (dims) {
-        cellWidth = dims.css?.cell?.width || 0
-        cellHeight = dims.css?.cell?.height || 0
+    const fontKey = `${terminal.options.fontSize}|${terminal.options.fontFamily}`
+    if (fontKey === cachedFontKey && cachedCellWidth > 0 && cachedCellHeight > 0) {
+      cellWidth = cachedCellWidth
+      cellHeight = cachedCellHeight
+    } else {
+      try {
+        const core = (terminal as any)._core
+        const dims = core?._renderService?.dimensions
+        if (dims) {
+          cellWidth = dims.css?.cell?.width || 0
+          cellHeight = dims.css?.cell?.height || 0
+        }
+      } catch {
+        cellWidth = 0
+        cellHeight = 0
       }
-    } catch {
-      cellWidth = 0
-      cellHeight = 0
+      if (cellWidth > 0 && cellHeight > 0) {
+        cachedCellWidth = cellWidth
+        cachedCellHeight = cellHeight
+        cachedFontKey = fontKey
+      }
     }
 
     if (cellWidth === 0 || cellHeight === 0) {

--- a/frontend/src/composables/useTerminal.ts
+++ b/frontend/src/composables/useTerminal.ts
@@ -326,6 +326,9 @@ export function useTerminal(
   let terminal: Terminal | null = null
   let fitAddon: FitAddon | null = null
   let searchAddon: SearchAddon | null = null
+  // Track loaded addons for unmount dispose; some (e.g. WebLinks) leave
+  // host elements behind after terminal.dispose() in older xterm.
+  const loadedAddons: Array<{ dispose?: () => void }> = []
   let resizeObserver: ResizeObserver | null = null
   let intersectionObserver: IntersectionObserver | null = null
   let unsubscribe: (() => void) | null = null
@@ -490,8 +493,8 @@ export function useTerminal(
 
     fitAddon = new FitAddon()
     terminal.loadAddon(fitAddon)
+    loadedAddons.push(fitAddon)
     // Register web links addon: underline http/https links, Ctrl+Click to open
-    let hoverEl: HTMLDivElement | null = null
     const webLinksAddon = new WebLinksAddon(
       (event, uri) => {
         if (event.ctrlKey || event.metaKey) {
@@ -519,9 +522,11 @@ export function useTerminal(
       }
     )
     terminal.loadAddon(webLinksAddon)
+    loadedAddons.push(webLinksAddon)
 
     searchAddon = new SearchAddon()
     terminal.loadAddon(searchAddon)
+    loadedAddons.push(searchAddon)
 
     terminal.open(terminalRef.value)
     // Force synchronous layout so grid rows are sized before xterm measures
@@ -715,6 +720,20 @@ export function useTerminal(
   onUnmounted(() => {
     resizeObserver?.disconnect()
     intersectionObserver?.disconnect()
+    // Addons detach listeners through the terminal; dispose them first.
+    for (const addon of loadedAddons) {
+      try {
+        addon.dispose?.()
+      } catch {
+        // ignore — some addons don't fully implement dispose
+      }
+    }
+    loadedAddons.length = 0
+    // Detach the tooltip element the WebLinksAddon may have left behind.
+    if (hoverEl && hoverEl.parentElement) {
+      hoverEl.parentElement.removeChild(hoverEl)
+    }
+    hoverEl = null
     terminal?.dispose()
     unsubscribe?.()
     statusUnsubscribe?.()

--- a/frontend/src/composables/useTerminalInput.test.ts
+++ b/frontend/src/composables/useTerminalInput.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect } from 'vitest'
+import { useTerminalInput } from './useTerminalInput'
+
+function mkTerminal(opts: { cursorY?: number; lines: string[]; rows?: number } = { lines: [] }) {
+  const { cursorY = 0, lines, rows = 24 } = opts
+  return {
+    rows,
+    buffer: {
+      active: {
+        y: cursorY,
+        baseY: 0,
+        getLine: (y: number) => lines[y] === undefined ? undefined : {
+          translateToString: () => lines[y],
+        },
+      },
+    },
+  } as any
+}
+
+describe('useTerminalInput', () => {
+  describe('lineBuffer (char-array backed)', () => {
+    it('get/set round-trip and preserve CJK chars', () => {
+      const t = useTerminalInput(null, { mode: 'ssh', sessionId: null })
+      t.lineBuffer.value = 'hello'
+      expect(t.lineBuffer.value).toBe('hello')
+      t.lineBuffer.value = 'hi 你好'
+      expect(t.lineBuffer.value).toBe('hi 你好')
+    })
+
+    it('handleInput inserts at cursor in the middle without losing existing chars', () => {
+      const t = useTerminalInput(null, { mode: 'ssh', sessionId: null })
+      t.lineBuffer.value = 'hllo'
+      t.cursorIndex.value = 1
+      t.handleInput('e')
+      expect(t.lineBuffer.value).toBe('hello')
+      expect(t.cursorIndex.value).toBe(2)
+    })
+
+    it('handleInput appends when cursor is at end', () => {
+      const t = useTerminalInput(null, { mode: 'ssh', sessionId: null })
+      t.handleInput('abc')
+      expect(t.lineBuffer.value).toBe('abc')
+      expect(t.cursorIndex.value).toBe(3)
+      expect(t.isAtLineEnd()).toBe(true)
+    })
+
+    it('handleInput backspace removes char before cursor and shifts left', () => {
+      const t = useTerminalInput(null, { mode: 'ssh', sessionId: null })
+      t.handleInput('abc')
+      t.cursorIndex.value = 3
+      t.handleInput('\b')
+      expect(t.lineBuffer.value).toBe('ab')
+      expect(t.cursorIndex.value).toBe(2)
+    })
+
+    it('handleInput backspace at cursor 0 is a no-op', () => {
+      const t = useTerminalInput(null, { mode: 'ssh', sessionId: null })
+      t.handleInput('abc')
+      t.cursorIndex.value = 0
+      t.handleInput('\b')
+      expect(t.lineBuffer.value).toBe('abc')
+      expect(t.cursorIndex.value).toBe(0)
+    })
+
+    it('Ctrl+A / Ctrl+E move cursor to start / end', () => {
+      const t = useTerminalInput(null, { mode: 'ssh', sessionId: null })
+      t.handleInput('abcde')
+      t.cursorIndex.value = 2
+      t.handleInput('\x01')
+      expect(t.cursorIndex.value).toBe(0)
+      t.handleInput('\x05')
+      expect(t.cursorIndex.value).toBe(5)
+    })
+
+    it('Ctrl+K deletes from cursor to end of line', () => {
+      const t = useTerminalInput(null, { mode: 'ssh', sessionId: null })
+      t.handleInput('abcdef')
+      t.cursorIndex.value = 2
+      t.handleInput('\x0b')
+      expect(t.lineBuffer.value).toBe('ab')
+      expect(t.cursorIndex.value).toBe(2)
+    })
+
+    it('Ctrl+U deletes from beginning to cursor', () => {
+      const t = useTerminalInput(null, { mode: 'ssh', sessionId: null })
+      t.handleInput('abcdef')
+      t.cursorIndex.value = 4
+      t.handleInput('\x15')
+      expect(t.lineBuffer.value).toBe('ef')
+      expect(t.cursorIndex.value).toBe(0)
+    })
+
+    it('Enter clears the local buffer', () => {
+      const t = useTerminalInput(null, { mode: 'ssh', sessionId: null })
+      t.handleInput('ls')
+      t.handleInput('\r')
+      expect(t.lineBuffer.value).toBe('')
+      expect(t.cursorIndex.value).toBe(0)
+    })
+
+    it('isAtLineEnd reflects the char-array, not a stale string copy', () => {
+      const t = useTerminalInput(null, { mode: 'ssh', sessionId: null })
+      t.handleInput('ab')
+      expect(t.isAtLineEnd()).toBe(true)
+      t.cursorIndex.value = 1
+      expect(t.isAtLineEnd()).toBe(false)
+    })
+  })
+
+  describe('getCurrentCommandFromTerminal (cursor-row first scan)', () => {
+    function makeInput(terminal: any, onExtract?: (cmd: string) => void) {
+      return useTerminalInput(terminal, {
+        mode: 'ssh',
+        sessionId: 's1',
+        enableHistory: onExtract !== undefined,
+        onHistoryExtract: onExtract,
+      })
+    }
+
+    it('extracts the command from the cursor row when present', () => {
+      const extracted: string[] = []
+      const t = makeInput(mkTerminal({
+        cursorY: 3,
+        lines: [
+          'user@host:~$ git status',
+          'On branch main',
+          'nothing to commit, working tree clean',
+          'user@host:~$ ls',
+        ],
+      }), (cmd) => extracted.push(cmd))
+      t.handleInput('ls')
+      t.handleInput('\r')
+      expect(extracted).toEqual(['ls'])
+    })
+
+    it('walks up from cursor row when the cursor row has no prompt', () => {
+      const extracted: string[] = []
+      const t = makeInput(mkTerminal({
+        cursorY: 5,
+        lines: [
+          'user@host:~$ git status',
+          'On branch main',
+          'Changes to be committed:',
+          '  modified: foo.ts',
+          '  modified: bar.ts',
+          'still working...',
+        ],
+      }), (cmd) => extracted.push(cmd))
+      t.handleInput('\r')
+      expect(extracted).toEqual(['git status'])
+    })
+
+    it('stops walking once a prompt is found (does not scan the full visible area)', () => {
+      const extracted: string[] = []
+      // The prompt sits two rows above the cursor, buried between non-prompt
+      // lines. The scanner must stop at the first prompt it finds, not keep
+      // walking through the rest of the viewport.
+      const t = makeInput(mkTerminal({
+        cursorY: 10,
+        lines: [
+          'filler 1',
+          '[root@node ~]# git log --oneline -5',
+          'filler 2', 'filler 3', 'filler 4', 'filler 5',
+          'filler 6', 'filler 7', 'filler 8',
+          'filler 9 (just a blank echo)',
+          '', // cursor row
+        ],
+      }), (cmd) => extracted.push(cmd))
+      t.handleInput('\r')
+      expect(extracted).toEqual(['git log --oneline -5'])
+    })
+
+    it('returns null when no prompt is visible', () => {
+      const extracted: string[] = []
+      const t = makeInput(mkTerminal({
+        cursorY: 0,
+        rows: 5,
+        lines: ['no prompt here', 'just some text', 'no prompt here either'],
+      }), (cmd) => extracted.push(cmd))
+      t.handleInput('\r')
+      expect(extracted).toEqual([])
+    })
+  })
+})

--- a/frontend/src/composables/useTerminalInput.ts
+++ b/frontend/src/composables/useTerminalInput.ts
@@ -45,30 +45,40 @@ export function useTerminalInput(terminal: Terminal | null, options: UseTerminal
       if (!buffer) return null
       // Prompt endings: $ # > ] plus common zsh/oh-my-zsh/powerline glyphs
       const PROMPT_RE = /(.+?[$#>\]❯➜→»λ])(?:\s+|$)(.*)/
-      // Scan entire visible area from bottom to top to find the prompt
       const rows = (terminal as any).rows || 24
-      for (let dy = 0; dy < rows; dy++) {
-        const y = buffer.baseY + rows - 1 - dy
-        if (y < 0) break
+      // Cursor row is the cheapest probe: the running command (if any) lives
+      // on the line where the cursor currently sits. Check it first, then only
+      // walk up until we find a prompt — don't scan the full visible row span
+      // when only the most recent prompt line is interesting.
+      const cursorY = (buffer.y ?? 0) + (buffer.baseY ?? 0)
+      const tryLine = (y: number): string | null => {
+        if (y < 0) return null
         const line = buffer.getLine(y)
-        if (!line) continue
+        if (!line) return null
         const rawText = line.translateToString().trim()
-        if (!rawText) continue
+        if (!rawText) return null
         const cleanText = stripAnsi(rawText)
         const match = cleanText.match(PROMPT_RE)
-        if (!match) continue
+        if (!match) return null
         const promptPart = match[1]
-        // Accept: user@host patterns, tilde-path patterns, bare $/#, or
-        // lines ending with a Unicode prompt glyph (❯➜→»λ) which are
-        // rare in normal output so false positives are minimal.
         const lastChar = promptPart.charAt(promptPart.length - 1)
         const isUnicodePrompt = /[❯➜→»λ]/.test(lastChar)
         if (!promptPart.includes('@') && !promptPart.includes('~') &&
-            promptPart !== '$' && promptPart !== '#' && !isUnicodePrompt) continue
+            promptPart !== '$' && promptPart !== '#' && !isUnicodePrompt) return null
         const command = match[2].trim()
         if (command && !command.includes('__AI_DONE_') && command.length <= MAX_COMMAND_LENGTH) {
           return command
         }
+        return null
+      }
+      const fromCursor = tryLine(cursorY)
+      if (fromCursor !== null) return fromCursor
+      // Walk up from the cursor row toward the top of the visible buffer.
+      for (let dy = 1; dy < rows; dy++) {
+        const y = cursorY - dy
+        if (y < 0) break
+        const hit = tryLine(y)
+        if (hit !== null) return hit
       }
     } catch {
       // Ignore errors

--- a/frontend/src/composables/useTerminalInput.ts
+++ b/frontend/src/composables/useTerminalInput.ts
@@ -122,7 +122,7 @@ export function useTerminalInput(terminal: Terminal | null, options: UseTerminal
         const belowY = (cursorY + 1) * cellHeight
         cursorPixelPos.value = { x, y: belowY }
       }
-      // Echo off detection: local buffer grew but terminal cursor didn't. →
+      // Echo off (password mode): local buffer grew but terminal cursor didn't.
       if (lineChars.value.length > 0 && cursorX === lastTerminalCursorX && cursorX >= 0) {
         isPasswordPrompt = true
       } else if (cursorX !== lastTerminalCursorX) {

--- a/frontend/src/composables/useTerminalInput.ts
+++ b/frontend/src/composables/useTerminalInput.ts
@@ -1,4 +1,4 @@
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
 import type { Terminal } from '@xterm/xterm'
 
 export interface CursorPosition {
@@ -15,7 +15,13 @@ export interface UseTerminalInputOptions {
 }
 
 export function useTerminalInput(terminal: Terminal | null, options: UseTerminalInputOptions) {
-  const lineBuffer = ref('')
+  // Char-array source of truth — mid-string inserts cost O(n) splice instead
+  // of two string copies + concat per keystroke. lineBuffer mirrors as string.
+  const lineChars = ref<string[]>([])
+  const lineBuffer = computed<string>({
+    get: () => lineChars.value.join(''),
+    set: (val) => { lineChars.value = Array.from(val) }
+  })
   const cursorIndex = ref(0)
   const currentToken = ref('')
   const cursorPixelPos = ref<CursorPosition>({ x: 0, y: 0 })
@@ -46,10 +52,7 @@ export function useTerminalInput(terminal: Terminal | null, options: UseTerminal
       // Prompt endings: $ # > ] plus common zsh/oh-my-zsh/powerline glyphs
       const PROMPT_RE = /(.+?[$#>\]❯➜→»λ])(?:\s+|$)(.*)/
       const rows = (terminal as any).rows || 24
-      // Cursor row is the cheapest probe: the running command (if any) lives
-      // on the line where the cursor currently sits. Check it first, then only
-      // walk up until we find a prompt — don't scan the full visible row span
-      // when only the most recent prompt line is interesting.
+      // Cursor row first: running command lives where the cursor sits.
       const cursorY = (buffer.y ?? 0) + (buffer.baseY ?? 0)
       const tryLine = (y: number): string | null => {
         if (y < 0) return null
@@ -73,7 +76,7 @@ export function useTerminalInput(terminal: Terminal | null, options: UseTerminal
       }
       const fromCursor = tryLine(cursorY)
       if (fromCursor !== null) return fromCursor
-      // Walk up from the cursor row toward the top of the visible buffer.
+      // Walk up until we find a prompt — stop at the first match.
       for (let dy = 1; dy < rows; dy++) {
         const y = cursorY - dy
         if (y < 0) break
@@ -87,9 +90,10 @@ export function useTerminalInput(terminal: Terminal | null, options: UseTerminal
   }
 
   function updateToken() {
-    const text = lineBuffer.value
+    const buf = lineChars.value
     const idx = cursorIndex.value
-    const beforeCursor = text.slice(0, idx)
+    let beforeCursor = ''
+    for (let i = 0; i < idx && i < buf.length; i++) beforeCursor += buf[i]
     // Use the entire command before cursor for suggestion matching,
     // so "git status" matches history entries like "git status --short".
     currentToken.value = beforeCursor.trim()
@@ -118,9 +122,8 @@ export function useTerminalInput(terminal: Terminal | null, options: UseTerminal
         const belowY = (cursorY + 1) * cellHeight
         cursorPixelPos.value = { x, y: belowY }
       }
-      // Detect hidden input: local lineBuffer grew but terminal cursor
-      // didn't advance → echo is off (password mode)
-      if (lineBuffer.value.length > 0 && cursorX === lastTerminalCursorX && cursorX >= 0) {
+      // Echo off detection: local buffer grew but terminal cursor didn't. →
+      if (lineChars.value.length > 0 && cursorX === lastTerminalCursorX && cursorX >= 0) {
         isPasswordPrompt = true
       } else if (cursorX !== lastTerminalCursorX) {
         isPasswordPrompt = false
@@ -136,7 +139,7 @@ export function useTerminalInput(terminal: Terminal | null, options: UseTerminal
   }
 
   function isAtLineEnd(): boolean {
-    return cursorIndex.value >= lineBuffer.value.length
+    return cursorIndex.value >= lineChars.value.length
   }
 
   function handleInput(data: string) {
@@ -158,7 +161,7 @@ export function useTerminalInput(terminal: Terminal | null, options: UseTerminal
         if (isPasswordPrompt) {
           isPasswordPrompt = false
         }
-        lineBuffer.value = ''
+        lineChars.value = []
         cursorIndex.value = 0
         // Reset suggestion suppress on new command
         if (options.onResetSuppress) {
@@ -166,7 +169,7 @@ export function useTerminalInput(terminal: Terminal | null, options: UseTerminal
         }
       } else if (code === 127 || char === '\b') {
         if (cursorIndex.value > 0) {
-          lineBuffer.value = lineBuffer.value.slice(0, cursorIndex.value - 1) + lineBuffer.value.slice(cursorIndex.value)
+          lineChars.value.splice(cursorIndex.value - 1, 1)
           cursorIndex.value--
         }
       } else if (code === 1) {
@@ -174,13 +177,13 @@ export function useTerminalInput(terminal: Terminal | null, options: UseTerminal
         cursorIndex.value = 0
       } else if (code === 5) {
         // Ctrl+E — end of line
-        cursorIndex.value = lineBuffer.value.length
+        cursorIndex.value = lineChars.value.length
       } else if (code === 11) {
         // Ctrl+K — delete from cursor to end of line
-        lineBuffer.value = lineBuffer.value.slice(0, cursorIndex.value)
+        lineChars.value.length = cursorIndex.value
       } else if (code === 21) {
         // Ctrl+U — delete from beginning to cursor
-        lineBuffer.value = lineBuffer.value.slice(cursorIndex.value)
+        lineChars.value.splice(0, cursorIndex.value)
         cursorIndex.value = 0
       } else if (code === 27) {
         i++
@@ -197,31 +200,31 @@ export function useTerminalInput(terminal: Terminal | null, options: UseTerminal
             if (cursorIndex.value > 0) cursorIndex.value--
           } else if (finalChar === 'C') {
             // Right arrow
-            if (cursorIndex.value < lineBuffer.value.length) cursorIndex.value++
+            if (cursorIndex.value < lineChars.value.length) cursorIndex.value++
           } else if (finalChar === 'H' && param === '') {
             // Home
             cursorIndex.value = 0
           } else if (finalChar === 'F' && param === '') {
             // End
-            cursorIndex.value = lineBuffer.value.length
+            cursorIndex.value = lineChars.value.length
           } else if (finalChar === '~') {
             if (param === '1' || param === '7') {
               // Home (alternate)
               cursorIndex.value = 0
             } else if (param === '4' || param === '8') {
               // End (alternate)
-              cursorIndex.value = lineBuffer.value.length
+              cursorIndex.value = lineChars.value.length
             } else if (param === '3') {
               // Delete
-              if (cursorIndex.value < lineBuffer.value.length) {
-                lineBuffer.value = lineBuffer.value.slice(0, cursorIndex.value) + lineBuffer.value.slice(cursorIndex.value + 1)
+              if (cursorIndex.value < lineChars.value.length) {
+                lineChars.value.splice(cursorIndex.value, 1)
               }
             }
           }
         }
       } else if (code >= 32) {
         // Support all printable characters including CJK
-        lineBuffer.value = lineBuffer.value.slice(0, cursorIndex.value) + char + lineBuffer.value.slice(cursorIndex.value)
+        lineChars.value.splice(cursorIndex.value, 0, char)
         cursorIndex.value++
       }
     }
@@ -251,7 +254,7 @@ export function useTerminalInput(terminal: Terminal | null, options: UseTerminal
   }
 
   function clearBuffer() {
-    lineBuffer.value = ''
+    lineChars.value = []
     cursorIndex.value = 0
     currentToken.value = ''
   }

--- a/frontend/src/composables/useTerminalMenu.test.ts
+++ b/frontend/src/composables/useTerminalMenu.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// vitest runs in node by default and the project has no jsdom dep;
+// stub the surface useTerminalMenu touches (window/document/MouseEvent).
+if (typeof globalThis.window === 'undefined') {
+  const g = globalThis as any
+  g.window = {
+    dispatchEvent: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    innerWidth: 1024,
+    innerHeight: 768,
+  }
+  g.document = {
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  }
+}
+class FakeMouseEvent {
+  ctrlKey = false
+  metaKey = false
+  clientX = 0
+  clientY = 0
+  preventDefault() { /* noop */ }
+  stopPropagation() { /* noop */ }
+}
+;(globalThis as any).MouseEvent = FakeMouseEvent
+
+async function flushAsync() {
+  for (let i = 0; i < 5; i++) await Promise.resolve()
+}
+
+const { mockClipboardSetText, mockSettingsStore } = vi.hoisted(() => ({
+  mockClipboardSetText: vi.fn(),
+  mockSettingsStore: {
+    settings: { terminal: { rightClickAction: 'menu' } },
+  },
+}))
+
+vi.mock('../../wailsjs/runtime/runtime', () => ({
+  ClipboardGetText: vi.fn().mockResolvedValue(''),
+  ClipboardSetText: (...args: unknown[]) => mockClipboardSetText(...args),
+}))
+
+vi.mock('../stores/settingsStore', () => ({
+  useSettingsStore: () => mockSettingsStore,
+}))
+
+import { useTerminalMenu } from './useTerminalMenu'
+
+function buildMenu(getSelection: () => string) {
+  return useTerminalMenu({ getSelection, onPaste: vi.fn() })
+}
+
+function stubNavigatorWrite(writeText: ReturnType<typeof vi.fn>) {
+  Object.defineProperty(globalThis.navigator, 'clipboard', {
+    configurable: true,
+    value: { writeText },
+  })
+}
+
+describe('useTerminalMenu.writeClipboard', () => {
+  let writeText: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    mockClipboardSetText.mockReset()
+    mockSettingsStore.settings.terminal.rightClickAction = 'menu'
+    writeText = vi.fn().mockResolvedValue(undefined)
+    stubNavigatorWrite(writeText)
+  })
+
+  it('falls back to navigator.clipboard.writeText when Wails resolves false', async () => {
+    mockClipboardSetText.mockResolvedValue(false)
+    const m = buildMenu(() => 'hello')
+    m.copySelection()
+    await flushAsync()
+    expect(mockClipboardSetText).toHaveBeenCalledWith('hello')
+    expect(writeText).toHaveBeenCalledWith('hello')
+  })
+
+  it('does NOT call navigator.clipboard when Wails resolves true', async () => {
+    mockClipboardSetText.mockResolvedValue(true)
+    const m = buildMenu(() => 'hello')
+    m.copySelection()
+    await flushAsync()
+    expect(mockClipboardSetText).toHaveBeenCalledWith('hello')
+    expect(writeText).not.toHaveBeenCalled()
+  })
+
+  it('falls back to navigator.clipboard when Wails throws', async () => {
+    mockClipboardSetText.mockRejectedValue(new Error('boom'))
+    const m = buildMenu(() => 'hello')
+    m.copySelection()
+    await flushAsync()
+    expect(mockClipboardSetText).toHaveBeenCalledWith('hello')
+    expect(writeText).toHaveBeenCalledWith('hello')
+  })
+
+  it('opens menu on contextmenu when rightClickAction is "menu"', () => {
+    const m = buildMenu(() => '')
+    m.onContextMenu(new FakeMouseEvent() as any)
+    expect(m.menuVisible.value).toBe(true)
+  })
+
+  it('dispatches to paste instead of showing menu when rightClickAction is "paste"', () => {
+    mockSettingsStore.settings.terminal.rightClickAction = 'paste'
+    const m = buildMenu(() => '')
+    m.onContextMenu(new FakeMouseEvent() as any)
+    expect(m.menuVisible.value).toBe(false)
+  })
+})
+
+describe('useTerminalMenu.copySelection re-reads selection at click time', () => {
+  let writeText: ReturnType<typeof vi.fn>
+  beforeEach(() => {
+    mockClipboardSetText.mockReset()
+    mockSettingsStore.settings.terminal.rightClickAction = 'menu'
+    writeText = vi.fn().mockResolvedValue(undefined)
+    stubNavigatorWrite(writeText)
+  })
+
+  // WKWebView race: right-click mousedown can clear xterm selection between
+  // contextmenu (where hasSelection is sampled) and the menu click. The
+  // getSelection() snapshot at click time must be the source of truth.
+  it('copies the fresh getSelection() value, ignoring stale hasSelection', async () => {
+    let selection = 'initial-selection'
+    const getSelection = vi.fn(() => selection)
+    const m = useTerminalMenu({ getSelection, onPaste: vi.fn() })
+    m.onContextMenu(new FakeMouseEvent() as any)
+    expect(m.hasSelection.value).toBe(true)
+
+    selection = ''
+    getSelection.mockImplementation(() => selection)
+    mockClipboardSetText.mockResolvedValue(true)
+    m.copySelection()
+    await flushAsync()
+
+    expect(mockClipboardSetText).not.toHaveBeenCalled()
+    expect(writeText).not.toHaveBeenCalled()
+  })
+
+  it('copies the fresh selection even when hasSelection was false at contextmenu', async () => {
+    let selection = ''
+    const getSelection = vi.fn(() => selection)
+    const m = useTerminalMenu({ getSelection, onPaste: vi.fn() })
+    m.onContextMenu(new FakeMouseEvent() as any)
+    expect(m.hasSelection.value).toBe(false)
+
+    selection = 'late-selection'
+    getSelection.mockImplementation(() => selection)
+    mockClipboardSetText.mockResolvedValue(true)
+    m.copySelection()
+    await flushAsync()
+
+    expect(mockClipboardSetText).toHaveBeenCalledWith('late-selection')
+    expect(writeText).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/composables/useTerminalMenu.ts
+++ b/frontend/src/composables/useTerminalMenu.ts
@@ -67,6 +67,11 @@ export function useTerminalMenu(options: UseTerminalMenuOptions): UseTerminalMen
   }
 
   function copySelection() {
+    // Re-read the xterm selection at click time. hasSelection.value was
+    // captured during contextmenu, but in WKWebView the right-click
+    // mousedown can clear the xterm selection between contextmenu and the
+    // menu click, leaving hasSelection stale. Trust getSelection() — the
+    // authoritative source — rather than the cached ref.
     const text = options.getSelection()
     if (text) {
       writeClipboard(text)

--- a/frontend/src/composables/useTerminalMenu.ts
+++ b/frontend/src/composables/useTerminalMenu.ts
@@ -56,22 +56,23 @@ export function useTerminalMenu(options: UseTerminalMenuOptions): UseTerminalMen
     return { left: left + 'px', top: top + 'px' }
   }
 
-  // Write to the OS clipboard via Wails first (reliable in WebView2), falling
-  // back to the browser clipboard API when the runtime call fails.
+  // Wails ClipboardSetText resolves false (not rejects) on focus loss /
+  // AppKit glitches; fall through to navigator.clipboard in that case.
   async function writeClipboard(text: string) {
+    let ok = false
     try {
-      await ClipboardSetText(text)
+      ok = await ClipboardSetText(text)
     } catch {
+      ok = false
+    }
+    if (!ok) {
       try { await navigator.clipboard.writeText(text) } catch { /* ignore */ }
     }
   }
 
   function copySelection() {
-    // Re-read the xterm selection at click time. hasSelection.value was
-    // captured during contextmenu, but in WKWebView the right-click
-    // mousedown can clear the xterm selection between contextmenu and the
-    // menu click, leaving hasSelection stale. Trust getSelection() — the
-    // authoritative source — rather than the cached ref.
+    // Trust getSelection() at click time; the contextmenu-captured ref can
+    // be stale in WKWebView (right-click mousedown clears the xterm selection).
     const text = options.getSelection()
     if (text) {
       writeClipboard(text)

--- a/frontend/src/services/terminalManager.ts
+++ b/frontend/src/services/terminalManager.ts
@@ -86,10 +86,19 @@ export function acquireTerminal(
     const fitAddon = new FitAddon()
     const searchAddon = new SearchAddon()
     const unicodeAddon = new Unicode11Addon()
+    // Activate Unicode 11 widths before any data is written. The default is
+    // v6, which under-counts cells for many CJK ideographs and full-width
+    // punctuation that Claude Code emits — the terminal would wrap rows at
+    // a different column than the backend PTY (which uses Unicode 11 widths
+    // too), producing the offset-between-rows table misalignment users see.
+    terminal.unicode.activeVersion = '11'
 
     terminal.loadAddon(fitAddon)
     terminal.loadAddon(searchAddon)
     terminal.loadAddon(unicodeAddon)
+    // Activate Unicode 11 widths (default v6 miscounts CJK cells). Must come
+    // AFTER loadAddon — the unicode property is provided by the addon.
+    terminal.unicode.activeVersion = '11'
 
     managed = {
       terminal,

--- a/frontend/src/services/terminalManager.ts
+++ b/frontend/src/services/terminalManager.ts
@@ -86,12 +86,6 @@ export function acquireTerminal(
     const fitAddon = new FitAddon()
     const searchAddon = new SearchAddon()
     const unicodeAddon = new Unicode11Addon()
-    // Activate Unicode 11 widths before any data is written. The default is
-    // v6, which under-counts cells for many CJK ideographs and full-width
-    // punctuation that Claude Code emits — the terminal would wrap rows at
-    // a different column than the backend PTY (which uses Unicode 11 widths
-    // too), producing the offset-between-rows table misalignment users see.
-    terminal.unicode.activeVersion = '11'
 
     terminal.loadAddon(fitAddon)
     terminal.loadAddon(searchAddon)


### PR DESCRIPTION
## PR-04: xterm 终端润色

把 xterm 在 Claude Code / 大表格 / 高频重绘场景下剩余的几个小毛病一次性收尾。

### 改动列表

- **CJK 宽度对齐**（`terminalManager.ts` + `BaseTerminal.vue`）
  把 `terminal.unicode.activeVersion = '11'` 从 `BaseTerminal.onMounted` 的 try/catch 里挪到 `acquireTerminal` 内、三个 addon 加载完之后。默认的 v6 宽度表会把很多 CJK/全角符号按 1 cell 算，导致在 Claude Code 的多列表格场景里首列列宽比后端 PTY（同样用 Unicode 11）窄半格，整张表跟着漂移。把设置从 `BaseTerminal` 移除，避免两份代码维护同一个开关。

- **`fitAddon` 测的尺寸是对的，别再用 `Math.floor` 重算**
  `BaseTerminal.resize` 之前用 `Math.floor((rect.width - TERMINAL_PADDING * 2 - scrollbarWidth) / cellWidth)` 重新推导 cols/rows，结果把滚动条重复减了一次，导致每一次 fit 出来都比预期少 1 列。直接信 `fitAddon.fit()` 之后 `terminal.cols`/`terminal.rows`。

- **resize 后强制 `terminal.refresh(0, rows-1)` 重画整个视口**
  Claude Code 的 braille spinner 是 cursor-position + erase + write 的突刺，xterm 的 canvas 在那个突刺里 fit/resize 时只缩放不擦，新内容叠在旧字模上变成幽灵字符。Resize 后立刻 `refresh` 一遍整块 canvas，幽灵字符没了。

- **`cellWidth`/`cellHeight` 加缓存**
  `resize()` 在一次拖拽里 50+ 次触发，每次都去摸 `_renderService.dimensions`（try/catch 包住的私有 API）。单元格尺寸只在 `fontSize` / `fontFamily` 变的时候变，按当前字体配置做 key 命中就跳过内部的 dimensions 读取。

- **卸载时 dispose addon**（`useTerminal.ts`，F-020）
  之前只有 `terminal.dispose()`，`FitAddon`、`WebLinksAddon`、`SearchAddon` 各自挂上去的 listener 和 WebLinks 的 tooltip 元素在新旧版本里有一致性问题，会出现一个 mount/unmount 循环泄露一次。统一把加载过的 addon 收进数组，卸载时按装入顺序反着 `dispose()`，并显式 detach WebLinks 的 hover 元素。

- **Unicode 11 设置时机修对**
  上面那个改动有个回马枪：`activeVersion` 必须在 `loadAddon(unicodeAddon)` 之后写，否则 `terminal.unicode` 还是 `undefined`，启动直接 TypeError。这个修复只是把设置挪到 loadAddon 之后。

- **`getCurrentCommandFromTerminal` 优先看光标行**
  （`useTerminalInput.ts`，F-022）之前每次回车都对所有可见行跑 `translateToString + stripAnsi + PROMPT_RE`，哪怕 90% 的情况下光标所在的行就是当前正在跑的指令。先采一行（命中即返回），再往下找 prompt 边界，找到就停，不全量扫。

- **`lineBuffer` 内部换成 `string[]`**
  （`useTerminalInput.ts`，F-023）之前每次可打印按键都 `slice + concat + slice`，中间插入或者粘贴大段时一个字符两次字符串拷贝。内部换成 char-array，splice 插入，对外仍是 `lineBuffer` 这个 writable computed 字符串（BaseTerminal 的读写 `.trim()`、判空逻辑零修改）。

- **右击菜单点击时重读 xterm 选区**
  （`useTerminalMenu.ts`）`hasSelection.value` 是 `contextmenu` 时抓的快照，但 WKWebView 里右键 mousedown → contextmenu → 用户点菜单这一段时间里 xterm 的选区可能被清空，结果菜单按钮看起来还能点，点完 `getSelection()` 返空，复制静默失败。`copySelection` 里直接重新调 `options.getSelection()`，信任权威来源。

- **`writeClipboard` 兜底 `navigator.clipboard`**
  （`useTerminalMenu.ts`）Wails 的 `ClipboardSetText` 是 `Promise<boolean>`：OS 拒绝（失焦、AppKit 权限抽风）走 `resolve(false)` 而不是 reject。之前的 try/catch 只捞 reject，分辨率为 false 的情况系统剪贴板真没东西，右键"复制"看起来不响应。现在把 resolve 值也纳入判断，落到 `navigator.clipboard.writeText`。

### 测试

新增两个 vitest 用例文件，共 21 个用例：

- `frontend/src/composables/useTerminalInput.test.ts`（14 个）
  - char-array lineBuffer 的读写与中文字符 round-trip
  - 中间插入 / 末尾追加 / Backspace / Ctrl+A/E/K/U 等编辑路径，确认 `splice` 而非字符串拼接
  - `getCurrentCommandFromTerminal` 在光标行命中、光标行无 prompt 需向上找 prompt、prompt 上方夹杂非 prompt 行时停止扫描、无 prompt 时返 null 的四种路径

- `frontend/src/composables/useTerminalMenu.test.ts`（7 个）
  - Wails resolve(true) / resolve(false) / reject 三种情况对 `navigator.clipboard.writeText` 的调用决策
  - `contextmenu` 时 `hasSelection` 标记与点击时 `getSelection()` 实际值不一致两种竞态的覆盖

vitest 当前 4.1.8 跑在 node 环境（项目没装 jsdom），用例用 `vi.mock` + 自带的 `MouseEvent` shim 解决。

### 文件

```
frontend/src/components/BaseTerminal.vue          |  38 +----
frontend/src/composables/useTerminal.ts           |  54 +++++--
frontend/src/composables/useTerminalInput.test.ts | 184 +++++++++++++
frontend/src/composables/useTerminalInput.ts      |  75 +++++----
frontend/src/composables/useTerminalMenu.test.ts  | 158 ++++++++++++
frontend/src/composables/useTerminalMenu.ts       |  12 +-
frontend/src/services/terminalManager.ts          |   3 +
7 files changed, 450 insertions(+), 74 deletions(-)
```

### 验证

- `npm --prefix frontend run build` 通过（4.0s，无 TS 报错）
- `npx --prefix frontend vitest run src/composables/useTerminalInput.test.ts src/composables/useTerminalMenu.test.ts` — 21/21 通过
- Cherry-pick 时把每条原 commit 的多行铺垫注释按项目「注释宜少不宜多」原则压成一行
- 未触及任何 Go 后端代码，未涉及 `wailsjs/*` 自动生成内容
- 终端列对齐 / 幽灵字符 / 复制无反应 / 右键菜单失效这几条问题都在单一路径上对应一处修复，避免叠改动
