### PR TITLE
[08/20] feat(theme): Win11 + macOS26 UI themes (CSS vars + component overrides + picker)

### DIFF
--- a/frontend/src/components/SettingsTab.vue
+++ b/frontend/src/components/SettingsTab.vue
@@ -30,6 +30,8 @@
                 <el-option :label="t('settings.themeDeepBlue')" value="deep-blue" />
                 <el-option :label="t('settings.themeLight')" value="light" />
                 <el-option :label="t('settings.themeSystem')" value="system" />
+                <el-option :label="t('settings.themeWin11')" value="win11" />
+                <el-option :label="t('settings.themeMacOS26')" value="macos26" />
               </el-select>
             </div>
           </div>

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -216,6 +216,8 @@
             <el-option :label="t('settings.themeDeepBlue')" value="deep-blue" />
             <el-option :label="t('settings.themeLight')" value="light" />
             <el-option :label="t('settings.themeSystem')" value="system" />
+            <el-option :label="t('settings.themeWin11')" value="win11" />
+            <el-option :label="t('settings.themeMacOS26')" value="macos26" />
           </el-select>
         </div>
         <div class="persist-section">

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -305,6 +305,8 @@
   "settings.themeDeepBlue": "Tiefblau",
   "settings.themeLight": "Hell",
   "settings.themeSystem": "System",
+  "settings.themeWin11": "Windows 11",
+  "settings.themeMacOS26": "macOS 26",
   "settings.language": "Sprache",
   "settings.langSystem": "Systemstandard",
   "settings.closeTabPrompt": "Tab-Schließen-Bestätigung",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -308,6 +308,8 @@
   "settings.themeDeepBlue": "Deep Blue",
   "settings.themeLight": "Light",
   "settings.themeSystem": "System",
+  "settings.themeWin11": "Windows 11",
+  "settings.themeMacOS26": "macOS 26",
   "settings.language": "Language",
   "settings.langSystem": "System Default",
   "settings.closeTabPrompt": "Close Tab Confirmation",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -305,6 +305,8 @@
   "settings.themeDeepBlue": "Azul Profundo",
   "settings.themeLight": "Claro",
   "settings.themeSystem": "Sistema",
+  "settings.themeWin11": "Windows 11",
+  "settings.themeMacOS26": "macOS 26",
   "settings.language": "Idioma",
   "settings.langSystem": "Predeterminado del Sistema",
   "settings.closeTabPrompt": "Confirmación al cerrar pestaña",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -305,6 +305,8 @@
   "settings.themeDeepBlue": "Bleu profond",
   "settings.themeLight": "Clair",
   "settings.themeSystem": "Système",
+  "settings.themeWin11": "Windows 11",
+  "settings.themeMacOS26": "macOS 26",
   "settings.language": "Langue",
   "settings.langSystem": "Valeur par défaut du système",
   "settings.closeTabPrompt": "Confirmation de fermeture d'onglet",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -305,6 +305,8 @@
   "settings.themeDeepBlue": "ディープブルー",
   "settings.themeLight": "ライト",
   "settings.themeSystem": "システム",
+  "settings.themeWin11": "Windows 11",
+  "settings.themeMacOS26": "macOS 26",
   "settings.language": "言語",
   "settings.langSystem": "システムの既定値",
   "settings.closeTabPrompt": "タブを閉じる確認",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -305,6 +305,8 @@
   "settings.themeDeepBlue": "딥블루",
   "settings.themeLight": "라이트",
   "settings.themeSystem": "시스템",
+  "settings.themeWin11": "Windows 11",
+  "settings.themeMacOS26": "macOS 26",
   "settings.language": "언어",
   "settings.langSystem": "시스템 기본값",
   "settings.closeTabPrompt": "탭 닫기 확인",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -305,6 +305,8 @@
   "settings.themeDeepBlue": "Глубокий синий",
   "settings.themeLight": "Светлая",
   "settings.themeSystem": "Системная",
+  "settings.themeWin11": "Windows 11",
+  "settings.themeMacOS26": "macOS 26",
   "settings.language": "Язык",
   "settings.langSystem": "Системный по умолчанию",
   "settings.closeTabPrompt": "Подтверждение закрытия вкладки",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -308,6 +308,8 @@
   "settings.themeDeepBlue": "深蓝",
   "settings.themeLight": "浅色",
   "settings.themeSystem": "跟随系统",
+  "settings.themeWin11": "Windows 11",
+  "settings.themeMacOS26": "macOS 26",
   "settings.language": "语言",
   "settings.langSystem": "系统默认",
   "settings.closeTabPrompt": "关闭标签页提示",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -305,6 +305,8 @@
   "settings.themeDeepBlue": "深藍",
   "settings.themeLight": "淺色",
   "settings.themeSystem": "跟隨系統",
+  "settings.themeWin11": "Windows 11",
+  "settings.themeMacOS26": "macOS 26",
   "settings.language": "語言",
   "settings.langSystem": "系統預設",
   "settings.closeTabPrompt": "關閉分頁提示",

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -337,6 +337,8 @@
     --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.5);
     --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.5);
     --scrim: rgba(0, 0, 0, 0.35);
+    --scrollbar-thumb: rgba(255, 255, 255, 0.18);
+    --scrollbar-thumb-hover: rgba(255, 255, 255, 0.3);
     --el-bg-color: #2c2c2c;
     --el-bg-color-page: #202020;
     --el-fill-color-blank: #2c2c2c;
@@ -1284,6 +1286,8 @@ body.drag-active .zone {
     --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
     --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.5);
     --scrim: rgba(0, 0, 0, 0.4);
+    --scrollbar-thumb: rgba(255, 255, 255, 0.20);
+    --scrollbar-thumb-hover: rgba(255, 255, 255, 0.32);
     --el-bg-color: #1e1e1e;
     --el-bg-color-page: #1e1e1e;
     --el-fill-color-blank: #1e1e1e;

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1188,3 +1188,124 @@ body.drag-active .zone {
   border: 1px solid var(--border-subtle);
   border-radius: 4px;
 }
+
+/* macOS 26 - light (Liquid Glass simulation) */
+[data-theme="macos26"] {
+  --bg-base: #ffffff;
+  --bg-elevated: #ececef;
+  --bg-surface: #ffffff;
+  --bg-overlay: #f5f5f7;
+  --bg-hover: #f0f0f3;
+  --bg-active: #e5e5e8;
+  --text-primary: #1d1d1f;
+  --text-secondary: #6e6e73;
+  --text-muted: #86868b;
+  --text-disabled: #a1a1a6;
+  --accent: #007aff;
+  --accent-glow: rgba(0, 122, 255, 0.20);
+  --accent-subtle: rgba(0, 122, 255, 0.10);
+  --info: #0064cd;
+  --info-subtle: rgba(0, 100, 205, 0.08);
+  --on-accent: #ffffff;
+  --chart-1: #30b257;
+  --chart-2: #1e88e5;
+  --chart-3: #ff9500;
+  --chart-4: #af52de;
+  --chart-4-alt: #c184e8;
+  --success: #28a745;
+  --success-dim: #1e7e34;
+  --success-subtle: rgba(40, 167, 69, 0.08);
+  --success-glow: rgba(40, 167, 69, 0.18);
+  --warning: #ff9500;
+  --warning-subtle: rgba(255, 149, 0, 0.10);
+  --error: #ff3b30;
+  --error-subtle: rgba(255, 59, 48, 0.08);
+  --error-glow: rgba(255, 59, 48, 0.18);
+  --border-subtle: rgba(0, 0, 0, 0.08);
+  --border-hover: rgba(0, 0, 0, 0.16);
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.04);
+  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.06);
+  --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.08);
+  --scrim: rgba(255, 255, 255, 0.5);
+  --font-ui: -apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Helvetica Neue', sans-serif;
+  --radius-sm: 4px;
+  --radius-md: 10px;
+  --radius-lg: 14px;
+  --scrollbar-thumb: rgba(0, 0, 0, 0.20);
+  --scrollbar-thumb-hover: rgba(0, 0, 0, 0.32);
+  --el-bg-color: #ffffff;
+  --el-bg-color-page: #ffffff;
+  --el-fill-color-blank: #ffffff;
+  --el-fill-color: #ececef;
+  --el-fill-color-light: #f5f5f7;
+  --el-fill-color-lighter: #f0f0f3;
+  --el-text-color-primary: #1d1d1f;
+  --el-text-color-regular: #6e6e73;
+  --el-text-color-secondary: #86868b;
+  --el-text-color-placeholder: #a1a1a6;
+  --el-border-color: rgba(0, 0, 0, 0.16);
+  --el-border-color-light: rgba(0, 0, 0, 0.10);
+  --el-border-color-lighter: rgba(0, 0, 0, 0.08);
+  --el-input-height: 28px;
+  --el-component-size: 28px;
+}
+
+/* macOS 26 - dark (Liquid Glass dark) */
+@media (prefers-color-scheme: dark) {
+  [data-theme="macos26"] {
+    --bg-base: #1e1e1e;
+    --bg-elevated: #2c2c2e;
+    --bg-surface: #1e1e1e;
+    --bg-overlay: #3a3a3c;
+    --bg-hover: #3a3a3c;
+    --bg-active: #48484a;
+    --text-primary: #f5f5f7;
+    --text-secondary: #aeaeb2;
+    --text-muted: #8e8e93;
+    --text-disabled: #636366;
+    --accent: #0a84ff;
+    --accent-glow: rgba(10, 132, 255, 0.22);
+    --accent-subtle: rgba(10, 132, 255, 0.12);
+    --info: #64d2ff;
+    --info-subtle: rgba(100, 210, 255, 0.10);
+    --on-accent: #ffffff;
+    --success: #30d158;
+    --success-dim: #28a745;
+    --success-subtle: rgba(48, 209, 88, 0.10);
+    --success-glow: rgba(48, 209, 88, 0.20);
+    --warning: #ff9f0a;
+    --warning-subtle: rgba(255, 159, 10, 0.12);
+    --error: #ff453a;
+    --error-subtle: rgba(255, 69, 58, 0.10);
+    --error-glow: rgba(255, 69, 58, 0.20);
+    --border-subtle: rgba(255, 255, 255, 0.08);
+    --border-hover: rgba(255, 255, 255, 0.18);
+    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.3);
+    --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
+    --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.5);
+    --scrim: rgba(0, 0, 0, 0.4);
+    --el-bg-color: #1e1e1e;
+    --el-bg-color-page: #1e1e1e;
+    --el-fill-color-blank: #1e1e1e;
+    --el-fill-color: #2c2c2e;
+    --el-fill-color-light: #3a3a3c;
+    --el-fill-color-lighter: #48484a;
+    --el-text-color-primary: #f5f5f7;
+    --el-text-color-regular: #aeaeb2;
+    --el-text-color-secondary: #8e8e93;
+    --el-text-color-placeholder: #636366;
+    --el-border-color: rgba(255, 255, 255, 0.18);
+    --el-border-color-light: rgba(255, 255, 255, 0.10);
+    --el-border-color-lighter: rgba(255, 255, 255, 0.08);
+  }
+}
+
+/* macOS 26 - body Liquid Glass radial gradient */
+[data-theme="macos26"] body {
+  background: radial-gradient(ellipse at top, rgba(255, 255, 255, 0.6) 0%, transparent 50%), var(--bg-base);
+}
+@media (prefers-color-scheme: dark) {
+  [data-theme="macos26"] body {
+    background: radial-gradient(ellipse at top, rgba(255, 255, 255, 0.04) 0%, transparent 60%), var(--bg-base);
+  }
+}

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -242,6 +242,127 @@
   --scrollbar-thumb-hover: rgba(0, 0, 0, 0.35);
 }
 
+/* Windows 11 - mica light */
+[data-theme="win11"] {
+  --bg-base: #fafafa;
+  --bg-elevated: #f3f3f3;
+  --bg-surface: #ffffff;
+  --bg-overlay: #ebebeb;
+  --bg-hover: #e5e5e5;
+  --bg-active: #d9d9d9;
+  --text-primary: #1c1c1c;
+  --text-secondary: #5c5c5c;
+  --text-muted: #707070;
+  --text-disabled: #9a9a9a;
+  --accent: #0078d4;
+  --accent-glow: rgba(0, 120, 212, 0.22);
+  --accent-subtle: rgba(0, 120, 212, 0.08);
+  --info: #006ab1;
+  --info-subtle: rgba(0, 106, 177, 0.08);
+  --on-accent: #ffffff;
+  --chart-1: #16a34a;
+  --chart-2: #2563eb;
+  --chart-3: #d97706;
+  --chart-4: #7c3aed;
+  --chart-4-alt: #a78bfa;
+  --success: #107c41;
+  --success-dim: #0b5e30;
+  --success-subtle: rgba(16, 124, 65, 0.06);
+  --success-glow: rgba(16, 124, 65, 0.15);
+  --warning: #e07b00;
+  --warning-subtle: rgba(224, 123, 0, 0.08);
+  --error: #d13438;
+  --error-subtle: rgba(209, 52, 56, 0.06);
+  --error-glow: rgba(209, 52, 56, 0.15);
+  --border-subtle: rgba(0, 0, 0, 0.0578);
+  --border-hover: rgba(0, 0, 0, 0.16);
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.06);
+  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
+  --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.10);
+  --scrim: rgba(255, 255, 255, 0.6);
+  --font-ui: 'Segoe UI Variable Text', 'Segoe UI', system-ui, -apple-system, sans-serif;
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 8px;
+  --scrollbar-thumb: rgba(0, 0, 0, 0.22);
+  --scrollbar-thumb-hover: rgba(0, 0, 0, 0.35);
+  --el-bg-color: #ffffff;
+  --el-bg-color-page: #fafafa;
+  --el-fill-color-blank: #ffffff;
+  --el-fill-color: #f3f3f3;
+  --el-fill-color-light: #ebebeb;
+  --el-fill-color-lighter: #e5e5e5;
+  --el-text-color-primary: #1c1c1c;
+  --el-text-color-regular: #5c5c5c;
+  --el-text-color-secondary: #707070;
+  --el-text-color-placeholder: #9a9a9a;
+  --el-border-color: rgba(0, 0, 0, 0.16);
+  --el-border-color-light: rgba(0, 0, 0, 0.10);
+  --el-border-color-lighter: rgba(0, 0, 0, 0.0578);
+  --el-input-height: 28px;
+  --el-component-size: 28px;
+}
+
+/* Windows 11 - mica dark (auto-toggled by OS appearance) */
+@media (prefers-color-scheme: dark) {
+  [data-theme="win11"] {
+    --bg-base: #202020;
+    --bg-elevated: #2c2c2c;
+    --bg-surface: #2c2c2c;
+    --bg-overlay: #383838;
+    --bg-hover: #3f3f3f;
+    --bg-active: #4a4a4a;
+    --text-primary: #f0f0f0;
+    --text-secondary: #c8c8c8;
+    --text-muted: #a0a0a0;
+    --text-disabled: #6a6a6a;
+    --accent: #4cc2ff;
+    --accent-glow: rgba(76, 194, 255, 0.22);
+    --accent-subtle: rgba(76, 194, 255, 0.08);
+    --info: #5eb3f5;
+    --info-subtle: rgba(94, 179, 245, 0.1);
+    --on-accent: #000000;
+    --success: #34d399;
+    --success-dim: #059669;
+    --success-subtle: rgba(52, 211, 153, 0.06);
+    --success-glow: rgba(52, 211, 153, 0.15);
+    --warning: #f59e0b;
+    --warning-subtle: rgba(245, 158, 11, 0.1);
+    --error: #f87171;
+    --error-subtle: rgba(248, 113, 113, 0.06);
+    --error-glow: rgba(248, 113, 113, 0.15);
+    --border-subtle: rgba(255, 255, 255, 0.0837);
+    --border-hover: rgba(255, 255, 255, 0.16);
+    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+    --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.5);
+    --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.5);
+    --scrim: rgba(0, 0, 0, 0.35);
+    --el-bg-color: #2c2c2c;
+    --el-bg-color-page: #202020;
+    --el-fill-color-blank: #2c2c2c;
+    --el-fill-color: #2c2c2c;
+    --el-fill-color-light: #383838;
+    --el-fill-color-lighter: #3f3f3f;
+    --el-text-color-primary: #f0f0f0;
+    --el-text-color-regular: #c8c8c8;
+    --el-text-color-secondary: #a0a0a0;
+    --el-text-color-placeholder: #6a6a6a;
+    --el-border-color: rgba(255, 255, 255, 0.16);
+    --el-border-color-light: rgba(255, 255, 255, 0.10);
+    --el-border-color-lighter: rgba(255, 255, 255, 0.0837);
+  }
+}
+
+/* Windows 11 - body background gradient (Mica simulation) */
+[data-theme="win11"] body {
+  background: linear-gradient(180deg, #fafbfc 0%, #f3f3f3 100%);
+}
+@media (prefers-color-scheme: dark) {
+  [data-theme="win11"] body {
+    background: linear-gradient(180deg, #2b2b2b 0%, #202020 100%);
+  }
+}
+
 * {
   margin: 0;
   padding: 0;

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1112,18 +1112,33 @@ body.drag-active .zone {
 }
 [data-theme="win11"] .el-tabs__active-bar { display: none; }
 
-/* Buttons: 4px radius, accent primary, subtle secondary */
-[data-theme="win11"] .el-button { border-radius: 4px; font-weight: 400; }
+/* Buttons: Fluent-style 32px tall, 4px radius, accent primary with subtle shadow */
+[data-theme="win11"] .el-button {
+  height: 32px !important;
+  padding: 6px 16px !important;
+  font-size: 13px !important;
+  border-radius: 4px;
+  font-weight: 400;
+}
 [data-theme="win11"] .el-button--primary {
   background: var(--accent);
   border-color: var(--accent);
   color: var(--on-accent);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1), inset 0 -1px 0 rgba(0, 0, 0, 0.05);
 }
-[data-theme="win11"] .el-button--primary:hover { filter: brightness(1.08); }
+[data-theme="win11"] .el-button--primary:hover {
+  filter: brightness(1.05);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15), inset 0 -1px 0 rgba(0, 0, 0, 0.08);
+}
 [data-theme="win11"] .el-button:not(.el-button--primary):not(.el-button--text) {
-  background: var(--bg-elevated);
-  border-color: var(--border-subtle);
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
   color: var(--text-primary);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+}
+[data-theme="win11"] .el-button:not(.el-button--primary):not(.el-button--text):hover {
+  background: var(--bg-hover);
+  border-color: var(--border-hover);
 }
 
 /* Inputs: bottom-border only */
@@ -1167,10 +1182,19 @@ body.drag-active .zone {
   background: var(--accent);
 }
 
-/* Checkbox / Radio: 2px corner radius */
+/* Checkbox / Radio: 2px corner radius, 16px, hover state with accent border */
 [data-theme="win11"] .el-checkbox__inner,
-[data-theme="win11"] .el-radio__inner { border-radius: 2px; }
-[data-theme="win11"] .el-checkbox__inner { border-width: 1px; }
+[data-theme="win11"] .el-radio__inner {
+  border-radius: 2px;
+  width: 16px;
+  height: 16px;
+  border-width: 1px;
+  background: var(--bg-surface);
+}
+[data-theme="win11"] .el-checkbox__inner:hover,
+[data-theme="win11"] .el-radio__inner:hover {
+  border-color: var(--accent);
+}
 
 /* Scrollbar: 8px wide, fades in on hover */
 [data-theme="win11"] ::-webkit-scrollbar { width: 8px; height: 8px; }
@@ -1341,18 +1365,34 @@ body.drag-active .zone {
   border-radius: 1px;
 }
 
-/* Buttons: 6px radius, no border on primary */
-[data-theme="macos26"] .el-button { border-radius: 6px; font-weight: 500; }
+/* Buttons: pill-shaped capsule, 14px radius, accent primary with subtle fill */
+[data-theme="macos26"] .el-button {
+  height: 30px !important;
+  padding: 4px 18px !important;
+  font-size: 13px !important;
+  border-radius: 14px;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+}
 [data-theme="macos26"] .el-button--primary {
   background: var(--accent);
   border: none;
   color: var(--on-accent);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
 }
-[data-theme="macos26"] .el-button--primary:hover { filter: brightness(1.08); }
+[data-theme="macos26"] .el-button--primary:hover {
+  filter: brightness(1.06);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.12);
+}
 [data-theme="macos26"] .el-button:not(.el-button--primary):not(.el-button--text) {
   background: var(--bg-overlay);
   border: 1px solid var(--border-subtle);
   color: var(--text-primary);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+}
+[data-theme="macos26"] .el-button:not(.el-button--primary):not(.el-button--text):hover {
+  background: var(--bg-hover);
+  border-color: var(--border-hover);
 }
 
 /* Inputs: full border 1px, 6px radius, 2px focus ring */
@@ -1386,9 +1426,19 @@ body.drag-active .zone {
 }
 [data-theme="macos26"] .el-menu-item.is-active::before { display: none; }
 
-/* Checkbox / Radio: 4px corner radius (rounder than Win11) */
+/* Checkbox / Radio: 4px corner radius (rounder than Win11), 16px, hover state with accent border */
 [data-theme="macos26"] .el-checkbox__inner,
-[data-theme="macos26"] .el-radio__inner { border-radius: 4px; }
+[data-theme="macos26"] .el-radio__inner {
+  border-radius: 4px;
+  width: 16px;
+  height: 16px;
+  border-width: 1.5px;
+  background: var(--bg-surface);
+}
+[data-theme="macos26"] .el-checkbox__inner:hover,
+[data-theme="macos26"] .el-radio__inner:hover {
+  border-color: var(--accent);
+}
 
 /* Scrollbar */
 [data-theme="macos26"] ::-webkit-scrollbar { width: 8px; height: 8px; }

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1309,3 +1309,122 @@ body.drag-active .zone {
     background: radial-gradient(ellipse at top, rgba(255, 255, 255, 0.04) 0%, transparent 60%), var(--bg-base);
   }
 }
+
+/* ====================================================================
+   macOS 26 - component overrides
+   ==================================================================== */
+
+/* Tabs: rounder, 2px accent underline on active (no block) */
+[data-theme="macos26"] .el-tabs__item {
+  border-radius: 10px;
+  padding: 0 12px;
+  height: 32px;
+  line-height: 32px;
+  color: var(--text-secondary);
+  background: transparent;
+  transition: color 0.12s ease;
+}
+[data-theme="macos26"] .el-tabs__item:hover { color: var(--text-primary); }
+[data-theme="macos26"] .el-tabs__item.is-active,
+[data-theme="macos26"] .el-tabs__item.is-active:hover {
+  color: var(--accent);
+  font-weight: 600;
+  background: transparent;
+}
+[data-theme="macos26"] .el-tabs__active-bar {
+  background: var(--accent);
+  height: 2px;
+  border-radius: 1px;
+}
+
+/* Buttons: 6px radius, no border on primary */
+[data-theme="macos26"] .el-button { border-radius: 6px; font-weight: 500; }
+[data-theme="macos26"] .el-button--primary {
+  background: var(--accent);
+  border: none;
+  color: var(--on-accent);
+}
+[data-theme="macos26"] .el-button--primary:hover { filter: brightness(1.08); }
+[data-theme="macos26"] .el-button:not(.el-button--primary):not(.el-button--text) {
+  background: var(--bg-overlay);
+  border: 1px solid var(--border-subtle);
+  color: var(--text-primary);
+}
+
+/* Inputs: full border 1px, 6px radius, 2px focus ring */
+[data-theme="macos26"] .el-input__wrapper {
+  background: var(--bg-surface);
+  box-shadow: 0 0 0 1px var(--border-subtle);
+  border-radius: 6px;
+}
+[data-theme="macos26"] .el-input__wrapper.is-focus {
+  box-shadow: 0 0 0 2px var(--accent);
+}
+[data-theme="macos26"] .el-textarea__inner {
+  border-radius: 6px;
+  border: 1px solid var(--border-subtle);
+  background: var(--bg-surface);
+}
+[data-theme="macos26"] .el-textarea__inner:focus { border-color: var(--accent); }
+
+/* Dialog: 14px radius, soft shadow */
+[data-theme="macos26"] .el-dialog,
+[data-theme="macos26"] .el-message-box {
+  border-radius: 14px;
+  background: var(--bg-surface);
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.12);
+}
+
+/* Menu: macOS-style subtle background on active, no left bar */
+[data-theme="macos26"] .el-menu-item.is-active {
+  background: var(--accent-subtle);
+  color: var(--accent);
+}
+[data-theme="macos26"] .el-menu-item.is-active::before { display: none; }
+
+/* Checkbox / Radio: 4px corner radius (rounder than Win11) */
+[data-theme="macos26"] .el-checkbox__inner,
+[data-theme="macos26"] .el-radio__inner { border-radius: 4px; }
+
+/* Scrollbar */
+[data-theme="macos26"] ::-webkit-scrollbar { width: 8px; height: 8px; }
+[data-theme="macos26"] ::-webkit-scrollbar-thumb {
+  background: var(--scrollbar-thumb);
+  border-radius: 4px;
+}
+[data-theme="macos26"] ::-webkit-scrollbar-thumb:hover {
+  background: var(--scrollbar-thumb-hover);
+}
+
+/* Sidebar: force the macOS darker-sidebar look.
+   The existing .sidebar class lives in Sidebar.vue — this rule overrides
+   its background to --bg-elevated (the macOS signature darker-than-content
+   shade). No .vue change needed. */
+[data-theme="macos26"] .sidebar { background: var(--bg-elevated); }
+
+/* AppHeader: subtle backdrop (Liquid Glass lite).
+   NOTE: AppHeader.vue already paints a 1px hairline via .app-header::after,
+   so we deliberately omit `border-bottom` here to avoid stacking a 2px line. */
+[data-theme="macos26"] .app-header {
+  background: rgba(255, 255, 255, 0.7);
+  backdrop-filter: saturate(180%) blur(20px);
+}
+@media (prefers-color-scheme: dark) {
+  [data-theme="macos26"] .app-header {
+    background: rgba(30, 30, 30, 0.7);
+  }
+}
+
+/* Sidebar personalization panel: 14px row spacing (looser than Win11) */
+[data-theme="macos26"] .personalization-panel .persist-section { margin-bottom: 14px; }
+
+/* SettingsTab: 12px gap, no left bar */
+[data-theme="macos26"] .settings-tab-content .settings-section { margin-bottom: 12px; }
+[data-theme="macos26"] .settings-tab-content .settings-section.active { box-shadow: none; }
+
+/* BaseTerminal: rounded 8px frame.
+   NOTE: BaseTerminal.vue uses class="base-terminal", not .terminal-frame. */
+[data-theme="macos26"] .base-terminal {
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+}

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1085,3 +1085,106 @@ body.drag-active .zone {
 .el-autocomplete-suggestion .el-select-dropdown__item {
   font-size: 12px !important;
 }
+
+/* ====================================================================
+   Windows 11 - component overrides
+   ==================================================================== */
+
+/* Tabs: 8px rounded rectangles, accent block on active */
+[data-theme="win11"] .el-tabs__item {
+  border-radius: 8px;
+  padding: 0 16px;
+  height: 32px;
+  line-height: 32px;
+  color: var(--text-primary);
+  transition: background-color 0.1s ease;
+}
+[data-theme="win11"] .el-tabs__item:hover {
+  background: var(--bg-hover);
+}
+[data-theme="win11"] .el-tabs__item.is-active,
+[data-theme="win11"] .el-tabs__item.is-active:hover {
+  background: var(--accent);
+  color: var(--on-accent);
+  font-weight: 500;
+}
+[data-theme="win11"] .el-tabs__active-bar { display: none; }
+
+/* Buttons: 4px radius, accent primary, subtle secondary */
+[data-theme="win11"] .el-button { border-radius: 4px; font-weight: 400; }
+[data-theme="win11"] .el-button--primary {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--on-accent);
+}
+[data-theme="win11"] .el-button--primary:hover { filter: brightness(1.08); }
+[data-theme="win11"] .el-button:not(.el-button--primary):not(.el-button--text) {
+  background: var(--bg-elevated);
+  border-color: var(--border-subtle);
+  color: var(--text-primary);
+}
+
+/* Inputs: bottom-border only */
+[data-theme="win11"] .el-input__wrapper {
+  background: transparent;
+  box-shadow: none;
+  border-radius: 4px 4px 0 0;
+  border-bottom: 1px solid var(--border-subtle);
+}
+[data-theme="win11"] .el-input__wrapper:hover { border-bottom-color: var(--border-hover); }
+[data-theme="win11"] .el-input__wrapper.is-focus {
+  border-bottom-color: var(--accent);
+  box-shadow: 0 1px 0 0 var(--accent);
+}
+[data-theme="win11"] .el-textarea__inner {
+  border-radius: 4px;
+  border: 1px solid var(--border-subtle);
+  background: var(--bg-surface);
+}
+[data-theme="win11"] .el-textarea__inner:focus { border-color: var(--accent); }
+
+/* Dialog: 8px radius, deep shadow */
+[data-theme="win11"] .el-dialog,
+[data-theme="win11"] .el-message-box {
+  border-radius: 8px;
+  background: var(--bg-surface);
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.18), 0 0 0 1px rgba(0, 0, 0, 0.04);
+}
+
+/* Menu: 3px accent bar on active */
+[data-theme="win11"] .el-menu-item.is-active {
+  background: var(--accent-subtle);
+  color: var(--accent);
+  position: relative;
+}
+[data-theme="win11"] .el-menu-item.is-active::before {
+  content: '';
+  position: absolute;
+  left: 0; top: 0; bottom: 0;
+  width: 3px;
+  background: var(--accent);
+}
+
+/* Checkbox / Radio: 2px corner radius */
+[data-theme="win11"] .el-checkbox__inner,
+[data-theme="win11"] .el-radio__inner { border-radius: 2px; }
+[data-theme="win11"] .el-checkbox__inner { border-width: 1px; }
+
+/* Scrollbar: 8px wide, fades in on hover */
+[data-theme="win11"] ::-webkit-scrollbar { width: 8px; height: 8px; }
+[data-theme="win11"] ::-webkit-scrollbar-thumb {
+  background: var(--scrollbar-thumb);
+  border-radius: 4px;
+}
+[data-theme="win11"] ::-webkit-scrollbar-thumb:hover {
+  background: var(--scrollbar-thumb-hover);
+}
+
+/* Sidebar personalization panel: tighter 12px row spacing */
+[data-theme="win11"] .personalization-panel .persist-section { margin-bottom: 12px; }
+
+/* BaseTerminal outer frame: subtle border that matches Win11 surface */
+[data-theme="win11"] .base-terminal {
+  border: 1px solid var(--border-subtle);
+  border-radius: 4px;
+}

--- a/frontend/src/types/settings.test.ts
+++ b/frontend/src/types/settings.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { SUPPORTED_LOCALES } from './settings'
+
+// Regression guard for PR-08 (Win11 + macOS26 UI themes).
+// Every theme added to the Theme union must have a matching
+// settings.themeXxx key in every supported locale, otherwise
+// the picker falls back to the raw i18n key as the label.
+
+const ALL_THEMES = ['dark', 'deep-blue', 'light', 'system', 'win11', 'macos26'] as const
+
+// Map Theme -> i18n key suffix used in locale files.
+// Hand-maintained because 'macos26' capitalizes to 'MacOS26' (not 'Macos26'),
+// and 'deep-blue' would otherwise lose its hyphen handling.
+const THEME_KEYS: Record<(typeof ALL_THEMES)[number], string> = {
+  'dark': 'themeDark',
+  'deep-blue': 'themeDeepBlue',
+  'light': 'themeLight',
+  'system': 'themeSystem',
+  'win11': 'themeWin11',
+  'macos26': 'themeMacOS26',
+}
+
+const localesDir = join(__dirname, '..', 'i18n', 'locales')
+
+function loadLocale(name: string): Record<string, unknown> {
+  return JSON.parse(readFileSync(join(localesDir, `${name}.json`), 'utf-8'))
+}
+
+describe('settings theme picker / locale registration', () => {
+  it('every Theme has a settings.theme* key in every supported locale', () => {
+    const missing: string[] = []
+    for (const locale of SUPPORTED_LOCALES) {
+      const data = loadLocale(locale) as Record<string, unknown>
+      for (const theme of ALL_THEMES) {
+        const key = `settings.${THEME_KEYS[theme]}`
+        if (!(key in data)) {
+          missing.push(`${locale}: ${key}`)
+        }
+      }
+    }
+    expect(missing).toEqual([])
+  })
+
+  it('every supported locale has a non-empty label for Win11 and macOS26', () => {
+    for (const locale of SUPPORTED_LOCALES) {
+      const data = loadLocale(locale) as Record<string, string>
+      expect(data['settings.themeWin11']?.length ?? 0).toBeGreaterThan(0)
+      expect(data['settings.themeMacOS26']?.length ?? 0).toBeGreaterThan(0)
+    }
+  })
+
+  it('locale files on disk match SUPPORTED_LOCALES (no missing, no orphans)', () => {
+    const files = readdirSync(localesDir)
+      .filter(f => f.endsWith('.json'))
+      .map(f => f.replace(/\.json$/, ''))
+      .sort()
+    const supported = [...SUPPORTED_LOCALES].sort()
+    expect(files).toEqual(supported)
+  })
+})

--- a/frontend/src/types/settings.ts
+++ b/frontend/src/types/settings.ts
@@ -4,7 +4,7 @@ export const SUPPORTED_LOCALES = [
 
 export type Locale = typeof SUPPORTED_LOCALES[number]
 export type Language = Locale | 'system'
-export type Theme = 'dark' | 'deep-blue' | 'light' | 'system'
+export type Theme = 'dark' | 'deep-blue' | 'light' | 'system' | 'win11' | 'macos26'
 export type TerminalTheme = 'uniterm-dark' | 'uniterm-light' | 'solarized-dark' | 'solarized-light' | 'monokai' | 'dracula' | 'molokai' | 'tomorrow-night' | 'tomorrow-night-bright' | 'tomorrow' | 'one-dark' | 'one-light' | 'github-dark' | 'github-light' | 'gotham' | 'hybrid' | 'nord' | 'gruvbox-dark' | 'gruvbox-light' | 'catppuccin-mocha' | 'catppuccin-latte' | 'tokyo-night' | 'tokyo-day' | 'rose-pine' | 'rose-pine-dawn' | 'everforest-dark' | 'everforest-light'
 
 // xterm.js's ITheme shape: the 4 base colors plus the 16 ANSI colors, all as hex strings.


### PR DESCRIPTION
## 概述

为前端增加 Windows 11 与 macOS 26 两套 UI 主题，覆盖 CSS 变量、组件级覆写、以及选择器注册与多语言。

> 注：本 PR 是上游 #302 的超集 — 在「主题色跟随 accent」之外额外引入了完整的 Win11 / macOS26 组件覆写（如 Tab、Button、Input、Dialog、Menu、Scrollbar）。

## 改动

### CSS 变量（亮色 + 暗色 via `@media`）
- Win11：Mica 渐变背景、accent `#0078d4`（亮）/ `#4cc2ff`（暗）、Segoe UI Variable 字体、8px 圆角。
- macOS26：Liquid Glass 径向渐变、accent `#007aff`（亮）/ `#0a84ff`（暗）、SF Pro 字体、10–14px 圆角。Sidebar 强制走 `--bg-elevated` 以复刻 macOS 视觉签名。

### 组件覆写（作用域 `[data-theme="win11"|"macos26"]`，不影响其他主题）
- Tab、Button、Input、Dialog、Menu、Checkbox/Radio、Scrollbar、BaseTerminal 边框与密度按平台调优。
- Win11：32px Fluent 高度按钮、4px 圆角、底部边框输入框、激活菜单左侧 3px accent 条。
- macOS26：30px 胶囊按钮、6px 输入框全边框、14px Dialog 圆角、半透明 AppHeader。
- 暗色 `--scrollbar-thumb` 在两个主题里都补充了白色调的覆写，否则会继承亮色的 `rgba(0,0,0,…)` 在暗色背景上几乎不可见。

### 选择器注册与多语言
- `Theme` 类型扩展：`'dark' | 'deep-blue' | 'light' | 'system' | 'win11' | 'macos26'`。
- `Sidebar.vue` / `SettingsTab.vue` 增加 `<el-option>` 条目。
- 9 个 locale（zh-CN / zh-TW / en / ja / ko / de / es / fr / ru）同步增加 `settings.themeWin11` / `settings.themeMacOS26` 文案键。

## 测试

新增 `frontend/src/types/settings.test.ts`：
1. 每个 `Theme` id 在所有 `SUPPORTED_LOCALES` 中都有对应的 `settings.theme*` 键。
2. Win11 / macOS26 在所有 locale 下文案非空。
3. 磁盘上的 locale 文件集合与 `SUPPORTED_LOCALES` 一一对应（无遗漏、无孤儿）。

```
$ npx vitest run src/types/settings.test.ts
 Test Files  1 passed (1)
      Tests  3 passed (3)
```

## 构建

- `npm --prefix frontend run build`：通过。
- `go test ./backend/...`：通过。
- `go build ./...`：通过。
- `npx vitest run`：新增的 settings.test.ts 3/3 通过；其余 5 个失败用例为基线上已存在的回归（与本 PR 无关，在 origin/main 上同样失败）。

## 文件改动

```
 frontend/src/components/SettingsTab.vue |   2 +
 frontend/src/components/Sidebar.vue     |   2 +
 frontend/src/i18n/locales/de.json       |   2 +
 frontend/src/i18n/locales/en.json       |   2 +
 frontend/src/i18n/locales/es.json       |   2 +
 frontend/src/i18n/locales/fr.json       |   2 +
 frontend/src/i18n/locales/ja.json       |   2 +
 frontend/src/i18n/locales/ko.json       |   2 +
 frontend/src/i18n/locales/ru.json       |   2 +
 frontend/src/i18n/locales/zh-CN.json    |   2 +
 frontend/src/i18n/locales/zh-TW.json    |   2 +
 frontend/src/style.css                  | 518 ++++++++++++++++++++++++++++++++
 frontend/src/types/settings.ts          |   2 +-
 frontend/src/types/settings.test.ts     |  62 +++++ (新增)
```

## 关联

- 上游 #302（unify accent color to follow theme）的超集。
