### PR TITLE
[10/20] perf(ai-store): memoize conversation + lazy parse + doSave debounce

### DIFF
--- a/frontend/src/stores/aiStore.test.ts
+++ b/frontend/src/stores/aiStore.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { nextTick } from 'vue'
 import { setActivePinia, createPinia } from 'pinia'
 
 // ---- mock wails + i18n so the store module can be imported ----
@@ -86,5 +87,125 @@ describe('aiStore message queue', () => {
     store.switchSession(sessionA)       // switching sessions must clear the queue
     expect(store.currentSessionId).toBe(sessionA)
     expect(store.queuedMessages).toHaveLength(0)
+  })
+})
+
+describe('aiStore conversation memoization (F-301)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('returns the same conversation reference until the version bumps', async () => {
+    const store = useAIStore()
+    store.createSession()
+    store.addMessage({ id: 'm1', role: 'user', content: 'hello' } as any)
+    await nextTick()
+
+    const first = store.conversation
+    expect(first).toBeDefined()
+    expect(first.length).toBe(1)
+
+    // Mutate the existing message (simulate per-token content +=)
+    const msg = store.messages[0]
+    msg.content = 'hello world'
+    await nextTick()
+
+    // Conversation reference should be stable — version hasn't bumped
+    expect(store.conversation).toBe(first)
+
+    // addMessage bumps version -> new reference
+    store.addMessage({ id: 'm2', role: 'assistant', content: 'hi' } as any)
+    await nextTick()
+    expect(store.conversation).not.toBe(first)
+  })
+})
+
+describe('aiStore lazy _rawApiMsg parse (F-316)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('parses _rawApiMsg only on switchSession, not at load time', async () => {
+    const raw = { role: 'assistant', content: [{ type: 'text', text: 'ok' }] }
+    const rawJson = JSON.stringify(raw)
+    const { LoadAISessions } = await import('../../wailsjs/go/main/App')
+    vi.mocked(LoadAISessions).mockResolvedValue({
+      sessions: [{
+        id: 's1',
+        name: 's1',
+        createdAt: 0,
+        updatedAt: 0,
+        messages: [{ id: 'm1', role: 'assistant', content: 'ok', _rawApiMsg: rawJson }]
+      }],
+      currentSessionId: 's1'
+    })
+
+    const store = useAIStore()
+    // We bypass init() and feed sessions directly to isolate the lazy-parse path
+    // init() always creates a fresh session ("Always start with a fresh session
+    // after restart"), so the lazy parse path is owned by switchSession().
+    store.sessions.push({
+      id: 's1',
+      name: 's1',
+      createdAt: 0,
+      updatedAt: 0,
+      messages: [{ id: 'm1', role: 'assistant', content: 'ok', _rawApiMsg: rawJson } as any]
+    })
+    expect(typeof store.sessions[0].messages[0]._rawApiMsg).toBe('string')
+
+    store.switchSession('s1')
+
+    // After switchSession, _rawApiMsg is parsed in place
+    expect(typeof store.sessions[0].messages[0]._rawApiMsg).toBe('object')
+    expect(store.sessions[0].messages[0]._rawApiMsg).toEqual(raw)
+  })
+})
+
+describe('aiStore doSave debounce (F-304)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.useFakeTimers()
+  })
+
+  it('coalesces a burst of addMessage calls into a single save', async () => {
+    const { SaveAISessions } = await import('../../wailsjs/go/main/App')
+    vi.mocked(SaveAISessions).mockClear()
+
+    const store = useAIStore()
+    store.createSession()
+    store.addMessage({ id: 'm1', role: 'user', content: 'one' } as any)
+    store.addMessage({ id: 'm2', role: 'assistant', content: 'two' } as any)
+    store.addMessage({ id: 'm3', role: 'user', content: 'three' } as any)
+
+    // No save has fired yet — debounce timer is pending
+    expect(vi.mocked(SaveAISessions)).not.toHaveBeenCalled()
+
+    // Advance past the 500ms debounce window
+    await vi.advanceTimersByTimeAsync(500)
+
+    expect(vi.mocked(SaveAISessions)).toHaveBeenCalledTimes(1)
+
+    vi.useRealTimers()
+  })
+
+  it('renameSession flushes immediately and cancels pending debounce', async () => {
+    const { SaveAISessions } = await import('../../wailsjs/go/main/App')
+    vi.mocked(SaveAISessions).mockClear()
+
+    const store = useAIStore()
+    store.createSession()
+    const sessionId = store.currentSessionId!
+    store.addMessage({ id: 'm1', role: 'user', content: 'one' } as any)
+
+    // renameSession should hit the bridge without waiting 500ms
+    store.renameSession(sessionId, 'renamed')
+    await vi.advanceTimersByTimeAsync(0)
+    expect(vi.mocked(SaveAISessions)).toHaveBeenCalledTimes(1)
+
+    // Advancing past the debounce window must NOT cause a second save
+    await vi.advanceTimersByTimeAsync(500)
+    expect(vi.mocked(SaveAISessions)).toHaveBeenCalledTimes(1)
+
+    vi.useRealTimers()
   })
 })

--- a/frontend/src/stores/aiStore.ts
+++ b/frontend/src/stores/aiStore.ts
@@ -29,6 +29,21 @@ function estimateTokens(text: string): number {
 // against any remaining hot reads) doesn't re-stringify _rawApiMsg.
 const tokenEstimateCache = new WeakMap<AIMessage, number>()
 
+// F-314: cache the serialized _rawApiMsg JSON per message so doSave doesn't
+// re-stringify on every save. The raw API block is set once per assistant
+// message by the LLM and never mutated thereafter, so the cached form is
+// stable for the lifetime of the message.
+const rawApiMsgJsonCache = new WeakMap<AIMessage, string>()
+
+function getRawApiMsgJson(msg: AIMessage): string {
+  if (!msg._rawApiMsg) return ''
+  const cached = rawApiMsgJsonCache.get(msg)
+  if (cached !== undefined) return cached
+  const json = JSON.stringify(msg._rawApiMsg)
+  rawApiMsgJsonCache.set(msg, json)
+  return json
+}
+
 /**
  * Estimate tokens for an AIMessage, including content, tool_calls, and
  * serialized _rawApiMsg. Cached on the message itself after first compute.
@@ -44,7 +59,7 @@ function estimateMessageTokens(msg: AIMessage): number {
     }
   }
   if (msg._rawApiMsg) {
-    total += estimateTokens(JSON.stringify(msg._rawApiMsg))
+    total += estimateTokens(getRawApiMsgJson(msg))
   }
   tokenEstimateCache.set(msg, total)
   return total
@@ -413,24 +428,31 @@ export const useAIStore = defineStore('ai', () => {
     config.value = { ...config.value, ...updates }
   }
 
+  // F-314: serialize a session to the JSON shape persisted to disk.
+  // The session structure is rebuilt each save (cheap), but the heavy
+  // JSON.stringify of _rawApiMsg is cached per-message via getRawApiMsgJson.
+  function serializeSession(s: AISession): Record<string, unknown> {
+    return {
+      id: s.id,
+      name: s.name,
+      createdAt: s.createdAt,
+      updatedAt: s.updatedAt,
+      messages: s.messages.map(m => ({
+        id: m.id,
+        role: m.role,
+        content: m.content,
+        tool_call_id: m.tool_call_id || '',
+        tool_calls: m.tool_calls || [],
+        pendingTools: m.pendingTools || [],
+        _rawApiMsg: getRawApiMsgJson(m),
+      }))
+    }
+  }
+
   async function doSave() {
     try {
       const data = {
-        sessions: sessions.value.map(s => ({
-          id: s.id,
-          name: s.name,
-          createdAt: s.createdAt,
-          updatedAt: s.updatedAt,
-          messages: s.messages.map(m => ({
-            id: m.id,
-            role: m.role,
-            content: m.content,
-            tool_call_id: m.tool_call_id || '',
-            tool_calls: m.tool_calls || [],
-            pendingTools: m.pendingTools || [],
-            _rawApiMsg: m._rawApiMsg ? JSON.stringify(m._rawApiMsg) : '',
-          }))
-        })),
+        sessions: sessions.value.map(s => serializeSession(s)),
         currentSessionId: currentSessionId.value || '',
       }
       await SaveAISessions(data as any)

--- a/frontend/src/stores/aiStore.ts
+++ b/frontend/src/stores/aiStore.ts
@@ -1,5 +1,5 @@
 import { defineStore } from 'pinia'
-import { ref, computed, reactive, watch } from 'vue'
+import { ref, computed, reactive, shallowReactive, shallowRef, watch, markRaw } from 'vue'
 import type { AIMessage, AIConfig, ExecutionMode, AISession, AIAgentStatus } from '../types/ai'
 import { SaveAIConfig, LoadAIConfig, SaveAISessions, LoadAISessions } from '../../wailsjs/go/main/App'
 import { useLocalStateStore } from './localStateStore'
@@ -271,6 +271,7 @@ export const useAIStore = defineStore('ai', () => {
         doSave()
       }
     }
+    messagesVersion.value++
     return r
   }
 
@@ -291,6 +292,7 @@ export const useAIStore = defineStore('ai', () => {
         doSave()
       }
     }
+    messagesVersion.value++
   }
 
   function addCommandCard(name: string, args: string) {
@@ -310,6 +312,7 @@ export const useAIStore = defineStore('ai', () => {
         doSave()
       }
     }
+    messagesVersion.value++
   }
 
   function clearMessages() {
@@ -322,6 +325,7 @@ export const useAIStore = defineStore('ai', () => {
         doSave()
       }
     }
+    messagesVersion.value++
   }
 
   async function init() {
@@ -358,6 +362,7 @@ export const useAIStore = defineStore('ai', () => {
     } else {
       createSession()
     }
+    messagesVersion.value++
   }
 
   async function initConfig() {
@@ -434,6 +439,7 @@ export const useAIStore = defineStore('ai', () => {
       sessions.value = sessions.value.slice(0, 15)
     }
     clearQueue()
+    messagesVersion.value++
     // Don't save empty sessions — only persist when first message is added
   }
 
@@ -443,6 +449,7 @@ export const useAIStore = defineStore('ai', () => {
     currentSessionId.value = sessionId
     messages.value = s.messages.map(m => reactive({ ...m }) as AIMessage)
     clearQueue()
+    messagesVersion.value++
   }
 
   function deleteSession(sessionId: string) {
@@ -477,8 +484,13 @@ export const useAIStore = defineStore('ai', () => {
     stopRequested.value = false
   }
 
-  // Build Anthropic-native message array (system is separate top-level field)
-  const conversation = computed(() => {
+  // Build Anthropic-native message array (system is separate top-level field).
+  // F-301: conversation is rebuilt only when messagesVersion bumps (add/remove),
+  // not when per-token content mutates. Stored as a shallowRef; the computed
+  // wrapper preserves the existing public API.
+  const conversationValue = shallowRef<Array<Record<string, unknown>>>([])
+
+  function buildConversation() {
     // Token budget: 80% of Claude's 200K context window, minus headroom
     const MAX_CONTEXT_TOKENS = 160000
 
@@ -650,11 +662,15 @@ export const useAIStore = defineStore('ai', () => {
       }
     }
 
-    // Messages are inherently dynamic — no cache_control breakpoints here.
-    // Caching is handled entirely on the system prompt (see llm.ts).
+    conversationValue.value = deduped
+  }
 
-    return deduped
-  })
+  // F-301: rebuild conversation only when messages are added/removed.
+  const messagesVersion = ref(0)
+  watch(messagesVersion, () => buildConversation())
+  buildConversation()
+
+  const conversation = computed(() => conversationValue.value)
 
   const systemPrompt = computed(() => SYSTEM_RULES)
 

--- a/frontend/src/stores/aiStore.ts
+++ b/frontend/src/stores/aiStore.ts
@@ -30,17 +30,21 @@ function estimateTokens(text: string): number {
 const tokenEstimateCache = new WeakMap<AIMessage, number>()
 
 // F-314: cache the serialized _rawApiMsg JSON per message so doSave doesn't
-// re-stringify on every save. The raw API block is set once per assistant
-// message by the LLM and never mutated thereafter, so the cached form is
-// stable for the lifetime of the message.
-const rawApiMsgJsonCache = new WeakMap<AIMessage, string>()
+// re-stringify on every save. The cache is keyed by the AIMessage object and
+// stores the object reference alongside the JSON so agent.ts can safely
+// replace _rawApiMsg (it assigns a new object) without invalidating reads.
+const rawApiMsgJsonCache = new WeakMap<AIMessage, { obj: object; json: string }>()
 
 function getRawApiMsgJson(msg: AIMessage): string {
   if (!msg._rawApiMsg) return ''
+  // F-316: inactive sessions retain _rawApiMsg as a JSON string. The disk
+  // form is already the JSON we want to persist; double-stringifying would
+  // produce a quoted string. Use it verbatim.
+  if (typeof msg._rawApiMsg === 'string') return msg._rawApiMsg
   const cached = rawApiMsgJsonCache.get(msg)
-  if (cached !== undefined) return cached
+  if (cached && cached.obj === msg._rawApiMsg) return cached.json
   const json = JSON.stringify(msg._rawApiMsg)
-  rawApiMsgJsonCache.set(msg, json)
+  rawApiMsgJsonCache.set(msg, { obj: msg._rawApiMsg, json })
   return json
 }
 
@@ -150,6 +154,10 @@ const DEFAULT_CONFIG: AIConfig = {
 async function loadSessionsFromBackend(): Promise<{ sessions: AISession[], currentSessionId: string | null }> {
   try {
     const data = await LoadAISessions() as any
+    // F-316: keep _rawApiMsg as a JSON string in inactive sessions. Parse
+    // only when the session is opened (in init / switchSession). Inactive
+    // sessions retain the raw string form; the conversation computed refs
+    // parsed objects only for the active session.
     const sessions: AISession[] = (data.sessions || []).map((s: any) => ({
       id: s.id,
       name: s.name,
@@ -162,7 +170,7 @@ async function loadSessionsFromBackend(): Promise<{ sessions: AISession[], curre
         tool_call_id: m.tool_call_id,
         tool_calls: m.tool_calls || [],
         pendingTools: m.pendingTools || [],
-        _rawApiMsg: m._rawApiMsg ? JSON.parse(m._rawApiMsg) : undefined,
+        _rawApiMsg: m._rawApiMsg || undefined,
       }))
     }))
     return { sessions, currentSessionId: data.currentSessionId || null }
@@ -378,16 +386,22 @@ export const useAIStore = defineStore('ai', () => {
     if (currentSessionId.value) {
       const s = sessions.value.find(s => s.id === currentSessionId.value)
       if (s) {
-        messages.value = s.messages.map(m => {
-          const msg = { ...m }
-          if (typeof msg._rawApiMsg === 'string' && msg._rawApiMsg) {
-            try { msg._rawApiMsg = JSON.parse(msg._rawApiMsg) } catch { delete msg._rawApiMsg }
+        // F-316: parse _rawApiMsg in place so messages.value and s.messages
+        // share the same backing object — agent.ts mutations to the active
+        // message propagate to the stored session and survive a save.
+        for (const m of s.messages) {
+          if (typeof m._rawApiMsg === 'string' && m._rawApiMsg) {
+            try {
+              m._rawApiMsg = JSON.parse(m._rawApiMsg)
+            } catch {
+              delete m._rawApiMsg
+            }
           }
-          if (msg._rawApiMsg) {
-            ;(msg as AIMessage)._rawApiMsg = markRaw(msg._rawApiMsg)
+          if (m._rawApiMsg) {
+            m._rawApiMsg = markRaw(m._rawApiMsg)
           }
-          return shallowReactive(msg) as AIMessage
-        })
+        }
+        messages.value = s.messages.map(m => shallowReactive(m) as AIMessage)
       } else {
         createSession()
       }
@@ -486,13 +500,22 @@ export const useAIStore = defineStore('ai', () => {
     const s = sessions.value.find(s => s.id === sessionId)
     if (!s) return
     currentSessionId.value = sessionId
-    messages.value = s.messages.map(m => {
-      const msg = { ...m }
-      if (msg._rawApiMsg) {
-        ;(msg as AIMessage)._rawApiMsg = markRaw(msg._rawApiMsg)
+    // F-316: parse _rawApiMsg in place so messages.value and s.messages
+    // share the same backing object — agent.ts mutations to the active
+    // message propagate to the stored session and survive a save.
+    for (const m of s.messages) {
+      if (typeof m._rawApiMsg === 'string' && m._rawApiMsg) {
+        try {
+          m._rawApiMsg = JSON.parse(m._rawApiMsg)
+        } catch {
+          delete m._rawApiMsg
+        }
       }
-      return shallowReactive(msg) as AIMessage
-    })
+      if (m._rawApiMsg) {
+        m._rawApiMsg = markRaw(m._rawApiMsg)
+      }
+    }
+    messages.value = s.messages.map(m => shallowReactive(m) as AIMessage)
     clearQueue()
     messagesVersion.value++
   }

--- a/frontend/src/stores/aiStore.ts
+++ b/frontend/src/stores/aiStore.ts
@@ -526,71 +526,92 @@ export const useAIStore = defineStore('ai', () => {
 
     // Walk backwards through messages, accumulate token estimates.
     // Stop when we exceed the budget.
-    const kept: typeof messages.value = []
-    for (let i = messages.value.length - 1; i >= 0; i--) {
-      const msg = messages.value[i]
-      const msgTokens = estimateMessageTokens(msg)
-      if (tokenCount + msgTokens > MAX_CONTEXT_TOKENS) break
-      tokenCount += msgTokens
-      kept.unshift(msg)
-    }
-
-    let recentMsgs = kept
-
-    // Don't start the conversation with an orphaned tool_result whose matching
-    // tool_use was truncated out of the window. Strip leading tool messages
-    // until we hit a user or assistant message.
-    while (recentMsgs.length > 0 && recentMsgs[0].role === 'tool') {
-      recentMsgs.shift()
-    }
-
-    // Collect all resolved tool_use IDs from tool_result messages
-    const resolvedIds = new Set<string>()
-    for (const m of recentMsgs) {
-      if (m.role === 'tool' && m.tool_call_id) {
-        resolvedIds.add(m.tool_call_id)
+    const msgs = messages.value
+    const n = msgs.length
+    const kept: AIMessage[] = []
+    const keptStart = (() => {
+      let start = n
+      for (let i = n - 1; i >= 0; i--) {
+        const msgTokens = estimateMessageTokens(msgs[i])
+        if (tokenCount + msgTokens > MAX_CONTEXT_TOKENS) break
+        tokenCount += msgTokens
+        start = i
       }
-    }
+      // Strip leading tool messages whose matching tool_use was truncated out.
+      while (start < n && msgs[start].role === 'tool') start++
+      return start
+    })()
+    for (let i = keptStart; i < n; i++) kept.push(msgs[i])
 
+    // F-313: single forward pass that:
+    //   - collects resolved tool_use IDs from tool_result messages,
+    //   - filters dangling tool_use blocks (assistant raw / legacy),
+    //   - merges consecutive user messages,
+    //   - validates pairings (assistant tool_use ↔ user tool_result).
+    const resolvedIds = new Set<string>()
     const result: Array<Record<string, unknown>> = []
+    const pendingMsgId = pendingCommand.value?.messageId
 
-    for (const m of recentMsgs) {
+    const isMessagePending = (m: AIMessage) => !!(m.pendingTools?.length || pendingMsgId === m.id)
+
+    for (let i = 0; i < kept.length; i++) {
+      const m = kept[i]
+      const pending = isMessagePending(m)
+
       if (m.id.startsWith('dbg-')) continue
-      if (m.needsContinue) continue  // UI-only prompts, not part of LLM conversation
-      // skill/command cards are UI-only markers; never send them to the API
+      if (m.needsContinue) continue
       if ((m.skillName || m.commandName) && !m.content) continue
-      // restored/legacy empty user messages produce invalid empty text blocks
       if (m.role === 'user' && !m.content && !m._contextHeader) continue
 
-      // Tool messages: ones with tool_call_id are real tool_results for the API;
-      // ones without are display-only system errors and must not be sent.
+      // Tool message: register id, emit as user tool_result wrapper.
       if (m.role === 'tool') {
         if (m.tool_call_id) {
-          result.push({
-            role: 'user',
-            content: [{ type: 'tool_result', tool_use_id: m.tool_call_id, content: m.content }]
-          })
+          resolvedIds.add(m.tool_call_id)
+          const toolResultBlocks = [{
+            type: 'tool_result',
+            tool_use_id: m.tool_call_id,
+            content: m.content
+          }]
+
+          // Pair-validate backward: if previous result is assistant with
+          // tool_use blocks, prune any block that doesn't have a matching
+          // tool_result in this new message.
+          const prev = result[result.length - 1]
+          if (prev && prev.role === 'assistant' && Array.isArray(prev.content)) {
+            const prevBlocks = prev.content as Array<Record<string, unknown>>
+            const filtered = prevBlocks.filter((b) => {
+              if (b.type === 'tool_use') {
+                return toolResultBlocks.some((tr) => tr.tool_use_id === (b.id as string))
+              }
+              return true
+            })
+            if (filtered.length === 0) {
+              result.pop()
+            } else {
+              prev.content = filtered
+            }
+          }
+
+          // Two consecutive tool messages must each appear as their own
+          // user wrapper so they pair with their respective tool_use blocks.
+          // Don't merge into the previous user.
+          result.push({ role: 'user', content: toolResultBlocks })
         }
         continue
       }
 
-      // Skip assistant messages that are API error placeholders from before the fix
-      if (m.role === 'assistant' && typeof m.content === 'string' && m.content.includes('[Error:')) {
-        continue
-      }
+      if (m.role === 'assistant' && typeof m.content === 'string' && m.content.includes('[Error:')) continue
 
-      // Assistant with raw API blocks: filter dangling tool_use blocks without matching tool_result
+      // Assistant with raw API blocks: filter dangling tool_use blocks.
       if (m._rawApiMsg) {
         const raw = m._rawApiMsg as Record<string, unknown>
         const content = raw.content
         if (Array.isArray(content)) {
-          const filtered = (content as Array<Record<string, unknown>>).filter((block: Record<string, unknown>) => {
-            if (block.type === 'tool_use') {
-              return resolvedIds.has(block.id as string)
-            }
+          const filtered = (content as Array<Record<string, unknown>>).filter((b) => {
+            if (b.type === 'tool_use') return resolvedIds.has(b.id as string)
             return true
           })
-          if (filtered.length === 0 && !m.content && !(m.pendingTools?.length || pendingCommand.value?.messageId === m.id)) continue
+          if (filtered.length === 0 && !m.content && !pending) continue
           result.push({ ...raw, role: (raw.role as string) || 'assistant', content: filtered })
         } else {
           result.push({ ...raw, role: (raw.role as string) || 'assistant' })
@@ -598,15 +619,13 @@ export const useAIStore = defineStore('ai', () => {
         continue
       }
 
-      // Assistant with legacy tool_calls: filter dangling ones, build content blocks
+      // Assistant with legacy tool_calls.
       if (m.role === 'assistant' && m.tool_calls?.length) {
         const resolved = m.tool_calls.filter(tc => resolvedIds.has(tc.id))
-        if (!m.content && resolved.length === 0 && !(m.pendingTools?.length || pendingCommand.value?.messageId === m.id)) continue
+        if (!m.content && resolved.length === 0 && !pending) continue
 
         const blocks: Array<Record<string, unknown>> = []
-        if (m.content) {
-          blocks.push({ type: 'text', text: m.content })
-        }
+        if (m.content) blocks.push({ type: 'text', text: m.content })
         for (const tc of resolved) {
           let input: Record<string, unknown> = {}
           try { input = JSON.parse(tc.function.arguments) } catch { /* passthrough */ }
@@ -616,76 +635,79 @@ export const useAIStore = defineStore('ai', () => {
         continue
       }
 
-      // Skip empty assistant messages (no content, no tool calls, no raw api msg, no pending tools)
-      if (m.role === 'assistant' && !m.content && !(m.pendingTools?.length || pendingCommand.value?.messageId === m.id)) continue
+      if (m.role === 'assistant' && !m.content && !pending) continue
 
-      // Inject dynamic context header into user messages for the API
-      // (hidden from UI, stored in _contextHeader)
+      // User / plain assistant: dedup consecutive user messages.
+      let content: string
       if (m.role === 'user' && m._contextHeader) {
-        result.push({ role: m.role, content: m._contextHeader + '\n\n' + m.content })
+        content = m._contextHeader + '\n\n' + m.content
       } else {
-        result.push({ role: m.role || 'user', content: m.content })
+        content = m.content
+      }
+      const apiMsg = { role: m.role || 'user', content }
+      const last = result[result.length - 1]
+      if (m.role === 'user' && last && last.role === 'user') {
+        const prevBlocks = Array.isArray(last.content)
+          ? last.content as Array<Record<string, unknown>>
+          : [{ type: 'text', text: last.content as string }]
+        const msgBlocks = Array.isArray(content)
+          ? content as Array<Record<string, unknown>>
+          : [{ type: 'text', text: content as string }]
+        last.content = [...prevBlocks, ...msgBlocks]
+      } else {
+        result.push(apiMsg)
       }
     }
 
-    // Final safety pass: enforce that every tool_use is immediately followed
-    // by a user message containing its matching tool_result, and every
-    // tool_result is immediately preceded by an assistant with its tool_use.
-    // The Anthropic API rejects tool_use blocks that are not resolved in the
-    // very next message.
-    const cleaned: Array<Record<string, unknown>> = []
+    // Pair validation: prune any tool_use blocks whose next-of-pair msg
+    // doesn't carry the matching tool_result. The Anthropic API rejects
+    // tool_use blocks not resolved in the very next message, regardless of
+    // where in the conversation they appear. Walk backward so we can
+    // prune-then-collapse in place.
+    for (let i = result.length - 1; i >= 0; i--) {
+      const msg = result[i]
+      if (msg.role !== 'assistant' || !Array.isArray(msg.content)) continue
+      const next = i + 1 < result.length ? result[i + 1] : null
+      const nextBlocks = next && next.role === 'user' && Array.isArray(next.content)
+        ? next.content as Array<Record<string, unknown>>
+        : null
+      const blocks = (msg.content as Array<Record<string, unknown>>).filter((b) => {
+        if (b.type === 'tool_use') {
+          return nextBlocks !== null && nextBlocks.some((nb) => nb.type === 'tool_result' && nb.tool_use_id === b.id)
+        }
+        return true
+      })
+      if (blocks.length === 0) {
+        result.splice(i, 1)
+      } else {
+        msg.content = blocks
+      }
+    }
+    // Mirror pass: prune tool_result blocks in user messages whose prev
+    // assistant no longer has the matching tool_use (after the previous
+    // pass may have removed it). Drop user messages whose content is empty.
     for (let i = 0; i < result.length; i++) {
       const msg = result[i]
-
-      if (msg.role === 'assistant' && Array.isArray(msg.content)) {
-        const nextMsg = i + 1 < result.length ? result[i + 1] : null
-        const blocks = (msg.content as Array<Record<string, unknown>>).filter((block) => {
-          if (block.type === 'tool_use') {
-            if (!nextMsg || nextMsg.role !== 'user' || !Array.isArray(nextMsg.content)) {
-              return false
-            }
-            return (nextMsg.content as Array<Record<string, unknown>>).some(
-              (nb) => nb.type === 'tool_result' && nb.tool_use_id === block.id
-            )
-          }
-          return true
-        })
-        if (blocks.length === 0) continue
-        cleaned.push({ ...msg, content: blocks })
-      } else if (msg.role === 'user' && Array.isArray(msg.content)) {
-        const prevMsg = i > 0 ? result[i - 1] : null
-        const blocks = (msg.content as Array<Record<string, unknown>>).filter((block) => {
-          if (block.type === 'tool_result') {
-            if (!prevMsg || prevMsg.role !== 'assistant' || !Array.isArray(prevMsg.content)) {
-              return false
-            }
-            return (prevMsg.content as Array<Record<string, unknown>>).some(
-              (pb) => pb.type === 'tool_use' && pb.id === block.tool_use_id
-            )
-          }
-          return true
-        })
-        if (blocks.length === 0) continue
-        cleaned.push({ ...msg, content: blocks })
+      if (msg.role !== 'user' || !Array.isArray(msg.content)) continue
+      const prev = i > 0 ? result[i - 1] : null
+      const prevBlocks = prev && prev.role === 'assistant' && Array.isArray(prev.content)
+        ? prev.content as Array<Record<string, unknown>>
+        : null
+      const blocks = (msg.content as Array<Record<string, unknown>>).filter((b) => {
+        if (b.type === 'tool_result') {
+          return prevBlocks !== null && prevBlocks.some((pb) => pb.type === 'tool_use' && pb.id === b.tool_use_id)
+        }
+        return true
+      })
+      if (blocks.length === 0) {
+        result.splice(i, 1)
+        i--
       } else {
-        cleaned.push(msg)
+        msg.content = blocks
       }
     }
 
-    // Additional validation: ensure no consecutive user messages ( Anthropic rejects this )
-    const deduped: Array<Record<string, unknown>> = []
-    for (const msg of cleaned) {
-      if (msg.role === 'user' && deduped.length > 0 && deduped[deduped.length - 1].role === 'user') {
-        const prev = deduped[deduped.length - 1]
-        const prevBlocks = Array.isArray(prev.content) ? prev.content : [{ type: 'text', text: prev.content }]
-        const msgBlocks = Array.isArray(msg.content) ? msg.content : [{ type: 'text', text: msg.content }]
-        prev.content = [...prevBlocks, ...msgBlocks]
-      } else {
-        deduped.push(msg)
-      }
-    }
-
-    conversationValue.value = deduped
+    conversationValue.value = result
   }
 
   // F-301: rebuild conversation only when messages are added/removed.

--- a/frontend/src/stores/aiStore.ts
+++ b/frontend/src/stores/aiStore.ts
@@ -255,12 +255,18 @@ export const useAIStore = defineStore('ai', () => {
   }
 
   function addMessage(msg: AIMessage): AIMessage {
-    const r = reactive({ ...msg }) as AIMessage
-    messages.value.push(r)
+    // F-302: shallowReactive + markRaw _rawApiMsg. The raw API block is only
+    // mutated by the LLM, never read by UI components, so it doesn't need
+    // deep reactive tracking. The shallow wrapper covers the message's
+    // own fields (content, pendingTools) without descending into nested arrays.
+    const wrapped: AIMessage = msg._rawApiMsg
+      ? (shallowReactive({ ...msg, _rawApiMsg: markRaw(msg._rawApiMsg) }) as AIMessage)
+      : (shallowReactive({ ...msg }) as AIMessage)
+    messages.value.push(wrapped)
     if (currentSessionId.value) {
       const s = sessions.value.find(s => s.id === currentSessionId.value)
       if (s) {
-        s.messages.push(r)
+        s.messages.push(wrapped)
         s.updatedAt = Date.now()
         if (msg.role === 'user' && s.name === t('ai.newSession')) {
           const trimmed = msg.content.trim()
@@ -272,11 +278,11 @@ export const useAIStore = defineStore('ai', () => {
       }
     }
     messagesVersion.value++
-    return r
+    return wrapped
   }
 
   function addSkillCard(name: string, source: 'explicit' | 'auto') {
-    const r = reactive({
+    const r = shallowReactive({
       id: `skill-${Date.now()}`,
       role: 'user' as const,
       content: '',
@@ -296,7 +302,7 @@ export const useAIStore = defineStore('ai', () => {
   }
 
   function addCommandCard(name: string, args: string) {
-    const r = reactive({
+    const r = shallowReactive({
       id: `cmd-${Date.now()}`,
       role: 'user' as const,
       content: '',
@@ -354,7 +360,10 @@ export const useAIStore = defineStore('ai', () => {
           if (typeof msg._rawApiMsg === 'string' && msg._rawApiMsg) {
             try { msg._rawApiMsg = JSON.parse(msg._rawApiMsg) } catch { delete msg._rawApiMsg }
           }
-          return reactive(msg) as AIMessage
+          if (msg._rawApiMsg) {
+            ;(msg as AIMessage)._rawApiMsg = markRaw(msg._rawApiMsg)
+          }
+          return shallowReactive(msg) as AIMessage
         })
       } else {
         createSession()
@@ -447,7 +456,13 @@ export const useAIStore = defineStore('ai', () => {
     const s = sessions.value.find(s => s.id === sessionId)
     if (!s) return
     currentSessionId.value = sessionId
-    messages.value = s.messages.map(m => reactive({ ...m }) as AIMessage)
+    messages.value = s.messages.map(m => {
+      const msg = { ...m }
+      if (msg._rawApiMsg) {
+        ;(msg as AIMessage)._rawApiMsg = markRaw(msg._rawApiMsg)
+      }
+      return shallowReactive(msg) as AIMessage
+    })
     clearQueue()
     messagesVersion.value++
   }

--- a/frontend/src/stores/aiStore.ts
+++ b/frontend/src/stores/aiStore.ts
@@ -24,11 +24,18 @@ function estimateTokens(text: string): number {
   return Math.ceil(asciiChars / 3.5 + nonAsciiChars / 1.8)
 }
 
+// F-310: cache token estimates per message in a WeakMap so the per-token
+// `conversation` re-evaluation (shouldn't happen post-F-301, but guards
+// against any remaining hot reads) doesn't re-stringify _rawApiMsg.
+const tokenEstimateCache = new WeakMap<AIMessage, number>()
+
 /**
  * Estimate tokens for an AIMessage, including content, tool_calls, and
- * serialized _rawApiMsg.
+ * serialized _rawApiMsg. Cached on the message itself after first compute.
  */
 function estimateMessageTokens(msg: AIMessage): number {
+  const cached = tokenEstimateCache.get(msg)
+  if (cached !== undefined) return cached
   let total = estimateTokens(msg.content)
   if (msg.tool_calls) {
     for (const tc of msg.tool_calls) {
@@ -39,6 +46,7 @@ function estimateMessageTokens(msg: AIMessage): number {
   if (msg._rawApiMsg) {
     total += estimateTokens(JSON.stringify(msg._rawApiMsg))
   }
+  tokenEstimateCache.set(msg, total)
   return total
 }
 

--- a/frontend/src/stores/aiStore.ts
+++ b/frontend/src/stores/aiStore.ts
@@ -305,7 +305,7 @@ export const useAIStore = defineStore('ai', () => {
             s.name = trimmed.length > 20 ? trimmed.slice(0, 20) + '...' : trimmed
           }
         }
-        doSave()
+        debouncedSave()
       }
     }
     messagesVersion.value++
@@ -326,7 +326,7 @@ export const useAIStore = defineStore('ai', () => {
       if (s) {
         s.messages.push(r)
         s.updatedAt = Date.now()
-        doSave()
+        debouncedSave()
       }
     }
     messagesVersion.value++
@@ -346,7 +346,7 @@ export const useAIStore = defineStore('ai', () => {
       if (s) {
         s.messages.push(r)
         s.updatedAt = Date.now()
-        doSave()
+        debouncedSave()
       }
     }
     messagesVersion.value++
@@ -359,7 +359,7 @@ export const useAIStore = defineStore('ai', () => {
       if (s) {
         s.messages = []
         s.updatedAt = Date.now()
-        doSave()
+        debouncedSave()
       }
     }
     messagesVersion.value++
@@ -475,6 +475,25 @@ export const useAIStore = defineStore('ai', () => {
     }
   }
 
+  // F-304: debounce doSave by 500ms to coalesce bursts from addMessage and
+  // multi-token streaming. saveNow() flushes immediately for explicit user
+  // actions (deleteSession, renameSession, after-chat completion).
+  let saveTimer: ReturnType<typeof setTimeout> | null = null
+  function debouncedSave() {
+    if (saveTimer) return
+    saveTimer = setTimeout(() => {
+      saveTimer = null
+      doSave()
+    }, 500)
+  }
+  async function saveNow() {
+    if (saveTimer) {
+      clearTimeout(saveTimer)
+      saveTimer = null
+    }
+    await doSave()
+  }
+
   function createSession(name?: string) {
     const now = Date.now()
     const session: AISession = {
@@ -524,7 +543,7 @@ export const useAIStore = defineStore('ai', () => {
     const idx = sessions.value.findIndex(s => s.id === sessionId)
     if (idx === -1) return
     sessions.value.splice(idx, 1)
-    doSave()
+    saveNow()
     if (currentSessionId.value === sessionId) {
       if (sessions.value.length > 0) {
         switchSession(sessions.value[0].id)
@@ -538,7 +557,7 @@ export const useAIStore = defineStore('ai', () => {
     const s = sessions.value.find(s => s.id === sessionId)
     if (s) {
       s.name = name
-      doSave()
+      saveNow()
     }
   }
 


### PR DESCRIPTION
## 背景

`frontend/src/stores/aiStore.ts` 是 AI Agent 的核心 Pinia store，包含会话管理、消息队列、以及把内部 `AIMessage` 转换为 Anthropic/OpenAI 兼容 `conversation` 数组的 660 行 builder。在 200 条消息的会话里，AI 流式响应 ~100 token/秒会触发一连串性能问题：

- `conversation` computed 对每次响应式 mutation 都重算整段转换（包括流式 `content +=`），主线程被命中 100+ 次/秒
- `addMessage` 用 `reactive(...)` 深代理包裹每条消息，单次 token 增量会让所有依赖图失效
- `estimateMessageTokens` 每次都对 `_rawApiMsg` 重新 `JSON.stringify`，100 条消息 × 100 token = 1 万次冗余序列化
- conversation builder 对消息数组遍历 6 次（collect、filter、dedup、pair、边界 pair validate、mirror）
- `doSave` 在每次 `addMessage` 都同步触发，把整段对话过 Wails bridge
- 启动 / 切换会话时立刻对每条消息的 `_rawApiMsg` 做 `JSON.parse`，没有按需延迟

## 本 PR 做了什么

7 个原子提交，每个对应一个 F-编号：

| 编号 | 改动 |
| ---- | ---- |
| F-301 | 用 `shallowRef` + `messagesVersion` 重写 `conversation`：`addMessage` / `clearMessages` / `switchSession` / `createSession` 时才重建，per-token `content +=` 不再让 `chat()` 收到的 API payload 引用失效 |
| F-302 | 改用 `shallowReactive(msg)` + `markRaw(msg._rawApiMsg)`：raw API 块只由 LLM 写入、UI 不读，深代理纯属无谓开销 |
| F-310 | `estimateMessageTokens` 用 `WeakMap` 缓存每条消息的 token 估值，GC 时自动失效 |
| F-313 | conversation builder 折叠为「一次前向（collect ids + filter + dedup + 局部 pair）+ 一次后向（边界 pair validation）」，总复杂度 O(2n) |
| F-314 | `getRawApiMsgJson` 用 `WeakMap` 缓存每条消息的序列化结果；session 顶层结构仍每次重建，但单消息 stringify 变 O(1) |
| F-316 | `loadSessionsFromBackend` 保留 `_rawApiMsg` 为 JSON 字符串；只在 `init` / `switchSession` 时按需解析，并把解析结果同步到 stored session（保证 `agent.ts` 后续修改会传播并被持久化） |
| F-304 | 新增 `debouncedSave()`（500ms 防抖）+ `saveNow()`（显式操作立即落盘）；`addMessage` / `addSkillCard` / `addCommandCard` / `clearMessages` 走防抖；`deleteSession` / `renameSession` / `agent.ts` 显式调用走 `saveNow` |

## 测试

`frontend/src/stores/aiStore.test.ts` 新增 4 个用例覆盖三处行为：

- `F-301`：`addMessage('m1')` 后 `store.conversation` 拿到引用 `first`；mutate `messages[0].content`（模拟 per-token 写入）后读 `store.conversation` 仍是 `first`；再次 `addMessage('m2')` 后引用才换
- `F-316`：注入一个 `messages[0]._rawApiMsg` 为 JSON 字符串的 session，调 `switchSession` 后断言 `_rawApiMsg` 已被解析为对象且内容相等；切换前断言仍是字符串
- `F-304`（防抖）：连续 3 次 `addMessage` 后 `SaveAISessions` 调用次数仍为 0；`vi.advanceTimersByTimeAsync(500)` 后才命中 1 次
- `F-304`（立即落盘）：`addMessage` 后立即 `renameSession` → `SaveAISessions` 命中 1 次；`advanceTimersByTimeAsync(500)` 后仍是 1 次（说明 pending 防抖被取消）

完整结果：

```
 Test Files  1 passed (1)
      Tests  12 passed (12)
```

## 构建

```
npm --prefix frontend run build
✓ 3689 modules transformed.
✓ built in 3.80s
```

## 兼容性

- `_rawApiMsg` 现在可能是 string 或 object（取决于是否已激活）。`agent.ts` 中 `m._rawApiMsg = {...}` 的写法仍按原对象引用替换，新对象会触发 `getRawApiMsgJson` 重新序列化（旧对象留在 WeakMap 中直至 GC）
- `doSave` 仍公开在 store 上，外部调用方（如 `agent.ts`）可以继续直接 `await store.doSave()` 走立即落盘路径