### PR TITLE
fix(settings): trim log directory description to a single line

### DIFF
--- a/frontend/src/components/SettingsTab.vue
+++ b/frontend/src/components/SettingsTab.vue
@@ -345,7 +345,7 @@
           <div class="setting-card">
             <div class="setting-info">
               <div class="setting-title">{{ t('settings.sessionLogDir') }}</div>
-              <div class="setting-desc">{{ t('settings.sessionLogDirDesc', { path: defaultLogDir }) }}</div>
+              <div class="setting-desc">{{ t('settings.sessionLogDirDesc') }}</div>
             </div>
             <div class="setting-control setting-control-wide">
               <el-input

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -353,7 +353,7 @@
   "settings.cursorBlink": "Cursor blinken",
   "settings.cursorBlinkDesc": "Ob der Terminal-Cursor blinkt",
   "settings.sessionLogDir": "Log-Verzeichnis",
-  "settings.sessionLogDirDesc": "Speicherort für Sitzungsprotokolle. Leer lassen, um den Standard zu verwenden: {path}",
+  "settings.sessionLogDirDesc": "Speicherort für Sitzungsprotokolle.",
   "settings.browse": "Durchsuchen…",
   "settings.maxTurns": "Max. autonome Runden",
   "settings.maxTurnsDesc": "Maximale Anzahl autonomer Interaktionsrunden pro KI-Anfrage. 0 = unbegrenzt. Standard: 20.",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -356,7 +356,7 @@
   "settings.cursorBlink": "Cursor Blink",
   "settings.cursorBlinkDesc": "Whether the terminal cursor blinks",
   "settings.sessionLogDir": "Log directory",
-  "settings.sessionLogDirDesc": "Where session logs are saved. Leave empty to use the default: {path}",
+  "settings.sessionLogDirDesc": "Where session logs are saved.",
   "settings.browse": "Browse…",
   "settings.maxTurns": "Max Autonomous Rounds",
   "settings.maxTurnsDesc": "Maximum autonomous interaction rounds per AI request. Set to 0 for unlimited. Default 20.",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -353,7 +353,7 @@
   "settings.cursorBlink": "Parpadeo del cursor",
   "settings.cursorBlinkDesc": "Si el cursor del terminal parpadea",
   "settings.sessionLogDir": "Directorio de logs",
-  "settings.sessionLogDirDesc": "Ubicación donde se guardan los logs de sesión. Dejar vacío para usar el predeterminado: {path}",
+  "settings.sessionLogDirDesc": "Ubicación donde se guardan los logs de sesión.",
   "settings.browse": "Examinar…",
   "settings.maxTurns": "Máx. rondas autónomas",
   "settings.maxTurnsDesc": "Rondas máximas de interacción autónoma por solicitud de IA. 0 = ilimitado. Predeterminado: 20.",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -353,7 +353,7 @@
   "settings.cursorBlink": "Clignotement du curseur",
   "settings.cursorBlinkDesc": "Indique si le curseur du terminal clignote",
   "settings.sessionLogDir": "Dossier des logs",
-  "settings.sessionLogDirDesc": "Emplacement des logs de session. Laisser vide pour utiliser le défaut : {path}",
+  "settings.sessionLogDirDesc": "Emplacement des logs de session.",
   "settings.browse": "Parcourir…",
   "settings.maxTurns": "Max. de tours autonomes",
   "settings.maxTurnsDesc": "Nombre maximum de tours d'interaction autonome par requête IA. 0 = illimité. Défaut : 20.",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -353,7 +353,7 @@
   "settings.cursorBlink": "カーソル点滅",
   "settings.cursorBlinkDesc": "端末カーソルを点滅させるかどうか",
   "settings.sessionLogDir": "ログ保存先",
-  "settings.sessionLogDirDesc": "セッションログの保存場所。空欄でデフォルトを使用: {path}",
+  "settings.sessionLogDirDesc": "セッションログの保存場所。",
   "settings.browse": "参照…",
   "settings.maxTurns": "AI自律対話の最大ラウンド数",
   "settings.maxTurnsDesc": "AIリクエストあたりの自律的な対話ラウンドの上限。0は無制限。デフォルト：20。",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -353,7 +353,7 @@
   "settings.cursorBlink": "커서 깜박임",
   "settings.cursorBlinkDesc": "터미널 커서를 깜박일지 여부",
   "settings.sessionLogDir": "로그 저장 폴더",
-  "settings.sessionLogDirDesc": "세션 로그를 저장할 위치. 비워두면 기본값 사용: {path}",
+  "settings.sessionLogDirDesc": "세션 로그를 저장할 위치.",
   "settings.browse": "찾아보기…",
   "settings.maxTurns": "AI 자율 상호작용 최대 라운드",
   "settings.maxTurnsDesc": "AI 요청당 자율 상호작용 라운드의 최대 횟수. 0은 무제한. 기본값: 20.",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -353,7 +353,7 @@
   "settings.cursorBlink": "Мигание курсора",
   "settings.cursorBlinkDesc": "Должен ли мигать курсор терминала",
   "settings.sessionLogDir": "Папка для журналов",
-  "settings.sessionLogDirDesc": "Место сохранения журналов сеансов. Оставьте пустым для использования пути по умолчанию: {path}",
+  "settings.sessionLogDirDesc": "Место сохранения журналов сеансов.",
   "settings.browse": "Обзор…",
   "settings.maxTurns": "Макс. автономных раундов",
   "settings.maxTurnsDesc": "Максимальное количество автономных раундов взаимодействия на один запрос ИИ. 0 — без ограничений. По умолчанию: 20.",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -356,7 +356,7 @@
   "settings.cursorBlink": "光标闪烁",
   "settings.cursorBlinkDesc": "是否启用终端光标闪烁",
   "settings.sessionLogDir": "日志保存目录",
-  "settings.sessionLogDirDesc": "会话日志文件的存放位置。留空使用默认路径：{path}",
+  "settings.sessionLogDirDesc": "会话日志文件的存放位置。",
   "settings.browse": "浏览…",
   "settings.maxTurns": "AI 自主交互最大轮次",
   "settings.maxTurnsDesc": "AI 自主执行命令与反馈的对话轮数上限。设为 0 表示不限制。默认 20。",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -353,7 +353,7 @@
   "settings.cursorBlink": "游標閃爍",
   "settings.cursorBlinkDesc": "是否啟用終端游標閃爍",
   "settings.sessionLogDir": "日誌儲存目錄",
-  "settings.sessionLogDirDesc": "工作階段日誌檔案的儲存位置。留空使用預設路徑：{path}",
+  "settings.sessionLogDirDesc": "工作階段日誌檔案的儲存位置。",
   "settings.browse": "瀏覽…",
   "settings.maxTurns": "AI 自主互動最大輪次",
   "settings.maxTurnsDesc": "AI 自主執行命令與回饋的對話輪數上限。設為 0 表示不限制。預設 20。",


### PR DESCRIPTION
## Summary

The Settings → Log directory row showed a two-line description that included the backend default path. The el-input already exposes that path via its placeholder, so the trailing Leave empty to use the default: {path} sentence only added vertical noise — and on narrow settings panels it wrapped onto a second line, breaking the one-line-per-row layout used by every other setting on the page.

Drop the default-value clause from all nine locales. The placeholder keeps the default discoverable for anyone who clears the field.

## Changes
- frontend/src/components/SettingsTab.vue — description now just renders the short label; placeholder still shows the default path.
- frontend/src/i18n/locales/{en,zh-CN,zh-TW,ja,de,fr,es,ru,ko}.json — drop the Leave empty to use the default: {path} tail in each translation.

## Verification
- npm --prefix frontend run build passes

---
设置界面里「日志保存目录」的说明文字会带上后端默认值路径，整段偏长，
在窗口未全屏时会换行成两行，破坏每行一项的整齐排版。该默认值路径
已通过 el-input 的 placeholder 提示，因此说明里再去重复一遍只是冗余
信息：「留空使用默认路径：{path}」这一句可以删掉，placeholder 依然会
显示默认路径。

精简九种语言的描述文案，保留「会话日志文件的存放位置。」等核心说明。