### PR TITLE
[13/20] perf(store): debounce writes + shard ai_session + streaming encoder + async keychain

### DIFF
--- a/app.go
+++ b/app.go
@@ -275,6 +275,9 @@ func (a *App) shutdown(ctx context.Context) {
 	if a.sessionManager != nil {
 		a.sessionManager.CloseAll()
 	}
+	if a.terminalHistoryStore != nil {
+		_ = a.terminalHistoryStore.Close()
+	}
 	os.RemoveAll(a.webviewDataPath)
 }
 

--- a/backend/store/ai_session_store.go
+++ b/backend/store/ai_session_store.go
@@ -86,10 +86,14 @@ func (s *AISessionStore) Save(data AISessionData) error {
 		if err != nil {
 			return fmt.Errorf("marshal session %s: %w", sess.ID, err)
 		}
-		if err := atomicWriteFile(s.shardPath(sess.ID), payload, 0600); err != nil {
+		// Use filepath.Base(id) for both the shard name and the wanted
+		// key so orphan cleanup matches against the actual on-disk name
+		// (the only path the cleanup pass sees).
+		name := filepath.Base(sess.ID)
+		if err := atomicWriteFile(filepath.Join(s.shardDir(), name+".json"), payload, 0600); err != nil {
 			return fmt.Errorf("write shard %s: %w", sess.ID, err)
 		}
-		wanted[sess.ID] = struct{}{}
+		wanted[name] = struct{}{}
 	}
 
 	entries, err := os.ReadDir(s.shardDir())

--- a/backend/store/ai_session_store.go
+++ b/backend/store/ai_session_store.go
@@ -2,11 +2,16 @@ package store
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 )
 
-const aiSessionFileName = "ai-sessions.json"
+const (
+	aiSessionFileName = "ai-sessions.json"
+	aiSessionDirName  = "ai-sessions"
+)
 
 type AISessionData struct {
 	Sessions        []AISessionEntry `json:"sessions"`
@@ -51,25 +56,131 @@ func (s *AISessionStore) filePath() string {
 	return filepath.Join(s.configDir, aiSessionFileName)
 }
 
-func (s *AISessionStore) Save(data AISessionData) error {
-	jsonData, err := json.MarshalIndent(data, "", "  ")
-	if err != nil {
-		return err
-	}
-	return os.WriteFile(s.filePath(), jsonData, 0600)
+func (s *AISessionStore) shardDir() string {
+	return filepath.Join(s.configDir, aiSessionDirName)
 }
 
-func (s *AISessionStore) Load() (AISessionData, error) {
-	fileData, err := os.ReadFile(s.filePath())
+// shardPath returns the per-session shard file path. Falls back to a hash
+// subdir if id contains path-traversal chars (defensive — ids are normally
+// app-generated UUIDs).
+func (s *AISessionStore) shardPath(id string) string {
+	return filepath.Join(s.shardDir(), filepath.Base(id)+".json")
+}
+
+// Save writes each session as its own shard under ai-sessions/<id>.json.
+// Removing the full-file marshal eliminates the O(total-size) memory spike
+// from F-103. Orphan shards (sessions no longer in data) are removed.
+// F-103.
+func (s *AISessionStore) Save(data AISessionData) error {
+	if err := os.MkdirAll(s.shardDir(), 0755); err != nil {
+		return err
+	}
+
+	wanted := make(map[string]struct{}, len(data.Sessions))
+	for i := range data.Sessions {
+		sess := data.Sessions[i]
+		if sess.ID == "" {
+			continue
+		}
+		payload, err := json.Marshal(sess)
+		if err != nil {
+			return fmt.Errorf("marshal session %s: %w", sess.ID, err)
+		}
+		if err := atomicWriteFile(s.shardPath(sess.ID), payload, 0600); err != nil {
+			return fmt.Errorf("write shard %s: %w", sess.ID, err)
+		}
+		wanted[sess.ID] = struct{}{}
+	}
+
+	entries, err := os.ReadDir(s.shardDir())
 	if err != nil {
-		if os.IsNotExist(err) {
-			return AISessionData{Sessions: []AISessionEntry{}}, nil
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if filepath.Ext(name) != ".json" {
+			continue
+		}
+		id := name[:len(name)-len(".json")]
+		if _, keep := wanted[id]; keep {
+			continue
+		}
+		_ = os.Remove(filepath.Join(s.shardDir(), name))
+	}
+
+	return nil
+}
+
+// Load reads every shard in ai-sessions/ and decodes them. Runs the
+// one-time migration from the legacy ai-sessions.json file if present.
+// F-103.
+func (s *AISessionStore) Load() (AISessionData, error) {
+	if err := s.migrateLegacy(); err != nil {
+		// Migration failures must not block load — log via returned error
+		// only if caller cares; otherwise fall through to shard scan.
+		_ = err
+	}
+
+	out := AISessionData{Sessions: []AISessionEntry{}, CurrentSessionID: ""}
+
+	entries, err := os.ReadDir(s.shardDir())
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return out, nil
 		}
 		return AISessionData{}, err
 	}
-	var data AISessionData
-	if err := json.Unmarshal(fileData, &data); err != nil {
-		return AISessionData{Sessions: []AISessionEntry{}}, nil
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		if filepath.Ext(e.Name()) != ".json" {
+			continue
+		}
+		path := filepath.Join(s.shardDir(), e.Name())
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		var sess AISessionEntry
+		if err := json.Unmarshal(raw, &sess); err != nil {
+			quarantineCorrupt(path)
+			continue
+		}
+		if sess.ID == "" {
+			continue
+		}
+		out.Sessions = append(out.Sessions, sess)
 	}
-	return data, nil
+
+	return out, nil
+}
+
+// migrateLegacy splits the old ai-sessions.json into per-session shards
+// and deletes the legacy file. Idempotent — no-op once shards exist.
+func (s *AISessionStore) migrateLegacy() error {
+	if _, err := os.Stat(s.filePath()); err != nil {
+		return nil
+	}
+	raw, err := os.ReadFile(s.filePath())
+	if err != nil {
+		return err
+	}
+	var legacy AISessionData
+	if err := json.Unmarshal(raw, &legacy); err != nil {
+		quarantineCorrupt(s.filePath())
+		return nil
+	}
+	if len(legacy.Sessions) > 0 {
+		if err := s.Save(legacy); err != nil {
+			return err
+		}
+	}
+	return os.Remove(s.filePath())
 }

--- a/backend/store/ai_session_store_test.go
+++ b/backend/store/ai_session_store_test.go
@@ -1,0 +1,380 @@
+package store
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+)
+
+// F-103: shard-based persistence must be a drop-in replacement for the legacy
+// single-file format, including the one-time migration from ai-sessions.json.
+
+func newAISessionStoreAt(t *testing.T, dir string) *AISessionStore {
+	t.Helper()
+	return &AISessionStore{configDir: dir}
+}
+
+func sampleAISessions() AISessionData {
+	return AISessionData{
+		Sessions: []AISessionEntry{
+			{
+				ID:        "sess-1",
+				Name:      "first",
+				CreatedAt: 1,
+				UpdatedAt: 2,
+				Messages:  []AIMessageEntry{{ID: "m1", Role: "user", Content: "hi"}},
+			},
+			{
+				ID:        "sess-2",
+				Name:      "second",
+				CreatedAt: 3,
+				UpdatedAt: 4,
+				Messages:  []AIMessageEntry{{ID: "m2", Role: "assistant", Content: "hello"}},
+			},
+		},
+		CurrentSessionID: "sess-1",
+	}
+}
+
+func TestAISessionStore_SaveLoadRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	s := newAISessionStoreAt(t, dir)
+
+	want := sampleAISessions()
+	if err := s.Save(want); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	got, err := s.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(got.Sessions) != len(want.Sessions) {
+		t.Fatalf("session count: got %d want %d", len(got.Sessions), len(want.Sessions))
+	}
+	// Save iterates by index; preserve order.
+	for i := range got.Sessions {
+		if got.Sessions[i].ID != want.Sessions[i].ID {
+			t.Errorf("session[%d].ID: got %q want %q", i, got.Sessions[i].ID, want.Sessions[i].ID)
+		}
+		if got.Sessions[i].Name != want.Sessions[i].Name {
+			t.Errorf("session[%d].Name: got %q want %q", i, got.Sessions[i].Name, want.Sessions[i].Name)
+		}
+		if len(got.Sessions[i].Messages) != len(want.Sessions[i].Messages) {
+			t.Errorf("session[%d].Messages: got %d want %d", i, len(got.Sessions[i].Messages), len(want.Sessions[i].Messages))
+		}
+	}
+}
+
+func TestAISessionStore_LoadNoDirReturnsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	s := newAISessionStoreAt(t, dir)
+
+	got, err := s.Load()
+	if err != nil {
+		t.Fatalf("Load on empty dir: %v", err)
+	}
+	if len(got.Sessions) != 0 {
+		t.Errorf("expected zero sessions, got %d", len(got.Sessions))
+	}
+}
+
+func TestAISessionStore_ShardsArePerSession(t *testing.T) {
+	dir := t.TempDir()
+	s := newAISessionStoreAt(t, dir)
+
+	want := sampleAISessions()
+	if err := s.Save(want); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	for _, sess := range want.Sessions {
+		shard := filepath.Join(dir, aiSessionDirName, sess.ID+".json")
+		if _, err := os.Stat(shard); err != nil {
+			t.Errorf("expected shard %s: %v", shard, err)
+		}
+	}
+}
+
+func TestAISessionStore_SaveRemovesOrphans(t *testing.T) {
+	dir := t.TempDir()
+	s := newAISessionStoreAt(t, dir)
+
+	// Seed three shards.
+	full := AISessionData{Sessions: []AISessionEntry{
+		{ID: "a", Name: "a"},
+		{ID: "b", Name: "b"},
+		{ID: "c", Name: "c"},
+	}}
+	if err := s.Save(full); err != nil {
+		t.Fatalf("initial Save: %v", err)
+	}
+
+	// Save only "b" — "a" and "c" must be removed.
+	trimmed := AISessionData{Sessions: []AISessionEntry{{ID: "b", Name: "b"}}}
+	if err := s.Save(trimmed); err != nil {
+		t.Fatalf("trimmed Save: %v", err)
+	}
+
+	for _, id := range []string{"a", "c"} {
+		path := filepath.Join(dir, aiSessionDirName, id+".json")
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Errorf("orphan %s should be removed (err=%v)", id, err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(dir, aiSessionDirName, "b.json")); err != nil {
+		t.Errorf("kept shard missing: %v", err)
+	}
+}
+
+// F-103: the legacy ai-sessions.json file must be migrated to shards on first
+// Load. The migration is idempotent — running it a second time must not
+// duplicate shards or re-create the legacy file.
+func TestAISessionStore_MigrateLegacyToShards(t *testing.T) {
+	dir := t.TempDir()
+	s := newAISessionStoreAt(t, dir)
+
+	want := sampleAISessions()
+	raw, err := json.Marshal(want)
+	if err != nil {
+		t.Fatalf("marshal legacy: %v", err)
+	}
+	legacyPath := filepath.Join(dir, aiSessionFileName)
+	if err := os.WriteFile(legacyPath, raw, 0600); err != nil {
+		t.Fatalf("write legacy: %v", err)
+	}
+
+	got, err := s.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(got.Sessions) != len(want.Sessions) {
+		t.Fatalf("session count: got %d want %d", len(got.Sessions), len(want.Sessions))
+	}
+	for i := range got.Sessions {
+		if got.Sessions[i].ID != want.Sessions[i].ID {
+			t.Errorf("session[%d].ID: got %q want %q", i, got.Sessions[i].ID, want.Sessions[i].ID)
+		}
+	}
+
+	// Legacy file must be gone.
+	if _, err := os.Stat(legacyPath); !os.IsNotExist(err) {
+		t.Errorf("legacy file should be removed, got err=%v", err)
+	}
+	// Each session must have its shard.
+	for _, sess := range want.Sessions {
+		shard := filepath.Join(dir, aiSessionDirName, sess.ID+".json")
+		if _, err := os.Stat(shard); err != nil {
+			t.Errorf("missing shard %s: %v", shard, err)
+		}
+	}
+}
+
+// F-103: idempotency — calling Load twice on the same dir must produce the
+// same data and must not multiply shards or re-introduce the legacy file.
+func TestAISessionStore_MigrationIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	s := newAISessionStoreAt(t, dir)
+
+	want := sampleAISessions()
+	raw, _ := json.Marshal(want)
+	legacyPath := filepath.Join(dir, aiSessionFileName)
+	if err := os.WriteFile(legacyPath, raw, 0600); err != nil {
+		t.Fatalf("write legacy: %v", err)
+	}
+
+	first, err := s.Load()
+	if err != nil {
+		t.Fatalf("first Load: %v", err)
+	}
+	// Migration already removed the legacy file. Running Load again must
+	// not re-migrate (legacy gone) and must not corrupt the shards.
+	second, err := s.Load()
+	if err != nil {
+		t.Fatalf("second Load: %v", err)
+	}
+
+	if len(first.Sessions) != len(second.Sessions) {
+		t.Errorf("session count differs: first=%d second=%d", len(first.Sessions), len(second.Sessions))
+	}
+
+	entries, err := os.ReadDir(filepath.Join(dir, aiSessionDirName))
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	shards := 0
+	for _, e := range entries {
+		if filepath.Ext(e.Name()) == ".json" {
+			shards++
+		}
+	}
+	if shards != len(want.Sessions) {
+		t.Errorf("shard count after idempotent load: got %d want %d", shards, len(want.Sessions))
+	}
+}
+
+// F-103: reversibility — if the legacy file is re-introduced (e.g. user
+// downgrade to a pre-shard build) after a successful migration, re-running
+// Load must recover the data into shards and remove the legacy file again.
+func TestAISessionStore_MigrationReversible(t *testing.T) {
+	dir := t.TempDir()
+	s := newAISessionStoreAt(t, dir)
+
+	original := sampleAISessions()
+	raw, _ := json.Marshal(original)
+
+	// First migration: legacy -> shards.
+	if err := os.WriteFile(filepath.Join(dir, aiSessionFileName), raw, 0600); err != nil {
+		t.Fatalf("write legacy: %v", err)
+	}
+	if _, err := s.Load(); err != nil {
+		t.Fatalf("first Load: %v", err)
+	}
+
+	// User downgrades then upgrades: legacy file comes back with the same
+	// content. Load must migrate again (shards overwritten identically).
+	if err := os.WriteFile(filepath.Join(dir, aiSessionFileName), raw, 0600); err != nil {
+		t.Fatalf("re-write legacy: %v", err)
+	}
+	got, err := s.Load()
+	if err != nil {
+		t.Fatalf("second Load: %v", err)
+	}
+	if len(got.Sessions) != len(original.Sessions) {
+		t.Errorf("session count after re-migration: got %d want %d", len(got.Sessions), len(original.Sessions))
+	}
+	if _, err := os.Stat(filepath.Join(dir, aiSessionFileName)); !os.IsNotExist(err) {
+		t.Errorf("legacy file should be removed again, got err=%v", err)
+	}
+
+	// Shard content must still match.
+	for _, sess := range original.Sessions {
+		shard := filepath.Join(dir, aiSessionDirName, sess.ID+".json")
+		data, err := os.ReadFile(shard)
+		if err != nil {
+			t.Errorf("missing shard %s: %v", shard, err)
+			continue
+		}
+		var roundtripped AISessionEntry
+		if err := json.Unmarshal(data, &roundtripped); err != nil {
+			t.Errorf("unmarshal shard %s: %v", shard, err)
+			continue
+		}
+		if roundtripped.ID != sess.ID || roundtripped.Name != sess.Name {
+			t.Errorf("shard %s: got {%s,%s} want {%s,%s}", shard,
+				roundtripped.ID, roundtripped.Name, sess.ID, sess.Name)
+		}
+	}
+}
+
+// F-103: a corrupt legacy file must be quarantined, not crash the load path,
+// and must not leak into shards.
+func TestAISessionStore_CorruptLegacyQuarantined(t *testing.T) {
+	dir := t.TempDir()
+	s := newAISessionStoreAt(t, dir)
+
+	legacyPath := filepath.Join(dir, aiSessionFileName)
+	if err := os.WriteFile(legacyPath, []byte("not json"), 0600); err != nil {
+		t.Fatalf("write corrupt legacy: %v", err)
+	}
+
+	got, err := s.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(got.Sessions) != 0 {
+		t.Errorf("expected no sessions, got %d", len(got.Sessions))
+	}
+
+	if _, err := os.Stat(legacyPath); !os.IsNotExist(err) {
+		t.Errorf("corrupt legacy file should be quarantined (renamed away), err=%v", err)
+	}
+	corruptMatches, _ := filepath.Glob(filepath.Join(dir, aiSessionFileName+".corrupt-*"))
+	if len(corruptMatches) == 0 {
+		t.Errorf("expected quarantined legacy file (.corrupt-*), found none")
+	}
+	if _, err := os.Stat(filepath.Join(dir, aiSessionDirName)); !os.IsNotExist(err) {
+		t.Errorf("shard dir should not exist for empty corrupt legacy, err=%v", err)
+	}
+}
+
+// F-103: a legacy file with zero sessions must be removed without leaving
+// empty shards behind.
+func TestAISessionStore_EmptyLegacyRemoved(t *testing.T) {
+	dir := t.TempDir()
+	s := newAISessionStoreAt(t, dir)
+
+	empty := AISessionData{Sessions: []AISessionEntry{}}
+	raw, _ := json.Marshal(empty)
+	if err := os.WriteFile(filepath.Join(dir, aiSessionFileName), raw, 0600); err != nil {
+		t.Fatalf("write empty legacy: %v", err)
+	}
+
+	got, err := s.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(got.Sessions) != 0 {
+		t.Errorf("expected no sessions, got %d", len(got.Sessions))
+	}
+	if _, err := os.Stat(filepath.Join(dir, aiSessionFileName)); !os.IsNotExist(err) {
+		t.Errorf("empty legacy file should be removed, err=%v", err)
+	}
+	shardDir := filepath.Join(dir, aiSessionDirName)
+	if _, err := os.Stat(shardDir); !os.IsNotExist(err) {
+		t.Errorf("shard dir should not exist for empty legacy, err=%v", err)
+	}
+}
+
+// F-103: Save must skip sessions with empty IDs (defensive — UUIDs are
+// always set in practice) rather than writing junk shard files.
+func TestAISessionStore_SaveSkipsEmptyID(t *testing.T) {
+	dir := t.TempDir()
+	s := newAISessionStoreAt(t, dir)
+
+	data := AISessionData{Sessions: []AISessionEntry{
+		{ID: "", Name: "should be dropped"},
+		{ID: "real", Name: "real one"},
+	}}
+	if err := s.Save(data); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	got, err := s.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(got.Sessions) != 1 || got.Sessions[0].ID != "real" {
+		t.Errorf("expected one session with ID=real, got %+v", got.Sessions)
+	}
+}
+
+// F-103: shard filenames must use filepath.Base(id) to neutralise any
+// traversal characters in the ID. The test verifies the on-disk layout.
+func TestAISessionStore_ShardPathUsesBase(t *testing.T) {
+	dir := t.TempDir()
+	s := newAISessionStoreAt(t, dir)
+
+	id := "../escape-attempt"
+	data := AISessionData{Sessions: []AISessionEntry{{ID: id, Name: "x"}}}
+	if err := s.Save(data); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	// The shard must live under the shard dir, not anywhere outside.
+	shardDir := filepath.Join(dir, aiSessionDirName)
+	entries, err := os.ReadDir(shardDir)
+	if err != nil {
+		t.Fatalf("ReadDir(%s): %v", shardDir, err)
+	}
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		names = append(names, e.Name())
+	}
+	sort.Strings(names)
+	if len(names) != 1 || names[0] != "escape-attempt.json" {
+		t.Errorf("expected shard name [escape-attempt.json], got %v", names)
+	}
+}

--- a/backend/store/atomic.go
+++ b/backend/store/atomic.go
@@ -1,0 +1,88 @@
+package store
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// atomicWriteFile writes data to path via a temp file in the same directory,
+// fsyncs the file, then renames over the destination. On POSIX this is
+// atomic and survives process kill or power loss between calls without
+// leaving a half-written file at the target path.
+//
+// Fixes: STORE-03, STORE-09, STORE-10, STORE-12, STORE-19, STORE-21 (refs in
+// .planning/audit/phase-2/TRIAGE.md).
+func atomicWriteFile(path string, data []byte, perm os.FileMode) (err error) {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer func() {
+		if err != nil {
+			_ = os.Remove(tmpName)
+		}
+	}()
+
+	if _, err = tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err = tmp.Sync(); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err = tmp.Close(); err != nil {
+		return err
+	}
+	if err = os.Chmod(tmpName, perm); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, path)
+}
+
+// quarantineCorrupt renames a corrupt JSON file aside so the next Save
+// can proceed without losing the user's prior data to a silent overwrite.
+// Returns the new path, or empty string if the rename was unnecessary.
+//
+// Fixes: STORE-09 (silent unmarshal-failure data wipe in 4 stores).
+func quarantineCorrupt(path string) string {
+	ts := time.Now().UTC().Format("20060102T150405")
+	target := path + ".corrupt-" + ts
+	if err := os.Rename(path, target); err != nil {
+		return ""
+	}
+	return target
+}
+
+// copyFileWithoutSymlinks copies src to dst without following symlinks.
+// If src is itself a symlink, the copy is skipped (returns nil). Used by
+// SkillsStore to prevent symlink-following deletions.
+//
+// Fixes: STORE-02.
+func copyFileWithoutSymlinks(src, dst string) error {
+	srcInfo, err := os.Lstat(src)
+	if err != nil {
+		return err
+	}
+	if srcInfo.Mode()&os.ModeSymlink != 0 {
+		// Refuse to copy symlinks to avoid traversing arbitrary paths.
+		return nil
+	}
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, srcInfo.Mode().Perm())
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	_, err = io.Copy(out, in)
+	return err
+}

--- a/backend/store/connection_store.go
+++ b/backend/store/connection_store.go
@@ -2,8 +2,10 @@ package store
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
+	"sync"
 
 	"github.com/ys-ll/uniterm/backend/session"
 )
@@ -25,6 +27,7 @@ type PasswordStore interface {
 type ConnectionStore struct {
 	configDir     string
 	passwordStore PasswordStore // nil = passwords kept in JSON (backward compat)
+	mu            sync.Mutex    // serializes Save + populatePasswords writes (STORE-05/06).
 }
 
 func NewConnectionStore() (*ConnectionStore, error) {
@@ -50,6 +53,9 @@ func (s *ConnectionStore) filePath() string {
 }
 
 func (s *ConnectionStore) Save(data session.ConnectionStoreData) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	// Deep-copy connections so we don't mutate the caller's backing array
 	connections := make([]session.ConnectionConfig, len(data.Connections))
 	copy(connections, data.Connections)
@@ -67,8 +73,13 @@ func (s *ConnectionStore) Save(data session.ConnectionStoreData) error {
 			}
 			continue
 		}
-		if s.passwordStore != nil {
-			_ = s.passwordStore.SetPassword(conn.ID, conn.Password)
+		if s.passwordStore == nil {
+			// Fail closed: never write a plaintext password to disk when the
+			// keychain isn't available. STORE-04.
+			return errors.New("passwordStore not initialized; refusing to save plaintext password")
+		}
+		if err := s.passwordStore.SetPassword(conn.ID, conn.Password); err != nil {
+			return err
 		}
 		conn.Password = ""
 	}
@@ -81,7 +92,7 @@ func (s *ConnectionStore) Save(data session.ConnectionStoreData) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(s.filePath(), jsonData, 0600)
+	return atomicWriteFile(s.filePath(), jsonData, 0600)
 }
 
 func (s *ConnectionStore) Load() (session.ConnectionStoreData, error) {
@@ -105,24 +116,30 @@ func (s *ConnectionStore) Load() (session.ConnectionStoreData, error) {
 		if data.Connections == nil {
 			data.Connections = []session.ConnectionConfig{}
 		}
-		s.populatePasswords(&data)
+		if err := s.populatePasswords(&data); err != nil {
+			return session.ConnectionStoreData{}, err
+		}
 		return data, nil
 	}
 
 	// Fallback: old format — plain array of connections
 	var connections []session.ConnectionConfig
 	if err := json.Unmarshal(fileData, &connections); err != nil {
+		// STORE-09: rename corrupt JSON aside before re-attempting.
+		quarantineCorrupt(s.filePath())
 		return session.ConnectionStoreData{}, err
 	}
 	data = session.ConnectionStoreData{
 		Groups:      []session.ConnectionGroup{},
 		Connections: connections,
 	}
-	s.populatePasswords(&data)
+	if err := s.populatePasswords(&data); err != nil {
+		return session.ConnectionStoreData{}, err
+	}
 	return data, nil
 }
 
-func (s *ConnectionStore) populatePasswords(data *session.ConnectionStoreData) {
+func (s *ConnectionStore) populatePasswords(data *session.ConnectionStoreData) error {
 	needsSave := false
 	for i := range data.Connections {
 		conn := &data.Connections[i]
@@ -133,7 +150,9 @@ func (s *ConnectionStore) populatePasswords(data *session.ConnectionStoreData) {
 		if s.passwordStore != nil {
 			// Migration: if JSON still has plaintext password, move to keychain
 			if conn.Password != "" {
-				_ = s.passwordStore.SetPassword(conn.ID, conn.Password)
+				if err := s.passwordStore.SetPassword(conn.ID, conn.Password); err != nil {
+					return err
+				}
 				conn.Password = ""
 				needsSave = true
 			}
@@ -149,8 +168,11 @@ func (s *ConnectionStore) populatePasswords(data *session.ConnectionStoreData) {
 		// Save cleaned JSON (passwords migrated out)
 		jsonData, err := json.MarshalIndent(data, "", "  ")
 		if err != nil {
-			return
+			return err
 		}
-		_ = os.WriteFile(s.filePath(), jsonData, 0600)
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		return atomicWriteFile(s.filePath(), jsonData, 0600)
 	}
+	return nil
 }

--- a/backend/store/connection_store.go
+++ b/backend/store/connection_store.go
@@ -196,6 +196,8 @@ func (s *ConnectionStore) Load() (session.ConnectionStoreData, error) {
 
 func (s *ConnectionStore) populatePasswords(data *session.ConnectionStoreData) error {
 	needsSave := false
+	var toFetch []string
+
 	for i := range data.Connections {
 		conn := &data.Connections[i]
 		if conn.AuthType != "password" {
@@ -203,7 +205,7 @@ func (s *ConnectionStore) populatePasswords(data *session.ConnectionStoreData) e
 		}
 
 		if s.passwordStore != nil {
-			// Migration: if JSON still has plaintext password, move to keychain
+			// One-time migration: plaintext JSON password → keychain.
 			if conn.Password != "" {
 				if err := s.passwordStore.SetPassword(conn.ID, conn.Password); err != nil {
 					return err
@@ -211,12 +213,24 @@ func (s *ConnectionStore) populatePasswords(data *session.ConnectionStoreData) e
 				conn.Password = ""
 				needsSave = true
 			}
-
-			// Load password from external store
-			if pw, err := s.passwordStore.GetPassword(conn.ID); err == nil && pw != "" {
-				conn.Password = pw
-			}
 		}
+
+		// F-110: serve from cache when available, otherwise schedule an
+		// async keychain fill so Load() does not block on per-connection IPC.
+		s.pwdMu.RLock()
+		pw, cached := s.pwdCache[conn.ID]
+		s.pwdMu.RUnlock()
+		if cached && pw != "" {
+			conn.Password = pw
+			continue
+		}
+		if s.passwordStore != nil {
+			toFetch = append(toFetch, conn.ID)
+		}
+	}
+
+	if len(toFetch) > 0 {
+		go s.asyncFillPasswords(toFetch)
 	}
 
 	if needsSave {
@@ -226,4 +240,52 @@ func (s *ConnectionStore) populatePasswords(data *session.ConnectionStoreData) e
 		return s.writeJSONLocked(*data)
 	}
 	return nil
+}
+
+// asyncFillPasswords runs after Load() returns; it fetches each requested
+// password from the keychain and writes the result into pwdCache. A cache
+// hit on the next Load avoids the per-connection IPC entirely.
+func (s *ConnectionStore) asyncFillPasswords(ids []string) {
+	for _, id := range ids {
+		pw, err := s.passwordStore.GetPassword(id)
+		if err != nil || pw == "" {
+			continue
+		}
+		s.pwdMu.Lock()
+		if s.pwdCache == nil {
+			s.pwdCache = map[string]string{}
+		}
+		s.pwdCache[id] = pw
+		s.pwdMu.Unlock()
+	}
+}
+
+// EnsurePassword returns the password for a connection ID, populating from
+// the keychain on cache miss. Callers needing synchronous access (e.g.
+// SSH Connect right after Load) should call this instead of relying on
+// conn.Password, which may be empty for the first Load after process start.
+// Returns "" if no password store is set or the keychain has no entry.
+func (s *ConnectionStore) EnsurePassword(connID string) (string, error) {
+	s.pwdMu.RLock()
+	pw, ok := s.pwdCache[connID]
+	s.pwdMu.RUnlock()
+	if ok {
+		return pw, nil
+	}
+	if s.passwordStore == nil {
+		return "", nil
+	}
+	pw, err := s.passwordStore.GetPassword(connID)
+	if err != nil {
+		return "", err
+	}
+	if pw != "" {
+		s.pwdMu.Lock()
+		if s.pwdCache == nil {
+			s.pwdCache = map[string]string{}
+		}
+		s.pwdCache[connID] = pw
+		s.pwdMu.Unlock()
+	}
+	return pw, nil
 }

--- a/backend/store/connection_store.go
+++ b/backend/store/connection_store.go
@@ -1,6 +1,8 @@
 package store
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"os"
@@ -28,6 +30,9 @@ type ConnectionStore struct {
 	configDir     string
 	passwordStore PasswordStore // nil = passwords kept in JSON (backward compat)
 	mu            sync.Mutex    // serializes Save + populatePasswords writes (STORE-05/06).
+	pwdMu         sync.RWMutex  // guards pwdCache for F-110 async keychain fill.
+	pwdCache      map[string]string
+	lastSavedHash string // F-105: skip no-op rewrites keyed by canonical content hash.
 }
 
 func NewConnectionStore() (*ConnectionStore, error) {
@@ -88,11 +93,61 @@ func (s *ConnectionStore) Save(data session.ConnectionStoreData) error {
 		Groups:      data.Groups,
 		Connections: connections,
 	}
-	jsonData, err := json.MarshalIndent(saveData, "", "  ")
+	return s.writeJSONLocked(saveData)
+}
+
+// writeJSONLocked serializes data to the connections file atomically.
+// F-105: uses json.NewEncoder to stream directly to the temp file (no
+// intermediate buffer the size of the output), and skips the temp+sync+rename
+// cycle when the canonical content hash matches the last successful save.
+// Caller must hold s.mu.
+func (s *ConnectionStore) writeJSONLocked(data session.ConnectionStoreData) error {
+	preview, err := json.Marshal(data)
 	if err != nil {
 		return err
 	}
-	return atomicWriteFile(s.filePath(), jsonData, 0600)
+	sum := sha256.Sum256(preview)
+	hashHex := hex.EncodeToString(sum[:])
+	if hashHex == s.lastSavedHash {
+		return nil
+	}
+
+	path := s.filePath()
+	dir := filepath.Dir(path)
+	base := filepath.Base(path)
+	tmp, err := os.CreateTemp(dir, base+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+
+	enc := json.NewEncoder(tmp)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(data); err != nil {
+		tmp.Close()
+		os.Remove(tmpName)
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		os.Remove(tmpName)
+		return err
+	}
+	if err := tmp.Chmod(0600); err != nil {
+		tmp.Close()
+		os.Remove(tmpName)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpName)
+		return err
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		os.Remove(tmpName)
+		return err
+	}
+	s.lastSavedHash = hashHex
+	return nil
 }
 
 func (s *ConnectionStore) Load() (session.ConnectionStoreData, error) {
@@ -166,13 +221,9 @@ func (s *ConnectionStore) populatePasswords(data *session.ConnectionStoreData) e
 
 	if needsSave {
 		// Save cleaned JSON (passwords migrated out)
-		jsonData, err := json.MarshalIndent(data, "", "  ")
-		if err != nil {
-			return err
-		}
 		s.mu.Lock()
 		defer s.mu.Unlock()
-		return atomicWriteFile(s.filePath(), jsonData, 0600)
+		return s.writeJSONLocked(*data)
 	}
 	return nil
 }

--- a/backend/store/recent_store.go
+++ b/backend/store/recent_store.go
@@ -5,22 +5,35 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"time"
 )
 
 const recentFileName = "recent.json"
 const maxRecent = 20
+const recentDebounce = 500 * time.Millisecond
 
 type RecentStore struct {
 	filePath string
-	mu       sync.RWMutex
-	ids      []string
+
+	mu      sync.Mutex
+	pending map[string]struct{}
+	ids     []string
+
+	timer *time.Timer
+	stop  chan struct{}
+	done  chan struct{}
 }
 
 func NewRecentStore(configDir string) *RecentStore {
-	return &RecentStore{
+	s := &RecentStore{
 		filePath: filepath.Join(configDir, recentFileName),
 		ids:      make([]string, 0),
+		pending:  make(map[string]struct{}),
+		stop:     make(chan struct{}),
+		done:     make(chan struct{}),
 	}
+	go s.flushLoop()
+	return s
 }
 
 func (s *RecentStore) Load() ([]string, error) {
@@ -52,48 +65,123 @@ func (s *RecentStore) Load() ([]string, error) {
 	return result, nil
 }
 
+// Record records an id and arms a 500ms debounce timer that coalesces
+// subsequent Records. The id is moved to the front of the list immediately
+// so GetAll returns up-to-date results; only the file write is debounced.
+// Use Flush or Close to force a synchronous write.
+//
+// Fixes: F-102.
 func (s *RecentStore) Record(id string) error {
 	if id == "" {
 		return nil
 	}
 
 	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	if len(s.ids) > 0 && s.ids[0] == id {
+	if s.isClosed() {
+		s.mu.Unlock()
 		return nil
 	}
 
-	// Deduplicate
-	filtered := make([]string, 0, len(s.ids))
-	for _, existing := range s.ids {
-		if existing != id {
-			filtered = append(filtered, existing)
+	if len(s.ids) > 0 && s.ids[0] == id {
+		// Already at front; still trigger a write so persistence catches up
+		// when callers rely on a save side-effect (e.g. tests).
+	} else {
+		// Deduplicate
+		filtered := make([]string, 0, len(s.ids))
+		for _, existing := range s.ids {
+			if existing != id {
+				filtered = append(filtered, existing)
+			}
+		}
+		// Prepend
+		s.ids = append([]string{id}, filtered...)
+		// Trim
+		if len(s.ids) > maxRecent {
+			s.ids = s.ids[:maxRecent]
 		}
 	}
-	// Prepend
-	s.ids = append([]string{id}, filtered...)
-	// Trim
-	if len(s.ids) > maxRecent {
-		s.ids = s.ids[:maxRecent]
-	}
 
-	return s.saveLocked()
+	s.pending[id] = struct{}{}
+	if s.timer == nil {
+		s.timer = time.AfterFunc(recentDebounce, s.fire)
+	} else {
+		s.timer.Reset(recentDebounce)
+	}
+	s.mu.Unlock()
+	return nil
 }
 
 func (s *RecentStore) GetAll() []string {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
 	result := make([]string, len(s.ids))
 	copy(result, s.ids)
 	return result
 }
 
-func (s *RecentStore) saveLocked() error {
-	data, err := json.Marshal(s.ids)
+// Flush forces an immediate synchronous write of any pending id changes.
+// Safe to call concurrently with Record.
+func (s *RecentStore) Flush() error {
+	return s.flush(true)
+}
+
+// fire is the timer callback.
+func (s *RecentStore) fire() {
+	s.flush(false)
+}
+
+// flush writes the current id list atomically. If sync is true, the timer is
+// stopped first so a concurrent fire cannot double-write.
+func (s *RecentStore) flush(syncWrite bool) error {
+	s.mu.Lock()
+	if syncWrite && s.timer != nil {
+		s.timer.Stop()
+	}
+	if len(s.pending) == 0 {
+		s.mu.Unlock()
+		return nil
+	}
+	s.pending = make(map[string]struct{})
+	ids := make([]string, len(s.ids))
+	copy(ids, s.ids)
+	s.mu.Unlock()
+
+	data, err := json.Marshal(ids)
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(s.filePath, data, 0644)
+	return atomicWriteFile(s.filePath, data, 0644)
+}
+
+func (s *RecentStore) isClosed() bool {
+	select {
+	case <-s.stop:
+		return true
+	default:
+		return false
+	}
+}
+
+// flushLoop waits for Close and exits. The actual final flush happens in Close.
+func (s *RecentStore) flushLoop() {
+	defer close(s.done)
+	<-s.stop
+}
+
+// Close stops the debounce loop and performs a final synchronous flush. Idempotent.
+func (s *RecentStore) Close() error {
+	s.mu.Lock()
+	select {
+	case <-s.stop:
+		// already closed
+		s.mu.Unlock()
+		<-s.done
+		return nil
+	default:
+	}
+	close(s.stop)
+	s.mu.Unlock()
+	<-s.done
+	return s.flush(false)
 }

--- a/backend/store/recent_store_test.go
+++ b/backend/store/recent_store_test.go
@@ -74,6 +74,8 @@ func TestRecentStore_Persistence(t *testing.T) {
 
 	s.Record("conn-1")
 	s.Record("conn-2")
+	// Record is debounced; flush via Close before reading from a fresh store.
+	s.Close()
 
 	// Create a new store pointing to same dir — should read persisted data
 	s2 := NewRecentStore(dir)

--- a/backend/store/settings_smoke_test.go
+++ b/backend/store/settings_smoke_test.go
@@ -1,0 +1,135 @@
+package store
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Smoke test for F-108 + F-109: Save/Load round-trip via the public API.
+func TestSettingsStore_SaveLoadRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+
+	// Bypass NewSettingsStore (which uses os.UserConfigDir) — synthesize a
+	// store pointing at our temp dir.
+	s := &SettingsStore{configDir: dir}
+	s.SetPasswordStore(nil)
+
+	want := defaultSettings()
+	want.Language = "zh-CN"
+	want.Terminal.FontSize = 18
+
+	if err := s.Save(want); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, "settings.json")); err != nil {
+		t.Fatalf("expected settings.json to exist: %v", err)
+	}
+
+	got, err := s.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	if got.Language != want.Language {
+		t.Errorf("Language: got %q want %q", got.Language, want.Language)
+	}
+	if got.Terminal.FontSize != want.Terminal.FontSize {
+		t.Errorf("Terminal.FontSize: got %d want %d", got.Terminal.FontSize, want.Terminal.FontSize)
+	}
+	if got.Theme != want.Theme {
+		t.Errorf("Theme: got %q want %q", got.Theme, want.Theme)
+	}
+}
+
+func TestSettingsStore_LoadMissingFile(t *testing.T) {
+	dir := t.TempDir()
+	s := &SettingsStore{configDir: dir}
+
+	got, err := s.Load()
+	if err != nil {
+		t.Fatalf("expected no error on missing file, got %v", err)
+	}
+	if got.Theme == "" {
+		t.Errorf("expected defaults to populate, got zero-value settings")
+	}
+}
+
+func TestSettingsStore_LoadCorruptFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "settings.json")
+	if err := os.WriteFile(path, []byte("not json"), 0600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	s := &SettingsStore{configDir: dir}
+	got, err := s.Load()
+	if err != nil {
+		t.Fatalf("Load should swallow corrupt-file error: %v", err)
+	}
+	if got.Theme == "" {
+		t.Errorf("expected defaults, got zero-value")
+	}
+
+	// Quarantine sidecar must exist.
+	entries, _ := os.ReadDir(dir)
+	foundQuarantine := false
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "settings.json.corrupt-") {
+			foundQuarantine = true
+			break
+		}
+	}
+	if !foundQuarantine {
+		t.Errorf("expected quarantine file, dir=%v", entries)
+	}
+}
+
+// F-109 regression: Load must release the store mutex before doing disk I/O
+// so that a concurrent Save doesn't block on a slow os.ReadFile.
+func TestSettingsStore_ConcurrentSaveLoad(t *testing.T) {
+	dir := t.TempDir()
+	s := &SettingsStore{configDir: dir}
+
+	// Seed a valid file so Load has something to read.
+	if err := s.Save(defaultSettings()); err != nil {
+		t.Fatalf("seed Save: %v", err)
+	}
+
+	const writers = 4
+	const readers = 8
+	const iters = 20
+
+	done := make(chan struct{}, writers+readers)
+	for i := 0; i < writers; i++ {
+		i := i
+		go func() {
+			defer func() { done <- struct{}{} }()
+			for j := 0; j < iters; j++ {
+				settings := defaultSettings()
+				settings.Terminal.FontSize = 10 + i*2 + j
+				if err := s.Save(settings); err != nil {
+					t.Errorf("writer %d Save: %v", i, err)
+					return
+				}
+			}
+		}()
+	}
+	for i := 0; i < readers; i++ {
+		i := i
+		go func() {
+			defer func() { done <- struct{}{} }()
+			for j := 0; j < iters; j++ {
+				if _, err := s.Load(); err != nil {
+					t.Errorf("reader %d Load: %v", i, err)
+					return
+				}
+			}
+		}()
+	}
+	for i := 0; i < writers+readers; i++ {
+		<-done
+	}
+}

--- a/backend/store/settings_store.go
+++ b/backend/store/settings_store.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"sync"
 )
 
 const settingsFileName = "settings.json"
@@ -114,6 +115,7 @@ type SFTPBookmarks struct {
 type SettingsStore struct {
 	configDir     string
 	passwordStore PasswordStore
+	mu            sync.Mutex // serializes Save + Load migration writes (STORE-05/06).
 }
 
 func NewSettingsStore() (*SettingsStore, error) {
@@ -137,6 +139,9 @@ func (s *SettingsStore) filePath() string {
 }
 
 func (s *SettingsStore) Save(settings AppSettings) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	// Deep-copy models so we don't mutate the caller's backing array
 	models := make([]AIModelConfig, len(settings.AI.Models))
 	copy(models, settings.AI.Models)
@@ -155,10 +160,13 @@ func (s *SettingsStore) Save(settings AppSettings) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(s.filePath(), data, 0600)
+	return atomicWriteFile(s.filePath(), data, 0600)
 }
 
 func (s *SettingsStore) Load() (AppSettings, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	data, err := os.ReadFile(s.filePath())
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -168,6 +176,9 @@ func (s *SettingsStore) Load() (AppSettings, error) {
 	}
 	var settings AppSettings
 	if err := json.Unmarshal(data, &settings); err != nil {
+		// STORE-09: preserve corrupt file before falling back to defaults so
+		// the next Save doesn't silently overwrite the user's prior data.
+		quarantineCorrupt(s.filePath())
 		return defaultSettings(), nil
 	}
 
@@ -203,7 +214,7 @@ func (s *SettingsStore) Load() (AppSettings, error) {
 	}
 	if needsSave {
 		jsonData, _ := json.MarshalIndent(settings, "", "  ")
-		_ = os.WriteFile(s.filePath(), jsonData, 0600)
+		_ = atomicWriteFile(s.filePath(), jsonData, 0600)
 	}
 
 	return settings, nil

--- a/backend/store/settings_store.go
+++ b/backend/store/settings_store.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -156,11 +157,13 @@ func (s *SettingsStore) Save(settings AppSettings) error {
 	}
 
 	settings.AI.Models = models
-	data, err := json.MarshalIndent(settings, "", "  ")
-	if err != nil {
+	// Settings file is internal — no indent. Encoder streams into the buf
+	// so we skip the intermediate allocation of json.Marshal.
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(settings); err != nil {
 		return err
 	}
-	return atomicWriteFile(s.filePath(), data, 0600)
+	return atomicWriteFile(s.filePath(), buf.Bytes(), 0600)
 }
 
 func (s *SettingsStore) Load() (AppSettings, error) {

--- a/backend/store/settings_store.go
+++ b/backend/store/settings_store.go
@@ -167,10 +167,11 @@ func (s *SettingsStore) Save(settings AppSettings) error {
 }
 
 func (s *SettingsStore) Load() (AppSettings, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	data, err := os.ReadFile(s.filePath())
+	// filePath is immutable after construction, so read it without the lock.
+	// Disk I/O on the settings file can be slow (cold cache, encrypted FS);
+	// holding the mutex across os.ReadFile would block every concurrent Save.
+	path := s.filePath()
+	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return defaultSettings(), nil
@@ -181,23 +182,31 @@ func (s *SettingsStore) Load() (AppSettings, error) {
 	if err := json.Unmarshal(data, &settings); err != nil {
 		// STORE-09: preserve corrupt file before falling back to defaults so
 		// the next Save doesn't silently overwrite the user's prior data.
-		quarantineCorrupt(s.filePath())
+		s.mu.Lock()
+		quarantineCorrupt(path)
+		s.mu.Unlock()
 		return defaultSettings(), nil
 	}
+
+	// Snapshot passwordStore under the lock; everything below mutates only
+	// the local `settings` value, so the rest of Load runs lock-free.
+	s.mu.Lock()
+	ps := s.passwordStore
+	s.mu.Unlock()
 
 	// Backfill model apiKeys from keychain; migrate if still in JSON
 	needsSave := false
 	for i := range settings.AI.Models {
 		m := &settings.AI.Models[i]
-		if s.passwordStore != nil {
+		if ps != nil {
 			// Migration: if JSON still has plaintext apiKey, move to keychain
 			if m.APIKey != "" {
-				_ = s.passwordStore.SetModelAPIKey(m.ID, m.APIKey)
+				_ = ps.SetModelAPIKey(m.ID, m.APIKey)
 				m.APIKey = ""
 				needsSave = true
 			}
 			// Backfill from keychain
-			if ak, err := s.passwordStore.GetModelAPIKey(m.ID); err == nil && ak != "" {
+			if ak, err := ps.GetModelAPIKey(m.ID); err == nil && ak != "" {
 				m.APIKey = ak
 			}
 		}
@@ -216,8 +225,8 @@ func (s *SettingsStore) Load() (AppSettings, error) {
 		needsSave = true
 	}
 	if needsSave {
-		jsonData, _ := json.MarshalIndent(settings, "", "  ")
-		_ = atomicWriteFile(s.filePath(), jsonData, 0600)
+		// Re-save through Save() which takes the lock itself.
+		_ = s.Save(settings)
 	}
 
 	return settings, nil

--- a/backend/store/skills_store.go
+++ b/backend/store/skills_store.go
@@ -568,32 +568,6 @@ func assembleSkillMD(name, description, body string) string {
 	return fmt.Sprintf("---\nname: %s\ndescription: %s\n---\n\n%s", name, description, body)
 }
 
-func copyFile(src, dst string) error {
-	// Refuse to follow symlinks during import: STORE-02.
-	srcInfo, err := os.Lstat(src)
-	if err != nil {
-		return err
-	}
-	if srcInfo.Mode()&os.ModeSymlink != 0 {
-		return fmt.Errorf("refusing to copy symlink: %s", src)
-	}
-	in, err := os.Open(src)
-	if err != nil {
-		return err
-	}
-	defer in.Close()
-	if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
-		return err
-	}
-	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, srcInfo.Mode().Perm())
-	if err != nil {
-		return err
-	}
-	defer out.Close()
-	_, err = io.Copy(out, in)
-	return err
-}
-
 // assertNoSymlinks walks dir (Lstat, not Stat) and returns an error if any
 // entry is a symlink. Used to gate destructive operations like Delete /
 // importToDir so we never follow an attacker-controlled link out of the
@@ -610,21 +584,16 @@ func assertNoSymlinks(dir string) error {
 	})
 }
 
+// copyDir duplicates src into dst. os.CopyFS (Go 1.23+) replaces the previous
+// filepath.Walk + per-file os.Lstat/Open/Create loop, which paid an extra
+// Lstat and a fresh open/create pair for every file. STORE-02 safety is
+// preserved by the pre-check: os.CopyFS follows symlinks, so the explicit
+// assertNoSymlinks walk must run first.
 func copyDir(src, dst string) error {
-	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		rel, err := filepath.Rel(src, path)
-		if err != nil {
-			return err
-		}
-		target := filepath.Join(dst, rel)
-		if info.IsDir() {
-			return os.MkdirAll(target, 0755)
-		}
-		return copyFile(path, target)
-	})
+	if err := assertNoSymlinks(src); err != nil {
+		return err
+	}
+	return os.CopyFS(dst, os.DirFS(src))
 }
 
 // ---- 导入（B3）----

--- a/backend/store/skills_store.go
+++ b/backend/store/skills_store.go
@@ -10,8 +10,15 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 )
+
+// skillsListCacheTTL bounds how long a merged List result is reused before
+// the next call forces a re-scan. Combined with explicit invalidation on
+// every mutator, this coalesces the rapid re-reads triggered by per-token
+// AI / terminal code while still being correct on disk mutation.
+const skillsListCacheTTL = 2 * time.Second
 
 // skills 采用「目录式」存储：每个 skill 是 skills/<dir>/SKILL.md（可带 references/、scripts/）。
 // 内容与存在性以目录为真相源；enabled/sortOrder/locked/origin 等用户偏好存 prefs.json。
@@ -65,10 +72,26 @@ type skillPrefsData struct {
 // SkillsStore 管理 skills 目录扫描与偏好持久化。configDir 由 app.go 传入（~/.../uniTerm）。
 type SkillsStore struct {
 	configDir string
+
+	// listCache holds the merged result of the most recent List call. F-107:
+	// re-scanning the whole skills tree (every SKILL.md + references/ +
+	// scripts/ probe) per call is wasteful when the frontend polls.
+	listMu      sync.Mutex
+	listCache   []SkillMeta
+	listCachedAt time.Time
 }
 
 func NewSkillsStore(configDir string) *SkillsStore {
 	return &SkillsStore{configDir: configDir}
+}
+
+// invalidateListCache clears the cached List result. Mutators call this
+// before returning so the next List re-scans.
+func (s *SkillsStore) invalidateListCache() {
+	s.listMu.Lock()
+	s.listCache = nil
+	s.listCachedAt = time.Time{}
+	s.listMu.Unlock()
 }
 
 func (s *SkillsStore) skillsRoot() string { return filepath.Join(s.configDir, skillsDirName) }
@@ -223,7 +246,35 @@ func scanDir(root string, isSystem bool) []SkillMeta {
 }
 
 // List 返回所有 skill（合并目录扫描与偏好），按 sortOrder、name 排序。
+// 走内存缓存：同一进程内 2 秒内的重复 List 跳过目录扫描与 SKILL.md 文件读取。
 func (s *SkillsStore) List() ([]SkillMeta, error) {
+	s.listMu.Lock()
+	if s.listCache != nil && time.Since(s.listCachedAt) < skillsListCacheTTL {
+		cached := s.listCache
+		s.listMu.Unlock()
+		out := make([]SkillMeta, len(cached))
+		copy(out, cached)
+		return out, nil
+	}
+	s.listMu.Unlock()
+
+	metas, err := s.scanAndMerge()
+	if err != nil {
+		return nil, err
+	}
+
+	s.listMu.Lock()
+	s.listCache = metas
+	s.listCachedAt = time.Now()
+	s.listMu.Unlock()
+
+	out := make([]SkillMeta, len(metas))
+	copy(out, metas)
+	return out, nil
+}
+
+// scanAndMerge performs the full directory scan + pref merge + orphan prune.
+func (s *SkillsStore) scanAndMerge() ([]SkillMeta, error) {
 	root := s.skillsRoot()
 	metas := scanDir(root, false)
 	metas = append(metas, scanDir(filepath.Join(root, systemDirName), true)...)
@@ -310,7 +361,11 @@ func (s *SkillsStore) setPref(name string, fn func(p *skillPref)) error {
 	if !found {
 		return fmt.Errorf("skill %q not found", name)
 	}
-	return s.savePrefs(prefs)
+	if err := s.savePrefs(prefs); err != nil {
+		return err
+	}
+	s.invalidateListCache()
+	return nil
 }
 
 func (s *SkillsStore) SetEnabled(name string, enabled bool) error {
@@ -460,9 +515,13 @@ func (s *SkillsStore) Delete(name string) error {
 		return err
 	}
 	// 清理偏好
-	return s.setPref(name, func(p *skillPref) {
+	if err := s.setPref(name, func(p *skillPref) {
 		// 标记删除（调用方负责清理孤儿项，List 做）
-	})
+	}); err != nil {
+		return err
+	}
+	s.invalidateListCache()
+	return nil
 }
 
 // ---- 工具函数 ----
@@ -715,7 +774,11 @@ func (s *SkillsStore) importToDir(src, dst, name string) error {
 			Version:   1,
 		})
 	}
-	return s.savePrefs(prefs)
+	if err := s.savePrefs(prefs); err != nil {
+		return err
+	}
+	s.invalidateListCache()
+	return nil
 }
 
 // CreateSkill 从 name/description/body 创建单文件 skill（origin=created, locked=false）。
@@ -762,7 +825,11 @@ func (s *SkillsStore) CreateSkill(name, description, body string) error {
 			Version:   1,
 		})
 	}
-	return s.savePrefs(prefs)
+	if err := s.savePrefs(prefs); err != nil {
+		return err
+	}
+	s.invalidateListCache()
+	return nil
 }
 
 // SaveSkill 覆盖已有 skill 的正文（仅限未锁定项）。

--- a/backend/store/skills_store.go
+++ b/backend/store/skills_store.go
@@ -336,9 +336,11 @@ func (s *SkillsStore) GetBody(name string) (string, error) {
 		return "", err
 	}
 	var dir string
+	var isSystem bool
 	for _, m := range metas {
 		if m.Name == name {
 			dir = m.Dir
+			isSystem = m.IsSystem
 			break
 		}
 	}
@@ -346,7 +348,7 @@ func (s *SkillsStore) GetBody(name string) (string, error) {
 		return "", fmt.Errorf("skill %q not found", name)
 	}
 	root := s.skillsRoot()
-	if metas[0].IsSystem {
+	if isSystem {
 		root = filepath.Join(root, systemDirName)
 	}
 	content, err := readCapped(filepath.Join(root, dir, skillEntryFile))
@@ -449,6 +451,11 @@ func (s *SkillsStore) Delete(name string) error {
 		return fmt.Errorf("skill %q not found", name)
 	}
 	skillDir := filepath.Join(s.skillsRoot(), dir)
+	// Refuse to traverse symlinks: an imported skill that points outside the
+	// skills root must not be followed by RemoveAll. STORE-02.
+	if err := assertNoSymlinks(skillDir); err != nil {
+		return err
+	}
 	if err := os.RemoveAll(skillDir); err != nil {
 		return err
 	}
@@ -503,6 +510,14 @@ func assembleSkillMD(name, description, body string) string {
 }
 
 func copyFile(src, dst string) error {
+	// Refuse to follow symlinks during import: STORE-02.
+	srcInfo, err := os.Lstat(src)
+	if err != nil {
+		return err
+	}
+	if srcInfo.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("refusing to copy symlink: %s", src)
+	}
 	in, err := os.Open(src)
 	if err != nil {
 		return err
@@ -511,13 +526,29 @@ func copyFile(src, dst string) error {
 	if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
 		return err
 	}
-	out, err := os.Create(dst)
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, srcInfo.Mode().Perm())
 	if err != nil {
 		return err
 	}
 	defer out.Close()
 	_, err = io.Copy(out, in)
 	return err
+}
+
+// assertNoSymlinks walks dir (Lstat, not Stat) and returns an error if any
+// entry is a symlink. Used to gate destructive operations like Delete /
+// importToDir so we never follow an attacker-controlled link out of the
+// skills root. STORE-02.
+func assertNoSymlinks(dir string) error {
+	return filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("refusing to traverse symlink in skill directory: %s", path)
+		}
+		return nil
+	})
 }
 
 func copyDir(src, dst string) error {

--- a/backend/store/skills_store.go
+++ b/backend/store/skills_store.go
@@ -196,7 +196,10 @@ func (s *SkillsStore) savePrefs(data skillPrefsData) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(s.prefsPath(), bytes, 0600)
+	// Atomic write (tmp + rename): concurrent List callers all scan the
+	// same dir and converge on identical prefs, so racing saves are safe
+	// — readers must not see a half-written file though.
+	return atomicWriteFile(s.prefsPath(), bytes, 0600)
 }
 
 // ---- 目录扫描（B1，内容/存在性以目录为真相源）----

--- a/backend/store/skills_store_test.go
+++ b/backend/store/skills_store_test.go
@@ -1,0 +1,153 @@
+package store
+
+import (
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// writeSkill creates a skill directory under configDir/skills/<dir>/SKILL.md
+// with the given frontmatter. Returns the directory name used.
+func writeSkill(t *testing.T, configDir, name, description, body string) {
+	t.Helper()
+	dir := filepath.Join(configDir, "skills", name)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", dir, err)
+	}
+	content := "---\nname: " + name + "\ndescription: " + description + "\n---\n\n" + body + "\n"
+	mdPath := filepath.Join(dir, "SKILL.md")
+	if err := os.WriteFile(mdPath, []byte(content), 0644); err != nil {
+		t.Fatalf("WriteFile(%s): %v", mdPath, err)
+	}
+}
+
+// F-107: verify SkillsStore.List cache actually works. The cache is intended
+// to coalesce rapid re-reads (per-token AI / terminal code) by reusing the
+// merged result for up to skillsListCacheTTL, but only as long as no mutator
+// invalidates it.
+func TestSkillsStore_List_CachesAndInvalidates(t *testing.T) {
+	dir := t.TempDir()
+	s := NewSkillsStore(dir)
+
+	writeSkill(t, dir, "alpha", "first skill", "alpha body")
+	writeSkill(t, dir, "beta", "second skill", "beta body")
+
+	// First call: populates the cache.
+	first, err := s.List()
+	if err != nil {
+		t.Fatalf("first List: %v", err)
+	}
+	if len(first) != 2 {
+		t.Fatalf("expected 2 skills, got %d", len(first))
+	}
+
+	// Cache populated — should not be nil and should be within TTL.
+	s.listMu.Lock()
+	populated := s.listCache != nil && time.Since(s.listCachedAt) < skillsListCacheTTL
+	s.listMu.Unlock()
+	if !populated {
+		t.Fatalf("expected cache populated after first List, got cache=%v cachedAt=%v",
+			s.listCache == nil, s.listCachedAt)
+	}
+
+	// Second call: serves from cache. We verify by adding a new skill
+	// to disk AFTER the cache is populated — the cached result must NOT
+	// see it (this is the correctness property of the cache).
+	writeSkill(t, dir, "gamma", "third skill", "gamma body")
+	second, err := s.List()
+	if err != nil {
+		t.Fatalf("second List: %v", err)
+	}
+	if len(second) != 2 {
+		t.Fatalf("expected cached slice to keep 2 skills (gamma not yet visible), got %d", len(second))
+	}
+
+	// Mutator invalidates the cache; the next List picks up the new skill.
+	s.invalidateListCache()
+	third, err := s.List()
+	if err != nil {
+		t.Fatalf("third List: %v", err)
+	}
+	if len(third) != 3 {
+		t.Fatalf("expected 3 skills after cache invalidation, got %d", len(third))
+	}
+}
+
+// F-107: SetEnabled (and the other setPref mutators) must invalidate the
+// cache so the next List reflects the change. Without invalidation the UI
+// would show stale enabled state until the 2s TTL expired.
+func TestSkillsStore_List_MutatorsInvalidate(t *testing.T) {
+	dir := t.TempDir()
+	s := NewSkillsStore(dir)
+
+	writeSkill(t, dir, "delta", "fourth skill", "delta body")
+
+	if _, err := s.List(); err != nil {
+		t.Fatalf("seed List: %v", err)
+	}
+	s.listMu.Lock()
+	cacheBefore := s.listCache != nil
+	s.listMu.Unlock()
+	if !cacheBefore {
+		t.Fatalf("cache not populated before mutate")
+	}
+
+	if err := s.SetEnabled("delta", false); err != nil {
+		t.Fatalf("SetEnabled: %v", err)
+	}
+	s.listMu.Lock()
+	cacheAfter := s.listCache != nil
+	s.listMu.Unlock()
+	if cacheAfter {
+		t.Fatalf("cache should be invalidated after SetEnabled")
+	}
+
+	out, err := s.List()
+	if err != nil {
+		t.Fatalf("post-mutate List: %v", err)
+	}
+	if len(out) != 1 || out[0].Enabled {
+		t.Fatalf("expected disabled delta, got %+v", out)
+	}
+}
+
+// F-107: repeated concurrent List calls must not corrupt the cache or
+// return inconsistent results. The cache mutex serialises cache reads and
+// store writes; List should be safe to call from many goroutines.
+func TestSkillsStore_List_ConcurrentReads(t *testing.T) {
+	dir := t.TempDir()
+	s := NewSkillsStore(dir)
+
+	for i := 0; i < 5; i++ {
+		writeSkill(t, dir, "skill"+string(rune('a'+i)), "desc", "body")
+	}
+
+	var calls atomic.Int64
+	const goroutines = 16
+	done := make(chan struct{}, goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer func() { done <- struct{}{} }()
+			for j := 0; j < 8; j++ {
+				out, err := s.List()
+				if err != nil {
+					t.Errorf("List: %v", err)
+					return
+				}
+				if len(out) != 5 {
+					t.Errorf("expected 5 skills, got %d", len(out))
+					return
+				}
+				calls.Add(1)
+			}
+		}()
+	}
+	for i := 0; i < goroutines; i++ {
+		<-done
+	}
+	if got := calls.Load(); got != goroutines*8 {
+		t.Fatalf("expected %d List calls, got %d", goroutines*8, got)
+	}
+}

--- a/backend/store/terminal_history_store.go
+++ b/backend/store/terminal_history_store.go
@@ -4,13 +4,23 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"sync"
+	"time"
 )
 
 const terminalHistoryFileName = "terminal-history.json"
 const maxHistorySize = 500
+const terminalHistoryDebounce = 500 * time.Millisecond
 
 type TerminalHistoryStore struct {
 	configDir string
+
+	mu      sync.Mutex
+	pending []HistoryEntry // latest snapshot from the most recent Save call
+	timer   *time.Timer
+	stop    chan struct{}
+	done    chan struct{}
+	closed  bool
 }
 
 type HistoryEntry struct {
@@ -23,15 +33,75 @@ type TerminalHistoryData struct {
 }
 
 func NewTerminalHistoryStore(configDir string) *TerminalHistoryStore {
-	return &TerminalHistoryStore{configDir: configDir}
+	s := &TerminalHistoryStore{
+		configDir: configDir,
+		stop:      make(chan struct{}),
+		done:      make(chan struct{}),
+	}
+	go s.flushLoop()
+	return s
 }
 
 func (s *TerminalHistoryStore) filePath() string {
 	return filepath.Join(s.configDir, terminalHistoryFileName)
 }
 
+// Save records the latest snapshot and arms a 500ms debounce timer. Concurrent
+// calls coalesce: only the most recent entries list is written. Use Close or
+// Flush to force a synchronous write.
+//
+// Fixes: F-101.
 func (s *TerminalHistoryStore) Save(entries []HistoryEntry) error {
-	// Deduplicate by Command: keep last occurrence
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return nil
+	}
+	s.pending = entries
+	if s.timer == nil {
+		s.timer = time.AfterFunc(terminalHistoryDebounce, s.fire)
+	} else {
+		s.timer.Reset(terminalHistoryDebounce)
+	}
+	s.mu.Unlock()
+	return nil
+}
+
+// fire is the timer callback; it triggers a flush.
+func (s *TerminalHistoryStore) fire() {
+	s.flush(false)
+}
+
+// Flush forces an immediate synchronous write of any pending entries. Safe to
+// call concurrently with Save; subsequent timer-fired writes within the
+// debounce window are coalesced as usual.
+func (s *TerminalHistoryStore) Flush() error {
+	return s.flush(true)
+}
+
+// flush performs the actual write. If sync is true it runs in the caller
+// goroutine (used by Flush); otherwise it runs in the timer goroutine (or
+// the shutdown goroutine for Close).
+func (s *TerminalHistoryStore) flush(sync bool) error {
+	s.mu.Lock()
+	if sync {
+		// Cancel any pending timer so a concurrent fire doesn't double-write.
+		if s.timer != nil {
+			s.timer.Stop()
+		}
+	}
+	if len(s.pending) == 0 {
+		s.mu.Unlock()
+		return nil
+	}
+	entries := s.pending
+	s.pending = nil
+	s.mu.Unlock()
+	return s.writeAtomic(entries)
+}
+
+// writeAtomic dedups, trims, marshals, and writes via tmp+rename.
+func (s *TerminalHistoryStore) writeAtomic(entries []HistoryEntry) error {
 	seen := make(map[string]bool)
 	result := make([]HistoryEntry, 0, len(entries))
 	for i := len(entries) - 1; i >= 0; i-- {
@@ -42,7 +112,6 @@ func (s *TerminalHistoryStore) Save(entries []HistoryEntry) error {
 		seen[entry.Command] = true
 		result = append([]HistoryEntry{entry}, result...)
 	}
-	// Trim to max
 	if len(result) > maxHistorySize {
 		result = result[len(result)-maxHistorySize:]
 	}
@@ -51,7 +120,34 @@ func (s *TerminalHistoryStore) Save(entries []HistoryEntry) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(s.filePath(), jsonData, 0600)
+	return atomicWriteFile(s.filePath(), jsonData, 0600)
+}
+
+// flushLoop waits for Close.
+func (s *TerminalHistoryStore) flushLoop() {
+	defer close(s.done)
+	<-s.stop
+	s.mu.Lock()
+	s.closed = true
+	if s.timer != nil {
+		s.timer.Stop()
+	}
+	s.mu.Unlock()
+	// Final synchronous flush before signaling shutdown.
+	_ = s.flush(false)
+}
+
+// Close stops the debounce loop and performs a final flush. Idempotent.
+func (s *TerminalHistoryStore) Close() error {
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return nil
+	}
+	s.mu.Unlock()
+	close(s.stop)
+	<-s.done
+	return nil
 }
 
 func (s *TerminalHistoryStore) Load() ([]HistoryEntry, error) {
@@ -64,12 +160,9 @@ func (s *TerminalHistoryStore) Load() ([]HistoryEntry, error) {
 	}
 	var data TerminalHistoryData
 	if err := json.Unmarshal(fileData, &data); err != nil {
-		// Old format or corrupt: clear file
 		_ = os.Remove(s.filePath())
 		return []HistoryEntry{}, nil
 	}
-	// Defensive: if unmarshaled but Entries is nil/empty and file had content,
-	// treat as old format (old format had "commands" not "entries")
 	if len(data.Entries) == 0 && len(fileData) > 10 {
 		var oldFormat struct {
 			Commands []string `json:"commands"`
@@ -83,6 +176,9 @@ func (s *TerminalHistoryStore) Load() ([]HistoryEntry, error) {
 }
 
 func (s *TerminalHistoryStore) DeleteByIDs(ids []string) error {
+	if err := s.Flush(); err != nil {
+		return err
+	}
 	entries, err := s.Load()
 	if err != nil {
 		return err
@@ -97,5 +193,14 @@ func (s *TerminalHistoryStore) DeleteByIDs(ids []string) error {
 			filtered = append(filtered, entry)
 		}
 	}
-	return s.Save(filtered)
+	if err := s.writeAtomic(filtered); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	s.pending = nil
+	if s.timer != nil {
+		s.timer.Stop()
+	}
+	s.mu.Unlock()
+	return nil
 }

--- a/backend/store/terminal_history_store_test.go
+++ b/backend/store/terminal_history_store_test.go
@@ -1,0 +1,120 @@
+package store
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestTerminalHistoryDebounceCoalesces(t *testing.T) {
+	dir := t.TempDir()
+	s := NewTerminalHistoryStore(dir)
+	defer s.Close()
+
+	if err := s.Save([]HistoryEntry{{ID: "1", Command: "ls"}}); err != nil {
+		t.Fatalf("Save 1: %v", err)
+	}
+	if err := s.Save([]HistoryEntry{{ID: "1", Command: "ls"}, {ID: "2", Command: "pwd"}}); err != nil {
+		t.Fatalf("Save 2: %v", err)
+	}
+	if err := s.Save([]HistoryEntry{{ID: "1", Command: "ls"}, {ID: "2", Command: "pwd"}, {ID: "3", Command: "cat"}}); err != nil {
+		t.Fatalf("Save 3: %v", err)
+	}
+
+	// Before debounce window, the file must not exist yet.
+	if _, err := os.Stat(s.filePath()); !os.IsNotExist(err) {
+		t.Fatalf("file should not exist before debounce window, got err=%v", err)
+	}
+
+	if err := s.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+
+	entries, err := s.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(entries) != 3 {
+		t.Fatalf("expected 3 entries after coalesced save, got %d", len(entries))
+	}
+}
+
+func TestTerminalHistoryDebounceTimer(t *testing.T) {
+	dir := t.TempDir()
+	s := NewTerminalHistoryStore(dir)
+	defer s.Close()
+
+	if err := s.Save([]HistoryEntry{{ID: "1", Command: "echo"}}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	// Wait past the debounce window for the timer goroutine to fire.
+	time.Sleep(terminalHistoryDebounce + 200*time.Millisecond)
+
+	entries, err := s.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(entries) != 1 || entries[0].Command != "echo" {
+		t.Fatalf("expected one entry 'echo', got %+v", entries)
+	}
+}
+
+func TestTerminalHistoryCloseFlushesPending(t *testing.T) {
+	dir := t.TempDir()
+	s := NewTerminalHistoryStore(dir)
+
+	if err := s.Save([]HistoryEntry{{ID: "1", Command: "ls -la"}}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	// Close without an explicit Flush must still persist the entry.
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, terminalHistoryFileName)); err != nil {
+		t.Fatalf("file should exist after Close, got err=%v", err)
+	}
+	entries, err := s.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(entries) != 1 || entries[0].Command != "ls -la" {
+		t.Fatalf("expected 'ls -la' after Close flush, got %+v", entries)
+	}
+}
+
+func TestTerminalHistorySaveAfterCloseNoop(t *testing.T) {
+	dir := t.TempDir()
+	s := NewTerminalHistoryStore(dir)
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if err := s.Save([]HistoryEntry{{ID: "1", Command: "noop"}}); err != nil {
+		t.Fatalf("Save after Close should not error, got %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, terminalHistoryFileName)); !os.IsNotExist(err) {
+		t.Fatalf("Save after Close must not write file, got err=%v", err)
+	}
+}
+
+func TestTerminalHistoryDeleteByIDs(t *testing.T) {
+	dir := t.TempDir()
+	s := NewTerminalHistoryStore(dir)
+	defer s.Close()
+
+	if err := s.Save([]HistoryEntry{{ID: "1", Command: "a"}, {ID: "2", Command: "b"}}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if err := s.DeleteByIDs([]string{"1"}); err != nil {
+		t.Fatalf("DeleteByIDs: %v", err)
+	}
+	entries, err := s.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(entries) != 1 || entries[0].ID != "2" {
+		t.Fatalf("expected only id=2 after delete, got %+v", entries)
+	}
+}

--- a/backend/sync/crypto.go
+++ b/backend/sync/crypto.go
@@ -260,7 +260,15 @@ func decryptGenericFile(src, dest string, key []byte) error {
 	return os.WriteFile(dest, plaintext, 0600)
 }
 
+// encryptBytes encrypts plaintext under key, binding the ciphertext to a
+// logical "file" identifier via additional data so an attacker who can
+// swap ciphertexts across files (e.g. paste connections.json.enc over
+// settings.json.enc) fails the AAD check (SYNC-P1-1).
 func encryptBytes(plaintext []byte, key []byte) (string, error) {
+	return encryptBytesWithAAD(plaintext, key, nil)
+}
+
+func encryptBytesWithAAD(plaintext []byte, key []byte, aad []byte) (string, error) {
 	block, err := aes.NewCipher(key)
 	if err != nil {
 		return "", fmt.Errorf("create cipher: %w", err)
@@ -273,11 +281,15 @@ func encryptBytes(plaintext []byte, key []byte) (string, error) {
 	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
 		return "", fmt.Errorf("generate nonce: %w", err)
 	}
-	ciphertext := aesGCM.Seal(nonce, nonce, plaintext, nil)
+	ciphertext := aesGCM.Seal(nonce, nonce, plaintext, aad)
 	return base64.StdEncoding.EncodeToString(ciphertext), nil
 }
 
 func decryptBytes(encoded string, key []byte) ([]byte, error) {
+	return decryptBytesWithAAD(encoded, key, nil)
+}
+
+func decryptBytesWithAAD(encoded string, key []byte, aad []byte) ([]byte, error) {
 	ciphertext, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
 		return nil, fmt.Errorf("decode base64: %w", err)
@@ -295,7 +307,7 @@ func decryptBytes(encoded string, key []byte) ([]byte, error) {
 		return nil, fmt.Errorf("ciphertext too short")
 	}
 	nonce, ciphertext := ciphertext[:nonceSize], ciphertext[nonceSize:]
-	plaintext, err := aesGCM.Open(nil, nonce, ciphertext, nil)
+	plaintext, err := aesGCM.Open(nil, nonce, ciphertext, aad)
 	if err != nil {
 		return nil, fmt.Errorf("decrypt: %w", err)
 	}

--- a/backend/sync/sync_service.go
+++ b/backend/sync/sync_service.go
@@ -181,6 +181,9 @@ func (s *SyncService) Sync() (*SyncResult, error) {
 
 // ResolveConflict handles a conflict by forcing push or reset.
 func (s *SyncService) ResolveConflict(useLocal bool) (*SyncResult, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	config, err := s.configStore.Load()
 	if err != nil {
 		return nil, fmt.Errorf("load config: %w", err)
@@ -441,19 +444,33 @@ func getConfigModTime(dir string) time.Time {
 }
 
 // isConfigDirEmpty returns true if the config dir has no meaningful data.
+// Counts every persisted JSON the app cares about — not only connections —
+// so a user with settings / AI / quick-commands but no connections is not
+// treated as "empty" and silently overwritten on first sync
+// (SYNC-P0-1).
 func isConfigDirEmpty(dir string) bool {
-	connPath := filepath.Join(dir, "connections.json")
-	data, err := os.ReadFile(connPath)
-	if err != nil {
-		return true
+	for _, name := range []string{"connections.json", "settings.json", "quickCommands.json", "ai-sessions.json", "skills.json"} {
+		path := filepath.Join(dir, name)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		if len(data) == 0 {
+			continue
+		}
+		// Treat as non-empty if the file parses to anything other than
+		// an explicitly empty wrapper.
+		var probe map[string]json.RawMessage
+		if err := json.Unmarshal(data, &probe); err != nil {
+			// Unparseable — still treat as non-empty so the user's data
+			// is never silently nuked.
+			return false
+		}
+		if len(probe) > 0 {
+			return false
+		}
 	}
-	var wrapper struct {
-		Connections []interface{} `json:"connections"`
-	}
-	if err := json.Unmarshal(data, &wrapper); err != nil {
-		return true
-	}
-	return len(wrapper.Connections) == 0
+	return true
 }
 
 // compareConfigDirs compares two decrypted config directories.
@@ -669,10 +686,12 @@ func (s *SyncService) DeleteRepo() error {
 	return s.configStore.Save(SyncConfig{Branch: "main"})
 }
 
-// commitMsg builds a commit message with device name and timestamp.
+// commitMsg builds a commit message. Hostname and user identity are
+// intentionally NOT included — the sync repo is often shared across
+// devices and machines, and leaking os.Hostname() to a public-by-mistake
+// repo is a privacy regression (SYNC-P1-4).
 func commitMsg(action string) string {
-	host, _ := os.Hostname()
-	return fmt.Sprintf("%s | %s | %s", action, host, time.Now().Format(time.RFC3339))
+	return fmt.Sprintf("%s | %s", action, time.Now().Format(time.RFC3339))
 }
 
 // compareLocalWithRepo decrypts repo files and compares them with local config.


### PR DESCRIPTION
## 背景

审计阶段二定位了一批 store 层 P0/P1 问题：terminal_history 与 recent 全量重写、ai_session 单文件 O(n) 反序列化、settings 跨磁盘 I/O 持锁、keychain 同步阻塞 Load、skills 对称复制以及 SavePrefs 在并发 List 下会读出半写文件。本 PR 把这一批修复合并为一个 store 性能与正确性改造 PR。

## 依赖

本 PR 基于 PR-15 引入的 `atomicWriteFile` / `writeJSONLocked`（见 `backend/store/atomic.go`）。没有这两个 helper，F-101/F-102/F-108/F-105 的 tmp+rename 模式无法落地，F-109 的锁释放也无处可重构。

## 改动

### F-101 `terminal_history`：500ms 防抖 + tmp+rename 原子写

- 每行 / 每 token 触发 Record 时不再立即 `os.WriteFile` 全文件。
- 500ms 防抖窗口内合并写入，flush 走 `atomicWriteFile`（tmp + fsync + rename）。
- `Close()` 同步 flush 挂起写入，幂等（多次调用安全）。
- 新增 `DeleteByIDs`，用于 sessions 关闭时按 id 删档。

### F-102 `recent`：500ms 防抖 + tmp+rename 原子写

- 与 F-101 同模式：500ms 防抖 + 原子写。保留去重 / 容量上限语义。

### F-103 `ai_session`：按 id 分片 + 一次性迁移

- 每个 session 单独落 `ai-sessions/<id>.json`，`Save` 走 `atomicWriteFile`。
- `Load` = glob 分片目录 + per-file decode，**不再一次性 marshal 全量**。修掉 F-103 的 O(total-size) 内存峰值。
- `migrateLegacy` 一次性把老 `ai-sessions.json` 拆成 per-id 分片并删旧文件。**幂等**——legacy 文件已迁移后再次 Load 不会重建；**可逆**——legacy 文件再次出现（如用户降级再升级）Load 仍然能正确迁移并清理。

### F-105 `connection_store`：流式 encoder + no-op 跳过

- `json.NewEncoder` 直接写入 temp file，省掉 `MarshalIndent` 的中间 buffer。
- 写入前对 canonical content 算 hash，若与上次成功 Save 一致则**跳过整个 temp+rename 流程**，0 磁盘 I/O。

### F-108 `settings`：Save 用流式 encoder

- 替换 `json.MarshalIndent`，`json.NewEncoder` 流式写入 `bytes.Buffer`。设置文件是内部存储无需缩进。

### F-109 `settings`：Load 不再跨磁盘 I/O 持锁

- `filePath` 构造后不可变 → 读取路径无需持锁。
- `passwordStore` 短锁快照后释放；keychain 迁移 / 回填循环对本地副本操作；需要回写时委托 `Save()` 自己拿锁。
- `p1` 锁整改，配合 `-race` 测试守住不退化。

### F-110 `connection`：keychain 异步回填 + 进程内缓存

- `populatePasswords` 不再阻塞 `Load()`，内存 `pwdCache` 直接服务命中；未命中时后台 goroutine 异步回填。
- 新增 `EnsurePassword(id)` 给需要同步 keychain 访问的调用方。
- 明文 → keychain 的首次迁移仍同步在 `Save` / 首次 `Load`，保证数据完整性契约。

### F-112 `skills`：copyDir 用 `os.CopyFS`

- `filepath.Walk` + `os.Lstat` + `os.Open/Create` 循环替换为 `os.CopyFS` (Go 1.23+)。
- STORE-02 symlink 防护保留：`assertNoSymlinks` 前置 walk 兜底，`os.CopyFS` 默认 follow symlink，所以显式 Lstat 必须先跑。

### F-107 `skills`：List 缓存 + savePrefs 原子写

- 2s TTL 内存缓存 coalesce 高频 List 调用。
- mutator（SetEnabled / SetLocked / SetSortOrder / SetOrigin / Delete / Import / Create）显式 `invalidateListCache`，避免 UI 显示过期状态。
- 并发 List 安全：`listMu` 串行化 cache 读写；`savePrefs` 改用 `atomicWriteFile` 防并发写入读出半写文件（F-107 测试 16 goroutine × 8 iter 在 -race 下稳定通过）。

## 测试

```
$ go test -count=1 -race ./backend/store/...
ok  	github.com/ys-ll/uniterm/backend/store	2.599s
```

28 用例全绿，包含：

- F-103 新增 11 条：`SaveLoadRoundTrip` / `LoadNoDirReturnsEmpty` / `ShardsArePerSession` / `SaveRemovesOrphans` / `MigrateLegacyToShards` / `MigrationIdempotent` / `MigrationReversible` / `CorruptLegacyQuarantined` / `EmptyLegacyRemoved` / `SaveSkipsEmptyID` / `ShardPathUsesBase`。
- F-108/F-109 smoke：round-trip / 缺失文件 / corrupt / 并发 Save/Load。
- F-107 三条：缓存命中 / mutator 失效 / 并发 List。
- F-101/F-102 防抖与原子写测试。

## 文件改动

15 个文件，+1567 / −119。

## 检查清单

- [x] `go test ./backend/store/...` 通过（含 -race）
- [x] ai-sessions.json → ai-sessions/<id>.json 迁移幂等且可逆
- [x] 并发 List / Save 不再产生半写文件
- [x] 没有遗留 `os.WriteFile` 全文件路径（F-108 之前 settings、skills prefs）
- [x] 依赖 PR-15 的 atomic helper