### PR TITLE
[12/20] fix(store): atomic write + per-store mutex + skills symlink guard + AES-GCM AAD

### DIFF
--- a/app.go
+++ b/app.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"go.bug.st/serial"
 	"io"
@@ -79,6 +80,14 @@ type App struct {
 	// SetDefaultSessionLogDir; ongoing logs are not migrated.
 	customLogDir   string
 	customLogDirMu stdsync.RWMutex
+
+	// errCh accumulates non-fatal init failures during startup() so the
+	// frontend can surface them (see StartupError / "app:startup-error"
+	// event). Stores may stay nil if their init fails — the existing
+	// nil-guard pattern is preserved so today's working configs keep
+	// loading; the additive channel just makes the failure visible.
+	errCh      chan error
+	startupErr error
 }
 
 func NewApp(webviewDataPath string) *App {
@@ -88,7 +97,8 @@ func NewApp(webviewDataPath string) *App {
 		sessionToPanel:     make(map[string]string),
 		panelAutoTriggered: make(map[string]bool),
 		k8sManager:         k8s.NewManager(),
-		containerManager:   container.NewManager(),
+containerManager:   container.NewManager(),
+		errCh:              make(chan error, 16),
 	}
 }
 
@@ -132,29 +142,31 @@ func (a *App) startup(ctx context.Context) {
 	cs, err := store.NewConnectionStore()
 	if err != nil {
 		log.Writef("Failed to init connection store: %v", err)
-		return
+		a.sendStartupErr(fmt.Errorf("connection store: %w", err))
+	} else {
+		a.connectionStore = cs
 	}
-	a.connectionStore = cs
 
 	ass, err := store.NewAISessionStore()
 	if err != nil {
 		log.Writef("Failed to init AI session store: %v", err)
-		return
+		a.sendStartupErr(fmt.Errorf("ai session store: %w", err))
+	} else {
+		a.aiSessionStore = ass
 	}
-	a.aiSessionStore = ass
 
 	ss, err := store.NewSettingsStore()
 	if err != nil {
 		log.Writef("Failed to init settings store: %v", err)
-		return
-	}
-	a.settingsStore = ss
-
-	// Prime the session-log directory override from persisted settings
-	// so a log Enable that lands before the settings UI opens still
-	// respects the user's choice from a prior run.
-	if settings, err := ss.Load(); err == nil {
-		a.SetDefaultSessionLogDir(settings.Terminal.SessionLogDir)
+		a.sendStartupErr(fmt.Errorf("settings store: %w", err))
+	} else {
+		a.settingsStore = ss
+		// Prime the session-log directory override from persisted settings
+		// so a log Enable that lands before the settings UI opens still
+		// respects the user's choice from a prior run.
+		if settings, err := ss.Load(); err == nil {
+			a.SetDefaultSessionLogDir(settings.Terminal.SessionLogDir)
+		}
 	}
 
 	// Init terminal history store (same config dir as other stores)
@@ -180,6 +192,7 @@ func (a *App) startup(ctx context.Context) {
 	syncSvc, err := sync.NewSyncService()
 	if err != nil {
 		log.Writef("Failed to create sync service: %v", err)
+		a.sendStartupErr(fmt.Errorf("sync service: %w", err))
 	} else {
 		a.syncService = syncSvc
 		// Wire keychain into stores for password/API key migration
@@ -207,6 +220,59 @@ func (a *App) startup(ctx context.Context) {
 
 	// Restore window position and size from last session
 	a.restoreWindow(ctx)
+
+	// Drain any non-fatal init failures and surface them to the frontend so
+	// the user sees a banner instead of getting an NPE on the first store
+	// call. Additive only — stores that failed to init are still nil and
+	// guarded as before; the app still launches.
+	a.drainStartupErr()
+	if a.startupErr != nil {
+		runtime.EventsEmit(ctx, "app:startup-error", a.startupErr.Error())
+	}
+}
+
+// sendStartupErr records a non-fatal init failure so the frontend can see
+// it after startup completes. Channel is buffered (16) and only written
+// from the startup goroutine, so the send is non-blocking.
+func (a *App) sendStartupErr(err error) {
+	if err == nil {
+		return
+	}
+	select {
+	case a.errCh <- err:
+	default:
+		// Channel full — best-effort drop. The log line is the
+		// last-resort record in this case.
+		log.Writef("startup error channel full, dropping: %v", err)
+	}
+}
+
+// drainStartupErr joins every error sent during startup into a single
+// startupErr the frontend can query via StartupError().
+func (a *App) drainStartupErr() {
+	var errs []error
+	for {
+		select {
+		case err := <-a.errCh:
+			if err != nil {
+				errs = append(errs, err)
+			}
+		default:
+			a.startupErr = errors.Join(errs...)
+			return
+		}
+	}
+}
+
+// StartupError returns a human-readable, newline-joined list of any
+// non-fatal errors that occurred during startup, or "" if startup
+// completed cleanly. The frontend can call this on demand (e.g. after
+// the "app:startup-error" event) to display a banner.
+func (a *App) StartupError() string {
+	if a.startupErr == nil {
+		return ""
+	}
+	return a.startupErr.Error()
 }
 
 // restoreWindow restores the saved window position and size.

--- a/app_test.go
+++ b/app_test.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestApp_StartupError_CapturesSingleError verifies that a single error
+// sent during startup() surfaces through StartupError() after
+// drainStartupErr() has run. The frontend calls StartupError() on demand
+// after receiving the "app:startup-error" event to render a banner.
+func TestApp_StartupError_CapturesSingleError(t *testing.T) {
+	a := NewApp("")
+	a.sendStartupErr(errors.New("connection store: init failed"))
+
+	if got := a.StartupError(); got != "" {
+		t.Fatalf("StartupError() before drain = %q, want empty", got)
+	}
+
+	a.drainStartupErr()
+	got := a.StartupError()
+	want := "connection store: init failed"
+	if got != want {
+		t.Fatalf("StartupError() = %q, want %q", got, want)
+	}
+}
+
+// TestApp_StartupError_JoinsMultipleErrors verifies the errors.Join
+// behaviour: multiple sendStartupErr calls during startup() produce a
+// single newline-joined string readable by the frontend.
+func TestApp_StartupError_JoinsMultipleErrors(t *testing.T) {
+	a := NewApp("")
+	a.sendStartupErr(errors.New("connection store: read failed"))
+	a.sendStartupErr(errors.New("settings store: write failed"))
+	a.drainStartupErr()
+
+	got := a.StartupError()
+	for _, want := range []string{"connection store: read failed", "settings store: write failed"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("StartupError() = %q, missing %q", got, want)
+		}
+	}
+	if !strings.Contains(got, "\n") {
+		t.Errorf("StartupError() = %q, expected newline-separated entries", got)
+	}
+}
+
+// TestApp_StartupError_NilOnClean verifies StartupError() returns ""
+// when no init failures occurred. The frontend uses the empty string to
+// decide whether to render the banner.
+func TestApp_StartupError_NilOnClean(t *testing.T) {
+	a := NewApp("")
+	a.drainStartupErr()
+	if got := a.StartupError(); got != "" {
+		t.Fatalf("StartupError() with no errors = %q, want empty", got)
+	}
+}
+
+// TestApp_SendStartupErr_NilIsNoop confirms nil errors do not enqueue.
+// Defensive against a future caller passing nil from an error chain.
+func TestApp_SendStartupErr_NilIsNoop(t *testing.T) {
+	a := NewApp("")
+	a.sendStartupErr(nil)
+	a.drainStartupErr()
+	if got := a.StartupError(); got != "" {
+		t.Fatalf("StartupError() after nil send = %q, want empty", got)
+	}
+}
+
+// TestApp_SendStartupErr_OverflowDrops verifies that when the buffered
+// channel (size 16) overflows, sendStartupErr drops the extra error
+// instead of blocking. The send runs on the startup goroutine and must
+// remain non-blocking; the log line is the last-resort record.
+func TestApp_SendStartupErr_OverflowDrops(t *testing.T) {
+	a := NewApp("")
+	for i := 0; i < 32; i++ {
+		a.sendStartupErr(fmt.Errorf("store: %d", i))
+	}
+	a.drainStartupErr()
+	got := a.StartupError()
+	if got == "" {
+		t.Fatal("StartupError() empty after 32 sends, want at least one entry")
+	}
+	if strings.Count(got, "\n") >= 32 {
+		t.Errorf("StartupError() kept all 32 sends, expected some drops under cap=16")
+	}
+}
+
+// TestApp_StartupErr_ConcurrentSendSafe sends from many goroutines and
+// confirms drainStartupErr() collects everything safely. Catches data
+// races in the channel/snapshot interaction under -race.
+func TestApp_StartupErr_ConcurrentSendSafe(t *testing.T) {
+	a := NewApp("")
+	const N = 32
+	var wg sync.WaitGroup
+	wg.Add(N)
+	for i := 0; i < N; i++ {
+		go func(i int) {
+			defer wg.Done()
+			a.sendStartupErr(fmt.Errorf("concurrent: %d", i))
+		}(i)
+	}
+	wg.Wait()
+	a.drainStartupErr()
+	got := a.StartupError()
+	if got == "" {
+		t.Fatal("StartupError() empty after concurrent sends")
+	}
+}
+
+// TestApp_PanelLogTitle_FallbackAndLookup exercises panelLogTitle: with
+// no registered session the helper returns a synthetic fallback rather
+// than crashing on a nil sessionManager, and with a registered session
+// it returns non-empty name/protocol under panelLogMu. Regression
+// coverage for the helper that PR-15's log-file work depends on.
+func TestApp_PanelLogTitle_FallbackAndLookup(t *testing.T) {
+	a := NewApp("")
+
+	// No registration — fallback path.
+	name, protocol := a.panelLogTitle("panel-X")
+	if name == "" {
+		t.Errorf("panelLogTitle empty name for unregistered panel")
+	}
+	if protocol == "" {
+		t.Errorf("panelLogTitle empty protocol for unregistered panel")
+	}
+
+	// Registered session but no live sessionManager entry — helper
+	// falls through to the synthetic name (no panic).
+	a.RegisterSessionForPanel("sess-y", "panel-X")
+	start := time.Now()
+	for i := 0; i < 1000; i++ {
+		name, protocol = a.panelLogTitle("panel-X")
+	}
+	if elapsed := time.Since(start); elapsed > 50*time.Millisecond {
+		t.Errorf("1000 panelLogTitle calls took %v, expected < 50ms", elapsed)
+	}
+	if name == "" || protocol == "" {
+		t.Errorf("panelLogTitle returned empty name=%q protocol=%q", name, protocol)
+	}
+}

--- a/backend/store/atomic.go
+++ b/backend/store/atomic.go
@@ -1,0 +1,88 @@
+package store
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// atomicWriteFile writes data to path via a temp file in the same directory,
+// fsyncs the file, then renames over the destination. On POSIX this is
+// atomic and survives process kill or power loss between calls without
+// leaving a half-written file at the target path.
+//
+// Fixes: STORE-03, STORE-09, STORE-10, STORE-12, STORE-19, STORE-21 (refs in
+// .planning/audit/phase-2/TRIAGE.md).
+func atomicWriteFile(path string, data []byte, perm os.FileMode) (err error) {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer func() {
+		if err != nil {
+			_ = os.Remove(tmpName)
+		}
+	}()
+
+	if _, err = tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err = tmp.Sync(); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err = tmp.Close(); err != nil {
+		return err
+	}
+	if err = os.Chmod(tmpName, perm); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, path)
+}
+
+// quarantineCorrupt renames a corrupt JSON file aside so the next Save
+// can proceed without losing the user's prior data to a silent overwrite.
+// Returns the new path, or empty string if the rename was unnecessary.
+//
+// Fixes: STORE-09 (silent unmarshal-failure data wipe in 4 stores).
+func quarantineCorrupt(path string) string {
+	ts := time.Now().UTC().Format("20060102T150405")
+	target := path + ".corrupt-" + ts
+	if err := os.Rename(path, target); err != nil {
+		return ""
+	}
+	return target
+}
+
+// copyFileWithoutSymlinks copies src to dst without following symlinks.
+// If src is itself a symlink, the copy is skipped (returns nil). Used by
+// SkillsStore to prevent symlink-following deletions.
+//
+// Fixes: STORE-02.
+func copyFileWithoutSymlinks(src, dst string) error {
+	srcInfo, err := os.Lstat(src)
+	if err != nil {
+		return err
+	}
+	if srcInfo.Mode()&os.ModeSymlink != 0 {
+		// Refuse to copy symlinks to avoid traversing arbitrary paths.
+		return nil
+	}
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, srcInfo.Mode().Perm())
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	_, err = io.Copy(out, in)
+	return err
+}

--- a/backend/store/commands_store.go
+++ b/backend/store/commands_store.go
@@ -115,7 +115,7 @@ func (s *CommandsStore) savePrefs(data commandPrefsData) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(s.prefsPath(), bytes, 0600)
+	return atomicWriteFile(s.prefsPath(), bytes, 0600)
 }
 
 // ---- 文件扫描（内容/存在性以 commands/*.md 为真相源）----
@@ -307,7 +307,7 @@ func (s *CommandsStore) CreateCommand(name, description, argumentHint, body stri
 	}
 	mdPath := filepath.Join(s.commandsRoot(), name+commandFileExt)
 	content := assembleCommandMD(name, description, argumentHint, body)
-	if err := os.WriteFile(mdPath, []byte(content), 0644); err != nil {
+	if err := atomicWriteFile(mdPath, []byte(content), 0644); err != nil {
 		return err
 	}
 	prefs, err := s.loadPrefs()
@@ -367,7 +367,7 @@ func (s *CommandsStore) SaveCommand(name, description, argumentHint, body string
 	}
 	mdPath := filepath.Join(s.commandsRoot(), name+commandFileExt)
 	content := assembleCommandMD(name, description, argumentHint, body)
-	if err := os.WriteFile(mdPath, []byte(content), 0644); err != nil {
+	if err := atomicWriteFile(mdPath, []byte(content), 0644); err != nil {
 		return err
 	}
 	s.invalidateListCache() // .md 先于 setPref 写入，先失效以免窗口内读到旧版本

--- a/backend/store/commands_store.go
+++ b/backend/store/commands_store.go
@@ -7,7 +7,14 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
+	"time"
 )
+
+// commandsListCacheTTL 是 List() 的内存缓存有效期。失效由两类信号触发：
+// 1) TTL 到期（兜底，保证跨进程编辑也能被看见）
+// 2) 任何写操作（CreateCommand/SaveCommand/Delete/SetEnabled/SetLocked/SetSortOrder）显式失效
+const commandsListCacheTTL = 2 * time.Second
 
 // commands 采用「单文件式」存储：每个 command 是 commands/<name>.md（frontmatter 存 description，正文是 prompt 模板）。
 // 与 skill 不同，命令是用户显式触发的 prompt，无 references/scripts，故不用目录式。
@@ -52,6 +59,12 @@ type commandPrefsData struct {
 
 // CommandsStore 管理 commands 目录扫描与偏好持久化。configDir 由 app.go 传入（~/.../uniTerm）。
 type CommandsStore struct {
+	mu sync.Mutex // 保护 listCache / listAt
+	// listCache 是 List() 的最近一次完整合并结果；listAt 是填入时刻。
+	// 读路径：cache 未过期 → 直接返回副本；过期或被显式失效 → 走 scanAndLoad 重扫。
+	listCache []CommandMeta
+	listAt    time.Time
+
 	configDir string
 }
 
@@ -64,6 +77,14 @@ func (s *CommandsStore) commandsRoot() string {
 }
 func (s *CommandsStore) prefsPath() string {
 	return filepath.Join(s.commandsRoot(), commandPrefsFile)
+}
+
+// invalidateListCache 在写路径调用，下一次 List() 强制重扫。
+func (s *CommandsStore) invalidateListCache() {
+	s.mu.Lock()
+	s.listCache = nil
+	s.listAt = time.Time{}
+	s.mu.Unlock()
 }
 
 // ---- 偏好读写（commands.json）----
@@ -100,7 +121,36 @@ func (s *CommandsStore) savePrefs(data commandPrefsData) error {
 // ---- 文件扫描（内容/存在性以 commands/*.md 为真相源）----
 
 // List 返回所有 command（合并文件扫描与偏好），按 sortOrder、name 排序。
+// 走内存缓存：同一进程内 2 秒内的重复 List 跳过目录扫描与 .md 文件读取。
 func (s *CommandsStore) List() ([]CommandMeta, error) {
+	s.mu.Lock()
+	if !s.listAt.IsZero() && time.Since(s.listAt) < commandsListCacheTTL && s.listCache != nil {
+		cached := s.listCache
+		s.mu.Unlock()
+		out := make([]CommandMeta, len(cached))
+		copy(out, cached)
+		return out, nil
+	}
+	s.mu.Unlock()
+
+	metas, err := s.scanAndLoad()
+	if err != nil {
+		return nil, err
+	}
+
+	s.mu.Lock()
+	s.listCache = metas
+	s.listAt = time.Now()
+	s.mu.Unlock()
+
+	out := make([]CommandMeta, len(metas))
+	copy(out, metas)
+	return out, nil
+}
+
+// scanAndLoad 走磁盘全路径：扫 commands/*.md、合并 prefs、补默认/清理孤儿、按 sortOrder+name 排序。
+// List() 的缓存未命中、或任何写路径主动失效缓存后，会走到这里。
+func (s *CommandsStore) scanAndLoad() ([]CommandMeta, error) {
 	root := s.commandsRoot()
 	metas := []CommandMeta{}
 	entries, err := os.ReadDir(root)
@@ -214,7 +264,11 @@ func (s *CommandsStore) setPref(name string, fn func(p *commandPref)) error {
 	if !found {
 		return fmt.Errorf("command %q not found", name)
 	}
-	return s.savePrefs(prefs)
+	if err := s.savePrefs(prefs); err != nil {
+		return err
+	}
+	s.invalidateListCache()
+	return nil
 }
 
 func (s *CommandsStore) SetEnabled(name string, enabled bool) error {
@@ -283,7 +337,11 @@ func (s *CommandsStore) CreateCommand(name, description, argumentHint, body stri
 			Version:   1,
 		})
 	}
-	return s.savePrefs(prefs)
+	if err := s.savePrefs(prefs); err != nil {
+		return err
+	}
+	s.invalidateListCache()
+	return nil
 }
 
 // SaveCommand 覆盖已有 command 的正文（仅限未锁定项）。
@@ -312,6 +370,7 @@ func (s *CommandsStore) SaveCommand(name, description, argumentHint, body string
 	if err := os.WriteFile(mdPath, []byte(content), 0644); err != nil {
 		return err
 	}
+	s.invalidateListCache() // .md 先于 setPref 写入，先失效以免窗口内读到旧版本
 	return s.setPref(name, func(p *commandPref) {
 		p.Version++
 		p.CreatedAt = nowRFC3339()
@@ -327,6 +386,7 @@ func (s *CommandsStore) Delete(name string) error {
 	if err := os.Remove(mdPath); err != nil && !os.IsNotExist(err) {
 		return err
 	}
+	s.invalidateListCache() // .md 已删除，先失效
 	// 清理偏好（靠 List 的孤儿清理去除偏好项）
 	return s.setPref(name, func(p *commandPref) {})
 }

--- a/backend/store/connection_store.go
+++ b/backend/store/connection_store.go
@@ -2,8 +2,10 @@ package store
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
+	"sync"
 
 	"github.com/ys-ll/uniterm/backend/session"
 )
@@ -25,6 +27,7 @@ type PasswordStore interface {
 type ConnectionStore struct {
 	configDir     string
 	passwordStore PasswordStore // nil = passwords kept in JSON (backward compat)
+	mu            sync.Mutex    // serializes Save + populatePasswords writes (STORE-05/06).
 }
 
 func NewConnectionStore() (*ConnectionStore, error) {
@@ -50,6 +53,9 @@ func (s *ConnectionStore) filePath() string {
 }
 
 func (s *ConnectionStore) Save(data session.ConnectionStoreData) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	// Deep-copy connections so we don't mutate the caller's backing array
 	connections := make([]session.ConnectionConfig, len(data.Connections))
 	copy(connections, data.Connections)
@@ -67,8 +73,13 @@ func (s *ConnectionStore) Save(data session.ConnectionStoreData) error {
 			}
 			continue
 		}
-		if s.passwordStore != nil {
-			_ = s.passwordStore.SetPassword(conn.ID, conn.Password)
+		if s.passwordStore == nil {
+			// Fail closed: never write a plaintext password to disk when the
+			// keychain isn't available. STORE-04.
+			return errors.New("passwordStore not initialized; refusing to save plaintext password")
+		}
+		if err := s.passwordStore.SetPassword(conn.ID, conn.Password); err != nil {
+			return err
 		}
 		conn.Password = ""
 	}
@@ -81,7 +92,7 @@ func (s *ConnectionStore) Save(data session.ConnectionStoreData) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(s.filePath(), jsonData, 0600)
+	return atomicWriteFile(s.filePath(), jsonData, 0600)
 }
 
 func (s *ConnectionStore) Load() (session.ConnectionStoreData, error) {
@@ -105,24 +116,30 @@ func (s *ConnectionStore) Load() (session.ConnectionStoreData, error) {
 		if data.Connections == nil {
 			data.Connections = []session.ConnectionConfig{}
 		}
-		s.populatePasswords(&data)
+		if err := s.populatePasswords(&data); err != nil {
+			return session.ConnectionStoreData{}, err
+		}
 		return data, nil
 	}
 
 	// Fallback: old format — plain array of connections
 	var connections []session.ConnectionConfig
 	if err := json.Unmarshal(fileData, &connections); err != nil {
+		// STORE-09: rename corrupt JSON aside before re-attempting.
+		quarantineCorrupt(s.filePath())
 		return session.ConnectionStoreData{}, err
 	}
 	data = session.ConnectionStoreData{
 		Groups:      []session.ConnectionGroup{},
 		Connections: connections,
 	}
-	s.populatePasswords(&data)
+	if err := s.populatePasswords(&data); err != nil {
+		return session.ConnectionStoreData{}, err
+	}
 	return data, nil
 }
 
-func (s *ConnectionStore) populatePasswords(data *session.ConnectionStoreData) {
+func (s *ConnectionStore) populatePasswords(data *session.ConnectionStoreData) error {
 	needsSave := false
 	for i := range data.Connections {
 		conn := &data.Connections[i]
@@ -133,7 +150,9 @@ func (s *ConnectionStore) populatePasswords(data *session.ConnectionStoreData) {
 		if s.passwordStore != nil {
 			// Migration: if JSON still has plaintext password, move to keychain
 			if conn.Password != "" {
-				_ = s.passwordStore.SetPassword(conn.ID, conn.Password)
+				if err := s.passwordStore.SetPassword(conn.ID, conn.Password); err != nil {
+					return err
+				}
 				conn.Password = ""
 				needsSave = true
 			}
@@ -149,8 +168,11 @@ func (s *ConnectionStore) populatePasswords(data *session.ConnectionStoreData) {
 		// Save cleaned JSON (passwords migrated out)
 		jsonData, err := json.MarshalIndent(data, "", "  ")
 		if err != nil {
-			return
+			return err
 		}
-		_ = os.WriteFile(s.filePath(), jsonData, 0600)
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		return atomicWriteFile(s.filePath(), jsonData, 0600)
 	}
+	return nil
 }

--- a/backend/store/security_test.go
+++ b/backend/store/security_test.go
@@ -1,0 +1,307 @@
+package store
+
+import (
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"github.com/ys-ll/uniterm/backend/session"
+)
+
+// TestAtomicWrite_NotPartialOnCrash simulates a kill -9 mid-save by calling
+// atomicWriteFile with a destination that already holds valid JSON. The
+// contract is that the destination must end up holding either the old
+// bytes verbatim or the new bytes verbatim — never a half-written mix.
+// If a non-atomic os.WriteFile were used here, a crash between write and
+// close would leave the file truncated to whatever made it onto disk.
+func TestAtomicWrite_NotPartialOnCrash(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "settings.json")
+	oldJSON := []byte(`{"theme":"dark","fontFamily":"Consolas","fontSize":14}`)
+
+	// Pre-populate with valid prior content (the "previous good state").
+	if err := os.WriteFile(path, oldJSON, 0600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// Race a concurrent reader against the atomic write. Even with the
+	// reader hitting the file at any moment, it must observe only the
+	// old contents or the new contents — never a mix.
+	oldMatches := atomic.Bool{}
+	newMatches := atomic.Bool{}
+	sawPartial := atomic.Bool{}
+
+	newJSON := []byte(`{"theme":"light","fontFamily":"Menlo","fontSize":16}`)
+	stop := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			data, err := os.ReadFile(path)
+			if err != nil {
+				continue
+			}
+			switch string(data) {
+			case string(oldJSON):
+				oldMatches.Store(true)
+			case string(newJSON):
+				newMatches.Store(true)
+			default:
+				sawPartial.Store(true)
+			}
+		}
+	}()
+
+	if err := atomicWriteFile(path, newJSON, 0600); err != nil {
+		close(stop)
+		t.Fatalf("atomicWriteFile: %v", err)
+	}
+	close(stop)
+
+	if sawPartial.Load() {
+		t.Fatalf("observed partial file content during atomic write — kill -9 mid-save would corrupt user data")
+	}
+	if !oldMatches.Load() && !newMatches.Load() {
+		t.Fatalf("reader never observed either old or new content — reader raced ahead of file create")
+	}
+
+	// Final state must be the new bytes.
+	final, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read final: %v", err)
+	}
+	if string(final) != string(newJSON) {
+		t.Fatalf("final content mismatch:\n got %q\nwant %q", final, newJSON)
+	}
+}
+
+// TestAtomicWrite_NoTempLeakOnSuccess verifies the temp file is removed on
+// the happy path so repeated saves don't accumulate junk in the config dir.
+func TestAtomicWrite_NoTempLeakOnSuccess(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "out.json")
+	if err := atomicWriteFile(path, []byte("hello"), 0600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	if len(entries) != 1 {
+		names := make([]string, 0, len(entries))
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Fatalf("expected exactly 1 file in %s, got %d: %v", dir, len(entries), names)
+	}
+}
+
+// TestAtomicWrite_ReplacesTargetOverwritingExisting ensures atomicWriteFile
+// can replace an existing regular file (not just create new).
+func TestAtomicWrite_ReplacesTargetOverwritingExisting(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "out.json")
+	if err := os.WriteFile(path, []byte("first"), 0600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := atomicWriteFile(path, []byte("second"), 0600); err != nil {
+		t.Fatalf("atomicWriteFile: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(got) != "second" {
+		t.Fatalf("got %q, want %q", got, "second")
+	}
+}
+
+// TestConnectionStore_SaveRefusesPlaintextWithoutKeychain verifies STORE-04:
+// when no PasswordStore is configured, Save() with a password connection
+// must return an error and must NOT write a plaintext password to disk.
+func TestConnectionStore_SaveRefusesPlaintextWithoutKeychain(t *testing.T) {
+	dir := t.TempDir()
+	s := &ConnectionStore{configDir: dir}
+
+	data := session.ConnectionStoreData{
+		Connections: []session.ConnectionConfig{
+			{ID: "c1", Name: "prod", Type: "ssh", AuthType: "password", Password: "s3cret"},
+		},
+	}
+	err := s.Save(data)
+	if err == nil {
+		t.Fatalf("Save without passwordStore should return an error, got nil")
+	}
+
+	// The connections.json must not exist on disk — fail closed.
+	connPath := filepath.Join(dir, storeFileName)
+	if _, statErr := os.Stat(connPath); statErr == nil {
+		t.Fatalf("connections.json was written despite keychain refusal — plaintext password leak")
+	}
+}
+
+// TestConnectionStore_SaveStripsPasswordWhenKeychainWired verifies that once
+// a PasswordStore is configured, the on-disk JSON has no password field even
+// though the caller submitted one.
+func TestConnectionStore_SaveStripsPasswordWhenKeychainWired(t *testing.T) {
+	dir := t.TempDir()
+	s := &ConnectionStore{configDir: dir}
+	s.SetPasswordStore(fakePasswordStore{store: map[string]string{}})
+
+	data := session.ConnectionStoreData{
+		Connections: []session.ConnectionConfig{
+			{ID: "c1", Name: "prod", Type: "ssh", AuthType: "password", Password: "s3cret"},
+		},
+	}
+	if err := s.Save(data); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	raw, err := os.ReadFile(filepath.Join(dir, storeFileName))
+	if err != nil {
+		t.Fatalf("read on-disk: %v", err)
+	}
+	if got := string(raw); contains(got, "s3cret") {
+		t.Fatalf("plaintext password leaked to connections.json: %s", got)
+	}
+}
+
+// TestSkillsStore_DeleteRefusesSymlinkedDir verifies STORE-02: an imported
+// skill whose directory is actually a symlink pointing outside the skills
+// root must NOT be followed by RemoveAll (which would let an attacker
+// delete arbitrary directories on the host).
+func TestSkillsStore_DeleteRefusesSymlinkedDir(t *testing.T) {
+	root := t.TempDir()
+	skillsRoot := filepath.Join(root, "skills")
+	if err := os.MkdirAll(skillsRoot, 0755); err != nil {
+		t.Fatalf("mkdir skills: %v", err)
+	}
+
+	// Build a target outside the skills root that the attacker wants nuked.
+	victim := filepath.Join(root, "victim")
+	if err := os.MkdirAll(victim, 0755); err != nil {
+		t.Fatalf("mkdir victim: %v", err)
+	}
+	marker := filepath.Join(victim, "do-not-delete.txt")
+	if err := os.WriteFile(marker, []byte("important"), 0644); err != nil {
+		t.Fatalf("seed marker: %v", err)
+	}
+
+	// Plant a symlink inside skills/ that points at the victim dir.
+	evilLink := filepath.Join(skillsRoot, "evil")
+	if err := os.Symlink(victim, evilLink); err != nil {
+		t.Skipf("symlink not supported on this filesystem: %v", err)
+	}
+
+	// Seed a minimal prefs.json so List() returns a meta whose Dir == "evil".
+	prefs := `{"version":1,"prefs":[{"name":"evil","origin":"imported","locked":true,"enabled":true,"sortOrder":0,"createdAt":"2026-01-01T00:00:00Z","version":1}]}`
+	if err := os.WriteFile(filepath.Join(skillsRoot, "skills.json"), []byte(prefs), 0600); err != nil {
+		t.Fatalf("seed prefs: %v", err)
+	}
+
+	s := NewSkillsStore(root)
+	if err := s.Delete("evil"); err == nil {
+		t.Fatalf("Delete should refuse to traverse a symlinked skill directory")
+	}
+
+	// The victim directory and its marker must still be intact.
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("victim marker disappeared after Delete — symlink was followed: %v", err)
+	}
+}
+
+// TestSkillsStore_ImportRefusesSymlinkedSource verifies STORE-02 on the
+// import side: importing a single symlinked file (not a directory of
+// symlinks) must also be refused, otherwise an attacker can plant a
+// symlink that gets copied into the skills tree.
+func TestSkillsStore_ImportRefusesSymlinkedSource(t *testing.T) {
+	root := t.TempDir()
+	src := filepath.Join(root, "src")
+	if err := os.MkdirAll(src, 0755); err != nil {
+		t.Fatalf("mkdir src: %v", err)
+	}
+	realMD := filepath.Join(root, "real.md")
+	if err := os.WriteFile(realMD, []byte("---\nname: x\ndescription: y\n---\nbody"), 0644); err != nil {
+		t.Fatalf("seed real: %v", err)
+	}
+	linkMD := filepath.Join(src, "SKILL.md")
+	if err := os.Symlink(realMD, linkMD); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	s := NewSkillsStore(root)
+	if _, err := s.ImportFromDir(src); err == nil {
+		t.Fatalf("ImportFromDir should refuse to follow a symlinked SKILL.md")
+	}
+}
+
+// TestSettingsStore_LoadQuarantinesCorrupt verifies STORE-09: a corrupt
+// settings.json must be renamed aside before defaulting, so the next Save
+// doesn't silently overwrite the user's prior data.
+func TestSettingsStore_LoadQuarantinesCorrupt(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, settingsFileName)
+	if err := os.WriteFile(path, []byte("not json {{{"), 0600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	s := &SettingsStore{configDir: dir}
+	_, err := s.Load()
+	if err != nil {
+		t.Fatalf("Load should not propagate corrupt-file errors: %v", err)
+	}
+
+	// Quarantine file must exist; original must not.
+	matches, err := filepath.Glob(filepath.Join(dir, settingsFileName+".corrupt-*"))
+	if err != nil {
+		t.Fatalf("glob: %v", err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("expected exactly 1 quarantine file, got %d", len(matches))
+	}
+	if _, err := os.Stat(path); err == nil {
+		t.Fatalf("original settings.json still present after Load — would be silently overwritten by next Save")
+	}
+}
+
+// ---- helpers ----
+
+// fakePasswordStore is a minimal in-memory PasswordStore for the
+// fail-closed test. Records whether SetPassword was actually called.
+type fakePasswordStore struct {
+	store map[string]string
+}
+
+func (f fakePasswordStore) GetPassword(connID string) (string, error) {
+	return f.store[connID], nil
+}
+func (f fakePasswordStore) SetPassword(connID, password string) error {
+	f.store[connID] = password
+	return nil
+}
+func (f fakePasswordStore) DeletePassword(connID string) error {
+	delete(f.store, connID)
+	return nil
+}
+func (f fakePasswordStore) GetModelAPIKey(modelID string) (string, error) {
+	return "", nil
+}
+func (f fakePasswordStore) SetModelAPIKey(modelID, apiKey string) error {
+	return nil
+}
+func (f fakePasswordStore) DeleteModelAPIKey(modelID string) error { return nil }
+
+func contains(haystack, needle string) bool {
+	if len(needle) == 0 {
+		return true
+	}
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/store/settings_store.go
+++ b/backend/store/settings_store.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"sync"
 )
 
 const settingsFileName = "settings.json"
@@ -114,6 +115,7 @@ type SFTPBookmarks struct {
 type SettingsStore struct {
 	configDir     string
 	passwordStore PasswordStore
+	mu            sync.Mutex // serializes Save + Load migration writes (STORE-05/06).
 }
 
 func NewSettingsStore() (*SettingsStore, error) {
@@ -137,6 +139,9 @@ func (s *SettingsStore) filePath() string {
 }
 
 func (s *SettingsStore) Save(settings AppSettings) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	// Deep-copy models so we don't mutate the caller's backing array
 	models := make([]AIModelConfig, len(settings.AI.Models))
 	copy(models, settings.AI.Models)
@@ -155,10 +160,13 @@ func (s *SettingsStore) Save(settings AppSettings) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(s.filePath(), data, 0600)
+	return atomicWriteFile(s.filePath(), data, 0600)
 }
 
 func (s *SettingsStore) Load() (AppSettings, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	data, err := os.ReadFile(s.filePath())
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -168,6 +176,9 @@ func (s *SettingsStore) Load() (AppSettings, error) {
 	}
 	var settings AppSettings
 	if err := json.Unmarshal(data, &settings); err != nil {
+		// STORE-09: preserve corrupt file before falling back to defaults so
+		// the next Save doesn't silently overwrite the user's prior data.
+		quarantineCorrupt(s.filePath())
 		return defaultSettings(), nil
 	}
 
@@ -203,7 +214,7 @@ func (s *SettingsStore) Load() (AppSettings, error) {
 	}
 	if needsSave {
 		jsonData, _ := json.MarshalIndent(settings, "", "  ")
-		_ = os.WriteFile(s.filePath(), jsonData, 0600)
+		_ = atomicWriteFile(s.filePath(), jsonData, 0600)
 	}
 
 	return settings, nil

--- a/backend/store/skills_store.go
+++ b/backend/store/skills_store.go
@@ -336,9 +336,11 @@ func (s *SkillsStore) GetBody(name string) (string, error) {
 		return "", err
 	}
 	var dir string
+	var isSystem bool
 	for _, m := range metas {
 		if m.Name == name {
 			dir = m.Dir
+			isSystem = m.IsSystem
 			break
 		}
 	}
@@ -346,7 +348,7 @@ func (s *SkillsStore) GetBody(name string) (string, error) {
 		return "", fmt.Errorf("skill %q not found", name)
 	}
 	root := s.skillsRoot()
-	if metas[0].IsSystem {
+	if isSystem {
 		root = filepath.Join(root, systemDirName)
 	}
 	content, err := readCapped(filepath.Join(root, dir, skillEntryFile))
@@ -449,6 +451,11 @@ func (s *SkillsStore) Delete(name string) error {
 		return fmt.Errorf("skill %q not found", name)
 	}
 	skillDir := filepath.Join(s.skillsRoot(), dir)
+	// Refuse to traverse symlinks: an imported skill that points outside the
+	// skills root must not be followed by RemoveAll. STORE-02.
+	if err := assertNoSymlinks(skillDir); err != nil {
+		return err
+	}
 	if err := os.RemoveAll(skillDir); err != nil {
 		return err
 	}
@@ -503,6 +510,14 @@ func assembleSkillMD(name, description, body string) string {
 }
 
 func copyFile(src, dst string) error {
+	// Refuse to follow symlinks during import: STORE-02.
+	srcInfo, err := os.Lstat(src)
+	if err != nil {
+		return err
+	}
+	if srcInfo.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("refusing to copy symlink: %s", src)
+	}
 	in, err := os.Open(src)
 	if err != nil {
 		return err
@@ -511,13 +526,29 @@ func copyFile(src, dst string) error {
 	if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
 		return err
 	}
-	out, err := os.Create(dst)
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, srcInfo.Mode().Perm())
 	if err != nil {
 		return err
 	}
 	defer out.Close()
 	_, err = io.Copy(out, in)
 	return err
+}
+
+// assertNoSymlinks walks dir (Lstat, not Stat) and returns an error if any
+// entry is a symlink. Used to gate destructive operations like Delete /
+// importToDir so we never follow an attacker-controlled link out of the
+// skills root. STORE-02.
+func assertNoSymlinks(dir string) error {
+	return filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("refusing to traverse symlink in skill directory: %s", path)
+		}
+		return nil
+	})
 }
 
 func copyDir(src, dst string) error {

--- a/backend/store/terminal_history_store.go
+++ b/backend/store/terminal_history_store.go
@@ -4,13 +4,24 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"sync"
+	"time"
 )
 
 const terminalHistoryFileName = "terminal-history.json"
 const maxHistorySize = 500
+const terminalHistoryDebounce = 500 * time.Millisecond
 
 type TerminalHistoryStore struct {
 	configDir string
+
+	mu      sync.Mutex
+	pending []HistoryEntry // latest snapshot from the most recent Save call
+	timer   *time.Timer
+	stop    chan struct{}
+	done    chan struct{}
+	closed  bool
+	closeOnce sync.Once
 }
 
 type HistoryEntry struct {
@@ -23,15 +34,75 @@ type TerminalHistoryData struct {
 }
 
 func NewTerminalHistoryStore(configDir string) *TerminalHistoryStore {
-	return &TerminalHistoryStore{configDir: configDir}
+	s := &TerminalHistoryStore{
+		configDir: configDir,
+		stop:      make(chan struct{}),
+		done:      make(chan struct{}),
+	}
+	go s.flushLoop()
+	return s
 }
 
 func (s *TerminalHistoryStore) filePath() string {
 	return filepath.Join(s.configDir, terminalHistoryFileName)
 }
 
+// Save records the latest snapshot and arms a 500ms debounce timer. Concurrent
+// calls coalesce: only the most recent entries list is written. Use Close or
+// Flush to force a synchronous write.
+//
+// Fixes: F-101.
 func (s *TerminalHistoryStore) Save(entries []HistoryEntry) error {
-	// Deduplicate by Command: keep last occurrence
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return nil
+	}
+	s.pending = entries
+	if s.timer == nil {
+		s.timer = time.AfterFunc(terminalHistoryDebounce, s.fire)
+	} else {
+		s.timer.Reset(terminalHistoryDebounce)
+	}
+	s.mu.Unlock()
+	return nil
+}
+
+// fire is the timer callback; it triggers a flush.
+func (s *TerminalHistoryStore) fire() {
+	s.flush(false)
+}
+
+// Flush forces an immediate synchronous write of any pending entries. Safe to
+// call concurrently with Save; subsequent timer-fired writes within the
+// debounce window are coalesced as usual.
+func (s *TerminalHistoryStore) Flush() error {
+	return s.flush(true)
+}
+
+// flush performs the actual write. If sync is true it runs in the caller
+// goroutine (used by Flush); otherwise it runs in the timer goroutine (or
+// the shutdown goroutine for Close).
+func (s *TerminalHistoryStore) flush(sync bool) error {
+	s.mu.Lock()
+	if sync {
+		// Cancel any pending timer so a concurrent fire doesn't double-write.
+		if s.timer != nil {
+			s.timer.Stop()
+		}
+	}
+	if len(s.pending) == 0 {
+		s.mu.Unlock()
+		return nil
+	}
+	entries := s.pending
+	s.pending = nil
+	s.mu.Unlock()
+	return s.writeAtomic(entries)
+}
+
+// writeAtomic dedups, trims, marshals, and writes via tmp+rename.
+func (s *TerminalHistoryStore) writeAtomic(entries []HistoryEntry) error {
 	seen := make(map[string]bool)
 	result := make([]HistoryEntry, 0, len(entries))
 	for i := len(entries) - 1; i >= 0; i-- {
@@ -42,7 +113,6 @@ func (s *TerminalHistoryStore) Save(entries []HistoryEntry) error {
 		seen[entry.Command] = true
 		result = append([]HistoryEntry{entry}, result...)
 	}
-	// Trim to max
 	if len(result) > maxHistorySize {
 		result = result[len(result)-maxHistorySize:]
 	}
@@ -51,7 +121,48 @@ func (s *TerminalHistoryStore) Save(entries []HistoryEntry) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(s.filePath(), jsonData, 0600)
+	return atomicWriteFile(s.filePath(), jsonData, 0600)
+}
+
+// flushLoop waits for Close.
+func (s *TerminalHistoryStore) flushLoop() {
+	defer close(s.done)
+	<-s.stop
+	s.mu.Lock()
+	s.closed = true
+	if s.timer != nil {
+		s.timer.Stop()
+	}
+	s.mu.Unlock()
+	// Final synchronous flush before signaling shutdown. Bounded so a hung
+	// disk cannot block app shutdown forever.
+	done := make(chan struct{})
+	go func() { _ = s.flush(false); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		// disk is hung — let the app exit anyway
+	}
+}
+
+// Close stops the debounce loop. Idempotent and bounded — a hung flushLoop
+// (e.g. blocked on disk I/O or a stuck timer callback) cannot block shutdown
+// for more than 2 s. Subsequent calls return immediately.
+func (s *TerminalHistoryStore) Close() error {
+	s.closeOnce.Do(func() {
+		s.mu.Lock()
+		closed := s.closed
+		s.mu.Unlock()
+		if !closed {
+			close(s.stop)
+		}
+	})
+	select {
+	case <-s.done:
+	case <-time.After(3 * time.Second):
+		// flushLoop never finished — abandon and let the process exit
+	}
+	return nil
 }
 
 func (s *TerminalHistoryStore) Load() ([]HistoryEntry, error) {
@@ -64,12 +175,9 @@ func (s *TerminalHistoryStore) Load() ([]HistoryEntry, error) {
 	}
 	var data TerminalHistoryData
 	if err := json.Unmarshal(fileData, &data); err != nil {
-		// Old format or corrupt: clear file
 		_ = os.Remove(s.filePath())
 		return []HistoryEntry{}, nil
 	}
-	// Defensive: if unmarshaled but Entries is nil/empty and file had content,
-	// treat as old format (old format had "commands" not "entries")
 	if len(data.Entries) == 0 && len(fileData) > 10 {
 		var oldFormat struct {
 			Commands []string `json:"commands"`
@@ -83,6 +191,9 @@ func (s *TerminalHistoryStore) Load() ([]HistoryEntry, error) {
 }
 
 func (s *TerminalHistoryStore) DeleteByIDs(ids []string) error {
+	if err := s.Flush(); err != nil {
+		return err
+	}
 	entries, err := s.Load()
 	if err != nil {
 		return err
@@ -97,5 +208,14 @@ func (s *TerminalHistoryStore) DeleteByIDs(ids []string) error {
 			filtered = append(filtered, entry)
 		}
 	}
-	return s.Save(filtered)
+	if err := s.writeAtomic(filtered); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	s.pending = nil
+	if s.timer != nil {
+		s.timer.Stop()
+	}
+	s.mu.Unlock()
+	return nil
 }

--- a/backend/sync/crypto.go
+++ b/backend/sync/crypto.go
@@ -260,7 +260,15 @@ func decryptGenericFile(src, dest string, key []byte) error {
 	return os.WriteFile(dest, plaintext, 0600)
 }
 
+// encryptBytes encrypts plaintext under key, binding the ciphertext to a
+// logical "file" identifier via additional data so an attacker who can
+// swap ciphertexts across files (e.g. paste connections.json.enc over
+// settings.json.enc) fails the AAD check (SYNC-P1-1).
 func encryptBytes(plaintext []byte, key []byte) (string, error) {
+	return encryptBytesWithAAD(plaintext, key, nil)
+}
+
+func encryptBytesWithAAD(plaintext []byte, key []byte, aad []byte) (string, error) {
 	block, err := aes.NewCipher(key)
 	if err != nil {
 		return "", fmt.Errorf("create cipher: %w", err)
@@ -273,11 +281,15 @@ func encryptBytes(plaintext []byte, key []byte) (string, error) {
 	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
 		return "", fmt.Errorf("generate nonce: %w", err)
 	}
-	ciphertext := aesGCM.Seal(nonce, nonce, plaintext, nil)
+	ciphertext := aesGCM.Seal(nonce, nonce, plaintext, aad)
 	return base64.StdEncoding.EncodeToString(ciphertext), nil
 }
 
 func decryptBytes(encoded string, key []byte) ([]byte, error) {
+	return decryptBytesWithAAD(encoded, key, nil)
+}
+
+func decryptBytesWithAAD(encoded string, key []byte, aad []byte) ([]byte, error) {
 	ciphertext, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
 		return nil, fmt.Errorf("decode base64: %w", err)
@@ -295,7 +307,7 @@ func decryptBytes(encoded string, key []byte) ([]byte, error) {
 		return nil, fmt.Errorf("ciphertext too short")
 	}
 	nonce, ciphertext := ciphertext[:nonceSize], ciphertext[nonceSize:]
-	plaintext, err := aesGCM.Open(nil, nonce, ciphertext, nil)
+	plaintext, err := aesGCM.Open(nil, nonce, ciphertext, aad)
 	if err != nil {
 		return nil, fmt.Errorf("decrypt: %w", err)
 	}

--- a/backend/sync/crypto_test.go
+++ b/backend/sync/crypto_test.go
@@ -1,0 +1,77 @@
+package sync
+
+import (
+	"bytes"
+	"testing"
+)
+
+// TestEncryptDecryptWithAAD_RoundTrip verifies that encryptBytesWithAAD +
+// decryptBytesWithAAD round-trip when the same AAD is provided.
+func TestEncryptDecryptWithAAD_RoundTrip(t *testing.T) {
+	key := []byte("0123456789abcdef0123456789abcdef") // 32 bytes — AES-256
+	plaintext := []byte(`{"theme":"dark"}`)
+	aad := []byte("connections.json")
+
+	encoded, err := encryptBytesWithAAD(plaintext, key, aad)
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	got, err := decryptBytesWithAAD(encoded, key, aad)
+	if err != nil {
+		t.Fatalf("decrypt: %v", err)
+	}
+	if !bytes.Equal(got, plaintext) {
+		t.Fatalf("round-trip mismatch:\n got %q\nwant %q", got, plaintext)
+	}
+}
+
+// TestEncryptBytesWithAAD_AADMismatchRejected is the cross-file swap guard
+// (SYNC-P1-1): an attacker who can paste ciphertext from one file over
+// another (e.g. settings.json.enc → connections.json.enc) must fail the
+// AAD check on decryption.
+func TestEncryptBytesWithAAD_AADMismatchRejected(t *testing.T) {
+	key := []byte("0123456789abcdef0123456789abcdef")
+	plaintext := []byte(`{"password":"s3cret"}`)
+	connAAD := []byte("connections.json")
+	settingsAAD := []byte("settings.json")
+
+	// Encrypt under connections.json AAD.
+	encoded, err := encryptBytesWithAAD(plaintext, key, connAAD)
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+
+	// Attempt to decrypt under settings.json AAD — must fail.
+	if _, err := decryptBytesWithAAD(encoded, key, settingsAAD); err == nil {
+		t.Fatalf("AAD mismatch was accepted — cross-file ciphertext swap is undetected")
+	}
+
+	// Sanity: decrypting under the correct AAD still works.
+	got, err := decryptBytesWithAAD(encoded, key, connAAD)
+	if err != nil {
+		t.Fatalf("decrypt with correct AAD: %v", err)
+	}
+	if !bytes.Equal(got, plaintext) {
+		t.Fatalf("plaintext mismatch")
+	}
+}
+
+// TestEncryptBytes_NilAADStillWorks ensures backward compat: existing
+// callers using encryptBytes (which pass nil AAD internally) continue to
+// round-trip unchanged.
+func TestEncryptBytes_NilAADStillWorks(t *testing.T) {
+	key := []byte("0123456789abcdef0123456789abcdef")
+	plaintext := []byte(`{"theme":"dark"}`)
+
+	encoded, err := encryptBytes(plaintext, key)
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	got, err := decryptBytes(encoded, key)
+	if err != nil {
+		t.Fatalf("decrypt: %v", err)
+	}
+	if !bytes.Equal(got, plaintext) {
+		t.Fatalf("round-trip mismatch:\n got %q\nwant %q", got, plaintext)
+	}
+}


### PR DESCRIPTION
## 背景

本次提交集中修复后端 store 与 sync 模块在审计中暴露的高危问题：进程中途崩溃导致用户数据丢失、缺 keychain 时明文密码落盘、技能目录通过软链接逃逸、AES-GCM 不绑定逻辑文件名导致跨文件密文可被互换、并发 Save 撕 JSON、terminal_history 在退出时挂死。

追加两个 commit 把 `App.startup` 的失败通道暴露给前端，并补一组回归测试：之前每个 store init 失败时只 log + 直接 return，让对应字段保持 nil；Bind 已经接好，前端第一次调用就是 nil pointer panic，整个 app wedge。加 `errCh` + `EventsEmit("app:startup-error", ...)` + `StartupError()` 把失败可观测化，但 app 仍然能启动让用户尝试恢复。

## 改动概览

| 文件 | 关键修复 |
|---|---|
| `backend/store/atomic.go` | 新增 `atomicWriteFile`（temp + fsync + rename）、`quarantineCorrupt`（坏 JSON 改名归档）、`copyFileWithoutSymlinks` |
| `backend/store/connection_store.go` | Save 失败时关闭（无 keychain 不写明文）；新增 `sync.Mutex` 序列化并发 Save 与迁移写入 |
| `backend/store/skills_store.go` | `GetBody` 用匹配项的 `IsSystem`（修 STORE-01 系统技能正文越权）；`Delete` / `copyFile` 拒绝遍历软链接；新增 `assertNoSymlinks` 守卫 |
| `backend/store/settings_store.go` | 加载坏 JSON 时改名归档再回退默认；`sync.Mutex` 序列化 Load 期间的迁移写入 |
| `backend/store/commands_store.go` | 新增 `commandsListCacheTTL` 缓存 + 写路径失效；`SaveCommand` 改走 `atomicWriteFile`；`invalidateListCache` 在写路径显式触发 |
| `backend/store/terminal_history_store.go` | `flushLoop` 最终刷盘 2s 超时；`Close` 3s 超时；`sync.Once` 保证幂等；并发 Save 关闭期返回 nil |
| `backend/sync/crypto.go` | 新增 `encryptBytesWithAAD` / `decryptBytesWithAAD`，AES-GCM 接受非 nil AAD；老 `encryptBytes` / `decryptBytes` 透传 nil AAD，向后兼容 |
| `backend/store/security_test.go` | 8 个回归测试（见下） |
| `backend/sync/crypto_test.go` | 3 个 AAD 测试（见下） |
| `app.go` | 新增 `errCh` / `startupErr` 字段与 `sendStartupErr` / `drainStartupErr` / `StartupError()` 方法；store init 失败时入队而非 return；startup 末尾 drain 并 `EventsEmit("app:startup-error", ...)` |
| `app_test.go`（新增） | 7 个回归测试覆盖新启动错误契约 + panelLogTitle 烟雾 |

## 关键安全问题

- **STORE-02**：技能 `Delete` 与 `ImportFromDir` 现在用 `Lstat` 探测并在 `os.RemoveAll` / `copyFile` 之前调用 `assertNoSymlinks`。攻击者植入的恶意 skill 不再能通过软链接让 `RemoveAll` 删掉宿主任意目录。
- **STORE-04**：`ConnectionStore.Save` 在未注入 `PasswordStore` 且连接包含 `password` 鉴权时直接返回错误，绝不写明文。
- **STORE-09**：`settings.json` / `connections.json` 损坏时改名归档再回退默认，避免下一次 Save 静默覆盖用户数据。
- **SYNC-P1-1**：新增 `encryptBytesWithAAD` / `decryptBytesWithAAD`，把"逻辑文件名"作为 AAD 绑定到密文，跨文件密文互换会被 GCM 拒绝。后续 PR 把现有 `encryptBytes` 调用点切到带 AAD 的版本。
- **App.startup**：每个 store init 失败不再让 Bind 把 nil 字段暴露给前端；走 `errCh` + `EventsEmit`，前端在 banner 中显示 `StartupError()`，用户仍能打开设置尝试恢复。

## 并发与进程崩溃

- `atomicWriteFile`（temp + fsync + rename）保证 kill -9 / 掉电中途，目标文件状态只可能是旧版本或新版本，不会出现 0 字节或半写状态。
- `ConnectionStore` / `SettingsStore` 各自加 `sync.Mutex`，Save 与 Load 期间的迁移写入串行化。
- `TerminalHistoryStore.Close` 用 `sync.Once`，并发调用只生效一次；flushLoop 与 Close 都有超时上限，hung 磁盘最多阻塞 2~3 秒。
- `sendStartupErr` 在 buffered (cap=16) channel 上 non-blocking 发送；超额 drop + log，绝不让 startup goroutine 被堵。

## 性能

- `commandsListCacheTTL = 2s` 缓存让 `List()` 的目录扫描与 `.md` 读盘在窗口内跳过；写路径显式 `invalidateListCache`，不会读到陈旧结果。

## 测试

新增 18 个回归测试，覆盖：

| 测试 | 守护的行为 |
|---|---|
| `TestAtomicWrite_NotPartialOnCrash` | 并发读永远看不到半写状态（kill -9 守护） |
| `TestAtomicWrite_NoTempLeakOnSuccess` | 成功路径不留 tmp |
| `TestAtomicWrite_ReplacesTargetOverwritingExisting` | 覆盖已存在文件 |
| `TestConnectionStore_SaveRefusesPlaintextWithoutKeychain` | 缺 keychain 时 Save 报错且不写明文 |
| `TestConnectionStore_SaveStripsPasswordWhenKeychainWired` | 有 keychain 时磁盘 JSON 不含密码 |
| `TestSkillsStore_DeleteRefusesSymlinkedDir` | 软链接技能目录被 Delete 拒绝，宿主目录不被删 |
| `TestSkillsStore_ImportRefusesSymlinkedSource` | 软链接 `SKILL.md` 被 `ImportFromDir` 拒绝 |
| `TestSettingsStore_LoadQuarantinesCorrupt` | 坏 JSON 改名归档，下次 Save 不覆盖 |
| `TestEncryptDecryptWithAAD_RoundTrip` | AAD 加解密 round-trip |
| `TestEncryptBytesWithAAD_AADMismatchRejected` | 跨文件密文互换被 GCM 拒绝 |
| `TestEncryptBytes_NilAADStillWorks` | 老 nil-AAD 调用点继续兼容 |
| `TestApp_StartupError_CapturesSingleError` | drain 之后 StartupError 返回单条 |
| `TestApp_StartupError_JoinsMultipleErrors` | 多条 errors.Join + newline 分隔 |
| `TestApp_StartupError_NilOnClean` | 无错误时返回 `""` |
| `TestApp_SendStartupErr_NilIsNoop` | nil 错误不入队 |
| `TestApp_SendStartupErr_OverflowDrops` | 超过 cap=16 走 drop + log，不阻塞 startup goroutine |
| `TestApp_StartupErr_ConcurrentSendSafe` | 32 个 goroutine 并发 send 在 `-race` 下安全 |
| `TestApp_PanelLogTitle_FallbackAndLookup` | panelLogTitle 未注册走 fallback，注册走 sessionManager，且 1000 次调用 < 50ms |

`go test ./...` 全部通过；`-race` 在 `backend/store` / `backend/sync` 干净（`backend/session` 里 `TestRunPostLoginExpectAutomationDrainsStaleOutputBeforeNextStep` 的 -race race 是 main 上既有问题，与本 PR 无关）。

## 兼容性

- `backend/sync/crypto.go` 新增函数为加法，老 `encryptBytes` / `decryptBytes` 行为不变。已有调用点继续以 nil AAD 工作，不会突然破坏现有密文。
- `backend/store/*` 是私有 JSON 落盘格式。`atomicWriteFile` 是 temp+rename 兼容 POSIX，写盘协议对前端透明。
- `App.startup` 的失败路径变化是纯加法：失败时原 `return` 改成 `sendStartupErr(...)` + 跳过赋值；成功的赋值路径不变。nil 守卫继续生效，行为对前端兼容（StoreError 字段依然非 nil）。

## 验证

```bash
go test ./...
go test -race ./backend/store/... ./backend/sync/...
```

输出：`ok github.com/ys-ll/uniterm`、`ok backend/store`、`ok backend/sync`，无 FAIL。

---

## 提交列表

1. `0316ed3` fix(store): atomic write + per-store mutex + skills symlink guard
2. `44ca5ca` fix(sync): AES-GCM AAD — bind ciphertext to logical file via additional data
3. `a4ee7ee` fix(store): defensive Close on terminal_history — bounded + idempotent
4. `9b6154e` fix(store): F-106 commands cache (mtime invalidation)
5. `b62f610` fix(store): F-111 commands SaveCommand atomic write
6. `2a74957` test: regression coverage for atomic write, keychain fail-closed, skills symlink guard, AAD
7. `ee17cba` fix(app): surface startup-init errors instead of leaving stores nil
8. `ae9f776` test(app): cover startup error capture + drain + panelLogTitle