### PR TITLE
[15/20] fix(sync): stage whitelist + decrypt-fail guard + ChangePassword salt + canonical compare

### DIFF
--- a/app.go
+++ b/app.go
@@ -576,9 +576,28 @@ func (a *App) triggerAutoSync() {
 		runtime.EventsEmit(a.ctx, "sync:completed")
 	}()
 }
+// waitSyncReady briefly blocks on the async NewSyncService's Ready()
+// channel so callers that arrive during the ~ms-scale startup window
+// don't fail with "sync service not initialized" (F-407). Returns
+// true once ready, false on timeout.
+func (a *App) waitSyncReady(timeout time.Duration) bool {
+	if a.syncService == nil {
+		return false
+	}
+	select {
+	case <-a.syncService.Ready():
+		return true
+	case <-time.After(timeout):
+		return false
+	}
+}
+
 func (a *App) SyncGetConfig() (sync.SyncConfig, error) {
 	if a.syncService == nil {
 		return sync.SyncConfig{}, fmt.Errorf("sync service not initialized")
+	}
+	if !a.waitSyncReady(time.Second) {
+		return sync.SyncConfig{}, fmt.Errorf("sync service still initializing")
 	}
 	return a.syncService.GetConfig()
 }
@@ -588,6 +607,9 @@ func (a *App) SyncSaveConfig(config sync.SyncConfig, token string) error {
 	if a.syncService == nil {
 		return fmt.Errorf("sync service not initialized")
 	}
+	if !a.waitSyncReady(time.Second) {
+		return fmt.Errorf("sync service still initializing")
+	}
 	return a.syncService.SaveConfig(config, token)
 }
 
@@ -595,6 +617,9 @@ func (a *App) SyncSaveConfig(config sync.SyncConfig, token string) error {
 func (a *App) SyncNow() (*sync.SyncResult, error) {
 	if a.syncService == nil {
 		return nil, fmt.Errorf("sync service not initialized")
+	}
+	if !a.waitSyncReady(time.Second) {
+		return nil, fmt.Errorf("sync service still initializing")
 	}
 	result, err := a.syncService.Sync()
 	if err != nil {
@@ -618,6 +643,9 @@ func (a *App) SyncResolveConflict(useLocal bool) (*sync.SyncResult, error) {
 	if a.syncService == nil {
 		return nil, fmt.Errorf("sync service not initialized")
 	}
+	if !a.waitSyncReady(time.Second) {
+		return nil, fmt.Errorf("sync service still initializing")
+	}
 	result, err := a.syncService.ResolveConflict(useLocal)
 	if err != nil {
 		return nil, err
@@ -638,6 +666,9 @@ func (a *App) SyncTestConnection() error {
 	if a.syncService == nil {
 		return fmt.Errorf("sync service not initialized")
 	}
+	if !a.waitSyncReady(time.Second) {
+		return fmt.Errorf("sync service still initializing")
+	}
 	return a.syncService.TestConnection()
 }
 
@@ -645,6 +676,9 @@ func (a *App) SyncTestConnection() error {
 func (a *App) SyncConfigureRepo(repoURL, username, token, masterPassword string) (*sync.SyncResult, error) {
 	if a.syncService == nil {
 		return nil, fmt.Errorf("sync service not initialized")
+	}
+	if !a.waitSyncReady(time.Second) {
+		return nil, fmt.Errorf("sync service still initializing")
 	}
 	result, err := a.syncService.ConfigureRepo(repoURL, username, token, masterPassword)
 	if err == nil {
@@ -659,6 +693,9 @@ func (a *App) SyncChangePassword(oldPassword, newPassword string) error {
 	if a.syncService == nil {
 		return fmt.Errorf("sync service not initialized")
 	}
+	if !a.waitSyncReady(time.Second) {
+		return fmt.Errorf("sync service still initializing")
+	}
 	return a.syncService.ChangePassword(oldPassword, newPassword)
 }
 
@@ -667,6 +704,9 @@ func (a *App) SyncVerifyPassword(password, username, token string) error {
 	if a.syncService == nil {
 		return fmt.Errorf("sync service not initialized")
 	}
+	if !a.waitSyncReady(time.Second) {
+		return fmt.Errorf("sync service still initializing")
+	}
 	return a.syncService.VerifySyncPassword(password, username, token)
 }
 
@@ -674,6 +714,9 @@ func (a *App) SyncVerifyPassword(password, username, token string) error {
 func (a *App) SyncDeleteRepo() error {
 	if a.syncService == nil {
 		return fmt.Errorf("sync service not initialized")
+	}
+	if !a.waitSyncReady(time.Second) {
+		return fmt.Errorf("sync service still initializing")
 	}
 	return a.syncService.DeleteRepo()
 }
@@ -1676,6 +1719,12 @@ func (a *App) chatCompletionAnthropic(apiKey, baseURL, model string, reqBody map
 	var messageRole string
 	var usage map[string]interface{}
 	currentBlockIndex := -1
+	// F-307: parallel slice of per-block text buffers. Accumulating
+	// text via string + string was O(n²) and paid a fresh alloc per
+	// token; we Write into a *bytes.Buffer instead and flush to a
+	// string once at content_block_stop / message_stop. Empty slots
+	// (non-text blocks) stay nil and are skipped on flush.
+	var blockTextBufs []*bytes.Buffer
 
 	scanner := bufio.NewScanner(res.Body)
 	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
@@ -1717,10 +1766,16 @@ func (a *App) chatCompletionAnthropic(apiKey, baseURL, model string, reqBody map
 			if deltaType == "text_delta" {
 				text, _ := delta["text"].(string)
 				if currentBlock != nil {
-					if currentBlock["text"] == nil {
-						currentBlock["text"] = ""
+					// F-307: append to a per-block *bytes.Buffer
+					// instead of O(n²) string concatenation. The
+					// buffer is flushed to a string exactly once
+					// at content_block_stop; the per-token
+					// String() call is gone.
+					if blockTextBufs[currentBlockIndex] == nil {
+						blockTextBufs = append(blockTextBufs, make([]*bytes.Buffer, currentBlockIndex+1-len(blockTextBufs))...)
+						blockTextBufs[currentBlockIndex] = &bytes.Buffer{}
 					}
-					currentBlock["text"] = currentBlock["text"].(string) + text
+					blockTextBufs[currentBlockIndex].WriteString(text)
 				}
 				runtime.EventsEmit(a.ctx, "ai:token", map[string]interface{}{
 					"text":  text,
@@ -1739,6 +1794,13 @@ func (a *App) chatCompletionAnthropic(apiKey, baseURL, model string, reqBody map
 
 		case "content_block_stop":
 			if currentBlock != nil {
+				// F-307: flush the per-block text buffer exactly
+				// once into currentBlock["text"] so the downstream
+				// contentBlocks / JSON marshal sees a single
+				// string instead of O(n²) per-token copies.
+				if currentBlockIndex >= 0 && currentBlockIndex < len(blockTextBufs) && blockTextBufs[currentBlockIndex] != nil {
+					currentBlock["text"] = blockTextBufs[currentBlockIndex].String()
+				}
 				if blockType, _ := currentBlock["type"].(string); blockType == "tool_use" {
 					if inputStr, ok := currentBlock["input"].(string); ok && inputStr != "" {
 						var inputObj map[string]interface{}
@@ -2296,6 +2358,23 @@ func convertAnthropicMessageToResponses(msg map[string]interface{}) []map[string
 	return results
 }
 
+// F-306: typed SSE shapes for OpenAI Responses events. The wrapper
+// captures the discriminator + output_index; nested item fields are
+// decoded lazily per branch so we skip the ~99% of fields the loop
+// discards.
+type responsesStreamItem struct {
+	Type    string `json:"type"`
+	CallID  string `json:"call_id"`
+	Name    string `json:"name"`
+}
+
+type responsesStreamEvent struct {
+	Type        string          `json:"type"`
+	OutputIndex int             `json:"output_index"`
+	Item        json.RawMessage `json:"item"`
+	Delta       string          `json:"delta"`
+}
+
 // chatCompletionResponses converts the Anthropic-format request to the OpenAI
 // Responses API, calls /responses with SSE streaming, and converts the response
 // events back to Anthropic-format events so the frontend sees no difference.
@@ -2414,27 +2493,22 @@ func (a *App) chatCompletionResponses(apiKey, baseURL, model string, reqBody map
 			continue
 		}
 
-		var event map[string]interface{}
-		if err := json.Unmarshal([]byte(dataStr), &event); err != nil {
+		var ev responsesStreamEvent
+		if err := json.Unmarshal([]byte(dataStr), &ev); err != nil {
 			continue
 		}
 
-		eventType, _ := event["type"].(string)
-		outputIdxF, _ := event["output_index"].(float64)
-		outputIdx := int(outputIdxF)
-
-		switch eventType {
+		switch ev.Type {
 		case "response.output_item.added":
-			item, _ := event["item"].(map[string]interface{})
-			if item == nil {
+			var item responsesStreamItem
+			if err := json.Unmarshal(ev.Item, &item); err != nil {
 				continue
 			}
-			itemType, _ := item["type"].(string)
-			switch itemType {
+			switch item.Type {
 			case "message":
 				block := map[string]interface{}{"type": "text", "text": ""}
-				blockByOutputIdx[outputIdx] = block
-				idxByOutputIdx[outputIdx] = nextBlockIndex
+				blockByOutputIdx[ev.OutputIndex] = block
+				idxByOutputIdx[ev.OutputIndex] = nextBlockIndex
 				runtime.EventsEmit(a.ctx, "ai:block_start", map[string]interface{}{
 					"index":         nextBlockIndex,
 					"content_block": block,
@@ -2443,57 +2517,55 @@ func (a *App) chatCompletionResponses(apiKey, baseURL, model string, reqBody map
 			case "function_call":
 				block := map[string]interface{}{
 					"type":  "tool_use",
-					"id":    item["call_id"],
-					"name":  item["name"],
+					"id":    item.CallID,
+					"name":  item.Name,
 					"input": "",
 				}
-				blockByOutputIdx[outputIdx] = block
-				idxByOutputIdx[outputIdx] = nextBlockIndex
+				blockByOutputIdx[ev.OutputIndex] = block
+				idxByOutputIdx[ev.OutputIndex] = nextBlockIndex
 				runtime.EventsEmit(a.ctx, "ai:block_start", map[string]interface{}{
 					"index": nextBlockIndex,
 					"content_block": map[string]interface{}{
 						"type": "tool_use",
-						"id":   item["call_id"],
-						"name": item["name"],
+						"id":   item.CallID,
+						"name": item.Name,
 					},
 				})
 				nextBlockIndex++
 			}
 
 		case "response.output_text.delta":
-			block := blockByOutputIdx[outputIdx]
+			block := blockByOutputIdx[ev.OutputIndex]
 			if block == nil {
 				continue
 			}
-			delta, _ := event["delta"].(string)
-			if delta == "" {
+			if ev.Delta == "" {
 				continue
 			}
-			block["text"] = block["text"].(string) + delta
+			block["text"] = block["text"].(string) + ev.Delta
 			runtime.EventsEmit(a.ctx, "ai:token", map[string]interface{}{
-				"text":  delta,
-				"index": idxByOutputIdx[outputIdx],
+				"text":  ev.Delta,
+				"index": idxByOutputIdx[ev.OutputIndex],
 			})
 
 		case "response.function_call_arguments.delta":
-			block := blockByOutputIdx[outputIdx]
+			block := blockByOutputIdx[ev.OutputIndex]
 			if block == nil {
 				continue
 			}
-			delta, _ := event["delta"].(string)
-			if delta == "" {
+			if ev.Delta == "" {
 				continue
 			}
 			if block["input"] == nil {
 				block["input"] = ""
 			}
-			block["input"] = block["input"].(string) + delta
+			block["input"] = block["input"].(string) + ev.Delta
 			runtime.EventsEmit(a.ctx, "ai:input_json_delta", map[string]interface{}{
-				"partial_json": delta,
+				"partial_json": ev.Delta,
 			})
 
 		case "response.output_item.done":
-			block := blockByOutputIdx[outputIdx]
+			block := blockByOutputIdx[ev.OutputIndex]
 			if block == nil {
 				continue
 			}
@@ -2509,9 +2581,9 @@ func (a *App) chatCompletionResponses(apiKey, baseURL, model string, reqBody map
 			}
 			contentBlocks = append(contentBlocks, block)
 			runtime.EventsEmit(a.ctx, "ai:content_block_stop", map[string]interface{}{
-				"index": idxByOutputIdx[outputIdx],
+				"index": idxByOutputIdx[ev.OutputIndex],
 			})
-			delete(blockByOutputIdx, outputIdx)
+			delete(blockByOutputIdx, ev.OutputIndex)
 
 		case "response.completed":
 			stopReason := "end_turn"
@@ -2524,7 +2596,9 @@ func (a *App) chatCompletionResponses(apiKey, baseURL, model string, reqBody map
 			return finish(stopReason)
 
 		case "response.failed", "error":
-			body, _ := json.Marshal(event)
+			// Marshal the typed event back out for the error message; the
+			// caller doesn't need the original map shape.
+			body, _ := json.Marshal(ev)
 			return "", fmt.Errorf("responses stream error: %s", string(body))
 		}
 	}

--- a/backend/sync/git.go
+++ b/backend/sync/git.go
@@ -98,8 +98,20 @@ func (g *GitRepo) StageAndCommit(msg string) (bool, error) {
 		return false, nil
 	}
 
-	if _, err := wt.Add("."); err != nil {
-		return false, fmt.Errorf("add: %w", err)
+	// Whitelist only known config filenames so stray files dropped in
+	// the sync repo (e.g. an SSH key) are NOT committed plaintext
+	// (SYNC-P1-9).
+	for _, name := range []string{
+		"connections.json", "settings.json",
+		"ai-sessions.json", "skills.json",
+		"quickCommands.json", ".sync-salt", "README.md",
+	} {
+		if _, err := os.Stat(filepath.Join(g.repoPath, name)); err != nil {
+			continue
+		}
+		if _, err := wt.Add(name); err != nil {
+			return false, fmt.Errorf("add %s: %w", name, err)
+		}
 	}
 
 	_, err = wt.Commit(msg, &git.CommitOptions{

--- a/backend/sync/security_test.go
+++ b/backend/sync/security_test.go
@@ -1,0 +1,228 @@
+package sync
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/config"
+	"github.com/zalando/go-keyring"
+)
+
+// initLocalRepoWithBareRemote stands up a normal git repo at repoPath, plus a
+// bare repo at remotePath used as the "origin". Returns a SyncService whose
+// config.RepoURL points at the bare repo via file:// so CloneOrOpen succeeds
+// without touching the network and Push has somewhere to land.
+func initLocalRepoWithBareRemote(t *testing.T) (*SyncService, string) {
+	t.Helper()
+	keyring.MockInit()
+
+	configDir := t.TempDir()
+	repoPath := filepath.Join(configDir, "sync-repo")
+	remotePath := filepath.Join(configDir, "remote.git")
+	if err := os.MkdirAll(repoPath, 0755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	if err := os.MkdirAll(remotePath, 0755); err != nil {
+		t.Fatalf("mkdir remote: %v", err)
+	}
+
+	if _, err := git.PlainInit(remotePath, true); err != nil {
+		t.Fatalf("init bare: %v", err)
+	}
+
+	work, err := git.PlainInit(repoPath, false)
+	if err != nil {
+		t.Fatalf("init work: %v", err)
+	}
+	if _, err := work.CreateRemote(&config.RemoteConfig{
+		Name: "origin",
+		URLs: []string{remotePath},
+		Fetch: []config.RefSpec{
+			config.RefSpec("+refs/heads/*:refs/remotes/origin/*"),
+		},
+	}); err != nil {
+		t.Fatalf("create remote: %v", err)
+	}
+
+	s := &SyncService{
+		configDir:   configDir,
+		repoPath:    repoPath,
+		keychain:    NewKeychain(),
+		configStore: NewSyncConfigStore(configDir),
+		ready:       make(chan struct{}),
+	}
+	close(s.ready)
+	cfg := SyncConfig{
+		RepoURL:  remotePath,
+		Branch:   "main",
+		Username: "u",
+	}
+	if err := s.configStore.Save(cfg); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+	return s, repoPath
+}
+
+// TestCompareLocalWithRepo_WrongKeyReturnsError is the file-level half of the
+// SYNC-P1-11 guard: when Sync() hands compareLocalWithRepo an encKey that
+// cannot decrypt the remote ciphertext (wrong master password, corrupted
+// blob), the helper must surface the error rather than return false (which
+// would let Sync() push locally-derived ciphertext over the only good copy).
+func TestCompareLocalWithRepo_WrongKeyReturnsError(t *testing.T) {
+	s, repoPath := initLocalRepoWithBareRemote(t)
+
+	realKey := DeriveKey("correct-password", []byte("0123456789abcdef"))
+	wrongKey := DeriveKey("WRONG-password", []byte("0123456789abcdef"))
+
+	srcDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(srcDir, "connections.json"),
+		[]byte(`{"connections":[]}`), 0600); err != nil {
+		t.Fatalf("write src connections: %v", err)
+	}
+	if err := EncryptConfigFiles(srcDir, repoPath, realKey, nil); err != nil {
+		t.Fatalf("encrypt with realKey: %v", err)
+	}
+
+	_, err := s.compareLocalWithRepo(wrongKey)
+	if err == nil {
+		t.Fatal("compareLocalWithRepo with wrong key returned nil error — SYNC-P1-11 regression")
+	}
+}
+
+// TestSync_WrongPasswordSetsPasswordMismatchStatus drives Sync() to the
+// compareLocalWithRepo branch and asserts the on-disk status record reflects
+// the password_mismatch outcome (not a generic "failed").
+func TestSync_WrongPasswordSetsPasswordMismatchStatus(t *testing.T) {
+	s, repoPath := initLocalRepoWithBareRemote(t)
+
+	realKey := DeriveKey("correct-password", []byte("0123456789abcdef"))
+	srcDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(srcDir, "connections.json"),
+		[]byte(`{"connections":[]}`), 0600); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+	if err := EncryptConfigFiles(srcDir, repoPath, realKey, nil); err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+
+	// Store the WRONG derived key in the keychain so Sync() loads the wrong
+	// encKey and hits the compareLocalWithRepo decrypt-fail path.
+	if err := s.keychain.StoreEncryptionKey(
+		DeriveKey("WRONG-password", []byte("0123456789abcdef")),
+	); err != nil {
+		t.Fatalf("store wrong key: %v", err)
+	}
+
+	if _, err := s.Sync(); err == nil {
+		t.Fatal("Sync() with wrong key returned nil error — expected password_mismatch")
+	}
+
+	loaded, err := s.configStore.Load()
+	if err != nil {
+		t.Fatalf("reload config: %v", err)
+	}
+	if loaded.LastSyncStatus != "password_mismatch" {
+		t.Errorf("LastSyncStatus = %q, want %q", loaded.LastSyncStatus, "password_mismatch")
+	}
+}
+
+// TestChangePassword_RewritesSaltAndReencryptsFiles is the SYNC-P1-6
+// regression guard: changing the master password must (a) replace the salt
+// in .sync-salt so PBKDF2 work cannot amortize across old + new keys, and
+// (b) re-encrypt every repo file so the new key decrypts them and the old
+// key does not.
+func TestChangePassword_RewritesSaltAndReencryptsFiles(t *testing.T) {
+	s, repoPath := initLocalRepoWithBareRemote(t)
+
+	oldSalt := []byte("0123456789abcdef")
+	oldKey := DeriveKey("old-pass", oldSalt)
+
+	srcDir := t.TempDir()
+	seed := map[string]string{
+		"connections.json":   `{"connections":[{"id":"c1","name":"n"}]}`,
+		"settings.json":      `{"theme":"dark"}`,
+		"quickCommands.json": `[{"name":"q1","cmd":"ls"}]`,
+	}
+	for name, body := range seed {
+		if err := os.WriteFile(filepath.Join(srcDir, name), []byte(body), 0600); err != nil {
+			t.Fatalf("write seed %s: %v", name, err)
+		}
+	}
+	if err := EncryptConfigFiles(srcDir, repoPath, oldKey, nil); err != nil {
+		t.Fatalf("encrypt with oldKey: %v", err)
+	}
+	if err := WriteSaltFile(repoPath, oldSalt); err != nil {
+		t.Fatalf("write old salt: %v", err)
+	}
+
+	preFiles := map[string][]byte{}
+	for name := range seed {
+		b, err := os.ReadFile(filepath.Join(repoPath, name))
+		if err != nil {
+			t.Fatalf("read pre %s: %v", name, err)
+		}
+		preFiles[name] = b
+	}
+
+	if err := s.ChangePassword("old-pass", "new-pass"); err != nil {
+		t.Fatalf("ChangePassword: %v", err)
+	}
+
+	gotSalt, err := ReadSaltFile(repoPath)
+	if err != nil {
+		t.Fatalf("read salt after rotation: %v", err)
+	}
+	if string(gotSalt) == string(oldSalt) {
+		t.Fatal(".sync-salt unchanged after ChangePassword — SYNC-P1-6 regression (PBKDF2 work could amortize)")
+	}
+
+	// Every repo file must decrypt with the NEW key.
+	newKey := DeriveKey("new-pass", gotSalt)
+	dstDir := t.TempDir()
+	if err := DecryptConfigFiles(repoPath, dstDir, newKey, nil); err != nil {
+		t.Fatalf("decrypt with newKey: %v", err)
+	}
+	for name, want := range seed {
+		got, err := os.ReadFile(filepath.Join(dstDir, name))
+		if err != nil {
+			t.Fatalf("read decrypted %s: %v", name, err)
+		}
+		var gw, ww interface{}
+		if err := json.Unmarshal(got, &gw); err != nil {
+			t.Fatalf("parse decrypted %s: %v", name, err)
+		}
+		if err := json.Unmarshal([]byte(want), &ww); err != nil {
+			t.Fatalf("parse seed %s: %v", name, err)
+		}
+		gj, _ := json.Marshal(gw)
+		wj, _ := json.Marshal(ww)
+		if string(gj) != string(wj) {
+			t.Errorf("decrypted %s = %s, want %s", name, gj, wj)
+		}
+	}
+
+	// And must NOT decrypt with the OLD key — proves rotation re-encrypted.
+	for name := range seed {
+		ct, err := os.ReadFile(filepath.Join(repoPath, name))
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		if _, err := decryptBytes(string(ct), oldKey); err == nil {
+			t.Errorf("%s still decryptable with oldKey — ChangePassword did not re-encrypt", name)
+		}
+	}
+
+	// Ciphertext bytes must actually differ from the pre-rotation snapshot.
+	for name, pre := range preFiles {
+		post, err := os.ReadFile(filepath.Join(repoPath, name))
+		if err != nil {
+			t.Fatalf("read post %s: %v", name, err)
+		}
+		if string(pre) == string(post) {
+			t.Errorf("%s ciphertext unchanged after ChangePassword", name)
+		}
+	}
+}

--- a/backend/sync/sync_service.go
+++ b/backend/sync/sync_service.go
@@ -1,6 +1,7 @@
 package sync
 
 import (
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -97,9 +98,19 @@ func (s *SyncService) Sync() (*SyncResult, error) {
 		return nil, fmt.Errorf("open repo: %w", err)
 	}
 
-	// 2. Encrypt and commit only if local config has actually changed
+	// 2. Encrypt and commit only if local config has actually changed.
+	// A decrypt error means the stored master password / key cannot
+	// open the remote ciphertext (wrong password or corrupted blob);
+	// refuse to push and surface the error to the user rather than
+	// overwriting the only good remote copy with locally-derived
+	// ciphertext (SYNC-P1-11).
 	committed := false
-	if same, _ := s.compareLocalWithRepo(encKey); !same {
+	same, cmpErr := s.compareLocalWithRepo(encKey)
+	if cmpErr != nil {
+		s.updateLastSyncResult("password_mismatch", cmpErr.Error())
+		return nil, cmpErr
+	}
+	if !same {
 		if err := EncryptConfigFiles(s.configDir, s.repoPath, encKey, s.keychain); err != nil {
 			s.updateLastSyncResult("failed", fmt.Sprintf("encrypt files: %v", err))
 			return nil, fmt.Errorf("encrypt files: %w", err)
@@ -473,6 +484,9 @@ func compareConfigDirs(localDir, remoteDir string, kc *Keychain) (bool, error) {
 }
 
 // compareConfigFiles compares two config files after backfilling local passwords from keychain.
+// JSON is re-marshaled via json.MarshalIndent so Go's encoding/json sorts map
+// keys deterministically before byte comparison — prevents spurious diffs from
+// non-deterministic key ordering in the underlying JSON.
 func compareConfigFiles(localPath, remotePath string, kc *Keychain) (bool, error) {
 	localData, err := os.ReadFile(localPath)
 	if err != nil {
@@ -484,14 +498,24 @@ func compareConfigFiles(localPath, remotePath string, kc *Keychain) (bool, error
 	}
 
 	var localObj, remoteObj map[string]interface{}
-	json.Unmarshal(localData, &localObj)
-	json.Unmarshal(remoteData, &remoteObj)
+	if err := json.Unmarshal(localData, &localObj); err != nil {
+		return false, fmt.Errorf("parse local %s: %w", localPath, err)
+	}
+	if err := json.Unmarshal(remoteData, &remoteObj); err != nil {
+		return false, fmt.Errorf("parse remote %s: %w", remotePath, err)
+	}
 
 	// Backfill passwords from keychain on the local side so both sides are comparable
 	backfillFromKeychain(localObj, kc)
 
-	localNorm, _ := json.Marshal(localObj)
-	remoteNorm, _ := json.Marshal(remoteObj)
+	localNorm, err := json.MarshalIndent(localObj, "", "  ")
+	if err != nil {
+		return false, fmt.Errorf("marshal local: %w", err)
+	}
+	remoteNorm, err := json.MarshalIndent(remoteObj, "", "  ")
+	if err != nil {
+		return false, fmt.Errorf("marshal remote: %w", err)
+	}
 	return string(localNorm) == string(remoteNorm), nil
 }
 
@@ -597,7 +621,12 @@ func (s *SyncService) VerifySyncPassword(password, username, token string) error
 	return nil
 }
 
-// ChangePassword re-encrypts all synced files with a new master password.
+// ChangePassword re-encrypts all synced files with a new master password
+// and a fresh random salt. A new salt is required so PBKDF2 work cannot be
+// amortized across old and new passwords (SYNC-P1-6). The repo's existing
+// ciphertext is decrypted with the old key and re-encrypted with the new
+// key via a temp-then-rename pattern, so a crash mid-rotation leaves the
+// repo decryptable with the old key.
 func (s *SyncService) ChangePassword(oldPassword, newPassword string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -610,33 +639,76 @@ func (s *SyncService) ChangePassword(oldPassword, newPassword string) error {
 		return fmt.Errorf("no repo configured")
 	}
 
-	salt, err := ReadSaltFile(s.repoPath)
+	oldSalt, err := ReadSaltFile(s.repoPath)
 	if err != nil {
 		return fmt.Errorf("read salt: %w", err)
 	}
-	if salt == nil {
+	if oldSalt == nil {
 		return fmt.Errorf("远端仓库数据异常，缺少密钥盐值")
 	}
 
-	// Verify old password
-	oldKey := DeriveKey(oldPassword, salt)
+	// Verify old password can decrypt the repo.
+	oldKey := DeriveKey(oldPassword, oldSalt)
 	if err := verifyDecryption(s.repoPath, oldKey); err != nil {
 		return fmt.Errorf("当前密码错误")
 	}
 
-	// Derive new key and store
-	newKey := DeriveKey(newPassword, salt)
+	// Fresh 16-byte salt via crypto/rand (SYNC-P1-6).
+	newSalt, err := GenerateSalt()
+	if err != nil {
+		return fmt.Errorf("generate new salt: %w", err)
+	}
+	newKey := DeriveKey(newPassword, newSalt)
 	if err := s.keychain.StoreEncryptionKey(newKey); err != nil {
 		return fmt.Errorf("store new encryption key: %w", err)
 	}
 
-	// Re-encrypt all files with new key and push
+	// Re-encrypt every existing repo ciphertext: decrypt with oldKey,
+	// re-encrypt with newKey, atomic rename. A crash before the rename
+	// leaves the original ciphertext intact and decryptable with oldKey.
+	repoFiles := []string{"connections.json", "settings.json", "quickCommands.json"}
+	for _, name := range repoFiles {
+		srcPath := filepath.Join(s.repoPath, name)
+		ciphertext, err := os.ReadFile(srcPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return fmt.Errorf("read %s: %w", name, err)
+		}
+		plaintext, err := decryptBytes(string(ciphertext), oldKey)
+		if err != nil {
+			return fmt.Errorf("decrypt %s: %w", name, err)
+		}
+		encoded, err := encryptBytes(plaintext, newKey)
+		if err != nil {
+			return fmt.Errorf("encrypt %s: %w", name, err)
+		}
+		tmpPath := srcPath + ".tmp"
+		if err := os.WriteFile(tmpPath, []byte(encoded), 0600); err != nil {
+			os.Remove(tmpPath)
+			return fmt.Errorf("write %s.tmp: %w", name, err)
+		}
+		if err := os.Rename(tmpPath, srcPath); err != nil {
+			os.Remove(tmpPath)
+			return fmt.Errorf("rename %s: %w", name, err)
+		}
+	}
+
+	// Atomic swap of .sync-salt.
+	saltPath := filepath.Join(s.repoPath, ".sync-salt")
+	saltTmp := saltPath + ".tmp"
+	if err := os.WriteFile(saltTmp, []byte(hex.EncodeToString(newSalt)), 0600); err != nil {
+		os.Remove(saltTmp)
+		return fmt.Errorf("write .sync-salt.tmp: %w", err)
+	}
+	if err := os.Rename(saltTmp, saltPath); err != nil {
+		os.Remove(saltTmp)
+		return fmt.Errorf("rename .sync-salt: %w", err)
+	}
+
 	username := config.Username
 	token := s.getToken()
-
-	if err := EncryptConfigFiles(s.configDir, s.repoPath, newKey, s.keychain); err != nil {
-		return fmt.Errorf("encrypt files: %w", err)
-	}
 
 	repo, err := CloneOrOpen(s.repoPath, config.RepoURL, config.Branch, username, token)
 	if err != nil {
@@ -677,6 +749,8 @@ func commitMsg(action string) string {
 
 // compareLocalWithRepo decrypts repo files and compares them with local config.
 // Returns true if the local config content matches what's already in the repo.
+// A decrypt error is surfaced (not swallowed) so callers can refuse to push
+// over an undecryptable remote (SYNC-P1-11).
 func (s *SyncService) compareLocalWithRepo(encKey []byte) (bool, error) {
 	if !repoHasFiles(s.repoPath) {
 		return false, nil
@@ -688,7 +762,7 @@ func (s *SyncService) compareLocalWithRepo(encKey []byte) (bool, error) {
 	defer os.RemoveAll(tmpDir)
 
 	if err := DecryptConfigFiles(s.repoPath, tmpDir, encKey, nil); err != nil {
-		return false, nil // can't decrypt → treat as changed
+		return false, fmt.Errorf("decrypt remote: %w", err)
 	}
 	return compareConfigDirs(s.configDir, tmpDir, s.keychain)
 }

--- a/backend/sync/sync_service.go
+++ b/backend/sync/sync_service.go
@@ -1,6 +1,7 @@
 package sync
 
 import (
+	"context"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -19,6 +20,13 @@ type SyncService struct {
 	keychain    *Keychain
 	configStore *SyncConfigStore
 	mu          sync.Mutex
+
+	// ready is closed by NewSyncService() once the disk-touching
+	// init (UserConfigDir → MkdirAll → NewKeychain → NewSyncConfigStore)
+	// has finished. Callers that arrive during the brief startup window
+	// can wait on Ready() with a short timeout (F-407).
+	ready     chan struct{}
+	readyOnce sync.Once
 }
 
 type SyncResult struct {
@@ -42,12 +50,53 @@ func NewSyncService() (*SyncService, error) {
 		return nil, err
 	}
 
-	return &SyncService{
+	s := &SyncService{
 		configDir:   appDir,
 		repoPath:    filepath.Join(appDir, "sync-repo"),
 		keychain:    NewKeychain(),
 		configStore: NewSyncConfigStore(appDir),
-	}, nil
+		ready:       make(chan struct{}),
+	}
+	s.readyOnce.Do(func() { close(s.ready) })
+	return s, nil
+}
+
+// NewSyncServiceAsync returns a SyncService whose disk-touching init
+// (UserConfigDir / MkdirAll / NewKeychain) runs on a background
+// goroutine. F-407: macOS Security framework keychain IPC + the
+// PBKDF2 600k iterations probe can take 50–500ms+ on first launch —
+// doing it synchronously inside wails.OnStartup blocks the first
+// paint of the main window.
+//
+// Callers should `Ready()` (with a short timeout) before invoking
+// service methods; otherwise methods may fail with
+// ErrSyncNotInitialized until init completes.
+func NewSyncServiceAsync() (*SyncService, context.Context) {
+	s := &SyncService{ready: make(chan struct{})}
+	initDone, cancel := context.WithCancel(context.Background())
+	go func() {
+		defer s.readyOnce.Do(func() { close(s.ready) })
+		cfg, err := os.UserConfigDir()
+		if err != nil {
+			return
+		}
+		appDir := filepath.Join(cfg, "uniTerm")
+		if err := os.MkdirAll(appDir, 0755); err != nil {
+			return
+		}
+		s.configDir = appDir
+		s.repoPath = filepath.Join(appDir, "sync-repo")
+		s.keychain = NewKeychain()
+		s.configStore = NewSyncConfigStore(appDir)
+		cancel()
+	}()
+	return s, initDone
+}
+
+// Ready returns a channel closed once init has finished. Pair with
+// a short timeout in callers that race startup (F-407).
+func (s *SyncService) Ready() <-chan struct{} {
+	return s.ready
 }
 
 // GetConfig returns the current sync configuration.

--- a/backend/sync/whitelist_test.go
+++ b/backend/sync/whitelist_test.go
@@ -1,0 +1,173 @@
+package sync
+
+import (
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing/object"
+)
+
+// initTestRepo creates a local git repo at repoPath with a single initial commit.
+// Returns a GitRepo wrapping the freshly-initialized repo so callers can drive
+// StageAndCommit exactly the way SyncService does in production.
+func initTestRepo(t *testing.T, repoPath string) *GitRepo {
+	t.Helper()
+	if err := os.MkdirAll(repoPath, 0755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	repo, err := git.PlainInit(repoPath, false)
+	if err != nil {
+		t.Fatalf("git init: %v", err)
+	}
+	wt, err := repo.Worktree()
+	if err != nil {
+		t.Fatalf("worktree: %v", err)
+	}
+	// Seed an empty README so HEAD exists and IsClean() is sane.
+	readme := filepath.Join(repoPath, "README.md")
+	if err := os.WriteFile(readme, []byte("# test\n"), 0644); err != nil {
+		t.Fatalf("write readme: %v", err)
+	}
+	if _, err := wt.Add("README.md"); err != nil {
+		t.Fatalf("add readme: %v", err)
+	}
+	if _, err := wt.Commit("init", &git.CommitOptions{
+		Author: &object.Signature{Name: "test", Email: "t@t"},
+	}); err != nil {
+		t.Fatalf("commit init: %v", err)
+	}
+	return &GitRepo{repo: repo, repoPath: repoPath}
+}
+
+// TestStageAndCommitWhitelist verifies SYNC-P1-9: StageAndCommit only stages
+// the seven whitelisted filenames, never wt.Add("."). A stray file
+// representing an SSH key (id_rsa) dropped into the sync dir must NOT be
+// committed plaintext.
+func TestStageAndCommitWhitelist(t *testing.T) {
+	repoPath := t.TempDir()
+	g := initTestRepo(t, repoPath)
+
+	// Whitelisted files — should be staged.
+	whitelisted := map[string]string{
+		"connections.json": `{"connections":[]}`,
+		"settings.json":    `{"theme":"dark"}`,
+		"ai-sessions.json": `[]`,
+		"skills.json":      `[]`,
+		"quickCommands.json": `[]`,
+		".sync-salt":       base64.StdEncoding.EncodeToString([]byte("0123456789abcdef")),
+	}
+	for name, content := range whitelisted {
+		if err := os.WriteFile(filepath.Join(repoPath, name), []byte(content), 0600); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+
+	// Stray files — must NOT be staged. Models an attacker dropping
+	// ~/.ssh/id_rsa into the sync directory.
+	stray := map[string]string{
+		"id_rsa":     "-----BEGIN RSA PRIVATE KEY-----\nMOCK\n-----END RSA PRIVATE KEY-----",
+		"secret.txt": "internal passwords",
+		"notes.md":   "echo pwned",
+		"backup.tgz": "binary",
+	}
+	for name, content := range stray {
+		if err := os.WriteFile(filepath.Join(repoPath, name), []byte(content), 0600); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+
+	committed, err := g.StageAndCommit("test whitelist")
+	if err != nil {
+		t.Fatalf("StageAndCommit: %v", err)
+	}
+	if !committed {
+		t.Fatalf("expected commit=true (whitelisted files present)")
+	}
+
+	wt, err := g.repo.Worktree()
+	if err != nil {
+		t.Fatalf("worktree: %v", err)
+	}
+	// Stray files MUST stay untracked — never appear in the index with a
+	// staged/modified/deleted code. The whitelist leaves them on disk; we
+	// only need to prove they did not get staged.
+	status, err := wt.Status()
+	if err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	for strayName := range stray {
+		if fileStatus, ok := status[strayName]; ok && fileStatus.Worktree != git.Untracked {
+			t.Errorf("stray file %s reached worktree status %q — must remain Untracked", strayName, fileStatus.Worktree)
+		}
+	}
+
+	// Walk the latest commit's tree and assert the stray files are absent.
+	head, err := g.repo.Head()
+	if err != nil {
+		t.Fatalf("head: %v", err)
+	}
+	commit, err := g.repo.CommitObject(head.Hash())
+	if err != nil {
+		t.Fatalf("commit object: %v", err)
+	}
+	tree, err := commit.Tree()
+	if err != nil {
+		t.Fatalf("tree: %v", err)
+	}
+	for strayName := range stray {
+		if _, err := tree.File(strayName); err == nil {
+			t.Errorf("stray file %s was committed plaintext — SYNC-P1-9 regression", strayName)
+		}
+	}
+	for wantName := range whitelisted {
+		if _, err := tree.File(wantName); err != nil {
+			t.Errorf("whitelisted file %s missing from commit", wantName)
+		}
+	}
+}
+
+// TestStageAndCommitIgnoresUnknownDirEntries — even nested junk under the
+// repo path must not be staged. Defends against a future maintainer who
+// might try to widen the whitelist by accident.
+func TestStageAndCommitIgnoresUnknownDirEntries(t *testing.T) {
+	repoPath := t.TempDir()
+	g := initTestRepo(t, repoPath)
+
+	subdir := filepath.Join(repoPath, "subdir")
+	if err := os.MkdirAll(subdir, 0755); err != nil {
+		t.Fatalf("mkdir subdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(subdir, "evil.pem"), []byte("PEM"), 0600); err != nil {
+		t.Fatalf("write evil: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repoPath, "connections.json"), []byte(`{"c":[]}`), 0600); err != nil {
+		t.Fatalf("write conn: %v", err)
+	}
+
+	committed, err := g.StageAndCommit("narrow whitelist")
+	if err != nil {
+		t.Fatalf("StageAndCommit: %v", err)
+	}
+	if !committed {
+		t.Fatalf("expected commit=true")
+	}
+
+	head, err := g.repo.Head()
+	if err != nil {
+		t.Fatalf("head: %v", err)
+	}
+	commit, err := g.repo.CommitObject(head.Hash())
+	if err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	tree, err := commit.Tree()
+	if err != nil {
+		t.Fatalf("tree: %v", err)
+	}
+	if _, err := tree.File("subdir/evil.pem"); err == nil {
+		t.Errorf("nested stray file subdir/evil.pem was committed — whitelist is too wide")
+	}
+}

--- a/backend/sync/whitelist_test.go
+++ b/backend/sync/whitelist_test.go
@@ -50,14 +50,16 @@ func TestStageAndCommitWhitelist(t *testing.T) {
 	repoPath := t.TempDir()
 	g := initTestRepo(t, repoPath)
 
-	// Whitelisted files — should be staged.
+	// Whitelisted files — should be staged. The list mirrors the
+	// exact names StageAndCommit iterates over.
 	whitelisted := map[string]string{
-		"connections.json": `{"connections":[]}`,
-		"settings.json":    `{"theme":"dark"}`,
-		"ai-sessions.json": `[]`,
-		"skills.json":      `[]`,
+		"connections.json":   `{"connections":[]}`,
+		"settings.json":      `{"theme":"dark"}`,
+		"ai-sessions.json":   `[]`,
+		"skills.json":        `[]`,
 		"quickCommands.json": `[]`,
-		".sync-salt":       base64.StdEncoding.EncodeToString([]byte("0123456789abcdef")),
+		".sync-salt":         base64.StdEncoding.EncodeToString([]byte("0123456789abcdef")),
+		"README.md":          "# sync repo\n",
 	}
 	for name, content := range whitelisted {
 		if err := os.WriteFile(filepath.Join(repoPath, name), []byte(content), 0600); err != nil {

--- a/backend/update/checker.go
+++ b/backend/update/checker.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/ys-ll/uniterm/backend/log"
@@ -30,6 +31,11 @@ type cacheEntry struct {
 	Result    UpdateInfo `json:"result"`
 	Source    string     `json:"source"`
 	Timestamp time.Time  `json:"timestamp"`
+	// ETag captured from the GitHub API response so a follow-up call
+	// inside the disk-cache TTL window can send If-None-Match and let
+	// GitHub return 304 Not Modified, skipping the body decode entirely
+	// (F-409).
+	ETag string `json:"etag,omitempty"`
 }
 
 func normalizeVersion(v string) string {
@@ -138,6 +144,21 @@ func shouldUpdate(current, latest string) bool {
 
 const cacheTTL = 5 * time.Minute
 
+// sharedClient is a package-level *http.Client with keep-alive enabled.
+// Reusing it avoids the per-call TCP+TLS handshake to api.github.com /
+// gitee.com on every Check() (F-409).
+var (
+	sharedClientOnce sync.Once
+	sharedClient     *http.Client
+)
+
+func sharedHTTPClient() *http.Client {
+	sharedClientOnce.Do(func() {
+		sharedClient = &http.Client{Timeout: 10 * time.Second}
+	})
+	return sharedClient
+}
+
 func cachePath() string {
 	dir, err := os.UserConfigDir()
 	if err != nil {
@@ -196,17 +217,19 @@ func Check(currentVersion, source string) (*UpdateInfo, error) {
 		apiURL = "https://gitee.com/api/v5/repos/ys-l/uniterm/releases/latest"
 	}
 
-	client := &http.Client{Timeout: 10 * time.Second}
-	req, err := http.NewRequest(
-		"GET",
-		apiURL,
-		nil,
-	)
+	// F-409: reuse a package-level client with keep-alive; send the
+	// cached ETag on the second-and-subsequent within-TTL call so
+	// GitHub/Gitee can answer 304 without re-serializing the release.
+	client := sharedHTTPClient()
+	req, err := http.NewRequest("GET", apiURL, nil)
 	if err != nil {
 		log.Writef("[update] create request error: %v", err)
 		return nil, fmt.Errorf("create request: %w", err)
 	}
 	req.Header.Set("User-Agent", "uniTerm")
+	if prev := loadCache(); prev != nil && prev.Source == source && prev.ETag != "" {
+		req.Header.Set("If-None-Match", prev.ETag)
+	}
 
 	resp, err := client.Do(req)
 	if err != nil {
@@ -216,6 +239,22 @@ func Check(currentVersion, source string) (*UpdateInfo, error) {
 	defer resp.Body.Close()
 
 	log.Writef("[update] %s API response status: %d", source, resp.StatusCode)
+
+	// 304: nothing changed since our cached ETag. Refresh timestamp
+	// so the disk TTL window slides forward and reuse the cached
+	// payload.
+	if resp.StatusCode == http.StatusNotModified {
+		if prev := loadCache(); prev != nil && prev.Source == source {
+			prev.Timestamp = time.Now()
+			saveCache(prev)
+			result := prev.Result
+			result.Current = currentVersion
+			result.HasUpdate = shouldUpdate(currentVersion, result.Latest)
+			return &result, nil
+		}
+		// No prior cache to fall back to — fall through and treat as error.
+		return nil, fmt.Errorf("unexpected status: 304 (no prior cache)")
+	}
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("unexpected status: %d", resp.StatusCode)
@@ -241,7 +280,12 @@ func Check(currentVersion, source string) (*UpdateInfo, error) {
 		HasUpdate:  shouldUpdate(currentVersion, release.TagName),
 	}
 
-	saveCache(&cacheEntry{Result: result, Source: source, Timestamp: time.Now()})
+	saveCache(&cacheEntry{
+		Result:    result,
+		Source:    source,
+		Timestamp: time.Now(),
+		ETag:      resp.Header.Get("ETag"),
+	})
 
 	return &result, nil
 }


### PR DESCRIPTION
## 背景

加密云同步链路中三个 P1 安全/数据完整性缺陷，叠加两项性能改进，统一进一个 PR 便于回归。

## 修复

### fix(sync) — 白名单、解密失败、改密盐值、规范化 JSON 比较

- **SYNC-P1-9 白名单**：commit 时不再 `wt.Add(".")`，改成显式列举 `connections.json / settings.json / ai-sessions.json / skills.json / quickCommands.json / .sync-salt / README.md` 七个文件。即使有人在同步目录里丢入 `id_rsa`、`secret.txt`、`notes.md` 等"路过"文件，也只会被原样留在工作区，绝不会被 commit 明文上传。
- **SYNC-P1-11 解密失败守卫**：`Sync()` 现在显式接收 `compareLocalWithRepo` 返回的解密错误，立刻把 `lastSyncStatus` 写成 `password_mismatch` 并中止后续 push/commit，避免错误主密码下"远端看着不一样 → 用本地垃圾密文覆盖远端唯一可用副本"这条恢复链路断裂的灾难路径。
- **SYNC-P1-6 改密换盐**：`ChangePassword` 现在用 `crypto/rand` 生成全新 16 字节盐，旧密文用旧 key 解密后用新 key 重新加密（`write-to-*.tmp + os.Rename` 原子模式），最后原子替换 `.sync-salt`。防止攻击者拿到旧主密码 + 旧盐后继续做 PBKDF2 brute-force 新 key（盐换了 = PBKDF2 工作量无法摊销）。
- **JSON 规范化比较**：`compareConfigFiles` 用 `json.MarshalIndent` 重新规范化后再做字节比较，消除 map key 顺序非确定性带来的伪 commit 噪声；`json.Unmarshal` 错误也不再被吞成 `{}`。

回归测试（`backend/sync/security_test.go`）：用 `go-keyring.MockInit()` 内存化 keychain、本地 bare git repo 当远端，全程不依赖网络 / 系统凭据库：
- `TestCompareLocalWithRepo_WrongKeyReturnsError` — 错误 key 必须返回错误
- `TestSync_WrongPasswordSetsPasswordMismatchStatus` — `Sync()` 错误密码必须把状态写成 `password_mismatch`
- `TestChangePassword_RewritesSaltAndReencryptsFiles` — `.sync-salt` 必须变更、每个 repo 文件新密码可解 / 旧密码不可解、密文字节必须不同

白名单测试（`backend/sync/whitelist_test.go`）：
- `TestStageAndCommitWhitelist` — 7 个白名单文件全部入树，散落文件保持 `Untracked` 不入树
- `TestStageAndCommitIgnoresUnknownDirEntries` — 子目录里的恶意文件（如 `subdir/evil.pem`）不入树

## 性能

### perf(sync) F-407 — `NewSyncService` 异步化

`NewSyncService` 原本在 `wails.OnStartup` 同步路径里跑（`os.UserConfigDir` + `MkdirAll` + `NewKeychain`，macOS Security framework keychain IPC + PBKDF2 600k 探针首次启动 50–500ms+），会阻塞主窗口首帧。新增 `NewSyncServiceAsync()` + `Ready()`，把磁盘初始化丢到 goroutine，调用方用短超时等待 ready channel。已有调用点无需改写。

### perf(update) F-409 — 共享 `http.Client` + 条件 GET

更新检查路径不再每次新建 `http.Client`，改为复用带 keep-alive 的共享 client；并加 `ETag` 缓存 + `If-None-Match` 头，命中 304 时跳过整个响应体解析。重复检查场景的握手成本从 1× TCP+TLS 降到 0。

## 验证

```bash
go test ./backend/sync/...   # ok
go build ./backend/sync/...  # clean
```

## 关联

- SYNC-P1-6 / SYNC-P1-9 / SYNC-P1-11
- F-407 / F-409