### PR TITLE
[14/20] fix(database): identifier escape + pool race + query timeout + sqlserver cleanup

### DIFF
--- a/backend/database/engine.go
+++ b/backend/database/engine.go
@@ -43,6 +43,10 @@ func NewDB(dbType, dsn string) (*sql.DB, error) {
 	if err != nil {
 		return nil, fmt.Errorf("open %s: %w", dbType, err)
 	}
+	db.SetMaxOpenConns(20)
+	db.SetMaxIdleConns(5)
+	db.SetConnMaxLifetime(5 * time.Minute)
+	db.SetConnMaxIdleTime(2 * time.Minute)
 	return db, nil
 }
 

--- a/backend/database/engine.go
+++ b/backend/database/engine.go
@@ -117,6 +117,44 @@ func queryAny(db *sql.DB, query string, args ...any) ([]map[string]any, []string
 	return result, cols, rows.Err()
 }
 
+// QueryRowsStream streams rows to a callback without allocating a map per row.
+// Use it for large results (>~1000 rows); for small results the existing
+// queryStrings / queryAny maps are fine. The callback receives a reusable
+// []string sized to len(cols); values are pre-converted via scanToString.
+// Returning a non-nil error from the callback aborts the scan.
+func QueryRowsStream(db *sql.DB, query string, callback func(row []string) error, args ...any) error {
+	rows, err := db.Query(query, args...)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	cols, err := rows.Columns()
+	if err != nil {
+		return err
+	}
+
+	values := make([]any, len(cols))
+	valuePtrs := make([]any, len(cols))
+	for i := range values {
+		valuePtrs[i] = &values[i]
+	}
+	out := make([]string, len(cols))
+
+	for rows.Next() {
+		if err := rows.Scan(valuePtrs...); err != nil {
+			return err
+		}
+		for i, v := range values {
+			out[i] = scanToString(v)
+		}
+		if err := callback(out); err != nil {
+			return err
+		}
+	}
+	return rows.Err()
+}
+
 func scanToAny(v any) any {
 	if v == nil {
 		return nil

--- a/backend/database/engine.go
+++ b/backend/database/engine.go
@@ -3,7 +3,9 @@ package database
 import (
 	"database/sql"
 	"fmt"
+	"strconv"
 	"strings"
+	"time"
 )
 
 // parseParams parses "key1=val1&key2=val2" into a map.
@@ -131,9 +133,19 @@ func scanToString(v any) string {
 	if v == nil {
 		return ""
 	}
-	switch s := v.(type) {
+	switch x := v.(type) {
 	case []byte:
-		return string(s)
+		return string(x)
+	case string:
+		return x
+	case int64:
+		return strconv.FormatInt(x, 10)
+	case float64:
+		return strconv.FormatFloat(x, 'g', -1, 64)
+	case bool:
+		return strconv.FormatBool(x)
+	case time.Time:
+		return x.Format(time.RFC3339Nano)
 	default:
 		return fmt.Sprintf("%v", v)
 	}

--- a/backend/database/executor.go
+++ b/backend/database/executor.go
@@ -4,7 +4,15 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"time"
 )
+
+// queryTimeout caps user-initiated ad-hoc queries / DDL on a single
+// connection. Without this the UI cannot cancel a stuck query — the user
+// has to kill the whole app. 30s is generous enough for normal browsing
+// and short enough that an accidental cross-join SELECT will not freeze the
+// result grid for half a minute.
+var queryTimeout = 30 * time.Second
 
 type QueryResultColumn struct {
 	Name string `json:"name"`
@@ -22,7 +30,8 @@ type ExecResult struct {
 }
 
 func ExecuteQuery(p Provider, db *sql.DB, dbName, sqlStr string) (*QueryResult, error) {
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
+	defer cancel()
 	conn, err := db.Conn(ctx)
 	if err != nil {
 		return nil, err
@@ -76,7 +85,8 @@ func ExecuteQuery(p Provider, db *sql.DB, dbName, sqlStr string) (*QueryResult, 
 }
 
 func ExecuteStatement(p Provider, db *sql.DB, dbName, sqlStr string) (*ExecResult, error) {
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
+	defer cancel()
 	conn, err := db.Conn(ctx)
 	if err != nil {
 		return nil, err

--- a/backend/database/executor_timeout_test.go
+++ b/backend/database/executor_timeout_test.go
@@ -1,0 +1,152 @@
+package database
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+// TestQueryTimeoutDefault verifies the package-level timeout is the
+// documented 30s value. Touching this constant should be a deliberate
+// decision — a regression here would silently re-enable stuck queries.
+func TestQueryTimeoutDefault(t *testing.T) {
+	if queryTimeout != 30*time.Second {
+		t.Errorf("queryTimeout = %v, want 30s", queryTimeout)
+	}
+}
+
+// TestQueryTimeoutHonouredByExecuteQuery verifies that a query which
+// exceeds queryTimeout is cancelled before its mock delay elapses.
+// We shorten queryTimeout to 50ms and have sqlmock delay 500ms so the
+// context always wins. The error returned is sqlmock.ErrCancelled; we
+// assert it is non-nil and that the elapsed time stayed near the cap.
+func TestQueryTimeoutHonouredByExecuteQuery(t *testing.T) {
+	orig := queryTimeout
+	queryTimeout = 50 * time.Millisecond
+	defer func() { queryTimeout = orig }()
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	// timeoutTestProvider.PrepareExec is a no-op, so no Exec expectation.
+	mock.ExpectQuery("SELECT 1").
+		WillDelayFor(500 * time.Millisecond).
+		WillReturnRows(sqlmock.NewRows([]string{"n"}).AddRow(1))
+
+	prov := timeoutTestProvider{}
+	start := time.Now()
+	_, err = ExecuteQuery(&prov, db, "", "SELECT 1")
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("ExecuteQuery returned nil error, want context cancellation")
+	}
+	// database/sql wraps the context deadline; sqlmock returns its own
+	// ErrCancelled sentinel, so check the timing instead of errors.Is.
+	if elapsed > 400*time.Millisecond {
+		t.Errorf("ExecuteQuery took %v, want < 400ms (timeout must abort early)", elapsed)
+	}
+	if !isContextDeadlineErr(err) && err.Error() != "canceling query due to user request" {
+		t.Errorf("err = %v, want deadline / cancellation", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet mock expectations: %v", err)
+	}
+}
+
+// TestExecuteStatementHonoursTimeout is the same shape but for the
+// non-result-set path (INSERT/UPDATE/DELETE via ExecContext).
+func TestExecuteStatementHonoursTimeout(t *testing.T) {
+	orig := queryTimeout
+	queryTimeout = 50 * time.Millisecond
+	defer func() { queryTimeout = orig }()
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectExec("INSERT").
+		WillDelayFor(500 * time.Millisecond).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	prov := timeoutTestProvider{}
+	start := time.Now()
+	_, err = ExecuteStatement(&prov, db, "", "INSERT INTO t VALUES (1)")
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("ExecuteStatement returned nil error, want context cancellation")
+	}
+	if elapsed > 400*time.Millisecond {
+		t.Errorf("ExecuteStatement took %v, want < 400ms", elapsed)
+	}
+	if !isContextDeadlineErr(err) && err.Error() != "canceling query due to user request" {
+		t.Errorf("err = %v, want deadline / cancellation", err)
+	}
+}
+
+// TestExecuteQuerySuccessWithinDeadline verifies that a fast query is
+// not aborted by queryTimeout. This guards against a regression where
+// the deadline is applied as an immediate cancel rather than a cap.
+func TestExecuteQuerySuccessWithinDeadline(t *testing.T) {
+	orig := queryTimeout
+	queryTimeout = 5 * time.Second
+	defer func() { queryTimeout = orig }()
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("SELECT 1").
+		WillReturnRows(sqlmock.NewRows([]string{"n"}).AddRow(1))
+
+	prov := timeoutTestProvider{}
+	got, err := ExecuteQuery(&prov, db, "", "SELECT 1")
+	if err != nil {
+		t.Fatalf("ExecuteQuery: %v", err)
+	}
+	if len(got.Rows) != 1 {
+		t.Errorf("rows = %d, want 1", len(got.Rows))
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet mock expectations: %v", err)
+	}
+}
+
+// timeoutTestProvider satisfies the Provider interface by embedding
+// mysqlProvider (which already implements every method) and overriding
+// PrepareExec to a no-op so we never need a real mysql driver.
+type timeoutTestProvider struct {
+	mysqlProvider
+}
+
+func (*timeoutTestProvider) PrepareExec(execer, string) error { return nil }
+func (*timeoutTestProvider) DSN(string, int, string, string, string, map[string]string) string {
+	return ""
+}
+
+// isContextDeadlineErr reports whether err is a context deadline / cancel
+// error or has a wrapped one. Used because sqlmock returns a sentinel
+// ErrCancelled that does not wrap context.DeadlineExceeded.
+func isContextDeadlineErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	return errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled)
+}
+
+// Silence unused-import warnings on the test helpers.
+var _ = errors.New
+var _ = context.Background

--- a/backend/database/postgres_schema_cache_test.go
+++ b/backend/database/postgres_schema_cache_test.go
@@ -1,0 +1,113 @@
+package database
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestPostgresSchemaCacheKey verifies the cache is keyed by "dbName.tableName"
+// so two tables in the same database have distinct entries, and the same
+// (dbName, tableName) tuple maps to the same SchemaResult pointer.
+func TestPostgresSchemaCacheKey(t *testing.T) {
+	// Use distinct keys to avoid stomping on entries left by other tests.
+	const dbName = "test_cache_db_key"
+	const tbl1 = "users_key"
+	const tbl2 = "orders_key"
+
+	// Wipe any prior state for these keys so the test is hermetic.
+	postgresSchemaCache.Delete(dbName + "." + tbl1)
+	postgresSchemaCache.Delete(dbName + "." + tbl2)
+
+	r1 := &SchemaResult{Columns: []ColumnInfo{{Name: "id", Type: "int"}}}
+	r2 := &SchemaResult{Columns: []ColumnInfo{{Name: "qty", Type: "int"}}}
+
+	postgresSchemaCache.Store(dbName+"."+tbl1, r1)
+	postgresSchemaCache.Store(dbName+"."+tbl2, r2)
+
+	// Same key returns same pointer.
+	if got, ok := postgresSchemaCache.Load(dbName + "." + tbl1); !ok || got != r1 {
+		t.Errorf("cache miss for %s.%s after Store", dbName, tbl1)
+	}
+	if got, ok := postgresSchemaCache.Load(dbName + "." + tbl2); !ok || got != r2 {
+		t.Errorf("cache miss for %s.%s after Store", dbName, tbl2)
+	}
+
+	// Different tables do not collide.
+	if r1 == r2 {
+		t.Fatal("r1 and r2 must be distinct pointers")
+	}
+
+	// Clean up so we don't leak across runs.
+	postgresSchemaCache.Delete(dbName + "." + tbl1)
+	postgresSchemaCache.Delete(dbName + "." + tbl2)
+}
+
+// TestPostgresSchemaCacheParallel exercises the cache under concurrent
+// Store / Load from many goroutines. With -race, this catches any
+// non-atomic access to the sync.Map itself or any unsynchronised
+// mutation of shared SchemaResult.
+func TestPostgresSchemaCacheParallel(t *testing.T) {
+	const dbName = "test_cache_db_par"
+	const tbl = "users_par"
+	key := dbName + "." + tbl
+	postgresSchemaCache.Delete(key)
+
+	expected := &SchemaResult{Columns: []ColumnInfo{{Name: "id", Type: "int"}}}
+	postgresSchemaCache.Store(key, expected)
+
+	const N = 64
+	var wg sync.WaitGroup
+	wg.Add(N)
+	for i := 0; i < N; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				if got, ok := postgresSchemaCache.Load(key); !ok || got != expected {
+					t.Errorf("concurrent Load returned %v ok=%v, want %v", got, ok, expected)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	postgresSchemaCache.Delete(key)
+}
+
+// TestPostgresSchemaCacheSameTableParallel verifies the design intent of
+// F-115: parallel callers requesting the same (dbName, tableName) get
+// the same SchemaResult pointer. We simulate the post-GetTableSchema
+// cache write and confirm a parallel Load picks it up.
+func TestPostgresSchemaCacheSameTableParallel(t *testing.T) {
+	const dbName = "test_cache_db_same"
+	const tbl = "users_same"
+	key := dbName + "." + tbl
+	postgresSchemaCache.Delete(key)
+
+	expected := &SchemaResult{Indexes: []IndexInfo{{Name: "pk", IsPrimary: true}}}
+
+	const N = 32
+	var wg sync.WaitGroup
+	wg.Add(N)
+
+	// Half the goroutines write, half read; they must converge.
+	for i := 0; i < N; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			if i%2 == 0 {
+				postgresSchemaCache.Store(key, expected)
+			} else {
+				if got, ok := postgresSchemaCache.Load(key); ok && got != expected {
+					t.Errorf("got unexpected pointer %p (want %p)", got, expected)
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	// Final value must be the one we stored.
+	if got, ok := postgresSchemaCache.Load(key); !ok || got != expected {
+		t.Errorf("final cache state: got=%v ok=%v, want %v", got, ok, expected)
+	}
+	postgresSchemaCache.Delete(key)
+}

--- a/backend/database/provider_mysql.go
+++ b/backend/database/provider_mysql.go
@@ -43,14 +43,19 @@ func (p *mysqlProvider) DriverName() string {
 }
 
 func (p *mysqlProvider) Quote(name string) string {
-	return "`" + name + "`"
+	q, _ := SafeMyIdent(name)
+	return q
 }
 
 func (p *mysqlProvider) PrepareExec(db execer, dbName string) error {
 	if dbName == "" {
 		return nil
 	}
-	_, err := db.ExecContext(context.Background(), fmt.Sprintf("USE `%s`", dbName))
+	q, err := SafeMyIdent(dbName)
+	if err != nil {
+		return err
+	}
+	_, err = db.ExecContext(context.Background(), "USE "+q)
 	return err
 }
 
@@ -149,7 +154,11 @@ func (p *mysqlProvider) GetDatabases(db *sql.DB) ([]string, error) {
 }
 
 func (p *mysqlProvider) GetTables(db *sql.DB, dbName string) ([]TableInfo, error) {
-	results, err := queryStrings(db, fmt.Sprintf("SHOW FULL TABLES FROM `%s`", dbName))
+	q, err := SafeMyIdent(dbName)
+	if err != nil {
+		return nil, err
+	}
+	results, err := queryStrings(db, "SHOW FULL TABLES FROM "+q)
 	if err != nil {
 		return nil, fmt.Errorf("get tables: %w", err)
 	}
@@ -174,7 +183,15 @@ func (p *mysqlProvider) GetTables(db *sql.DB, dbName string) ([]TableInfo, error
 }
 
 func (p *mysqlProvider) GetTableSchema(db *sql.DB, dbName, tableName string) (*SchemaResult, error) {
-	colRows, err := queryStrings(db, fmt.Sprintf("SHOW FULL COLUMNS FROM `%s`.`%s`", dbName, tableName))
+	qDb, err := SafeMyIdent(dbName)
+	if err != nil {
+		return nil, err
+	}
+	qTbl, err := SafeMyIdent(tableName)
+	if err != nil {
+		return nil, err
+	}
+	colRows, err := queryStrings(db, "SHOW FULL COLUMNS FROM "+qDb+"."+qTbl)
 	if err != nil {
 		return nil, fmt.Errorf("get columns: %w", err)
 	}
@@ -210,7 +227,7 @@ func (p *mysqlProvider) GetTableSchema(db *sql.DB, dbName, tableName string) (*S
 		})
 	}
 
-	idxRows, err := queryStrings(db, fmt.Sprintf("SHOW INDEX FROM `%s`.`%s`", dbName, tableName))
+	idxRows, err := queryStrings(db, "SHOW INDEX FROM "+qDb+"."+qTbl)
 	if err != nil {
 		return nil, fmt.Errorf("get indexes: %w", err)
 	}
@@ -242,12 +259,20 @@ func (p *mysqlProvider) GetTableSchema(db *sql.DB, dbName, tableName string) (*S
 // ── DDL: Database ──
 
 func (p *mysqlProvider) CreateDatabase(db *sql.DB, dbName string) error {
-	_, err := db.Exec(fmt.Sprintf("CREATE DATABASE `%s`", dbName))
+	q, err := SafeMyIdent(dbName)
+	if err != nil {
+		return err
+	}
+	_, err = db.Exec("CREATE DATABASE " + q)
 	return err
 }
 
 func (p *mysqlProvider) DropDatabase(db *sql.DB, dbName string) error {
-	_, err := db.Exec(fmt.Sprintf("DROP DATABASE `%s`", dbName))
+	q, err := SafeMyIdent(dbName)
+	if err != nil {
+		return err
+	}
+	_, err = db.Exec("DROP DATABASE " + q)
 	return err
 }
 
@@ -255,41 +280,73 @@ func (p *mysqlProvider) DropDatabase(db *sql.DB, dbName string) error {
 
 func (p *mysqlProvider) CreateTable(db *sql.DB, dbName, tableName string) error {
 	if dbName != "" {
-		if _, err := db.Exec(fmt.Sprintf("USE `%s`", dbName)); err != nil {
+		q, err := SafeMyIdent(dbName)
+		if err != nil {
+			return err
+		}
+		if _, err := db.Exec("USE " + q); err != nil {
 			return err
 		}
 	}
-	_, err := db.Exec(fmt.Sprintf("CREATE TABLE `%s` (id INT AUTO_INCREMENT PRIMARY KEY)", tableName))
+	qTbl, err := SafeMyIdent(tableName)
+	if err != nil {
+		return err
+	}
+	_, err = db.Exec("CREATE TABLE " + qTbl + " (id INT AUTO_INCREMENT PRIMARY KEY)")
 	return err
 }
 
 func (p *mysqlProvider) DropTable(db *sql.DB, dbName, tableName string) error {
 	if dbName != "" {
-		if _, err := db.Exec(fmt.Sprintf("USE `%s`", dbName)); err != nil {
+		q, err := SafeMyIdent(dbName)
+		if err != nil {
+			return err
+		}
+		if _, err := db.Exec("USE " + q); err != nil {
 			return err
 		}
 	}
-	_, err := db.Exec(fmt.Sprintf("DROP TABLE `%s`", tableName))
+	qTbl, err := SafeMyIdent(tableName)
+	if err != nil {
+		return err
+	}
+	_, err = db.Exec("DROP TABLE " + qTbl)
 	return err
 }
 
 func (p *mysqlProvider) DropView(db *sql.DB, dbName, viewName string) error {
 	if dbName != "" {
-		if _, err := db.Exec(fmt.Sprintf("USE `%s`", dbName)); err != nil {
+		q, err := SafeMyIdent(dbName)
+		if err != nil {
+			return err
+		}
+		if _, err := db.Exec("USE " + q); err != nil {
 			return err
 		}
 	}
-	_, err := db.Exec(fmt.Sprintf("DROP VIEW `%s`", viewName))
+	qView, err := SafeMyIdent(viewName)
+	if err != nil {
+		return err
+	}
+	_, err = db.Exec("DROP VIEW " + qView)
 	return err
 }
 
 func (p *mysqlProvider) TruncateTable(db *sql.DB, dbName, tableName string) error {
 	if dbName != "" {
-		if _, err := db.Exec(fmt.Sprintf("USE `%s`", dbName)); err != nil {
+		q, err := SafeMyIdent(dbName)
+		if err != nil {
+			return err
+		}
+		if _, err := db.Exec("USE " + q); err != nil {
 			return err
 		}
 	}
-	_, err := db.Exec(fmt.Sprintf("TRUNCATE TABLE `%s`", tableName))
+	qTbl, err := SafeMyIdent(tableName)
+	if err != nil {
+		return err
+	}
+	_, err = db.Exec("TRUNCATE TABLE " + qTbl)
 	return err
 }
 
@@ -297,7 +354,11 @@ func (p *mysqlProvider) TruncateTable(db *sql.DB, dbName, tableName string) erro
 
 func (p *mysqlProvider) AddColumn(db *sql.DB, dbName, tableName string, col ColumnDef) error {
 	if dbName != "" {
-		if _, err := db.Exec(fmt.Sprintf("USE `%s`", dbName)); err != nil {
+		q, err := SafeMyIdent(dbName)
+		if err != nil {
+			return err
+		}
+		if _, err := db.Exec("USE " + q); err != nil {
 			return err
 		}
 	}
@@ -308,7 +369,11 @@ func (p *mysqlProvider) AddColumn(db *sql.DB, dbName, tableName string, col Colu
 
 func (p *mysqlProvider) ModifyColumn(db *sql.DB, dbName, tableName string, col ColumnDef) error {
 	if dbName != "" {
-		if _, err := db.Exec(fmt.Sprintf("USE `%s`", dbName)); err != nil {
+		q, err := SafeMyIdent(dbName)
+		if err != nil {
+			return err
+		}
+		if _, err := db.Exec("USE " + q); err != nil {
 			return err
 		}
 	}
@@ -319,7 +384,11 @@ func (p *mysqlProvider) ModifyColumn(db *sql.DB, dbName, tableName string, col C
 
 func (p *mysqlProvider) DropColumn(db *sql.DB, dbName, tableName, colName string) error {
 	if dbName != "" {
-		if _, err := db.Exec(fmt.Sprintf("USE `%s`", dbName)); err != nil {
+		q, err := SafeMyIdent(dbName)
+		if err != nil {
+			return err
+		}
+		if _, err := db.Exec("USE " + q); err != nil {
 			return err
 		}
 	}
@@ -331,7 +400,11 @@ func (p *mysqlProvider) DropColumn(db *sql.DB, dbName, tableName, colName string
 
 func (p *mysqlProvider) AddIndex(db *sql.DB, dbName, tableName string, idx IndexDef) error {
 	if dbName != "" {
-		if _, err := db.Exec(fmt.Sprintf("USE `%s`", dbName)); err != nil {
+		q, err := SafeMyIdent(dbName)
+		if err != nil {
+			return err
+		}
+		if _, err := db.Exec("USE " + q); err != nil {
 			return err
 		}
 	}
@@ -361,7 +434,11 @@ func (p *mysqlProvider) AddIndex(db *sql.DB, dbName, tableName string, idx Index
 
 func (p *mysqlProvider) DropIndex(db *sql.DB, dbName, tableName, idxName string, isPrimary bool, autoIncCols []string) error {
 	if dbName != "" {
-		if _, err := db.Exec(fmt.Sprintf("USE `%s`", dbName)); err != nil {
+		q, err := SafeMyIdent(dbName)
+		if err != nil {
+			return err
+		}
+		if _, err := db.Exec("USE " + q); err != nil {
 			return err
 		}
 	}

--- a/backend/database/provider_mysql.go
+++ b/backend/database/provider_mysql.go
@@ -30,7 +30,8 @@ func (p *mysqlProvider) DSN(host string, port int, user, password, dbName string
 		"parseTime":    "true",
 		"loc":          "Local",
 		"timeout":      "10s",
-		"readTimeout":  "30s",
+		"readTimeout":  "10s",
+		"writeTimeout": "10s",
 	}
 	for k, v := range extraParams {
 		cfg.Params[k] = v

--- a/backend/database/provider_mysql.go
+++ b/backend/database/provider_mysql.go
@@ -276,138 +276,129 @@ func (p *mysqlProvider) DropDatabase(db *sql.DB, dbName string) error {
 	return err
 }
 
-// ── DDL: Table ──
-
-func (p *mysqlProvider) CreateTable(db *sql.DB, dbName, tableName string) error {
+// mysqlUseDB acquires a dedicated connection and issues USE against it.
+// All DDL helpers below return this conn so the subsequent DDL runs on the
+// same physical connection (the database/sql pool might otherwise hand out
+// different connections for USE and DDL, racing the session state).
+func (p *mysqlProvider) mysqlUseDB(db *sql.DB, dbName string) (*sql.Conn, error) {
+	conn, err := db.Conn(context.Background())
+	if err != nil {
+		return nil, err
+	}
 	if dbName != "" {
 		q, err := SafeMyIdent(dbName)
 		if err != nil {
-			return err
+			conn.Close()
+			return nil, err
 		}
-		if _, err := db.Exec("USE " + q); err != nil {
-			return err
+		if _, err := conn.ExecContext(context.Background(), "USE "+q); err != nil {
+			conn.Close()
+			return nil, err
 		}
 	}
+	return conn, nil
+}
+
+// ── DDL: Table ──
+
+func (p *mysqlProvider) CreateTable(db *sql.DB, dbName, tableName string) error {
+	conn, err := p.mysqlUseDB(db, dbName)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
 	qTbl, err := SafeMyIdent(tableName)
 	if err != nil {
 		return err
 	}
-	_, err = db.Exec("CREATE TABLE " + qTbl + " (id INT AUTO_INCREMENT PRIMARY KEY)")
+	_, err = conn.ExecContext(context.Background(), "CREATE TABLE "+qTbl+" (id INT AUTO_INCREMENT PRIMARY KEY)")
 	return err
 }
 
 func (p *mysqlProvider) DropTable(db *sql.DB, dbName, tableName string) error {
-	if dbName != "" {
-		q, err := SafeMyIdent(dbName)
-		if err != nil {
-			return err
-		}
-		if _, err := db.Exec("USE " + q); err != nil {
-			return err
-		}
+	conn, err := p.mysqlUseDB(db, dbName)
+	if err != nil {
+		return err
 	}
+	defer conn.Close()
 	qTbl, err := SafeMyIdent(tableName)
 	if err != nil {
 		return err
 	}
-	_, err = db.Exec("DROP TABLE " + qTbl)
+	_, err = conn.ExecContext(context.Background(), "DROP TABLE "+qTbl)
 	return err
 }
 
 func (p *mysqlProvider) DropView(db *sql.DB, dbName, viewName string) error {
-	if dbName != "" {
-		q, err := SafeMyIdent(dbName)
-		if err != nil {
-			return err
-		}
-		if _, err := db.Exec("USE " + q); err != nil {
-			return err
-		}
+	conn, err := p.mysqlUseDB(db, dbName)
+	if err != nil {
+		return err
 	}
+	defer conn.Close()
 	qView, err := SafeMyIdent(viewName)
 	if err != nil {
 		return err
 	}
-	_, err = db.Exec("DROP VIEW " + qView)
+	_, err = conn.ExecContext(context.Background(), "DROP VIEW "+qView)
 	return err
 }
 
 func (p *mysqlProvider) TruncateTable(db *sql.DB, dbName, tableName string) error {
-	if dbName != "" {
-		q, err := SafeMyIdent(dbName)
-		if err != nil {
-			return err
-		}
-		if _, err := db.Exec("USE " + q); err != nil {
-			return err
-		}
+	conn, err := p.mysqlUseDB(db, dbName)
+	if err != nil {
+		return err
 	}
+	defer conn.Close()
 	qTbl, err := SafeMyIdent(tableName)
 	if err != nil {
 		return err
 	}
-	_, err = db.Exec("TRUNCATE TABLE " + qTbl)
+	_, err = conn.ExecContext(context.Background(), "TRUNCATE TABLE "+qTbl)
 	return err
 }
 
 // ── DDL: Column ──
 
 func (p *mysqlProvider) AddColumn(db *sql.DB, dbName, tableName string, col ColumnDef) error {
-	if dbName != "" {
-		q, err := SafeMyIdent(dbName)
-		if err != nil {
-			return err
-		}
-		if _, err := db.Exec("USE " + q); err != nil {
-			return err
-		}
+	conn, err := p.mysqlUseDB(db, dbName)
+	if err != nil {
+		return err
 	}
+	defer conn.Close()
 	sql := p.buildColumnSQL("ADD COLUMN", tableName, col)
-	_, err := db.Exec(sql)
+	_, err = conn.ExecContext(context.Background(), sql)
 	return err
 }
 
 func (p *mysqlProvider) ModifyColumn(db *sql.DB, dbName, tableName string, col ColumnDef) error {
-	if dbName != "" {
-		q, err := SafeMyIdent(dbName)
-		if err != nil {
-			return err
-		}
-		if _, err := db.Exec("USE " + q); err != nil {
-			return err
-		}
+	conn, err := p.mysqlUseDB(db, dbName)
+	if err != nil {
+		return err
 	}
+	defer conn.Close()
 	sql := p.buildColumnSQL("MODIFY COLUMN", tableName, col)
-	_, err := db.Exec(sql)
+	_, err = conn.ExecContext(context.Background(), sql)
 	return err
 }
 
 func (p *mysqlProvider) DropColumn(db *sql.DB, dbName, tableName, colName string) error {
-	if dbName != "" {
-		q, err := SafeMyIdent(dbName)
-		if err != nil {
-			return err
-		}
-		if _, err := db.Exec("USE " + q); err != nil {
-			return err
-		}
+	conn, err := p.mysqlUseDB(db, dbName)
+	if err != nil {
+		return err
 	}
-	_, err := db.Exec(fmt.Sprintf("ALTER TABLE %s DROP COLUMN %s", p.Quote(tableName), p.Quote(colName)))
+	defer conn.Close()
+	_, err = conn.ExecContext(context.Background(), fmt.Sprintf("ALTER TABLE %s DROP COLUMN %s", p.Quote(tableName), p.Quote(colName)))
 	return err
 }
 
 // ── DDL: Index ──
 
 func (p *mysqlProvider) AddIndex(db *sql.DB, dbName, tableName string, idx IndexDef) error {
-	if dbName != "" {
-		q, err := SafeMyIdent(dbName)
-		if err != nil {
-			return err
-		}
-		if _, err := db.Exec("USE " + q); err != nil {
-			return err
-		}
+	conn, err := p.mysqlUseDB(db, dbName)
+	if err != nil {
+		return err
 	}
+	defer conn.Close()
 
 	q := p.Quote
 	var sql string
@@ -428,30 +419,26 @@ func (p *mysqlProvider) AddIndex(db *sql.DB, dbName, tableName string, idx Index
 		}
 		sql = fmt.Sprintf("CREATE %sINDEX %s ON %s (%s)", uniqueStr, q(idx.Name), q(tableName), strings.Join(cols, ", "))
 	}
-	_, err := db.Exec(sql)
+	_, err = conn.ExecContext(context.Background(), sql)
 	return err
 }
 
 func (p *mysqlProvider) DropIndex(db *sql.DB, dbName, tableName, idxName string, isPrimary bool, autoIncCols []string) error {
-	if dbName != "" {
-		q, err := SafeMyIdent(dbName)
-		if err != nil {
-			return err
-		}
-		if _, err := db.Exec("USE " + q); err != nil {
-			return err
-		}
-	}
-	q := p.Quote
-	if isPrimary {
-		sql, err := p.buildDropPK(db, tableName, autoIncCols)
-		if err != nil {
-			return err
-		}
-		_, err = db.Exec(sql)
+	conn, err := p.mysqlUseDB(db, dbName)
+	if err != nil {
 		return err
 	}
-	_, err := db.Exec(fmt.Sprintf("DROP INDEX %s ON %s", q(idxName), q(tableName)))
+	defer conn.Close()
+	q := p.Quote
+	if isPrimary {
+		sql, err := p.buildDropPK(conn, tableName, autoIncCols)
+		if err != nil {
+			return err
+		}
+		_, err = conn.ExecContext(context.Background(), sql)
+		return err
+	}
+	_, err = conn.ExecContext(context.Background(), fmt.Sprintf("DROP INDEX %s ON %s", q(idxName), q(tableName)))
 	return err
 }
 
@@ -497,16 +484,38 @@ func (p *mysqlProvider) buildColumnSQL(action, tableName string, col ColumnDef) 
 }
 
 // buildDropPK handles AUTO_INCREMENT columns that must be modified before dropping PK.
-func (p *mysqlProvider) buildDropPK(db *sql.DB, tableName string, autoIncCols []string) (string, error) {
+func (p *mysqlProvider) buildDropPK(conn *sql.Conn, tableName string, autoIncCols []string) (string, error) {
 	q := p.Quote
 	if len(autoIncCols) > 0 {
-		rows, err := queryStrings(db, fmt.Sprintf("SHOW FULL COLUMNS FROM %s", q(tableName)))
+		rows, err := conn.QueryContext(context.Background(), fmt.Sprintf("SHOW FULL COLUMNS FROM %s", q(tableName)))
 		if err != nil {
 			return "", fmt.Errorf("get columns for PK drop: %w", err)
 		}
+		defer rows.Close()
+
+		cols, err := rows.Columns()
+		if err != nil {
+			return "", fmt.Errorf("get columns for PK drop: %w", err)
+		}
+
 		colTypes := make(map[string]string)
-		for _, row := range rows {
+		for rows.Next() {
+			values := make([]any, len(cols))
+			valuePtrs := make([]any, len(cols))
+			for i := range values {
+				valuePtrs[i] = &values[i]
+			}
+			if err := rows.Scan(valuePtrs...); err != nil {
+				return "", fmt.Errorf("scan columns for PK drop: %w", err)
+			}
+			row := make(map[string]string, len(cols))
+			for i, col := range cols {
+				row[col] = scanToString(values[i])
+			}
 			colTypes[row["Field"]] = row["Type"]
+		}
+		if err := rows.Err(); err != nil {
+			return "", fmt.Errorf("iterate columns for PK drop: %w", err)
 		}
 
 		var modParts []string

--- a/backend/database/provider_postgres.go
+++ b/backend/database/provider_postgres.go
@@ -26,7 +26,13 @@ func (p *postgresProvider) DSN(host string, port int, user, password, dbName str
 		Path:   "/" + dbName,
 	}
 	q := u.Query()
-	q.Set("sslmode", "disable")
+	// Default to "prefer": encrypted when the server has TLS, plaintext
+	// fallback when it doesn't. Callers can override via extraParams
+	// (e.g. "sslmode=require" to refuse non-TLS, "sslmode=disable" to
+	// force plaintext against self-signed dev servers).
+	if _, ok := extraParams["sslmode"]; !ok {
+		q.Set("sslmode", "prefer")
+	}
 	for k, v := range extraParams {
 		q.Set(k, v)
 	}

--- a/backend/database/provider_postgres.go
+++ b/backend/database/provider_postgres.go
@@ -1,15 +1,23 @@
 package database
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"net/url"
 	"strings"
+	"sync"
 
 	_ "github.com/lib/pq"
+	"golang.org/x/sync/errgroup"
 )
 
 type postgresProvider struct{}
+
+// postgresSchemaCache memoises GetTableSchema results per "dbName.tableName".
+// The schema-tree panel walks every table on every refresh; without this cache
+// each browse issues 3*N serial round-trips even when nothing changed.
+var postgresSchemaCache sync.Map
 
 func init() {
 	Register("postgres", &postgresProvider{})
@@ -176,12 +184,52 @@ func (p *postgresProvider) GetTables(db *sql.DB, dbName string) ([]TableInfo, er
 }
 
 func (p *postgresProvider) GetTableSchema(db *sql.DB, dbName, tableName string) (*SchemaResult, error) {
-	colRows, err := queryStrings(db,
-		fmt.Sprintf("SELECT column_name, data_type, is_nullable, column_default FROM information_schema.columns WHERE table_name = $1 ORDER BY ordinal_position"),
-		tableName,
+	cacheKey := dbName + "." + tableName
+	if cached, ok := postgresSchemaCache.Load(cacheKey); ok {
+		return cached.(*SchemaResult), nil
+	}
+
+	var (
+		colRows []map[string]string
+		pkRows  []map[string]string
+		idxRows []map[string]string
 	)
-	if err != nil {
-		return nil, fmt.Errorf("get columns: %w", err)
+	g, _ := errgroup.WithContext(context.Background())
+	g.Go(func() error {
+		r, err := queryStrings(db,
+			"SELECT column_name, data_type, is_nullable, column_default FROM information_schema.columns WHERE table_name = $1 ORDER BY ordinal_position",
+			tableName,
+		)
+		if err != nil {
+			return fmt.Errorf("get columns: %w", err)
+		}
+		colRows = r
+		return nil
+	})
+	g.Go(func() error {
+		r, err := queryStrings(db,
+			"SELECT a.attname FROM pg_index i JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey) WHERE i.indrelid = $1::regclass AND i.indisprimary",
+			tableName,
+		)
+		if err != nil {
+			return nil // PKs are non-fatal like before
+		}
+		pkRows = r
+		return nil
+	})
+	g.Go(func() error {
+		r, err := queryStrings(db,
+			"SELECT i.relname AS index_name, ix.indisunique AS is_unique, ix.indisprimary AS is_primary, a.attname AS column_name FROM pg_class t JOIN pg_index ix ON t.oid = ix.indrelid JOIN pg_class i ON i.oid = ix.indexrelid JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = ANY(ix.indkey) WHERE t.relname = $1 ORDER BY i.relname, a.attnum",
+			tableName,
+		)
+		if err != nil {
+			return fmt.Errorf("get indexes: %w", err)
+		}
+		idxRows = r
+		return nil
+	})
+	if err := g.Wait(); err != nil {
+		return nil, err
 	}
 
 	columns := make([]ColumnInfo, 0, len(colRows))
@@ -205,28 +253,12 @@ func (p *postgresProvider) GetTableSchema(db *sql.DB, dbName, tableName string) 
 		})
 	}
 
-	// Primary keys
-	pkRows, err := queryStrings(db,
-		fmt.Sprintf("SELECT a.attname FROM pg_index i JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey) WHERE i.indrelid = $1::regclass AND i.indisprimary"),
-		tableName,
-	)
-	if err == nil {
-		for _, row := range pkRows {
-			for i := range columns {
-				if columns[i].Name == row["attname"] {
-					columns[i].IsPrimary = true
-				}
+	for _, row := range pkRows {
+		for i := range columns {
+			if columns[i].Name == row["attname"] {
+				columns[i].IsPrimary = true
 			}
 		}
-	}
-
-	// Indexes
-	idxRows, err := queryStrings(db,
-		fmt.Sprintf("SELECT i.relname AS index_name, ix.indisunique AS is_unique, ix.indisprimary AS is_primary, a.attname AS column_name FROM pg_class t JOIN pg_index ix ON t.oid = ix.indrelid JOIN pg_class i ON i.oid = ix.indexrelid JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = ANY(ix.indkey) WHERE t.relname = $1 ORDER BY i.relname, a.attnum"),
-		tableName,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("get indexes: %w", err)
 	}
 
 	idxMap := make(map[string]*IndexInfo)
@@ -250,7 +282,9 @@ func (p *postgresProvider) GetTableSchema(db *sql.DB, dbName, tableName string) 
 		indexes = append(indexes, *idxMap[name])
 	}
 
-	return &SchemaResult{Columns: columns, Indexes: indexes}, nil
+	result := &SchemaResult{Columns: columns, Indexes: indexes}
+	postgresSchemaCache.Store(cacheKey, result)
+	return result, nil
 }
 
 // ── DDL: Database ──

--- a/backend/database/provider_postgres.go
+++ b/backend/database/provider_postgres.go
@@ -39,7 +39,8 @@ func (p *postgresProvider) DriverName() string {
 }
 
 func (p *postgresProvider) Quote(name string) string {
-	return `"` + name + `"`
+	q, _ := SafePgIdent(name)
+	return q
 }
 
 func (p *postgresProvider) PrepareExec(db execer, dbName string) error {
@@ -304,7 +305,11 @@ func (p *postgresProvider) AddColumn(db *sql.DB, dbName, tableName string, col C
 		parts = append(parts, "DEFAULT NULL")
 	case "value":
 		if col.DefaultVal != "" {
-			parts = append(parts, "DEFAULT "+col.DefaultVal)
+			def, err := SafeDefaultLiteral(col.DefaultVal)
+			if err != nil {
+				return err
+			}
+			parts = append(parts, "DEFAULT "+def)
 		} else {
 			parts = append(parts, "DEFAULT ''")
 		}
@@ -336,8 +341,12 @@ func (p *postgresProvider) ModifyColumn(db *sql.DB, dbName, tableName string, co
 			q(tableName), q(col.Name)))
 	case "value":
 		if col.DefaultVal != "" {
+			def, err := SafeDefaultLiteral(col.DefaultVal)
+			if err != nil {
+				return err
+			}
 			stmts = append(stmts, fmt.Sprintf("ALTER TABLE %s ALTER COLUMN %s SET DEFAULT %s",
-				q(tableName), q(col.Name), col.DefaultVal))
+				q(tableName), q(col.Name), def))
 		} else {
 			stmts = append(stmts, fmt.Sprintf("ALTER TABLE %s ALTER COLUMN %s SET DEFAULT ''",
 				q(tableName), q(col.Name)))

--- a/backend/database/provider_rqlite.go
+++ b/backend/database/provider_rqlite.go
@@ -39,7 +39,8 @@ func (p *rqliteProvider) DriverName() string {
 }
 
 func (p *rqliteProvider) Quote(name string) string {
-	return `"` + name + `"`
+	q, _ := SafePgIdent(name)
+	return q
 }
 
 func (p *rqliteProvider) PrepareExec(db execer, dbName string) error {

--- a/backend/database/provider_sqlserver.go
+++ b/backend/database/provider_sqlserver.go
@@ -64,6 +64,16 @@ func (p *sqlserverProvider) qualifiedTable(tableName string) string {
 }
 
 // ── CRUD ──
+//
+// InsertRow/UpdateRow/DeleteRow go through execPrepared so that:
+//   - USE [dbName] and the actual statement run on the same pooled conn
+//     (DB-10, AUDIT-database-10). Previously each CRUD call issued a
+//     `USE [db];\n...` multi-statement batch; the driver handles it but
+//     the pool could still split work across conns for the trailing USE.
+//   - context propagation is consistent with the other providers.
+//
+// withUse is intentionally not prepended here — execPrepared already calls
+// PrepareExec, which issues USE [dbName] on the pinned connection.
 
 func (p *sqlserverProvider) InsertRow(db *sql.DB, dbName, tableName string, values map[string]any) error {
 	cols := sortedKeys(values)
@@ -77,8 +87,7 @@ func (p *sqlserverProvider) InsertRow(db *sql.DB, dbName, tableName string, valu
 	}
 	sql := fmt.Sprintf("INSERT INTO %s (%s) VALUES (%s)",
 		p.qualifiedTable(tableName), strings.Join(quotedCols, ", "), strings.Join(placeholders, ", "))
-	_, err := db.ExecContext(context.Background(), p.withUse(dbName, sql), args...)
-	return err
+	return execPrepared(p, db, dbName, sql, args)
 }
 
 func (p *sqlserverProvider) UpdateRow(db *sql.DB, dbName, tableName string, set, where map[string]any) error {
@@ -111,8 +120,7 @@ func (p *sqlserverProvider) UpdateRow(db *sql.DB, dbName, tableName string, set,
 	if len(whereParts) > 0 {
 		sql += " WHERE " + strings.Join(whereParts, " AND ")
 	}
-	_, err := db.ExecContext(context.Background(), p.withUse(dbName, sql), args...)
-	return err
+	return execPrepared(p, db, dbName, sql, args)
 }
 
 func (p *sqlserverProvider) DeleteRow(db *sql.DB, dbName, tableName string, where map[string]any) error {
@@ -133,8 +141,7 @@ func (p *sqlserverProvider) DeleteRow(db *sql.DB, dbName, tableName string, wher
 	if len(whereParts) > 0 {
 		sql += " WHERE " + strings.Join(whereParts, " AND ")
 	}
-	_, err := db.ExecContext(context.Background(), p.withUse(dbName, sql), args...)
-	return err
+	return execPrepared(p, db, dbName, sql, args)
 }
 
 // ── Capabilities ──
@@ -358,16 +365,19 @@ func (p *sqlserverProvider) DropColumn(db *sql.DB, dbName, tableName, colName st
 	if err != nil {
 		return fmt.Errorf("find default constraints: %w", err)
 	}
+	defer rows.Close()
+
 	var constraints []string
 	for rows.Next() {
 		var name string
 		if err := rows.Scan(&name); err != nil {
-			rows.Close()
 			return err
 		}
 		constraints = append(constraints, name)
 	}
-	rows.Close()
+	if err := rows.Err(); err != nil {
+		return err
+	}
 
 	qt := p.qualifiedTable(tableName)
 	for _, name := range constraints {

--- a/backend/database/safeident.go
+++ b/backend/database/safeident.go
@@ -1,0 +1,93 @@
+package database
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// SafeMyIdent returns the MySQL identifier with backticks escaped (doubled)
+// and rejects names containing NUL bytes, dot-segments, or excessive length.
+// Addresses AUDIT-database-01 / AUDIT-database-02 (SQL injection via dbName
+// and Quote on MySQL).
+func SafeMyIdent(name string) (string, error) {
+	if err := identValidate(name); err != nil {
+		return "", err
+	}
+	return "`" + strings.ReplaceAll(name, "`", "``") + "`", nil
+}
+
+// SafePgIdent returns the Postgres / rqlite identifier with double-quotes
+// escaped (doubled). Addresses AUDIT-database-03 and AUDIT-database-05.
+func SafePgIdent(name string) (string, error) {
+	if err := identValidate(name); err != nil {
+		return "", err
+	}
+	return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`, nil
+}
+
+// SafeDefaultLiteral validates a literal value suitable for embedding in a
+// `DEFAULT` clause. Only number / string / NULL / CURRENT_* / boolean
+// literals are accepted; everything else is rejected to prevent injection
+// into `ALTER TABLE ... SET DEFAULT %s` (AUDIT-database-04).
+func SafeDefaultLiteral(v string) (string, error) {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return "", errors.New("empty DEFAULT literal")
+	}
+	upper := strings.ToUpper(v)
+	switch {
+	case upper == "NULL",
+		upper == "TRUE",
+		upper == "FALSE",
+		upper == "CURRENT_TIMESTAMP",
+		upper == "CURRENT_DATE",
+		upper == "CURRENT_TIME",
+		strings.HasPrefix(upper, "CURRENT_TIMESTAMP("),
+		strings.HasPrefix(upper, "LOCALTIMESTAMP"),
+		strings.HasPrefix(upper, "LOCALTIME"):
+		return v, nil
+	}
+	// Numeric literal: digits + optional decimal + optional sign.
+	isNum := true
+	for i, r := range v {
+		if r == '+' || r == '-' || r == '.' {
+			continue
+		}
+		if r < '0' || r > '9' {
+			isNum = false
+			break
+		}
+		_ = i
+	}
+	if isNum {
+		return v, nil
+	}
+	// String literal: 'foo' (single quotes doubled).
+	if v[0] == '\'' && v[len(v)-1] == '\'' {
+		// no embedded unescaped quotes
+		if !strings.Contains(v[1:len(v)-1], "'") {
+			return v, nil
+		}
+	}
+	return "", fmt.Errorf("unsafe DEFAULT literal: %s", v)
+}
+
+// identValidate rejects names that are empty, contain path-traversal
+// segments, NUL bytes, or are absurdly long (MySQL limit is 64, Postgres
+// 63; we pick 128 as a generous cap covering schema-qualified forms).
+func identValidate(name string) error {
+	if name == "" {
+		return errors.New("empty identifier")
+	}
+	if len(name) > 128 {
+		return errors.New("identifier too long")
+	}
+	if strings.ContainsRune(name, 0) {
+		return errors.New("identifier contains NUL")
+	}
+	if strings.Contains(name, "..") || strings.ContainsAny(name, "/\\") {
+		return errors.New("identifier contains path separator")
+	}
+	return nil
+}

--- a/backend/database/safeident_test.go
+++ b/backend/database/safeident_test.go
@@ -1,0 +1,80 @@
+package database
+
+import (
+	"strings"
+	"testing"
+)
+
+// Regression test for AUDIT-database-01..05 — SQL injection in identifier quoting.
+// Covers payloads that previously escaped the quoting in MySQL/Postgres/rqlite.
+func TestSafeMyIdent(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		wantErr bool
+		want    string
+	}{
+		{"plain", "users", false, "`users`"},
+		{"backtick injection", "`; DROP TABLE users; --", false, "```; DROP TABLE users; --`"},
+		{"empty", "", true, ""},
+		{"nul byte", "foo\x00bar", true, ""},
+		{"path traversal", "../etc/passwd", true, ""},
+		{"too long", strings.Repeat("a", 200), true, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := SafeMyIdent(tc.input)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("err = %v, wantErr = %v", err, tc.wantErr)
+			}
+			if !tc.wantErr && got != tc.want {
+				t.Errorf("SafeMyIdent(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSafePgIdent(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"plain", "users", `"users"`},
+		{"double-quote injection", `x"; DROP TABLE users; --`, `"x""; DROP TABLE users; --"`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := SafePgIdent(tc.input)
+			if err != nil {
+				t.Fatalf("err = %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("SafePgIdent(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+// Regression test for AUDIT-database-04 — `SET DEFAULT %s` injection.
+func TestSafeDefaultLiteral(t *testing.T) {
+	cases := []struct {
+		input   string
+		wantErr bool
+	}{
+		{"NULL", false},
+		{"42", false},
+		{"'hello'", false},
+		{"CURRENT_TIMESTAMP", false},
+		{"bad(); DROP TABLE users; --", true},
+		{"", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			_, err := SafeDefaultLiteral(tc.input)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("SafeDefaultLiteral(%q): err=%v, wantErr=%v", tc.input, err, tc.wantErr)
+			}
+		})
+	}
+}

--- a/backend/database/safeident_test.go
+++ b/backend/database/safeident_test.go
@@ -5,8 +5,10 @@ import (
 	"testing"
 )
 
-// Regression test for AUDIT-database-01..05 — SQL injection in identifier quoting.
-// Covers payloads that previously escaped the quoting in MySQL/Postgres/rqlite.
+// TestSafeMyIdent covers MySQL identifier quoting and rejection cases.
+// Backtick escape relies on doubling; any name containing NUL, path
+// separators (.., /, \) or longer than 128 bytes must be rejected so that
+// user input cannot break out of the quoted form.
 func TestSafeMyIdent(t *testing.T) {
 	cases := []struct {
 		name    string
@@ -15,11 +17,16 @@ func TestSafeMyIdent(t *testing.T) {
 		want    string
 	}{
 		{"plain", "users", false, "`users`"},
+		{"underscore_digits", "user_2024", false, "`user_2024`"},
 		{"backtick injection", "`; DROP TABLE users; --", false, "```; DROP TABLE users; --`"},
+		{"only backtick escaped", "`", false, "````"},
 		{"empty", "", true, ""},
 		{"nul byte", "foo\x00bar", true, ""},
-		{"path traversal", "../etc/passwd", true, ""},
-		{"too long", strings.Repeat("a", 200), true, ""},
+		{"path traversal dot", "../etc/passwd", true, ""},
+		{"path traversal slash", "/etc/passwd", true, ""},
+		{"path traversal backslash", "..\\windows\\system32", true, ""},
+		{"too long", strings.Repeat("a", 129), true, ""},
+		{"at length cap", strings.Repeat("a", 128), false, "`" + strings.Repeat("a", 128) + "`"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -34,46 +41,101 @@ func TestSafeMyIdent(t *testing.T) {
 	}
 }
 
+// TestSafePgIdent covers Postgres / rqlite identifier quoting.
+// Identical rules to SafeMyIdent except the escape character is `"`.
 func TestSafePgIdent(t *testing.T) {
 	cases := []struct {
-		name  string
-		input string
-		want  string
+		name    string
+		input   string
+		wantErr bool
+		want    string
 	}{
-		{"plain", "users", `"users"`},
-		{"double-quote injection", `x"; DROP TABLE users; --`, `"x""; DROP TABLE users; --"`},
+		{"plain", "users", false, `"users"`},
+		{"double-quote injection", `x"; DROP TABLE users; --`, false, `"x""; DROP TABLE users; --"`},
+		{"only double quote escaped", `"`, false, `""""`},
+		{"empty", "", true, ""},
+		{"nul byte", "pg\x00table", true, ""},
+		{"path traversal", "../../etc/passwd", true, ""},
+		{"too long", strings.Repeat("a", 200), true, ""},
+		{"schema qualified", "public.users", false, `"public.users"`},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			got, err := SafePgIdent(tc.input)
-			if err != nil {
-				t.Fatalf("err = %v", err)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("err = %v, wantErr = %v", err, tc.wantErr)
 			}
-			if got != tc.want {
+			if !tc.wantErr && got != tc.want {
 				t.Errorf("SafePgIdent(%q) = %q, want %q", tc.input, got, tc.want)
 			}
 		})
 	}
 }
 
-// Regression test for AUDIT-database-04 — `SET DEFAULT %s` injection.
+// TestSafeDefaultLiteral verifies the whitelist for SET DEFAULT literals.
+// Allowed: NULL, booleans, CURRENT_*, LOCALTIME*, numeric literals, and
+// simple 'single-quoted' strings without embedded quotes.
+// Everything else (function calls, statements, expressions) must be rejected.
 func TestSafeDefaultLiteral(t *testing.T) {
 	cases := []struct {
 		input   string
 		wantErr bool
+		desc    string
 	}{
-		{"NULL", false},
-		{"42", false},
-		{"'hello'", false},
-		{"CURRENT_TIMESTAMP", false},
-		{"bad(); DROP TABLE users; --", true},
-		{"", true},
+		{"NULL", false, "null"},
+		{"TRUE", false, "true literal"},
+		{"FALSE", false, "false literal"},
+		{"42", false, "integer"},
+		{"-3.14", false, "signed decimal"},
+		{"+0", false, "signed zero"},
+		{"'hello'", false, "single-quoted string"},
+		{"'a''b'", true, "embedded quote in string (rejected)"},
+		{"CURRENT_TIMESTAMP", false, "timestamp keyword"},
+		{"CURRENT_DATE", false, "date keyword"},
+		{"CURRENT_TIME", false, "time keyword"},
+		{"CURRENT_TIMESTAMP(6)", false, "timestamp with precision"},
+		{"LOCALTIMESTAMP", false, "localtimestamp keyword"},
+		{"LOCALTIME", false, "localtime keyword"},
+		{"bad(); DROP TABLE users; --", true, "raw SQL injection"},
+		{"NOW()", true, "function call"},
+		{"user_input", true, "bare identifier"},
+		{"", true, "empty"},
+		{"   ", true, "whitespace only"},
+		{"'unterminated", true, "unterminated string"},
 	}
 	for _, tc := range cases {
-		t.Run(tc.input, func(t *testing.T) {
+		t.Run(tc.desc, func(t *testing.T) {
 			_, err := SafeDefaultLiteral(tc.input)
 			if (err != nil) != tc.wantErr {
 				t.Errorf("SafeDefaultLiteral(%q): err=%v, wantErr=%v", tc.input, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestSafeIdentRoundTrip checks that a valid identifier round-trips
+// through both SafeMyIdent and SafePgIdent without losing bytes. This
+// guards against future regressions where escaping might collapse
+// characters we want to preserve.
+func TestSafeIdentRoundTrip(t *testing.T) {
+	inputs := []string{"users", "user_2024", "weird name", "tab\tname", "newline\nname"}
+	for _, in := range inputs {
+		t.Run("mysql/"+in, func(t *testing.T) {
+			got, err := SafeMyIdent(in)
+			if err != nil {
+				t.Fatalf("SafeMyIdent(%q): %v", in, err)
+			}
+			if !strings.Contains(got, in) {
+				t.Errorf("SafeMyIdent(%q) = %q lost original bytes", in, got)
+			}
+		})
+		t.Run("pg/"+in, func(t *testing.T) {
+			got, err := SafePgIdent(in)
+			if err != nil {
+				t.Fatalf("SafePgIdent(%q): %v", in, err)
+			}
+			if !strings.Contains(got, in) {
+				t.Errorf("SafePgIdent(%q) = %q lost original bytes", in, got)
 			}
 		})
 	}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/ys-ll/uniterm
 go 1.26.2
 
 require (
+	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/UserExistsError/conpty v0.1.4
 	github.com/cloudsoda/go-smb2 v0.0.0-20260701064823-d8c5600d73b8
 	github.com/creack/pty v1.1.24
@@ -27,6 +28,7 @@ require (
 	go.mongodb.org/mongo-driver v1.17.9
 	golang.org/x/crypto v0.50.0
 	golang.org/x/net v0.53.0
+	golang.org/x/sync v0.20.0
 	golang.org/x/sys v0.43.0
 	golang.org/x/text v0.36.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -109,7 +111,6 @@ require (
 	github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	golang.org/x/mod v0.34.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/tools v0.43.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.2.0 h1:nCYfg
 github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.2.0/go.mod h1:ucUjca2JtSZboY8IoUqyQyuuXvwbMBVwFOm0vdQPNhA=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0 h1:XRzhVemXdgvJqCH0sFfrBUTnUJSBrBf7++ypk+twtRs=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0/go.mod h1:HKpQxkWaGLJ+D/5H8QRpyQXA1eKjxkFlOMwck5+33Jk=
+github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
+github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/Microsoft/go-winio v0.5.2/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v8QkMxJ6pZY=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
@@ -135,6 +137,7 @@ github.com/jlaffaye/ftp v0.2.1 h1:AICcTYPMkaXlmjLMm9I+lB36f6jXCsCvBqVQc6EfC1Y=
 github.com/jlaffaye/ftp v0.2.1/go.mod h1:gXSIr1pA9NhynDNigiFHs4+yL7o7I6bGF9Za9wi9tcE=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=
 github.com/kevinburke/ssh_config v1.2.0/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
+github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
 github.com/klauspost/compress v1.16.7 h1:2mk3MPGNzKyxErAw8YaohYh69+pa4sIQSC0fPGCFR9I=
 github.com/klauspost/compress v1.16.7/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
 github.com/klauspost/cpuid/v2 v2.2.10 h1:tBs3QSyvjDyFTq3uoc/9xFpCuOsJQFNPiAhYdw2skhE=


### PR DESCRIPTION
## 概述

本次 PR 整合 `backend/database/` 下六轮安全 / 健壮性 / 性能加固，含 7 个原子提交：

1. `fix(database): escape identifiers via SafeMyIdent / SafePgIdent` — 闭合 5 处 P0 SQL 注入
2. `fix(database): harden pool race, query timeout, sqlserver cleanup` — 连接池竞态修复 + 30s 查询超时 + SQL Server CRUD 统一走 execPrepared
3. `fix(database): F-116 mysql connection pool tuning` — parseTime + 读写超时 + 池参数
4. `fix(database): F-115 Postgres GetTableSchema parallel + cached` — errgroup 并行 + sync.Map 缓存
5. `fix(database): F-114 scanToString type-switch (no fmt.Sprintf)` — 消除 fmt.Sprintf 反射热路径
6. `fix(database): F-113 add QueryRowsStream to avoid per-row map alloc` — 大结果集行级复用
7. `test(database): extend safeident / timeout / schema cache coverage` — 新增 7 个测试文件 / 用例

---

## 安全 — SQL 注入闭合 (P0)

新增 `backend/database/safeident.go`，三个工具函数：

- `SafeMyIdent(name)` — MySQL 反引号转义，拒空 / NUL / `..` / `/` / `\` / 长度 > 128
- `SafePgIdent(name)` — Postgres / rqlite 双引号转义，同上校验
- `SafeDefaultLiteral(v)` — `SET DEFAULT %s` 字面量白名单：NULL / TRUE / FALSE / `CURRENT_*` / `LOCALTIME*` / 数值 / 单引号字符串；其余一律拒绝

接入点：

- `provider_mysql.go` 的 `SHOW / CREATE / DROP / USE` 处 `dbName + tableName` 共 10+ 处 `fmt.Sprintf` 改走 `SafeMyIdent`
- `provider_postgres.go` 的 `AddColumn / ModifyColumn` 的 `SET DEFAULT %s` 改走 `SafeDefaultLiteral`
- `provider_postgres.go` 与 `provider_rqlite.go` 的 `Quote()` 方法改用 `SafePgIdent`
- `provider_mysql.go` 的 `Quote()` 方法改用 `SafeMyIdent`

闭合的 5 处 P0 finding（编号沿用内部审计）：

| 编号 | 描述 | 位置 |
|---|---|---|
| AUDIT-database-01 | MySQL `dbName` 直接拼接进 `SHOW / CREATE DATABASE` | `provider_mysql.go` |
| AUDIT-database-02 | MySQL `tableName` 直接拼接进 DDL | `provider_mysql.go` |
| AUDIT-database-03 | MySQL `Quote()` 未转义反引号 | `provider_mysql.go` |
| AUDIT-database-04 | Postgres `SET DEFAULT %s` 字面量未校验 | `provider_postgres.go` |
| AUDIT-database-05 | Postgres / rqlite `Quote()` 未转义双引号 | `provider_postgres.go` / `provider_rqlite.go` |

可达路径：WebView 端 `App.GetTables / CreateDatabase / DropDatabase / AddColumn` 等接口，以及同步过来的连接配置（攻击者可在自己的同步源注入）。

---

## 健壮性 — 连接池 / 超时

- **MySQL DDL 连接固定** (`provider_mysql.go`) — `CreateTable / DropTable / DropView / TruncateTable / AddColumn / ModifyColumn / DropColumn / AddIndex / DropIndex` 改为经 `mysqlUseDB` helper 拿到独占 `*sql.Conn`，`USE` 与 DDL 在同一 conn 上执行，避免 `database/sql` 池切 conn 导致 USE 丢上下文（race session state）
- **Postgres sslmode** (`provider_postgres.go:29`) — 默认从 `"disable"` 改为 `"prefer"`；`extraParams` 含 `sslmode` 时让该值生效（保持向后兼容）
- **查询 30s 超时** (`executor.go`) — 新增包级 `queryTimeout = 30 * time.Second`，`ExecuteQuery / ExecuteStatement` 走 `context.WithTimeout(context.Background(), queryTimeout)`，UI 现在能取消 / 报错而不是卡死
- **SQL Server CRUD** (`provider_sqlserver.go`) — `InsertRow / UpdateRow / DeleteRow` 改走 `execPrepared`（pin conn + 单 USE），统一上下文传播与池行为
- **SQL Server DropColumn leak-safe** (`provider_sqlserver.go`) — `defer rows.Close()` + `rows.Err()`，未来加早返回不会泄漏

对应 finding：DB-06 / DB-08 / DB-09 / DB-10 / DB-11。

---

## 性能 — P1 IO / 分配

- **F-113 QueryRowsStream** — 大结果集走 row-callback（复用 `[]any` / `[]string`），每行只留下 `[]byte→string` 的拷贝开销；`queryStrings / queryAny` 维持 map 形态以服务小结果集
- **F-114 scanToString** — 反射 `fmt.Sprintf("%v", v)` 改为 `string/int64/float64/bool/time.Time` 类型分支，未知类型 fallback 到 `fmt.Sprintf` 保兼容
- **F-115 Postgres schema 缓存** — `errgroup` 并行查 3 个表结构查询；结果按 `dbName.tableName` 缓存到 `sync.Map`，重复调用零 IO
- **F-116 MySQL 连接池调优** — `parseTime=true`、读写超时、`SetMaxOpenConns(20)` / `IdleConns(5)` / `ConnMaxLifetime(5m)` / `ConnMaxIdleTime(2m)`

---

## 测试覆盖

新增 / 强化 11 个测试函数 / 46 个子用例，全部走 `go test ./backend/database/...` 一次绿：

- `TestSafeMyIdent` — 10 子用例：plain / 数字下划线 / 反引号注入 / 纯反引号 / 空 / NUL / 三种 path traversal（`..` `/` `\`）/ 长度超限 / 长度边界 (128)
- `TestSafePgIdent` — 8 子用例：plain / 双引号注入 / 纯双引号 / 空 / NUL / path traversal / 长度超限 / schema 限定
- `TestSafeDefaultLiteral` — 18 子用例：NULL / TRUE / FALSE / 整数 / 有符号小数 / 有符号零 / 单引号字符串 / 嵌入引号拒绝 / CURRENT_* / LOCALTIME* / 原始注入 / 函数调用 / bare identifier / 空 / 纯空白 / 未闭合
- `TestSafeIdentRoundTrip` — 10 子用例：跨 mysql/pg 验证转义后保留原字节
- `TestQueryTimeoutDefault` — 守 `queryTimeout == 30s` 常量
- `TestQueryTimeoutHonouredByExecuteQuery` — sqlmock 延迟 500ms / 超时 50ms，验证被中断
- `TestExecuteStatementHonoursTimeout` — 同上但 INSERT/UPDATE/DELETE 路径
- `TestExecuteQuerySuccessWithinDeadline` — 验证快速查询不被误中断
- `TestPostgresSchemaCacheKey` — 不同表条目互不污染
- `TestPostgresSchemaCacheParallel` — 64 goroutine × 100 次并发 Load
- `TestPostgresSchemaCacheSameTableParallel` — 32 goroutine 写读收敛到同一指针

新增测试依赖：`github.com/DATA-DOG/go-sqlmock v1.5.2`（仅 test 用，注释里已注明 `// indirect` 撤掉 → 直接依赖）。

---

## 验证

- `go build ./backend/...` — 通过
- `go vet ./backend/database/...` — 干净
- `go test ./backend/database/... -count=1` — `ok 0.440s`，54 个用例全绿
- `go test ./backend/...` — `backend/database` 包外无新增依赖受影响

---

## 拆分说明

如果上游偏好最小变更、希望只吃安全修复，本分支可以拆成两个 PR：

- **纯安全**（只 `c4ac8c0` + `9d80e01` 测试）—— 仅 `SafeMyIdent / SafePgIdent / SafeDefaultLiteral` + 5 处 P0 闭合
- **健壮性 + 性能**（剩下 5 个 commit）—— pool race / query timeout / F-113~F-116

需要拆分时告知，我可重做。

---

## 文件清单

```
backend/database/engine.go                     |  58 ++++++-
backend/database/executor.go                   |  14 +-
backend/database/executor_timeout_test.go      | 152 ++++++++++++++
backend/database/postgres_schema_cache_test.go | 113 ++++++++++
backend/database/provider_mysql.go             | 203 +++++++++++++++++-------
backend/database/provider_postgres.go          | 109 +++++++++----
backend/database/provider_rqlite.go            |   3 +-
backend/database/provider_sqlserver.go         |  26 +++-
backend/database/safeident.go                  |  93 +++++++++
backend/database/safeident_test.go             | 142 ++++++++++++++++
go.mod                                         |   3 +-
go.sum                                         |   3 +
12 files changed, 817 insertions(+), 102 deletions(-)
```

---

## 关联

- 内部审计：`AUDIT-database-01..05`（SQL 注入），`DB-06 / DB-08 / DB-09 / DB-10 / DB-11`（健壮性）
- 性能编号：`F-113 / F-114 / F-115 / F-116`（沿用本轮性能审计口径）