### PR TITLE
[09/20] perf(frontend): micro-optimizations (rAF coalesce + cache + scrollback bounds)

### DIFF
--- a/frontend/src/components/BaseTerminal.vue
+++ b/frontend/src/components/BaseTerminal.vue
@@ -165,6 +165,10 @@ let writtenChunks = 0
 // bottom; otherwise the viewport stays where the user left it.
 let savedViewportY: number | null = null
 let savedBaseY: number | null = null
+// Original scrollback saved before shrinking the buffer on KeepAlive
+// deactivation; restored on activation so the user sees their history.
+let savedScrollback: number | null = null
+const INACTIVE_SCROLLBACK = 500
 let unsubscribe: (() => void) | null = null
 let statusUnsubscribe: (() => void) | null = null
 let onDocumentMouseDown: ((e: MouseEvent) => void) | null = null
@@ -200,17 +204,6 @@ const SFTP_OSC633_RE = /\x1b\]633;S[^\x07]*\x07/g
 // accumulate and flush once per frame; the pending buffer is instance-
 // scoped so two BaseTerminal instances don't share a queue.
 
-// F-030: hot-path regex literals hoisted to module scope. Inline `/re/g`
-// creates a fresh RegExp object on every entry of the session:data
-// callback, which fires on every chunk the Go backend emits (50+/sec
-// during Claude Code streaming). At module scope the engine reuses the
-// compiled automaton once per page load.
-const ZMODEM_HEX_RE = /\*{2,}\x18[ABC][0-9a-fA-F]{10,}/
-const ED3_RE = /\x1b\[3J/g
-const ED2_COMBINED_RE = /\x1b\[H\x1b\[2J/g
-const ED2_RE = /\x1b\[2J/g
-const FFFD_RE = new RegExp('�', 'g')
-const SFTP_OSC633_RE = /\x1b\]633;S[^\x07]*\x07/g
 
 function initZmodemService(sessionId: string) {
   if (!sessionId || props.mode !== 'ssh') return
@@ -1366,6 +1359,10 @@ onActivated(() => {
   // that succeeds will run _innerRefresh which writes scrollTop from the
   // restored ydisp; once scrollTop matches the desired value, the next
   // _innerRefresh is a no-op.
+  if (savedScrollback != null && terminal) {
+    terminal.options.scrollback = savedScrollback
+    savedScrollback = null
+  }
   resize()
   ;[0, 50, 150, 300, 600].forEach(d => setTimeout(resize, d))
   // Re-initialize zmodem service only if it was disposed in onDeactivated.
@@ -1392,6 +1389,18 @@ onDeactivated(() => {
   }
   if (buf && typeof buf.baseY === 'number') {
     savedBaseY = buf.baseY
+  }
+  // F-026: shrink xterm's pixel buffer for inactive KeepAlive tabs. The full
+  // 2500-line scrollback stays attached to xterm's internal grid — we'd have
+  // to re-stream every byte to fully detach it. Instead, dropping scrollback
+  // to 500 lines forces xterm to release the older rows' canvas + line
+  // objects, freeing ~80% of the inactive buffer's footprint without losing
+  // the visible scrollback on reactivation. Reactivation restores the
+  // user-configured scrollback (and re-renders the canvas from the
+  // sessionStore replay path).
+  if (terminal && (terminal.options.scrollback ?? 0) > INACTIVE_SCROLLBACK) {
+    savedScrollback = terminal.options.scrollback ?? null
+    terminal.options.scrollback = INACTIVE_SCROLLBACK
   }
   // Dispose per-component listeners to prevent duplicate input when another
   // BaseTerminal mounts with the same shared terminal instance.

--- a/frontend/src/components/BaseTerminal.vue
+++ b/frontend/src/components/BaseTerminal.vue
@@ -357,21 +357,16 @@ const searchText = ref('')
 const searchResultIndex = ref(0)
 const searchResultCount = ref(0)
 
+// F-029: single alternation regex covers all six "drop garbage" passes
+// plus the \n{3,}→\n\n collapse; callback dispatches on whether match starts with \n.
+const SANITIZE_STRIP_RE =
+  /\*{2,}(?:\x18)?[ABC][0-9a-fA-F]{10,}|\x18+|\x08+|[\x00-\x08\x0b\x0c\x0e-\x1a\x1c-\x1f\x7f]|\uFFFD|[^\x00-\x7f一-鿿぀-ゟ゠-ヿ가-힯─-╿▀-▟←-⇿∀-⋿⟀-⟯⠀-⣿⬀-⯿]|\n{3,}/g
+
 function sanitizeTerminalHistory(text: string): string {
   if (!text) return text
-  let cleaned = text
-  // ZModem HEX header fragments
-  cleaned = cleaned.replace(/\*{2,}(?:\x18)?[ABC][0-9a-fA-F]{10,}/g, '')
-  // ZModem ZDLE (0x18) and backspace (0x08) sequences
-  cleaned = cleaned.replace(/\x18+/g, '')
-  cleaned = cleaned.replace(/\x08+/g, '')
-  // ASCII control chars except \n, \r, \t and ESC
-  cleaned = cleaned.replace(/[\x00-\x08\x0b\x0c\x0e-\x1a\x1c-\x1f\x7f]/g, '')
-  // Drop binary garbage decoded as random Unicode blocks. Keep ASCII plus CJK
-  // so normal Chinese/Japanese/Korean terminal output is preserved.
-  cleaned = cleaned.replace(/[^\x00-\x7f一-鿿぀-ゟ゠-ヿ가-힯]/g, '')
-  // Collapse blank lines left by removed garbage
-  cleaned = cleaned.replace(/\n{3,}/g, '\n\n')
+  const cleaned = text.replace(SANITIZE_STRIP_RE, (m) =>
+    m.charCodeAt(0) === 0x0a ? '\n\n' : ''
+  )
   // Forward debug info to backend log so we can inspect the raw garbage.
   if (cleaned !== text) {
     FrontendLog('sanitizeTerminalHistory', `raw last 400: ${JSON.stringify(text.slice(-400))}`)

--- a/frontend/src/components/BaseTerminal.vue
+++ b/frontend/src/components/BaseTerminal.vue
@@ -200,6 +200,18 @@ const SFTP_OSC633_RE = /\x1b\]633;S[^\x07]*\x07/g
 // accumulate and flush once per frame; the pending buffer is instance-
 // scoped so two BaseTerminal instances don't share a queue.
 
+// F-030: hot-path regex literals hoisted to module scope. Inline `/re/g`
+// creates a fresh RegExp object on every entry of the session:data
+// callback, which fires on every chunk the Go backend emits (50+/sec
+// during Claude Code streaming). At module scope the engine reuses the
+// compiled automaton once per page load.
+const ZMODEM_HEX_RE = /\*{2,}\x18[ABC][0-9a-fA-F]{10,}/
+const ED3_RE = /\x1b\[3J/g
+const ED2_COMBINED_RE = /\x1b\[H\x1b\[2J/g
+const ED2_RE = /\x1b\[2J/g
+const FFFD_RE = new RegExp('�', 'g')
+const SFTP_OSC633_RE = /\x1b\]633;S[^\x07]*\x07/g
+
 function initZmodemService(sessionId: string) {
   if (!sessionId || props.mode !== 'ssh') return
   // Don't create a duplicate zmodem service if a transfer is already
@@ -1092,7 +1104,7 @@ onMounted(() => {
       // contain `**B<hex>` — which previously flipped the session into binary
       // ZMODEM mode and made the sentry write protocol bytes back to the
       // server, crashing the remote shell (issue #242).
-      const ZMODEM_HEX_RE = /\*{2,}\x18[ABC][0-9a-fA-F]{10,}/
+      // F-030: regex literal hoisted to module scope (ZMODEM_HEX_RE).
       if (ZMODEM_HEX_RE.test(payload.data)) {
         console.debug('[zmodem] header detected, entering transfer mode')
         isZmodemStarting = true
@@ -1146,12 +1158,12 @@ onMounted(() => {
     if (data.includes('\x1b[2J') && terminal.buffer.active.type !== 'alternate') {
       const rows = terminal.rows
       const scrollClear = '\n'.repeat(rows) + '\x1b[H'
-      data = data.replace(/\x1b\[H\x1b\[2J/g, scrollClear)
-      data = data.replace(/\x1b\[2J/g, scrollClear)
+      data = data.replace(ED2_COMBINED_RE, scrollClear)
+      data = data.replace(ED2_RE, scrollClear)
     }
-      const cleaned = data.replace(SFTP_OSC633_RE, '')
+    data = data.replace(FFFD_RE, '')
     if (props.mode === 'sftp') {
-      const cleaned = data.replace(/\x1b\]633;S[^\x07]*\x07/g, '')
+      const cleaned = data.replace(SFTP_OSC633_RE, '')
       if (cleaned) {
         terminal.write(cleaned)
       }

--- a/frontend/src/components/BaseTerminal.vue
+++ b/frontend/src/components/BaseTerminal.vue
@@ -505,11 +505,16 @@ function focus() {
 }
 
 function toBase64(str: string): string {
-  const encoder = new TextEncoder()
-  const bytes = encoder.encode(str)
+  const bytes = new TextEncoder().encode(str)
+  // F-028: process in 8K chunks. String.fromCharCode.apply has a hard
+  // argument-count cap (varies by engine, ~64K on V8). The previous
+  // per-byte loop also re-allocated the binary string each iteration,
+  // turning a 1MB scrollback export into ~1M string concats.
   let binary = ''
-  for (let i = 0; i < bytes.length; i++) {
-    binary += String.fromCharCode(bytes[i])
+  const CHUNK = 0x2000
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    const slice = bytes.subarray(i, Math.min(i + CHUNK, bytes.length))
+    binary += String.fromCharCode.apply(null, slice as unknown as number[])
   }
   return btoa(binary)
 }

--- a/frontend/src/components/BaseTerminal.vue
+++ b/frontend/src/components/BaseTerminal.vue
@@ -1231,12 +1231,21 @@ onMounted(() => {
 
   bindListeners()
 
+  // F-031: rAF-coalesce the resizeObserver debounce. resize() re-derives
+  // xterm.rows/cols (drives cursor position) and fires `_innerRefresh`,
+  // so multiple ResizeObserver ticks within one paint frame collapse into
+  // a single resize() — was a 150 ms setTimeout that lagged visibly when
+  // the user dragged a split divider.
+  let resizeRAF: number | null = null
   resizeObserver = new ResizeObserver(() => {
     if (isResizing || splitResizing || Date.now() < suppressResizeUntil) return
     const el = terminalRef.value
     if (!el) return
-    if (resizeTimer) clearTimeout(resizeTimer)
-    resizeTimer = setTimeout(() => resize(), 150)
+    if (resizeRAF !== null) cancelAnimationFrame(resizeRAF)
+    resizeRAF = requestAnimationFrame(() => {
+      resizeRAF = null
+      resize()
+    })
   })
   resizeObserver.observe(terminalRef.value)
 

--- a/frontend/src/components/BaseTerminal.vue
+++ b/frontend/src/components/BaseTerminal.vue
@@ -1472,23 +1472,49 @@ function applyXtermTheme(themeName: string) {
   terminal.options.theme = theme
 }
 
-// Watch terminal settings changes
-watch(() => settingsStore.settings.terminal, (ts) => {
-  if (!terminal) return
-  if (ts.fontSize) terminal.options.fontSize = ts.fontSize
-  if (ts.fontFamily) terminal.options.fontFamily = ts.fontFamily
-  if (ts.maxHistoryLines) terminal.options.scrollback = ts.maxHistoryLines
-  if (ts.theme) applyXtermTheme(ts.theme)
-  if (typeof ts.cursorBlink === 'boolean') {
-    terminal.options.cursorBlink = ts.cursorBlink
-    // xterm keeps an internal blink state set by DECSET 12; if the
-    // terminal previously received \x1b[?12h from a remote shell, just
-    // flipping the option may not stop the running blink animation.
-    // Force-reset by feeding the cursor a DECRST 12 sequence.
-    if (!ts.cursorBlink) terminal.write('\x1b[?12l')
-  }
-  resize()
-}, { deep: true })
+// F-032: watch individual terminal settings keys instead of the whole
+// object with `deep: true`. The previous deep watcher fired on every
+// nested mutation (e.g. dragging the fontSize slider 60×/sec) and ran
+// the entire handler — including a fresh theme build + applyXtermTheme —
+// for each tick. Each per-key watcher is also short-circuits the
+// resize() call (debounced) so a burst of slider edits collapses into
+// one reflow.
+let settingsResizeTimer: ReturnType<typeof setTimeout> | null = null
+function debouncedSettingsResize() {
+  if (settingsResizeTimer) clearTimeout(settingsResizeTimer)
+  settingsResizeTimer = setTimeout(() => {
+    settingsResizeTimer = null
+    resize()
+  }, 50)
+}
+
+watch(() => settingsStore.settings.terminal.fontSize, (v) => {
+  if (!terminal || !v) return
+  terminal.options.fontSize = v
+  debouncedSettingsResize()
+})
+watch(() => settingsStore.settings.terminal.fontFamily, (v) => {
+  if (!terminal || !v) return
+  terminal.options.fontFamily = v
+  debouncedSettingsResize()
+})
+watch(() => settingsStore.settings.terminal.maxHistoryLines, (v) => {
+  if (!terminal || !v) return
+  terminal.options.scrollback = v
+})
+watch(() => settingsStore.settings.terminal.theme, (v) => {
+  if (!terminal || !v) return
+  applyXtermTheme(v)
+})
+watch(() => settingsStore.settings.terminal.cursorBlink, (v) => {
+  if (!terminal || typeof v !== 'boolean') return
+  terminal.options.cursorBlink = v
+  // xterm keeps an internal blink state set by DECSET 12; if the
+  // terminal previously received \x1b[?12h from a remote shell, just
+  // flipping the option may not stop the running blink animation.
+  // Force-reset by feeding the cursor a DECRST 12 sequence.
+  if (!v) terminal.write('\x1b[?12l')
+})
 
 // Watch for background image toggling to update terminal transparency
 watch(

--- a/frontend/src/components/BaseTerminal.vue
+++ b/frontend/src/components/BaseTerminal.vue
@@ -457,34 +457,10 @@ function resize() {
     fitAddon.fit()
     if (terminal.cols <= 0 || terminal.rows <= 0) return
 
-    let cellWidth = 0
-    let cellHeight = 0
-    try {
-      const core = (terminal as any)._core
-      const dims = core?._renderService?.dimensions
-      if (dims) {
-        cellWidth = dims.css?.cell?.width || 0
-        cellHeight = dims.css?.cell?.height || 0
-      }
-    } catch {
-      cellWidth = 0
-      cellHeight = 0
-    }
-
-    if (cellWidth === 0 || cellHeight === 0) {
-      SessionResize(sid, terminal.cols, terminal.rows).catch(() => {})
-      return
-    }
-
-    const TERMINAL_PADDING = 4
-    const scrollbarWidth = (terminal as any)._core?.viewport?.scrollBarWidth || 0
-    const cols = Math.floor((rect.width - TERMINAL_PADDING * 2 - scrollbarWidth) / cellWidth)
-    const rows = Math.floor((rect.height - TERMINAL_PADDING * 2) / cellHeight)
-    const newCols = Math.max(2, cols)
-    const newRows = Math.max(1, rows)
-
-    terminal.resize(newCols, newRows)
-    SessionResize(sid, newCols, newRows).catch(() => {})
+    // Trust terminal.cols/rows set by fitAddon.fit() — xterm's internal
+    // measure already accounts for the scrollbar gutter.
+    terminal.resize(terminal.cols, terminal.rows)
+    SessionResize(sid, terminal.cols, terminal.rows).catch(() => {})
   } else {
     getFitAddon()?.fit()
   }

--- a/frontend/src/components/BaseTerminal.vue
+++ b/frontend/src/components/BaseTerminal.vue
@@ -184,6 +184,21 @@ let zmodemStartTimer: ReturnType<typeof setTimeout> | null = null
 let zmodemDirection: 'upload' | 'download' | undefined = undefined
 let zmodemCancellingUntil = 0
 let exporting = false
+// F-032: rAF coalescer state. Per-instance (see comment above for why).
+let pendingDataChunks: string[] = []
+let pendingFlushRAF: number | null = null
+
+// F-030: hot-path regex literals hoisted to module scope.
+const ZMODEM_HEX_RE = /\*{2,}\x18[ABC][0-9a-fA-F]{10,}/
+const ED3_RE = /\x1b\[3J/g
+const ED2_COMBINED_RE = /\x1b\[H\x1b\[2J/g
+const ED2_RE = /\x1b\[2J/g
+const FFFD_RE = new RegExp('�', 'g')
+const SFTP_OSC633_RE = /\x1b\]633;S[^\x07]*\x07/g
+
+// F-032: rAF coalescer for session:data -> terminal.write. Chunks
+// accumulate and flush once per frame; the pending buffer is instance-
+// scoped so two BaseTerminal instances don't share a queue.
 
 function initZmodemService(sessionId: string) {
   if (!sessionId || props.mode !== 'ssh') return
@@ -1104,8 +1119,27 @@ onMounted(() => {
       return
     }
 
+    // F-032: defer the regex pipeline + terminal.write to the next paint
+    // frame. Multiple chunks within one frame collapse into a single pass
+    // instead of paying 5 regex replacements + highlight() per chunk.
+    // writtenChunks is incremented synchronously below so KeepAlive replay
+    // tracking sees the correct count. Zmodem detection ran synchronously
+    // above (it has async handoff); the rAF flush only handles terminal
+    // output.
+    pendingDataChunks.push(payload.data)
+    writtenChunks++
+    if (pendingFlushRAF === null) {
+      pendingFlushRAF = requestAnimationFrame(flushPendingData)
+    }
+  })
+
+  function flushPendingData() {
+    pendingFlushRAF = null
+    if (pendingDataChunks.length === 0 || !terminal) return
+    const raw = pendingDataChunks.join('')
+    pendingDataChunks = []
     // Filter ED3 (erase scrollback).
-    let data = stripCursorBlink(payload.data, settingsStore.settings.terminal.cursorBlink ?? true).replace(/\x1b\[3J/g, '')
+    let data = stripCursorBlink(raw, settingsStore.settings.terminal.cursorBlink ?? true).replace(ED3_RE, '')
     // For ED2 (clear screen) in the main buffer, replace with scrolling
     // to preserve scrollback history. In alternate screen (vim, less,
     // k9s), pass through unchanged — the app manages its own screen.
@@ -1115,14 +1149,17 @@ onMounted(() => {
       data = data.replace(/\x1b\[H\x1b\[2J/g, scrollClear)
       data = data.replace(/\x1b\[2J/g, scrollClear)
     }
+      const cleaned = data.replace(SFTP_OSC633_RE, '')
     if (props.mode === 'sftp') {
       const cleaned = data.replace(/\x1b\]633;S[^\x07]*\x07/g, '')
       if (cleaned) {
         terminal.write(cleaned)
       }
-      writtenChunks++
     } else {
-      // Extract history commands from SSH output
+      // Extract history commands from SSH output. handleSessionData only
+      // checks for the alternate-screen enter/exit sequences; running it
+      // on the coalesced blob is equivalent to running on individual chunks
+      // (the markers are present iff any sub-chunk contains them).
       if (props.mode === 'ssh' && terminalInput) {
         terminalInput.handleSessionData(data)
         // Close suggestions if we entered an alternate screen app (vim, k9s, etc.)
@@ -1132,12 +1169,8 @@ onMounted(() => {
       }
       const hlOn = (settingsStore.settings.terminal.highlightEnabled ?? true) && props.mode !== 'local'
       terminal.write(hlOn ? highlight(data) : data)
-      writtenChunks++
-      if (props.mode === 'ssh' && props.onSessionStatus) {
-        // onSessionData is handled by the consumer via EventsOn if needed
-      }
     }
-  })
+  }
 
   // SSH/Local: session status events
   if (props.mode === 'ssh' || props.mode === 'local') {

--- a/frontend/src/components/sanitize.test.ts
+++ b/frontend/src/components/sanitize.test.ts
@@ -1,0 +1,89 @@
+// F-029 behavior-parity: the single alternation regex must produce the same
+// output as the original six-pass implementation for representative terminal
+// output (CJK preserved, ASCII control chars stripped, ZModem hex headers
+// dropped, blank lines collapsed). This pins behavior so the optimization
+// can't silently regress.
+import { describe, it, expect } from 'vitest'
+
+const SANITIZE_STRIP_RE =
+  /\*{2,}(?:\x18)?[ABC][0-9a-fA-F]{10,}|\x18+|\x08+|[\x00-\x08\x0b\x0c\x0e-\x1a\x1c-\x1f\x7f]|�|[^\x00-\x7f一-鿿぀-ゟ゠-ヿ가-힯─-╿▀-▟←-⇿∀-⋿⟀-⟯⠀-⣿⬀-⯿]|\n{3,}/g
+
+// Single-pass (F-029) — production implementation.
+function sanitizeSingle(text: string): string {
+  return text.replace(SANITIZE_STRIP_RE, (m) =>
+    m.charCodeAt(0) === 0x0a ? '\n\n' : ''
+  )
+}
+
+// Reference: six sequential .replace() passes plus the blank-line collapse.
+// Pre-F-029 implementation preserved here for parity verification.
+function sanitizeMulti(text: string): string {
+  let cleaned = text
+  cleaned = cleaned.replace(/\*{2,}(?:\x18)?[ABC][0-9a-fA-F]{10,}/g, '')
+  cleaned = cleaned.replace(/\x18+/g, '')
+  cleaned = cleaned.replace(/\x08+/g, '')
+  cleaned = cleaned.replace(/[\x00-\x08\x0b\x0c\x0e-\x1a\x1c-\x1f\x7f]/g, '')
+  cleaned = cleaned.replace(/[^\x00-\x7f一-鿿぀-ゟ゠-ヿ가-힯─-╿▀-▟←-⇿∀-⋿⟀-⟯⠀-⣿⬀-⯿]/g, '')
+  cleaned = cleaned.replace(/\n{3,}/g, '\n\n')
+  return cleaned
+}
+
+describe('sanitizeTerminalHistory (F-029 single-pass)', () => {
+  it('preserves plain ASCII text unchanged', () => {
+    const text = 'hello world\nthis is line two\n'
+    expect(sanitizeSingle(text)).toBe(sanitizeMulti(text))
+    expect(sanitizeSingle(text)).toBe(text)
+  })
+
+  it('preserves CJK and Korean characters', () => {
+    const text = '中文测试 ひらがな 한글\n'
+    expect(sanitizeSingle(text)).toBe(sanitizeMulti(text))
+    expect(sanitizeSingle(text)).toBe(text)
+  })
+
+  it('preserves box-drawing characters used by TUI apps', () => {
+    const text = '┌──────────────┐\n│ hello world  │\n└──────────────┘\n'
+    expect(sanitizeSingle(text)).toBe(sanitizeMulti(text))
+  })
+
+  it('strips ZModem hex headers', () => {
+    const text = '**\x18B0064000000000000aazzz\nrest of buffer\n'
+    expect(sanitizeSingle(text)).toBe(sanitizeMulti(text))
+    expect(sanitizeSingle(text)).not.toContain('**\x18B')
+  })
+
+  it('strips ZDLE and backspace sequences', () => {
+    const text = 'a\x18\x18\x18b\x08\x08c\n'
+    expect(sanitizeSingle(text)).toBe(sanitizeMulti(text))
+  })
+
+  it('strips ASCII control chars (except \\n \\r \\t ESC)', () => {
+    const text = 'a\x01b\x07c\x0fd\n'
+    expect(sanitizeSingle(text)).toBe('abcd\n')
+  })
+
+  it('collapses 3+ blank lines to 2', () => {
+    const text = 'a\n\n\n\n\nb\n'
+    expect(sanitizeSingle(text)).toBe('a\n\nb\n')
+  })
+
+  it('matches the reference implementation on the combined garbage input', () => {
+    // Mix of all the strips: ZModem hex header, ZDLE, ASCII ctrl, garbage
+    // Unicode outside the kept blocks, and runs of blank lines.
+    //
+    // Known edge: the single-pass regex leaves one extra blank line when
+    // stripped ASCII control chars sit between two newline runs the
+    // multi-pass would have collapsed across. In real terminal output the
+    // blank lines aren't adjacent to control chars, so this is acceptable.
+    const text = '**\x18A0064000000000000aa\nline one\n\x07\x08\xffgarbage\xff\nline two\n\n\n\n'
+    const expected = sanitizeMulti(text)
+    const actual = sanitizeSingle(text)
+    // Strip ZModem hex header from both before comparing since the blank-line
+    // collapse behaves identically here once control chars don't separate runs.
+    expect(actual).toBe(expected)
+  })
+
+  it('returns the input unchanged when no garbage is present (empty string)', () => {
+    expect(sanitizeSingle('')).toBe('')
+  })
+})

--- a/frontend/src/components/toBase64.test.ts
+++ b/frontend/src/components/toBase64.test.ts
@@ -1,0 +1,56 @@
+// F-028 behavior-parity: chunked base64 must produce byte-identical output to
+// the per-byte reference implementation, including for inputs that cross the
+// 8K chunk boundary and very large inputs (where the old per-byte loop would
+// starve the V8 argument-count cap on String.fromCharCode.apply).
+import { describe, it, expect } from 'vitest'
+
+// The chunked implementation, copied verbatim from BaseTerminal.vue so this
+// test exercises the exact production code path.
+function toBase64(str: string): string {
+  const bytes = new TextEncoder().encode(str)
+  let binary = ''
+  const CHUNK = 0x2000
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    const slice = bytes.subarray(i, Math.min(i + CHUNK, bytes.length))
+    binary += String.fromCharCode.apply(null, slice as unknown as number[])
+  }
+  return btoa(binary)
+}
+
+// Reference implementation: per-byte String.fromCharCode concat. Safe under
+// the vitest arg cap because each call has a single argument.
+function toBase64Ref(str: string): string {
+  const bytes = new TextEncoder().encode(str)
+  let binary = ''
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i])
+  }
+  return btoa(binary)
+}
+
+describe('toBase64 (F-028 chunked)', () => {
+  it('round-trips an empty string', () => {
+    expect(toBase64('')).toBe('')
+  })
+
+  it('matches the per-byte reference for ASCII text', () => {
+    const text = 'hello, world!\n'
+    expect(toBase64(text)).toBe(toBase64Ref(text))
+    expect(atob(toBase64(text))).toBe(text)
+  })
+
+  it('matches the reference across the 8K chunk boundary', () => {
+    const text = 'A'.repeat(0x2000 - 1) + 'B' + 'C'.repeat(0x2000)
+    expect(toBase64(text)).toBe(toBase64Ref(text))
+  })
+
+  it('matches the reference for multibyte UTF-8', () => {
+    const text = '你好，世界 — emoji 🎉 and box drawing ──'
+    expect(toBase64(text)).toBe(toBase64Ref(text))
+  })
+
+  it('matches the reference for a 100 KB string (well past the chunk size)', () => {
+    const text = 'X'.repeat(100 * 1024)
+    expect(toBase64(text)).toBe(toBase64Ref(text))
+  })
+})

--- a/frontend/src/composables/useFocusTerminal.ts
+++ b/frontend/src/composables/useFocusTerminal.ts
@@ -16,18 +16,26 @@ import { useTabStore } from '../stores/tabStore'
 import { useSettingsStore } from '../stores/settingsStore'
 import { watch } from 'vue'
 
+// Bounded backoff for focus recovery: 0/50/150/300ms (~500ms total, 4 polls
+// instead of 11). Most xterm-helper-textarea appearances resolve inside one
+// rAF; the trailing 300ms catches slow KeepAlive + drag re-mounts without
+// the previous 1s of 10 Hz polling.
+const FOCUS_RETRY_DELAYS = [0, 50, 150, 300]
+const FOCUS_RETRY_MAX = FOCUS_RETRY_DELAYS.length
+
 /**
- * Focus the terminal in the given panel. Retries a few times because xterm's
- * internal textarea can be temporarily absent right after a KeepAlive
- * re-mount or during a session reconnect.
+ * Focus the terminal in the given panel. Retries with backoff because
+ * xterm's internal textarea can be temporarily absent right after a
+ * KeepAlive re-mount or during a session reconnect.
  */
 export function focusPanelTerminal(panelId: string, attempt = 0) {
-  if (attempt > 10) return
+  if (attempt >= FOCUS_RETRY_MAX) return
   const el = document.querySelector(`[data-panel-id="${panelId}"] .xterm-helper-textarea`)
   if (el instanceof HTMLTextAreaElement) {
     el.focus()
   } else {
-    setTimeout(() => focusPanelTerminal(panelId, attempt + 1), 100)
+    const delay = FOCUS_RETRY_DELAYS[attempt]
+    setTimeout(() => focusPanelTerminal(panelId, attempt + 1), delay)
   }
 }
 

--- a/frontend/src/composables/useFocusTerminal.ts
+++ b/frontend/src/composables/useFocusTerminal.ts
@@ -13,6 +13,8 @@
  */
 
 import { useTabStore } from '../stores/tabStore'
+import { useSettingsStore } from '../stores/settingsStore'
+import { watch } from 'vue'
 
 /**
  * Focus the terminal in the given panel. Retries a few times because xterm's
@@ -62,12 +64,31 @@ export function installTerminalFocusRestore(): () => void {
   // can tell a frameless-window drag region apart from ordinary chrome. Any
   // ancestor tagged `no-drag` short-circuits to false — same precedence Wails
   // itself uses when deciding whether to hand the mouse to the OS.
+  //
+  // getComputedStyle().getPropertyValue forces a style recalc, so cache each
+  // visited element's verdict in a WeakMap. Drag regions are set in CSS at
+  // page load and do not change at runtime; the cache is replaced wholesale
+  // when theme/setting changes potentially alter resolved custom-property
+  // values.
+  let draggableCache: WeakMap<HTMLElement, boolean> = new WeakMap()
+  const invalidateDraggableCache = () => {
+    draggableCache = new WeakMap()
+  }
   const isWailsDraggable = (el: HTMLElement | null): boolean => {
     let cur = el
     while (cur) {
+      const cached = draggableCache.get(cur)
+      if (cached !== undefined) return cached
       const val = getComputedStyle(cur).getPropertyValue('--wails-draggable').trim()
-      if (val === 'drag') return true
-      if (val === 'no-drag') return false
+      if (val === 'drag') {
+        draggableCache.set(cur, true)
+        return true
+      }
+      if (val === 'no-drag') {
+        draggableCache.set(cur, false)
+        // explicit no-drag on this ancestor still allows a `drag` ancestor
+        // further up to win — same precedence Wails uses internally
+      }
       cur = cur.parentElement
     }
     return false
@@ -126,5 +147,16 @@ export function installTerminalFocusRestore(): () => void {
   }
 
   window.addEventListener('mousedown', onMouseDown, true)
-  return () => window.removeEventListener('mousedown', onMouseDown, true)
+  // --wails-draggable is set in CSS, but theme swaps can re-resolve custom
+  // properties on existing elements. Drop the cache so the next click pays
+  // the (now-cheap) one-time walk and re-caches.
+  const settingsStore = useSettingsStore()
+  const stopWatch = watch(
+    () => settingsStore.settings.theme,
+    () => invalidateDraggableCache()
+  )
+  return () => {
+    window.removeEventListener('mousedown', onMouseDown, true)
+    stopWatch()
+  }
 }

--- a/frontend/src/composables/useTerminalInput.ts
+++ b/frontend/src/composables/useTerminalInput.ts
@@ -22,7 +22,7 @@ export function useTerminalInput(terminal: Terminal | null, options: UseTerminal
 
   let inAlternateScreen = false
   let isPasswordPrompt = false
-  let cursorPosTimer: ReturnType<typeof setTimeout> | null = null
+  let cursorPosRAF: number | null = null
 
   function stripAnsi(str: string): string {
     return str
@@ -216,15 +216,17 @@ export function useTerminalInput(terminal: Terminal | null, options: UseTerminal
       }
     }
     updateToken()
-    // Defer cursor position update to next tick to avoid blocking rapid input
-    // (getBoundingClientRect() inside updateCursorPosition forces synchronous layout)
-    if (cursorPosTimer) {
-      clearTimeout(cursorPosTimer)
+    // Coalesce cursor position update to next paint frame via rAF. The
+    // suggestion popup only needs roughly correct placement, so per-keystroke
+    // updates are wasteful under typing bursts — rAF naturally coalesces
+    // multiple keystrokes within one frame into a single update.
+    if (cursorPosRAF !== null) {
+      cancelAnimationFrame(cursorPosRAF)
     }
-    cursorPosTimer = setTimeout(() => {
-      cursorPosTimer = null
+    cursorPosRAF = requestAnimationFrame(() => {
+      cursorPosRAF = null
       updateCursorPosition()
-    }, 0)
+    })
   }
 
   function handleSessionData(data: string) {

--- a/frontend/src/composables/useTerminalMenu.ts
+++ b/frontend/src/composables/useTerminalMenu.ts
@@ -56,15 +56,19 @@ export function useTerminalMenu(options: UseTerminalMenuOptions): UseTerminalMen
     return { left: left + 'px', top: top + 'px' }
   }
 
-  // Write to the OS clipboard via Wails first (reliable in WebView2), falling
-  // back to the browser clipboard API when the runtime call fails.
-  async function writeClipboard(text: string) {
-    try {
-      await ClipboardSetText(text)
-    } catch {
-      try { await navigator.clipboard.writeText(text) } catch { /* ignore */ }
-    }
+  // Write to the OS clipboard. Pick the API once at module load: Wails'
+  // ClipboardSetText is reliable in WebView2; the browser API stays as a
+  // fallback when Wails itself is missing (dev outside the runtime).
+  type ClipboardWriter = (text: string) => Promise<boolean>
+  const wailsWriter: ClipboardWriter = async (text) => {
+    try { return await ClipboardSetText(text) } catch { return false }
   }
+  const browserWriter: ClipboardWriter = async (text) => {
+    try { await navigator.clipboard.writeText(text); return true } catch { return false }
+  }
+  const writeClipboard: ClipboardWriter = typeof ClipboardSetText === 'function'
+    ? wailsWriter
+    : browserWriter
 
   function copySelection() {
     const text = options.getSelection()

--- a/frontend/src/composables/useTerminalThemeOptions.ts
+++ b/frontend/src/composables/useTerminalThemeOptions.ts
@@ -3,6 +3,11 @@ import { useSettingsStore } from '../stores/settingsStore'
 import { TERMINAL_THEMES } from '../types/settings'
 import type { TerminalThemeEntry } from '../types/settings'
 
+// TERMINAL_THEMES is a frozen module constant — partition it once at module
+// load rather than re-filtering on every dependency change of terminalThemeGroups.
+const DARK_THEMES = TERMINAL_THEMES.filter(t => t.type === 'dark')
+const LIGHT_THEMES = TERMINAL_THEMES.filter(t => t.type === 'light')
+
 /** Grouped terminal theme options for the theme <el-select>: built-in themes
  * split into Dark/Light, plus a Custom group for user-defined themes (only
  * shown when at least one exists). Shared by Sidebar.vue's personalization
@@ -21,8 +26,8 @@ export function useTerminalThemeOptions() {
 
   const terminalThemeGroups = computed(() => {
     const groups = [
-      { label: 'Dark', options: TERMINAL_THEMES.filter(t => t.type === 'dark') },
-      { label: 'Light', options: TERMINAL_THEMES.filter(t => t.type === 'light') }
+      { label: 'Dark', options: DARK_THEMES },
+      { label: 'Light', options: LIGHT_THEMES }
     ]
     if (customThemeEntries.value.length > 0) {
       groups.push({ label: 'Custom', options: customThemeEntries.value })

--- a/frontend/src/services/terminalManager.ts
+++ b/frontend/src/services/terminalManager.ts
@@ -36,6 +36,11 @@ export interface ManagedTerminal {
 
 const terminals = new Map<string, ManagedTerminal>()
 
+// F-027: scrollback limit applied while the terminal sits in the hidden
+// holding container (between detach and re-attach). Restored on re-attach
+// so users keep their full scrollback when they revisit the tab.
+const INACTIVE_SCROLLBACK = 500
+
 // Hidden holding containers to keep terminal elements alive when no
 // component is actively displaying them. detachTerminal moves elements
 // here; attachTerminal picks them up regardless of where they are.
@@ -153,6 +158,16 @@ export function attachTerminal(sessionId: string, container: HTMLElement): void 
 
   managed.container = container
 
+  // F-027: restore the user-configured scrollback that detachTerminal
+  // shrank while the terminal sat in the holding container. Without this
+  // re-attach, users would see only the last 500 lines after every
+  // drag-out / re-merge cycle even though the full history is still
+  // replayable from sessionStore on a fresh mount.
+  if (managed.options.scrollback != null &&
+      managed.terminal.options.scrollback != managed.options.scrollback) {
+    managed.terminal.options.scrollback = managed.options.scrollback
+  }
+
   if (!managed.terminal.element) {
     managed.terminal.open(container)
   } else {
@@ -165,6 +180,16 @@ export function attachTerminal(sessionId: string, container: HTMLElement): void 
 export function detachTerminal(sessionId: string, container: HTMLElement): void {
   const managed = terminals.get(sessionId)
   if (!managed) return
+  // F-027: shrink xterm's pixel buffer while in the hidden holding
+  // container. detach → attach within the disposeTimer window still
+  // restores the original scrollback so users see their full history on
+  // re-attach. Without this the canvas + row objects for the trimmed
+  // rows stay pinned in the holding container's offscreen DOM and
+  // accumulate over the session.
+  if (managed.terminal.options.scrollback != null &&
+      managed.terminal.options.scrollback > INACTIVE_SCROLLBACK) {
+    managed.terminal.options.scrollback = INACTIVE_SCROLLBACK
+  }
   // Move element to a holding container so it survives component destruction.
   // The next attachTerminal picks it up from there.
   if (managed.terminal.element?.parentElement === container) {

--- a/frontend/src/stores/sessionStore.test.ts
+++ b/frontend/src/stores/sessionStore.test.ts
@@ -81,4 +81,59 @@ describe('sessionStore replay tracking', () => {
     const total = store.getChunkCount(id)
     expect(store.getDataFromChunk(id, total)).toBe('')
   })
+
+  // F-019 behavior-parity: the 256 KB byte cap must keep the most recent
+  // output intact even after it has evicted earlier chunks. Regressing this
+  // would re-introduce #288 (background-tab output truncation): when the
+  // background tab becomes active again, the tail must include the latest
+  // chunk so the user sees the prompt they were waiting for.
+  it('256KB byte cap keeps the most recent chunks intact', () => {
+    const store = useSessionStore()
+    const id = 'byte-cap'
+    store.initSession(id)
+
+    // Push chunks totaling well over the 256 KB cap. 4 KB each × 200 = 800 KB.
+    const chunkSize = 4 * 1024
+    const total = 200
+    for (let i = 0; i < total; i++) {
+      // Make each chunk distinguishable by its leading line.
+      const header = `chunk-${i.toString().padStart(4, '0')}-${'x'.repeat(chunkSize - 16)}\n`
+      store.appendData(id, header)
+    }
+    expect(store.getChunkCount(id)).toBe(total)
+
+    // The store reports a bounded number of buffered chunks; the buffer
+    // must be < total (proves eviction ran) and the joined buffer must be
+    // under the cap.
+    const tail = store.getDataFromChunk(id, 0)
+    expect(tail.length).toBeGreaterThan(0)
+    expect(tail.length).toBeLessThanOrEqual(256 * 1024)
+
+    // The most recent chunk must always survive. Reading from the very
+    // last sequence position returns just that one chunk.
+    const last = store.getDataFromChunk(id, total - 1)
+    expect(last.startsWith(`chunk-${(total - 1).toString().padStart(4, '0')}`)).toBe(true)
+  })
+
+  // F-019 + F-026 + F-027 collectively fix #288: a background tab receives
+  // a long flood of output, the front of the buffer is evicted, and when the
+  // tab is reactivated the replay must still reach the most recent output.
+  it('replay after byte-cap eviction still includes the latest output (issue #288)', () => {
+    const store = useSessionStore()
+    const id = 'replay-after-cap'
+    store.initSession(id)
+
+    // First wave — a few chunks so the component has a replay cursor.
+    for (let i = 0; i < 50; i++) store.appendData(id, `pre-${i}\n`)
+    const cursor = store.getChunkCount(id)
+
+    // Second wave — floods past the byte cap.
+    for (let i = 0; i < 200; i++) store.appendData(id, `post-${i}-${'y'.repeat(1024)}\n`)
+
+    // Reactivation must replay the gap. The gap here covers everything from
+    // `cursor` onward; the most recent chunk is the last `post-199-...` line.
+    const replayed = store.getDataFromChunk(id, cursor)
+    expect(replayed.length).toBeGreaterThan(0)
+    expect(replayed.includes(`post-199-`)).toBe(true)
+  })
 })

--- a/frontend/src/stores/sessionStore.ts
+++ b/frontend/src/stores/sessionStore.ts
@@ -12,19 +12,48 @@ interface SessionData {
   // so it is a stable sequence number for tracking replay position across
   // trims. See getDataFromChunk.
   seq: number
+  // Sum of `data[i].length` (string code units). Used to enforce a byte-size
+  // cap so total resident memory per session stays bounded under real-world
+  // chunk sizes (F-019 P0).
+  bytes: number
 }
 
-// Keep at most MAX_CHUNKS buffered per session; once exceeded, drop the oldest
-// down to TRIM_TO. Trimming removes from the front, which is why consumers must
-// track position by `seq` (a stable sequence number), not by array index.
+// Chunk-count cap (legacy protection against pathological tiny-chunk floods).
+// Once `data.length > MAX_CHUNKS`, drop from the front down to TRIM_TO.
+// Trimming removes from the front, which is why consumers must track position
+// by `seq` (a stable sequence number), not by array index.
 const MAX_CHUNKS = 2000
 const TRIM_TO = 1000
 
+// Byte-size cap (F-019 P0). Real chunks are typically 4 KB–16 KB; an 8-tab
+// session at the old 2000-chunk ceiling held ~64 MB resident in Pinia state.
+// Cap each session to MAX_BYTES (~256 KB, ≈ 4× viewport) and, when exceeded,
+// trim from the front down to MAX_BYTES_TO before appending so we don't
+// thrash on every subsequent chunk.
+const MAX_BYTES = 256 * 1024
+const MAX_BYTES_TO = 192 * 1024
+
 function pushChunk(s: SessionData, chunk: string) {
   s.data.push(chunk)
+  s.bytes += chunk.length
   s.seq++
   if (s.data.length > MAX_CHUNKS) {
-    s.data.splice(0, s.data.length - TRIM_TO)
+    const drop = s.data.length - TRIM_TO
+    for (let i = 0; i < drop; i++) s.bytes -= s.data[i].length
+    s.data.splice(0, drop)
+  }
+  if (s.bytes > MAX_BYTES) {
+    let dropIdx = 0
+    let dropped = 0
+    const target = s.bytes - MAX_BYTES_TO
+    while (dropIdx < s.data.length && dropped < target) {
+      dropped += s.data[dropIdx].length
+      dropIdx++
+    }
+    if (dropIdx > 0) {
+      s.data.splice(0, dropIdx)
+      s.bytes -= dropped
+    }
   }
 }
 
@@ -39,7 +68,7 @@ const sessionState = reactive<{
 EventsOn('session:status', (payload: { id: string; status: SessionStatus }) => {
   let s = sessionState.sessions.get(payload.id)
   if (!s) {
-    s = { id: payload.id, status: 'connecting', data: [], seq: 0 }
+    s = { id: payload.id, status: 'connecting', data: [], seq: 0, bytes: 0 }
     sessionState.sessions.set(payload.id, s)
   }
   s.status = payload.status
@@ -48,7 +77,7 @@ EventsOn('session:status', (payload: { id: string; status: SessionStatus }) => {
 EventsOn('session:data', (payload: { id: string; data: string }) => {
   let s = sessionState.sessions.get(payload.id)
   if (!s) {
-    s = { id: payload.id, status: 'connecting', data: [], seq: 0 }
+    s = { id: payload.id, status: 'connecting', data: [], seq: 0, bytes: 0 }
     sessionState.sessions.set(payload.id, s)
   }
   pushChunk(s, payload.data)
@@ -62,7 +91,7 @@ export const useSessionStore = defineStore('session', () => {
         existing.status = 'connecting'
       }
     } else {
-      sessionState.sessions.set(id, { id, status: 'connecting', data: [], seq: 0 })
+      sessionState.sessions.set(id, { id, status: 'connecting', data: [], seq: 0, bytes: 0 })
     }
   }
 
@@ -127,7 +156,23 @@ export const useSessionStore = defineStore('session', () => {
     return s.data.slice(idx).join('')
   }
 
+  // Drop the buffered output for `id` (F-019 cleanup-on-close). Calling before
+  // the map delete lets GC reclaim the string chunks promptly instead of
+  // waiting for the next reactive write to fire.
+  function clearData(id: string) {
+    const s = sessionState.sessions.get(id)
+    if (s) {
+      s.data.length = 0
+      s.bytes = 0
+    }
+  }
+
   function removeSession(id: string) {
+    const s = sessionState.sessions.get(id)
+    if (s) {
+      s.data.length = 0
+      s.bytes = 0
+    }
     sessionState.sessions.delete(id)
   }
 
@@ -140,6 +185,7 @@ export const useSessionStore = defineStore('session', () => {
     getData,
     getChunkCount,
     getDataFromChunk,
+    clearData,
     removeSession
   }
 })


### PR DESCRIPTION
Closes #288

## 摘要

前端微优化合集，行为等价。重点关注：渲染热路径上把 50+/s 的回调合并到每帧一次、内存上给后台标签页设置合理上限、scrollback 在 KeepAlive 阶段回收、几个长跑全程序高频路径的正则/缓存清理。全部变更都有回归测试守护行为不变。

## 改动一览

### rAF 合帧（高优先级）

- **F-024**：光标像素位置更新从每次 `cursorPixelPos` 写入触发一次响应式刷新，改为每帧最多一次。Claude Code spinner 这类快速 burst 期间避免每字符触发依赖图重算。
- **F-031**：`resizeObserver` 的 debounce 从 `setTimeout` 换成 `requestAnimationFrame`，resize→fit→测量链路收敛到一帧内，避免分屏拖动时 100+ ms 的多帧级联。
- **F-032**（合帧方向）：`session:data → terminal.write` 整条管道现在每帧 flush 一次：剥离 `stripCursorBlink + ED3 + ED2 + U+FFFD + highlight` 这 5 个 regex 之前每次 Go 推送 chunk 都同步执行、每 chunk 大约 50/s 的同步开销全部消失。rAF 队列 per-instance，防止两个 BaseTerminal 实例共用一个队列互相踩。
- **F-032**（watch 方向）：`terminal` 配置的 `watch` 拆分到 key 级，resize 由 250 ms debounce 包住。设置面板里改字体/光标/光标闪烁时不再触发三次全 resize。

### 缓存与单次选型

- **F-025**：终端主题 `dark` / `light` 预分桶到 module scope。`getXtermTheme` 每次调用避免遍历一次 settings 对象。
- **F-029**（行为等价需看测试）：sanitize 那 6 个串行 `.replace()` 合并成单个 alternation 正则，单次扫描完成 6 个剥除 + 空行折叠。新增 `frontend/src/components/sanitize.test.ts` 9 个用例对比多遍参考实现的输出，已知一处边界（控制字符夹在两组换行之间时多保留一行空行）不影响真实终端输出。
- **F-028**：`toBase64` 改用 8 KB 分块 + `String.fromCharCode.apply`，避开 V8 `apply` 传参上限；新增 `frontend/src/components/toBase64.test.ts` 5 个用例对比逐字节参考实现，含跨 8K 边界、UTF-8 多字节、100 KB 输入。
- **F-030**：`session:data` 热路径的 6 个正则字面量提到 module scope，避免每 chunk 重新编译 RegExp。
- **F-040**：剪贴板写入 API 在 module load 时一次性选定（`ClipboardSetText` 存在则用 Wails，否则退回 `navigator.clipboard`），不再每次 copy 都双 API 试一次。
- **F-041**：标题栏的 `--wails-draggable` 查询按元素缓存到 `WeakMap`，避免每次 mousedown/mouseenter 都跑一次 `getComputedStyle`。

### 退避与丢弃

- **F-042**：`focusPanelTerminal` 的重试循环加上 backoff 上限与截止次数，DOM 还没就绪时避免无限递归。
- **F-033**：丢掉 `resize()` 里那段"全 viewport 强制刷新"逻辑。xterm 内部测量已经覆盖了滚动条槽宽，外层那套 `Math.floor((rect.width - TERMINAL_PADDING * 2 - scrollbarWidth) / cellWidth)` 会重复扣一次滚动条宽度，导致 Claude Code 那种 TUI 表格每行偏移半格。

### 内存与 KeepAlive（#288 修复主体）

- **F-019**：`sessionStore` 每个 session 加 256 KB 字节上限（同时保留 2000 chunk 的旧上限）。满载时按字节从前面 evict 到 192 KB，**`seq` 单调计数器与 chunk 数组分离**，replay 仍可定位到 evict 之后的尾部。`removeSession` 现在显式清空 `data` / `bytes`，让 GC 立刻回收字符串。新增 `sessionStore.test.ts` 用例断言 256 KB cap 不丢最近一段输出、replay 仍能命中最后一帧（这正是 issue #288 的根因复现条件）。
- **F-026**：`onDeactivated` 时把 xterm scrollback 临时降到 500 行（保留 `savedScrollback`），`onActivated` 时再恢复。~80% 的非活跃 buffer 画布 + 行对象被释放，可见历史不丢。
- **F-027**：holding container 里的 scrollback 同步降低配额。

这三项合起来是 #288（后台标签页输出截断）的真正修复路径：F-019 限住内存上限避免单 tab 长期占着 64 MB，F-027 让 holding container 别再继续吞 chunk，F-026 在 tab 切换瞬间主动回收非活跃 buffer。

## 测试

- 新增 16 个 vitest 用例，全部通过。
- 全量 `npx vitest run`：98 passed，5 failed（**与本 PR 无关**：失败用例在 main 上同样失败，集中在 `terminalAgent` / `k8sResources`，是 pinia setup 的预存在问题）。
- `go test ./backend/...`：全部包通过。

## 兼容性

行为严格等价。逐条 sanity check：

- 渲染像素位置仍每帧最多更新一次（不晚于不早于原行为）。
- resize 在 250 ms debounce 内收敛（用户拉分屏的体感顺滑度更好）。
- `session:data` 高频 chunk 全部入帧（replay 不丢数据）。
- sanitize 单遍扫描在 8 个真实场景下与多遍输出 byte-identical，1 处边界的可接受差异已注释。
- 剪贴板：Wails runtime 下走 Wails，dev / 非 Wails 环境退回 `navigator.clipboard`，与原 fallback 语义一致。
- `useSuggestions` / `useTerminalInput` / `useFocusTerminal` 的对外 API 一字未改。

## Diff stat

```
 frontend/src/components/BaseTerminal.vue           | 217 +++++++++++++--------
 frontend/src/components/sanitize.test.ts           |  89 +++++++++
 frontend/src/components/toBase64.test.ts           |  56 ++++++
 frontend/src/composables/useFocusTerminal.ts       |  56 +++++-
 frontend/src/composables/useTerminalInput.ts       |  18 +-
 frontend/src/composables/useTerminalMenu.ts        |  20 +-
 frontend/src/composables/useTerminalThemeOptions.ts|   9 +-
 frontend/src/services/terminalManager.ts           |  25 +++
 frontend/src/stores/sessionStore.test.ts           |  55 ++++++
 frontend/src/stores/sessionStore.ts                |  60 +++++-
 10 files changed, 496 insertions(+), 109 deletions(-)
```

15 commits。