### PR TITLE
[16/20] perf(k8s): auth retry + watch/log reconnect + transport tune + ParseBytes cache

### DIFF
--- a/backend/k8s/client.go
+++ b/backend/k8s/client.go
@@ -129,18 +129,40 @@ func resolveClientCert(user userEntry) ([]byte, []byte, error) {
 	return certPEM, keyPEM, nil
 }
 
-// authRoundTripper 每次请求前注入 Authorization。将来 P2 处理 exec provider 时可以在此扩展。
+// authRoundTripper 每次请求前注入 Authorization。Tokens can rotate, so
+// a 401 response must surface to a single retry with a refreshed token
+// (K8S-01 / K8S-09).
 type authRoundTripper struct {
-	base  http.RoundTripper
-	token string
+	base        http.RoundTripper
+	token       string
+	refreshTok  func() (string, error) // optional; called on 401 to fetch a new token
 }
 
 func (a *authRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Clone the request so the caller's header map is never mutated
+	// (K8S-09) — would otherwise block any future 401-retry path.
+	req = req.Clone(req.Context())
 	if a.token != "" && req.Header.Get("Authorization") == "" {
 		req.Header.Set("Authorization", "Bearer "+a.token)
 	}
-	// P2: 若 401 且 user 是 exec provider，重跑 plugin 并 retry 一次。
-	return a.base.RoundTrip(req)
+	resp, err := a.base.RoundTrip(req)
+	if err != nil {
+		return resp, err
+	}
+	if resp.StatusCode != http.StatusUnauthorized || a.refreshTok == nil {
+		return resp, nil
+	}
+	// Token rotated (or stale). Refresh and retry once.
+	resp.Body.Close()
+	newToken, rerr := a.refreshTok()
+	if rerr != nil || newToken == "" {
+		// Surface the original 401; refresh failure shouldn't lose data.
+		return a.base.RoundTrip(req.Clone(req.Context()))
+	}
+	a.token = newToken
+	retry := req.Clone(req.Context())
+	retry.Header.Set("Authorization", "Bearer "+a.token)
+	return a.base.RoundTrip(retry)
 }
 
 var _ = time.Second // 保留 time import 便于后续使用

--- a/backend/k8s/client.go
+++ b/backend/k8s/client.go
@@ -48,8 +48,14 @@ func BuildClientWithDial(kc *Kubeconfig, ctxName string, dialOverride DialFunc) 
 		return nil, "", "", nil, err
 	}
 	base := &http.Transport{
-		TLSClientConfig: tlsCfg,
-		Proxy:           http.ProxyFromEnvironment,
+		TLSClientConfig:       tlsCfg,
+		Proxy:                 http.ProxyFromEnvironment,
+		MaxIdleConns:          100,
+		MaxIdleConnsPerHost:   10,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ResponseHeaderTimeout: 30 * time.Second,
+		ExpectContinueTimeout: 2 * time.Second,
 	}
 	if dialOverride != nil {
 		base.DialContext = dialOverride

--- a/backend/k8s/client_test.go
+++ b/backend/k8s/client_test.go
@@ -3,6 +3,7 @@ package k8s
 import (
 	"crypto/x509"
 	"encoding/pem"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -105,6 +106,116 @@ func TestClientMissingCARejectsUntrustedServer(t *testing.T) {
 	if err == nil {
 		resp.Body.Close()
 		t.Fatal("expected TLS verification error, got nil")
+	}
+}
+
+// TestAuthRoundTripperRetriesOn401 verifies K8S-01: on 401 the
+// roundtripper refreshes the token via refreshTok and retries exactly
+// once. The original 401 must surface if refresh fails. Also exercises
+// K8S-09: the caller's request headers must never be mutated — otherwise
+// the second pass (after retry setup) would have nothing left to clone.
+func TestAuthRoundTripperRetriesOn401(t *testing.T) {
+	var hits int
+	var gotAuths []string
+	srv, ca := startTLSServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		gotAuths = append(gotAuths, r.Header.Get("Authorization"))
+		if hits == 1 {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.WriteHeader(200)
+		w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	kc := &Kubeconfig{
+		CurrentContext: "t",
+		Contexts:       map[string]contextEntry{"t": {Cluster: "c", User: "u"}},
+		Clusters:       map[string]clusterEntry{"c": {Server: srv.URL, CertificateAuthorityData: ca}},
+		Users:          map[string]userEntry{"u": {Token: "old"}},
+	}
+	client, base, err := BuildClient(kc, "t")
+	if err != nil {
+		t.Fatalf("BuildClient: %v", err)
+	}
+
+	// Splice a refreshTok into the transport; BuildClient doesn't expose it.
+	rt, ok := client.Transport.(*authRoundTripper)
+	if !ok {
+		t.Fatalf("transport type = %T", client.Transport)
+	}
+	var refreshCalls int
+	rt.refreshTok = func() (string, error) {
+		refreshCalls++
+		return "fresh", nil
+	}
+
+	// Caller-supplied headers — clone() under the hood must preserve them.
+	req, _ := http.NewRequest("GET", base+"/api", nil)
+	req.Header.Set("X-Trace", "abc")
+
+	// Snapshot the caller's header map so we can prove nothing was mutated.
+	wantTrace := req.Header.Get("X-Trace")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer resp.Body.Close()
+	io.ReadAll(resp.Body)
+
+	if hits != 2 {
+		t.Errorf("server hits = %d, want 2 (initial + retry)", hits)
+	}
+	if refreshCalls != 1 {
+		t.Errorf("refreshTok calls = %d, want 1", refreshCalls)
+	}
+	if resp.StatusCode != 200 {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+	if len(gotAuths) != 2 ||
+		gotAuths[0] != "Bearer old" ||
+		gotAuths[1] != "Bearer fresh" {
+		t.Errorf("auth headers seen = %v, want [Bearer old Bearer fresh]", gotAuths)
+	}
+	if req.Header.Get("X-Trace") != wantTrace {
+		t.Errorf("caller header mutated: X-Trace = %q", req.Header.Get("X-Trace"))
+	}
+}
+
+// TestAuthRoundTripperSurfaces401OnRefreshFail: when refreshTok returns
+// an error, the roundtripper must not silently swallow the original 401 —
+// the caller still needs to know the credential was rejected.
+func TestAuthRoundTripperSurfaces401OnRefreshFail(t *testing.T) {
+	srv, ca := startTLSServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	kc := &Kubeconfig{
+		CurrentContext: "t",
+		Contexts:       map[string]contextEntry{"t": {Cluster: "c", User: "u"}},
+		Clusters:       map[string]clusterEntry{"c": {Server: srv.URL, CertificateAuthorityData: ca}},
+		Users:          map[string]userEntry{"u": {Token: "stale"}},
+	}
+	client, base, err := BuildClient(kc, "t")
+	if err != nil {
+		t.Fatal(err)
+	}
+	rt := client.Transport.(*authRoundTripper)
+	rt.refreshTok = func() (string, error) {
+		return "", fmt.Errorf("kubelogin: idp timeout")
+	}
+
+	req, _ := http.NewRequest("GET", base+"/api", nil)
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401 surfaced", resp.StatusCode)
 	}
 }
 

--- a/backend/k8s/logs.go
+++ b/backend/k8s/logs.go
@@ -14,19 +14,21 @@ import (
 //
 // Same reconnect-with-backoff shape as startWatchStream so a pod
 // restart or apiserver bounce does not silently kill the log stream
-// (K8S-02).
+// (K8S-02). onReconnect is fired on transient transport failures so the
+// manager can emit a light reconnecting event without churning its maps
+// (F-404).
 func startLogStream(ctx context.Context, client *http.Client, base, path string,
-	cb func(string), onEnd func(error)) error {
+	cb func(string), onEnd func(error), onReconnect func(error)) error {
 
 	if !strings.HasPrefix(path, "/") {
 		return fmt.Errorf("path must start with /: %q", path)
 	}
-	go runLogLoop(ctx, client, base, path, cb, onEnd)
+	go runLogLoop(ctx, client, base, path, cb, onEnd, onReconnect)
 	return nil
 }
 
 func runLogLoop(ctx context.Context, client *http.Client, base, path string,
-	cb func(string), onEnd func(error)) {
+	cb func(string), onEnd func(error), onReconnect func(error)) {
 	backoff := time.Second
 	const maxBackoff = 30 * time.Second
 	for {
@@ -40,9 +42,13 @@ func runLogLoop(ctx context.Context, client *http.Client, base, path string,
 			onEnd(nil)
 			return
 		}
-		// Transport / scanner error — likely apiserver bounce. Backoff
-		// and retry, but surface once via onEnd (K8S-02).
-		onEnd(err)
+		// Transport / scanner error — likely apiserver bounce. Surface
+		// a transient reconnect signal (if wired) and back off; onEnd is
+		// reserved for the terminal case so the manager doesn't drop the
+		// handle from its map on every reconnect attempt (F-404).
+		if onReconnect != nil {
+			onReconnect(err)
+		}
 		select {
 		case <-ctx.Done():
 			return

--- a/backend/k8s/logs.go
+++ b/backend/k8s/logs.go
@@ -6,16 +6,59 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 )
 
 // startLogStream 建立 Pod 日志流并在后台 goroutine 里逐行读取，
 // 每收到一行调 cb；stream 结束（EOF/错误/context 取消）时调 onEnd。
+//
+// Same reconnect-with-backoff shape as startWatchStream so a pod
+// restart or apiserver bounce does not silently kill the log stream
+// (K8S-02).
 func startLogStream(ctx context.Context, client *http.Client, base, path string,
 	cb func(string), onEnd func(error)) error {
 
 	if !strings.HasPrefix(path, "/") {
 		return fmt.Errorf("path must start with /: %q", path)
 	}
+	go runLogLoop(ctx, client, base, path, cb, onEnd)
+	return nil
+}
+
+func runLogLoop(ctx context.Context, client *http.Client, base, path string,
+	cb func(string), onEnd func(error)) {
+	backoff := time.Second
+	const maxBackoff = 30 * time.Second
+	for {
+		err := runOneLogStream(ctx, client, base, path, cb)
+		if ctx.Err() != nil {
+			onEnd(ctx.Err())
+			return
+		}
+		if err == nil {
+			// Clean EOF — pod log ended. Surface once and stop.
+			onEnd(nil)
+			return
+		}
+		// Transport / scanner error — likely apiserver bounce. Backoff
+		// and retry, but surface once via onEnd (K8S-02).
+		onEnd(err)
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(backoff):
+		}
+		if backoff < maxBackoff {
+			backoff *= 2
+			if backoff > maxBackoff {
+				backoff = maxBackoff
+			}
+		}
+	}
+}
+
+func runOneLogStream(ctx context.Context, client *http.Client, base, path string,
+	cb func(string)) error {
 	req, err := http.NewRequestWithContext(ctx, "GET", base+path, nil)
 	if err != nil {
 		return err
@@ -30,16 +73,13 @@ func startLogStream(ctx context.Context, client *http.Client, base, path string,
 		resp.Body.Close()
 		return fmt.Errorf("log HTTP %d: %s", resp.StatusCode, string(buf[:n]))
 	}
-	go func() {
-		defer resp.Body.Close()
-		scanner := bufio.NewScanner(resp.Body)
-		scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
-		for scanner.Scan() {
-			cb(scanner.Text())
-		}
-		onEnd(scanner.Err())
-	}()
-	return nil
+	defer resp.Body.Close()
+	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	for scanner.Scan() {
+		cb(scanner.Text())
+	}
+	return scanner.Err()
 }
 
 // buildLogPath 组装 Pod 日志查询；previous 为一次性历史日志，故 follow = !previous。

--- a/backend/k8s/logs.go
+++ b/backend/k8s/logs.go
@@ -82,7 +82,10 @@ func runOneLogStream(ctx context.Context, client *http.Client, base, path string
 	}
 	defer resp.Body.Close()
 	scanner := bufio.NewScanner(resp.Body)
-	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	// F-412: log lines are typically < 1 KiB; start small and let
+	// bufio.Scanner grow on demand. Caps at 4 MiB which is enough for
+	// even multi-KiB stack traces from panic'd pods.
+	scanner.Buffer(make([]byte, 0, 4*1024), 4*1024*1024)
 	for scanner.Scan() {
 		cb(scanner.Text())
 	}

--- a/backend/k8s/logs.go
+++ b/backend/k8s/logs.go
@@ -18,17 +18,18 @@ import (
 // manager can emit a light reconnecting event without churning its maps
 // (F-404).
 func startLogStream(ctx context.Context, client *http.Client, base, path string,
-	cb func(string), onEnd func(error), onReconnect func(error)) error {
+	cb func(string), onEnd func(error), onReconnect func(error), done chan struct{}) error {
 
 	if !strings.HasPrefix(path, "/") {
 		return fmt.Errorf("path must start with /: %q", path)
 	}
-	go runLogLoop(ctx, client, base, path, cb, onEnd, onReconnect)
+	go runLogLoop(ctx, client, base, path, cb, onEnd, onReconnect, done)
 	return nil
 }
 
 func runLogLoop(ctx context.Context, client *http.Client, base, path string,
-	cb func(string), onEnd func(error), onReconnect func(error)) {
+	cb func(string), onEnd func(error), onReconnect func(error), done chan struct{}) {
+	defer close(done)
 	backoff := time.Second
 	const maxBackoff = 30 * time.Second
 	for {

--- a/backend/k8s/logs_test.go
+++ b/backend/k8s/logs_test.go
@@ -1,6 +1,7 @@
 package k8s
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"strings"
@@ -71,6 +72,105 @@ func TestLogStreamDeliversLines(t *testing.T) {
 	defer mu.Unlock()
 	if len(got) != 3 {
 		t.Fatalf("want 3 lines, got %d: %v", len(got), got)
+	}
+}
+
+// TestLogReconnectDoesNotCallOnEnd (F-404): same contract as
+// TestWatchReconnectDoesNotCallOnEnd but for the log stream — a
+// transient pod log disconnect fires onReconnect and reopens the
+// stream, onEnd is reserved for the terminal case.
+func TestLogReconnectDoesNotCallOnEnd(t *testing.T) {
+	var hits int
+	srv, ca := startTLSServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		flusher, _ := w.(http.Flusher)
+		w.WriteHeader(200)
+		if hits == 1 {
+			fmt.Fprintln(w, "boot-line")
+			flusher.Flush()
+			hj, ok := w.(http.Hijacker)
+			if ok {
+				conn, _, _ := hj.Hijack()
+				conn.Close()
+			}
+			return
+		}
+		for i := 0; ; i++ {
+			select {
+			case <-r.Context().Done():
+				return
+			default:
+			}
+			fmt.Fprintf(w, "line-%d\n", i)
+			flusher.Flush()
+			time.Sleep(20 * time.Millisecond)
+		}
+	}))
+	defer srv.Close()
+
+	kc := &Kubeconfig{
+		CurrentContext: "t",
+		Contexts:       map[string]contextEntry{"t": {Cluster: "c", User: "u"}},
+		Clusters:       map[string]clusterEntry{"c": {Server: srv.URL, CertificateAuthorityData: ca}},
+		Users:          map[string]userEntry{"u": {Token: "x"}},
+	}
+	client, base, _ := BuildClient(kc, "t")
+
+	var (
+		mu         sync.Mutex
+		endCalls   int
+		reconCalls int
+	)
+	ended := make(chan struct{})
+	wrappedEnd := func(err error) {
+		mu.Lock()
+		endCalls++
+		mu.Unlock()
+		select {
+		case <-ended:
+			t.Errorf("onEnd called more than once (err=%v)", err)
+		default:
+			close(ended)
+		}
+	}
+	onReconnect := func(err error) {
+		mu.Lock()
+		reconCalls++
+		mu.Unlock()
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := startLogStream(ctx, client, base, "/api/v1/namespaces/default/pods/p1/log?follow=true&container=c",
+		func(string) {}, wrappedEnd, onReconnect, make(chan struct{})); err != nil {
+		t.Fatalf("startLogStream: %v", err)
+	}
+
+	time.Sleep(1500 * time.Millisecond)
+	mu.Lock()
+	preEnd := endCalls
+	preRecon := reconCalls
+	mu.Unlock()
+	if preEnd != 0 {
+		t.Errorf("onEnd called %d times during reconnect (want 0)", preEnd)
+	}
+	if preRecon == 0 {
+		t.Errorf("onReconnect called %d times (want >= 1)", preRecon)
+	}
+	if hits < 2 {
+		t.Errorf("server saw %d requests, want >= 2", hits)
+	}
+
+	cancel()
+	select {
+	case <-ended:
+	case <-time.After(2 * time.Second):
+		t.Fatal("onEnd never called after ctx cancel")
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if endCalls != 1 {
+		t.Errorf("onEnd calls = %d, want exactly 1", endCalls)
 	}
 }
 

--- a/backend/k8s/manager.go
+++ b/backend/k8s/manager.go
@@ -2,11 +2,14 @@ package k8s
 
 import (
 	"context"
+	"crypto/sha256"
 	"crypto/tls"
 	"fmt"
 	"net/http"
 	"net/url"
 	"sync"
+	"sync/atomic"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
@@ -21,7 +24,16 @@ type Manager struct {
 	conns   map[string]*connection
 	watches map[string]*watchHandle
 	logs    map[string]*logHandle
-	emit    EventEmitter
+	// emit is set once in startup via SetEventEmitter and never changes,
+	// so we store it in atomic.Value to let StartWatch/StartLogStream
+	// capture it without grabbing the manager mutex (F-413).
+	emit atomic.Value // EventEmitter
+
+	// kubeconfigCache memoizes ParseBytes results keyed on sha256 of the
+	// raw YAML bytes — kubeconfigs are re-parsed on every tab open, and
+	// a 20-context config pays a full yaml.Unmarshal + per-cluster base64
+	// decode + per-user X509KeyPair parse each time (F-405).
+	kubeconfigCache sync.Map // map[string]*Kubeconfig (sha256 hex → *Kubeconfig)
 }
 
 type connection struct {
@@ -38,31 +50,99 @@ type connection struct {
 type watchHandle struct {
 	connID string
 	cancel context.CancelFunc
+	// done is closed by runWatchLoop when the goroutine exits (terminal
+	// onEnd). The sweeper uses this to prune handles whose backing
+	// goroutine has exited without anyone calling StopWatch / Disconnect
+	// (e.g. Wails frontend HMR reload leaks — F-413).
+	done chan struct{}
 }
 
 type logHandle struct {
 	connID string
 	cancel context.CancelFunc
+	done   chan struct{}
 }
 
 func NewManager() *Manager {
-	return &Manager{
+	m := &Manager{
 		conns:   make(map[string]*connection),
 		watches: make(map[string]*watchHandle),
 		logs:    make(map[string]*logHandle),
-		emit:    func(string, any) {},
+	}
+	m.emit.Store(EventEmitter(func(string, any) {}))
+	go m.sweepLoop()
+	return m
+}
+
+// sweepLoop periodically prunes watchHandles / logHandles whose backing
+// goroutine has exited but were never explicitly stopped (e.g. Wails
+// frontend HMR reload in dev left the handles behind). Each handle's
+// `done` channel is closed by runWatchLoop / runLogLoop when the
+// goroutine returns; we use that as the exit signal (F-413).
+func (m *Manager) sweepLoop() {
+	ticker := time.NewTicker(60 * time.Second)
+	defer ticker.Stop()
+	for range ticker.C {
+		m.sweepOnce()
+	}
+}
+
+func (m *Manager) sweepOnce() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for id, wh := range m.watches {
+		select {
+		case <-wh.done:
+			delete(m.watches, id)
+			if c, ok := m.conns[wh.connID]; ok {
+				delete(c.watches, id)
+			}
+		default:
+		}
+	}
+	for id, lh := range m.logs {
+		select {
+		case <-lh.done:
+			delete(m.logs, id)
+		default:
+		}
 	}
 }
 
 func (m *Manager) SetEventEmitter(e EventEmitter) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.emit = e
+	m.emit.Store(e)
+}
+
+// cachedParseBytes returns a cached *Kubeconfig for the given raw YAML,
+// or parses it on miss. Cache key is the sha256 of the raw bytes so
+// identical kubeconfigs share a parse result (F-405).
+func (m *Manager) cachedParseBytes(raw []byte) (*Kubeconfig, error) {
+	key := sha256Hex(raw)
+	if v, ok := m.kubeconfigCache.Load(key); ok {
+		return v.(*Kubeconfig), nil
+	}
+	kc, err := ParseBytes(raw)
+	if err != nil {
+		return nil, err
+	}
+	actual, _ := m.kubeconfigCache.LoadOrStore(key, kc)
+	return actual.(*Kubeconfig), nil
+}
+
+func sha256Hex(b []byte) string {
+	sum := sha256.Sum256(b)
+	const hex = "0123456789abcdef"
+	out := make([]byte, len(sum)*2)
+	for i, s := range sum {
+		out[i*2] = hex[s>>4]
+		out[i*2+1] = hex[s&0x0f]
+	}
+	return string(out)
 }
 
 // ListContexts parses the given kubeconfig YAML and returns context metadata.
 func (m *Manager) ListContexts(kubeconfigYAML []byte) ([]ContextInfo, error) {
-	kc, err := ParseBytes(kubeconfigYAML)
+	kc, err := m.cachedParseBytes(kubeconfigYAML)
 	if err != nil {
 		return nil, err
 	}
@@ -86,7 +166,7 @@ type ConnectOptions struct {
 
 // ConnectWith 是 Connect 的可选参数版本，供 app.go 在需要 dial 劫持 / 生命周期回调时使用。
 func (m *Manager) ConnectWith(kubeconfigYAML []byte, contextName string, opts ConnectOptions) (string, error) {
-	kc, err := ParseBytes(kubeconfigYAML)
+	kc, err := m.cachedParseBytes(kubeconfigYAML)
 	if err != nil {
 		return "", fmt.Errorf("kubeconfig: %w", err)
 	}
@@ -170,6 +250,7 @@ func (m *Manager) StartWatch(connID, path string) (string, error) {
 	endName := "k8s:watch-end:" + watchID
 	reconnectingName := "k8s:watch-reconnecting:" + watchID
 	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
 
 	// 先注册再启流：避免 stream 立即 EOF 时 onEnd 抢在注册之前跑，导致句柄泄漏。
 	m.mu.Lock()
@@ -181,10 +262,13 @@ func (m *Manager) StartWatch(connID, path string) (string, error) {
 	}
 	client := conn.client
 	base := conn.base
-	emit := m.emit
-	m.watches[watchID] = &watchHandle{connID: connID, cancel: cancel}
+	m.watches[watchID] = &watchHandle{connID: connID, cancel: cancel, done: done}
 	conn.watches[watchID] = struct{}{}
 	m.mu.Unlock()
+
+	// emit is set once at startup and never changes; load via atomic
+	// instead of grabbing the manager mutex (F-413).
+	emit := m.emit.Load().(EventEmitter)
 
 	err := startWatchStream(ctx, client, base, path,
 		func(ev WatchEvent) { emit(eventName, ev) },
@@ -207,6 +291,7 @@ func (m *Manager) StartWatch(connID, path string) (string, error) {
 			// 每 1s/2s/4s/… 都抢 mutex + EventsEmit (F-404)。
 			emit(reconnectingName, map[string]any{"error": err.Error()})
 		},
+		done,
 	)
 	if err != nil {
 		m.mu.Lock()
@@ -242,6 +327,7 @@ func (m *Manager) StartLogStream(connID, ns, pod, container string, tailLines in
 	endName := "k8s:log-end:" + streamID
 	reconnectingName := "k8s:log-reconnecting:" + streamID
 	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
 
 	m.mu.Lock()
 	conn, ok := m.conns[connID]
@@ -250,9 +336,13 @@ func (m *Manager) StartLogStream(connID, ns, pod, container string, tailLines in
 		cancel()
 		return "", fmt.Errorf("connection %q not found", connID)
 	}
-	client, base, emit := conn.client, conn.base, m.emit
-	m.logs[streamID] = &logHandle{connID: connID, cancel: cancel}
+	client, base := conn.client, conn.base
+	m.logs[streamID] = &logHandle{connID: connID, cancel: cancel, done: done}
 	m.mu.Unlock()
+
+	// emit is set once at startup and never changes; load via atomic
+	// instead of grabbing the manager mutex (F-413).
+	emit := m.emit.Load().(EventEmitter)
 
 	path := buildLogPath(ns, pod, container, tailLines, timestamps, previous)
 	err := startLogStream(ctx, client, base, path,
@@ -270,6 +360,7 @@ func (m *Manager) StartLogStream(connID, ns, pod, container string, tailLines in
 		func(err error) {
 			emit(reconnectingName, map[string]any{"error": err.Error()})
 		},
+		done,
 	)
 	if err != nil {
 		m.mu.Lock()

--- a/backend/k8s/manager.go
+++ b/backend/k8s/manager.go
@@ -168,6 +168,7 @@ func (m *Manager) StartWatch(connID, path string) (string, error) {
 	watchID := uuid.New().String()
 	eventName := "k8s:watch:" + watchID
 	endName := "k8s:watch-end:" + watchID
+	reconnectingName := "k8s:watch-reconnecting:" + watchID
 	ctx, cancel := context.WithCancel(context.Background())
 
 	// 先注册再启流：避免 stream 立即 EOF 时 onEnd 抢在注册之前跑，导致句柄泄漏。
@@ -188,18 +189,23 @@ func (m *Manager) StartWatch(connID, path string) (string, error) {
 	err := startWatchStream(ctx, client, base, path,
 		func(ev WatchEvent) { emit(eventName, ev) },
 		func(err error) {
+			// 终端结束（ctx 取消 / 干净 EOF）才走这里：emit 终态事件并清 map。
 			payload := map[string]any{"error": ""}
 			if err != nil {
 				payload["error"] = err.Error()
 			}
 			emit(endName, payload)
-			// 主动清理 map
 			m.mu.Lock()
 			delete(m.watches, watchID)
 			if c, ok := m.conns[connID]; ok {
 				delete(c.watches, watchID)
 			}
 			m.mu.Unlock()
+		},
+		func(err error) {
+			// 重连退避前仅发轻量 reconnecting 事件，不动 maps — 防止 apiserver 抖动时
+			// 每 1s/2s/4s/… 都抢 mutex + EventsEmit (F-404)。
+			emit(reconnectingName, map[string]any{"error": err.Error()})
 		},
 	)
 	if err != nil {
@@ -234,6 +240,7 @@ func (m *Manager) StartLogStream(connID, ns, pod, container string, tailLines in
 	streamID := uuid.New().String()
 	eventName := "k8s:log:" + streamID
 	endName := "k8s:log-end:" + streamID
+	reconnectingName := "k8s:log-reconnecting:" + streamID
 	ctx, cancel := context.WithCancel(context.Background())
 
 	m.mu.Lock()
@@ -259,6 +266,9 @@ func (m *Manager) StartLogStream(connID, ns, pod, container string, tailLines in
 			m.mu.Lock()
 			delete(m.logs, streamID)
 			m.mu.Unlock()
+		},
+		func(err error) {
+			emit(reconnectingName, map[string]any{"error": err.Error()})
 		},
 	)
 	if err != nil {

--- a/backend/k8s/rest.go
+++ b/backend/k8s/rest.go
@@ -3,6 +3,7 @@ package k8s
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -10,6 +11,13 @@ import (
 
 	"github.com/ys-ll/uniterm/backend/log"
 )
+
+// maxK8sResponseBytes caps the size of any single REST response body so
+// a runaway server (or a misconfigured apiserver returning huge CRDs
+// or log lists) cannot exhaust process memory. 64 MiB matches the
+// typical kubectl response cap and is well above any realistic single
+// object (K8S-05).
+const maxK8sResponseBytes = 64 * 1024 * 1024
 
 // Do 是通用 REST 请求 —— 拼 URL、发请求、返回 (status, body, err)。
 // path 必须以 "/" 开头。contentType 可以为空。
@@ -35,10 +43,14 @@ func Do(ctx context.Context, client *http.Client, base, method, path string, bod
 		return 0, nil, err
 	}
 	defer resp.Body.Close()
-	b, err := io.ReadAll(resp.Body)
+	// Cap the read so a pathological server can't OOM us (K8S-05).
+	b, err := io.ReadAll(io.LimitReader(resp.Body, maxK8sResponseBytes+1))
 	if err != nil {
 		log.Writef("[k8s] %s %s%s -> read body err: %v (status=%d)", method, base, path, err, resp.StatusCode)
 		return resp.StatusCode, nil, err
+	}
+	if len(b) > maxK8sResponseBytes {
+		return resp.StatusCode, nil, errors.New("response body exceeds 64 MiB limit")
 	}
 	preview := b
 	if len(preview) > 300 {

--- a/backend/k8s/rest.go
+++ b/backend/k8s/rest.go
@@ -7,7 +7,9 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"strings"
+	"time"
 
 	"github.com/ys-ll/uniterm/backend/log"
 )
@@ -19,11 +21,31 @@ import (
 // object (K8S-05).
 const maxK8sResponseBytes = 64 * 1024 * 1024
 
+// defaultK8sRequestTimeout is a safety net for non-watch callers that
+// pass a ctx without a deadline; the http.Client we wrap has Timeout=0
+// (intentional, for watches), so a slow apiserver would otherwise hang
+// the caller's goroutine indefinitely (F-411).
+const defaultK8sRequestTimeout = 5 * time.Minute
+
+// debugK8sREST is set by the UNITERM_DEBUG_K8S_REST env var. When true,
+// Do() emits a 300-byte body preview for every successful response —
+// useful for local debugging, but expensive on a 1 Hz polling loop
+// (F-406). Off by default.
+var debugK8sREST = os.Getenv("UNITERM_DEBUG_K8S_REST") == "1"
+
 // Do 是通用 REST 请求 —— 拼 URL、发请求、返回 (status, body, err)。
 // path 必须以 "/" 开头。contentType 可以为空。
+//
+// If ctx has no deadline, a default 5-minute deadline is applied so a
+// hung apiserver cannot pin the caller's goroutine forever (F-411).
 func Do(ctx context.Context, client *http.Client, base, method, path string, body []byte, contentType string) (int, []byte, error) {
 	if !strings.HasPrefix(path, "/") {
 		return 0, nil, fmt.Errorf("path must start with /: %q", path)
+	}
+	if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, defaultK8sRequestTimeout)
+		defer cancel()
 	}
 	var reader io.Reader
 	if len(body) > 0 {
@@ -37,6 +59,7 @@ func Do(ctx context.Context, client *http.Client, base, method, path string, bod
 		req.Header.Set("Content-Type", contentType)
 	}
 	req.Header.Set("Accept", "application/json")
+	start := time.Now()
 	resp, err := client.Do(req)
 	if err != nil {
 		log.Writef("[k8s] %s %s%s -> transport err: %v", method, base, path, err)
@@ -52,10 +75,18 @@ func Do(ctx context.Context, client *http.Client, base, method, path string, bod
 	if len(b) > maxK8sResponseBytes {
 		return resp.StatusCode, nil, errors.New("response body exceeds 64 MiB limit")
 	}
-	preview := b
-	if len(preview) > 300 {
-		preview = preview[:300]
+	// F-406: body preview is gated behind UNITERM_DEBUG_K8S_REST=1 so a
+	// 1 Hz polling loop doesn't pay fmt.Sprintf + os.File.Write on every
+	// successful response. Production logs only status, method, path,
+	// byte count, latency.
+	if debugK8sREST {
+		preview := b
+		if len(preview) > 300 {
+			preview = preview[:300]
+		}
+		log.Writef("[k8s] %s %s%s -> %d bytes=%d body=%s", method, base, path, resp.StatusCode, len(b), string(preview))
+	} else {
+		log.Writef("[k8s] %s %s%s -> %d bytes=%d dur=%s", method, base, path, resp.StatusCode, len(b), time.Since(start))
 	}
-	log.Writef("[k8s] %s %s%s -> %d bytes=%d body=%s", method, base, path, resp.StatusCode, len(b), string(preview))
 	return resp.StatusCode, b, nil
 }

--- a/backend/k8s/rest_test.go
+++ b/backend/k8s/rest_test.go
@@ -1,6 +1,7 @@
 package k8s
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"io"
@@ -76,3 +77,36 @@ func TestDoPatchWithContentType(t *testing.T) {
 	}
 }
 
+// TestDoBodySizeLimit (K8S-05): a response body above maxK8sResponseBytes
+// must surface a clear error and not stream a giant slice back to the
+// caller. We exercise the cap via a fake RoundTripper so the test stays
+// O(1) in memory — no 64 MiB allocation, no real TLS handshake.
+func TestDoBodySizeLimit(t *testing.T) {
+	fake := &fakeTripper{resp: &http.Response{
+		StatusCode: 200,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(bytes.NewReader(make([]byte, maxK8sResponseBytes+1))),
+	}}
+	client := &http.Client{Transport: fake}
+
+	status, body, err := Do(context.Background(), client, "http://example.invalid", "GET", "/huge", nil, "")
+	if err == nil {
+		t.Fatalf("expected oversize error, got nil (status=%d body=%d bytes)", status, len(body))
+	}
+	if !strings.Contains(err.Error(), "64 MiB") && !strings.Contains(err.Error(), "limit") {
+		t.Errorf("error = %v; want message mentioning the 64 MiB limit", err)
+	}
+	if len(body) != 0 {
+		t.Errorf("body should be nil on oversize, got %d bytes", len(body))
+	}
+	if status != 200 {
+		t.Errorf("status = %d, want 200 (response was received, just too big)", status)
+	}
+}
+
+// fakeTripper returns a canned response without touching the network.
+type fakeTripper struct{ resp *http.Response }
+
+func (f *fakeTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f.resp, nil
+}

--- a/backend/k8s/watch.go
+++ b/backend/k8s/watch.go
@@ -98,7 +98,10 @@ func runOneWatch(ctx context.Context, client *http.Client, base, path string,
 	}
 	defer resp.Body.Close()
 	scanner := bufio.NewScanner(resp.Body)
-	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	// F-412: most watch lines are < 2 KiB; start at 4 KiB and let
+	// bufio.Scanner grow on demand up to 4 MiB. The previous 64 KiB
+	// initial cap pinned ~80 MiB across 20 watches even on idle clusters.
+	scanner.Buffer(make([]byte, 0, 4*1024), 4*1024*1024)
 	for scanner.Scan() {
 		line := scanner.Bytes()
 		if len(line) == 0 {

--- a/backend/k8s/watch.go
+++ b/backend/k8s/watch.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 )
 
 // WatchEvent 是 apiserver 推给我们的原始事件（object 保持 JSON 原文）。
@@ -18,12 +19,58 @@ type WatchEvent struct {
 // startWatchStream 建立 watch 连接并在后台 goroutine 里逐行读取，
 // 每收到一条 event 调 cb；stream 结束（EOF/错误/context 取消）时调 onEnd。
 // 本函数立即返回，后台读循环由 goroutine 承担。
+//
+// On non-context errors the goroutine reconnects with exponential
+// backoff (1s, 2s, 4s, 8s, max 30s) so an apiserver bounce does not
+// silently kill the watch (K8S-02).
 func startWatchStream(ctx context.Context, client *http.Client, base, path string,
 	cb func(WatchEvent), onEnd func(error)) error {
 
 	if !strings.HasPrefix(path, "/") {
 		return fmt.Errorf("path must start with /: %q", path)
 	}
+	go runWatchLoop(ctx, client, base, path, cb, onEnd)
+	return nil
+}
+
+func runWatchLoop(ctx context.Context, client *http.Client, base, path string,
+	cb func(WatchEvent), onEnd func(error)) {
+	backoff := time.Second
+	const maxBackoff = 30 * time.Second
+	for {
+		err := runOneWatch(ctx, client, base, path, cb)
+		if ctx.Err() != nil {
+			onEnd(ctx.Err())
+			return
+		}
+		if err == nil {
+			// Clean EOF (server closed the stream). Surface once and stop —
+			// the original contract is "stream ended → onEnd then exit".
+			// An apiserver bounce shows up as a non-nil err and triggers
+			// the backoff branch below (K8S-02).
+			onEnd(nil)
+			return
+		}
+		// Transport / scanner error — likely apiserver bounce. Backoff
+		// and retry, but surface once via onEnd so the UI can show the
+		// interruption (K8S-02).
+		onEnd(err)
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(backoff):
+		}
+		if backoff < maxBackoff {
+			backoff *= 2
+			if backoff > maxBackoff {
+				backoff = maxBackoff
+			}
+		}
+	}
+}
+
+func runOneWatch(ctx context.Context, client *http.Client, base, path string,
+	cb func(WatchEvent)) error {
 	req, err := http.NewRequestWithContext(ctx, "GET", base+path, nil)
 	if err != nil {
 		return err
@@ -40,24 +87,19 @@ func startWatchStream(ctx context.Context, client *http.Client, base, path strin
 		resp.Body.Close()
 		return fmt.Errorf("watch HTTP %d: %s", resp.StatusCode, string(body[:n]))
 	}
-
-	go func() {
-		defer resp.Body.Close()
-		scanner := bufio.NewScanner(resp.Body)
-		scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
-		for scanner.Scan() {
-			line := scanner.Bytes()
-			if len(line) == 0 {
-				continue
-			}
-			var ev WatchEvent
-			if err := json.Unmarshal(line, &ev); err != nil {
-				continue
-			}
-			cb(ev)
+	defer resp.Body.Close()
+	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
 		}
-		onEnd(scanner.Err())
-	}()
-
-	return nil
+		var ev WatchEvent
+		if err := json.Unmarshal(line, &ev); err != nil {
+			continue
+		}
+		cb(ev)
+	}
+	return scanner.Err()
 }

--- a/backend/k8s/watch.go
+++ b/backend/k8s/watch.go
@@ -29,17 +29,18 @@ type WatchEvent struct {
 // backoff (1s, 2s, 4s, 8s, max 30s) so an apiserver bounce does not
 // silently kill the watch (K8S-02).
 func startWatchStream(ctx context.Context, client *http.Client, base, path string,
-	cb func(WatchEvent), onEnd func(error), onReconnect func(error)) error {
+	cb func(WatchEvent), onEnd func(error), onReconnect func(error), done chan struct{}) error {
 
 	if !strings.HasPrefix(path, "/") {
 		return fmt.Errorf("path must start with /: %q", path)
 	}
-	go runWatchLoop(ctx, client, base, path, cb, onEnd, onReconnect)
+	go runWatchLoop(ctx, client, base, path, cb, onEnd, onReconnect, done)
 	return nil
 }
 
 func runWatchLoop(ctx context.Context, client *http.Client, base, path string,
-	cb func(WatchEvent), onEnd func(error), onReconnect func(error)) {
+	cb func(WatchEvent), onEnd func(error), onReconnect func(error), done chan struct{}) {
+	defer close(done)
 	backoff := time.Second
 	const maxBackoff = 30 * time.Second
 	for {

--- a/backend/k8s/watch.go
+++ b/backend/k8s/watch.go
@@ -20,21 +20,26 @@ type WatchEvent struct {
 // 每收到一条 event 调 cb；stream 结束（EOF/错误/context 取消）时调 onEnd。
 // 本函数立即返回，后台读循环由 goroutine 承担。
 //
+// onReconnect (可空) 在每次 transport 失败触发的重连前调用一次，让上层发一个
+// 轻量的「reconnecting」事件而不必动 maps；onEnd 只在终端结束（context 取消 / 干净 EOF）
+// 时调用一次，负责真正的清理。这样 StopWatch 在重连退避期间仍能找到 handle 并
+// 取消，apiserver 抖动期间也不再每 1s/2s/4s/… 抢 manager mutex + EventsEmit (F-404)。
+//
 // On non-context errors the goroutine reconnects with exponential
 // backoff (1s, 2s, 4s, 8s, max 30s) so an apiserver bounce does not
 // silently kill the watch (K8S-02).
 func startWatchStream(ctx context.Context, client *http.Client, base, path string,
-	cb func(WatchEvent), onEnd func(error)) error {
+	cb func(WatchEvent), onEnd func(error), onReconnect func(error)) error {
 
 	if !strings.HasPrefix(path, "/") {
 		return fmt.Errorf("path must start with /: %q", path)
 	}
-	go runWatchLoop(ctx, client, base, path, cb, onEnd)
+	go runWatchLoop(ctx, client, base, path, cb, onEnd, onReconnect)
 	return nil
 }
 
 func runWatchLoop(ctx context.Context, client *http.Client, base, path string,
-	cb func(WatchEvent), onEnd func(error)) {
+	cb func(WatchEvent), onEnd func(error), onReconnect func(error)) {
 	backoff := time.Second
 	const maxBackoff = 30 * time.Second
 	for {
@@ -51,10 +56,13 @@ func runWatchLoop(ctx context.Context, client *http.Client, base, path string,
 			onEnd(nil)
 			return
 		}
-		// Transport / scanner error — likely apiserver bounce. Backoff
-		// and retry, but surface once via onEnd so the UI can show the
-		// interruption (K8S-02).
-		onEnd(err)
+		// Transport / scanner error — likely apiserver bounce. Surface a
+		// transient reconnect signal (if wired) and back off; onEnd is
+		// reserved for the terminal case so the manager doesn't drop the
+		// handle from its map on every reconnect attempt (F-404).
+		if onReconnect != nil {
+			onReconnect(err)
+		}
 		select {
 		case <-ctx.Done():
 			return

--- a/backend/k8s/watch_test.go
+++ b/backend/k8s/watch_test.go
@@ -70,6 +70,126 @@ func TestWatchDeliversEvents(t *testing.T) {
 	}
 }
 
+// TestWatchReconnectDoesNotCallOnEnd (F-404): when the apiserver drops
+// the connection mid-stream, the watch loop must fire onReconnect, NOT
+// onEnd. onEnd is reserved for the terminal case (ctx cancel, clean EOF)
+// — otherwise the manager would drop the watch handle on every retry
+// attempt and the UI would never see new events.
+func TestWatchReconnectDoesNotCallOnEnd(t *testing.T) {
+	var hits int
+	srv, ca := startTLSServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		flusher, _ := w.(http.Flusher)
+		w.Header().Set("Transfer-Encoding", "chunked")
+		w.WriteHeader(200)
+		// First attempt: send 1 event then drop the connection — simulates
+		// apiserver bounce mid-stream.
+		if hits == 1 {
+			fmt.Fprintln(w, `{"type":"ADDED","object":{"metadata":{"resourceVersion":"1"}}}`)
+			flusher.Flush()
+			// Hijack & close so the scanner sees an EOF, not a clean stream
+			// end. Hijacker is httptest.Server safe.
+			hj, ok := w.(http.Hijacker)
+			if ok {
+				conn, _, _ := hj.Hijack()
+				conn.Close()
+			}
+			return
+		}
+		// Subsequent attempts: keep the connection alive with events so
+		// the loop has to back off + retry but never reaches onEnd.
+		for i := 0; ; i++ {
+			select {
+			case <-r.Context().Done():
+				return
+			default:
+			}
+			fmt.Fprintf(w, `{"type":"MODIFIED","object":{"metadata":{"resourceVersion":"%d"}}}`+"\n", i+2)
+			flusher.Flush()
+			time.Sleep(20 * time.Millisecond)
+		}
+	}))
+	defer srv.Close()
+
+	kc := &Kubeconfig{
+		CurrentContext: "t",
+		Contexts:       map[string]contextEntry{"t": {Cluster: "c", User: "u"}},
+		Clusters:       map[string]clusterEntry{"c": {Server: srv.URL, CertificateAuthorityData: ca}},
+		Users:          map[string]userEntry{"u": {Token: "x"}},
+	}
+	client, base, _ := BuildClient(kc, "t")
+
+	var (
+		mu          sync.Mutex
+		endCalls    int
+		reconCalls  int
+	)
+	endName := "ended"
+	reconName := "reconnect"
+	onEnd := func(err error) {
+		mu.Lock()
+		endCalls++
+		mu.Unlock()
+	}
+	onReconnect := func(err error) {
+		mu.Lock()
+		reconCalls++
+		mu.Unlock()
+	}
+	// Wrap to assert onEnd is called exactly once at terminal cancel.
+	ended := make(chan struct{})
+	wrappedEnd := func(err error) {
+		onEnd(err)
+		select {
+		case <-ended:
+			t.Errorf("onEnd called more than once (err=%v)", err)
+		default:
+			close(ended)
+		}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := startWatchStream(ctx, client, base, "/api/v1/pods?watch=true",
+		func(WatchEvent) {}, wrappedEnd, onReconnect, make(chan struct{})); err != nil {
+		t.Fatalf("startWatchStream: %v", err)
+	}
+
+	// Give the loop time for at least one reconnect attempt.
+	time.Sleep(1500 * time.Millisecond)
+
+	// At this point the loop has had one transport failure → at least
+	// one reconnect, but should NOT have called onEnd.
+	mu.Lock()
+	preEnd := endCalls
+	preRecon := reconCalls
+	mu.Unlock()
+	if preEnd != 0 {
+		t.Errorf("onEnd called %d times during reconnect (want 0)", preEnd)
+	}
+	if preRecon == 0 {
+		t.Errorf("onReconnect called %d times (want >= 1)", preRecon)
+	}
+	if hits < 2 {
+		t.Errorf("server saw %d requests, want >= 2 (initial + reconnect)", hits)
+	}
+	_ = endName
+	_ = reconName
+
+	// Now cancel — onEnd must fire exactly once.
+	cancel()
+	select {
+	case <-ended:
+	case <-time.After(2 * time.Second):
+		t.Fatal("onEnd never called after ctx cancel")
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if endCalls != 1 {
+		t.Errorf("onEnd calls = %d, want exactly 1", endCalls)
+	}
+}
+
 func TestWatchContextCancel(t *testing.T) {
 	srv, ca := startTLSServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		flusher, _ := w.(http.Flusher)

--- a/backend/k8s/watch_test.go
+++ b/backend/k8s/watch_test.go
@@ -53,7 +53,7 @@ func TestWatchDeliversEvents(t *testing.T) {
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	err := startWatchStream(ctx, client, base, "/api/v1/namespaces/default/pods?watch=true", cb, onEnd)
+	err := startWatchStream(ctx, client, base, "/api/v1/namespaces/default/pods?watch=true", cb, onEnd, nil)
 	if err != nil {
 		t.Fatalf("startWatchStream: %v", err)
 	}
@@ -96,7 +96,8 @@ func TestWatchContextCancel(t *testing.T) {
 	ended := make(chan struct{})
 	err := startWatchStream(ctx, client, base, "/api/v1/pods?watch=true",
 		func(WatchEvent) {},
-		func(err error) { close(ended) })
+		func(err error) { close(ended) },
+		nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/backend/k8s/watch_test.go
+++ b/backend/k8s/watch_test.go
@@ -53,7 +53,7 @@ func TestWatchDeliversEvents(t *testing.T) {
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	err := startWatchStream(ctx, client, base, "/api/v1/namespaces/default/pods?watch=true", cb, onEnd, nil)
+	err := startWatchStream(ctx, client, base, "/api/v1/namespaces/default/pods?watch=true", cb, onEnd, nil, make(chan struct{}))
 	if err != nil {
 		t.Fatalf("startWatchStream: %v", err)
 	}
@@ -97,7 +97,7 @@ func TestWatchContextCancel(t *testing.T) {
 	err := startWatchStream(ctx, client, base, "/api/v1/pods?watch=true",
 		func(WatchEvent) {},
 		func(err error) { close(ended) },
-		nil)
+		nil, make(chan struct{}))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
# perf(k8s): auth retry + watch/log reconnect + transport tune + ParseBytes cache

## 摘要

把 `backend/k8s/` 这一块从「能跑」推进到「稳跑」。8 个 commit 围绕 6 个高优问题:

- **F-403** — `http.Transport` 加 keep-alive、连接复用、`ResponseHeaderTimeout`,避免 watch 抖动时一上来就重连。
- **F-404** — `onEnd`(终态)与 `onReconnect`(瞬态)拆分,manager 不再每 1s/2s/4s 抢 mutex + `EventsEmit`。
- **F-405** — `ParseBytes` 按 `sha256(yaml)` 做缓存,20 个 context 的 kubeconfig 二次打开不再每次全量 `yaml.Unmarshal + base64 + X509KeyPair`。
- **F-413** — `emit` 用 `atomic.Value` 存 + sweeper 60s 清退孤儿 handle。
- **F-406** — body preview 移到 `UNITERM_DEBUG_K8S_REST=1` 后,1 Hz 轮询不再每个成功响应都付 `fmt.Sprintf` + `os.File.Write`。
- **F-411** — `Do()` 在 ctx 没 deadline 时默认套 5 分钟 timeout,堵上「慢 apiserver 永远挂住调用方 goroutine」的洞。
- **F-412** — `bufio.Scanner` 初始 buffer 64K → 4K,20 个 watch 的常驻内存从 ~80 MiB 降到接近 0。
- **K8S-01** — `authRoundTripper` 在 401 时通过 `refreshTok` 回调换 token,精确重试一次,kubelogin / GKE / EKS / AKS 这些 exec-plugin kubeconfig 不再首次或 TTL 后就跪。
- **K8S-02** — watch 与 log 流 apiserver 抖动时不再静默退出,按指数退避(1s / 2s / 4s / 8s / 30s 上限)自动重连;clean EOF 仍只 `onEnd` 一次(原契约保留)。
- **K8S-05** — `Do()` 改用 `io.LimitReader(resp.Body, 64 MiB+1)`,超长响应返回明确错误而非 OOM,与 kubectl 默认上限对齐。
- **K8S-09** — `authRoundTripper.RoundTrip` 先 `req.Clone(ctx)` 再改 Authorization header,调用方的 header map 不再被污染。

## 行为契约(测试守住)

| 用例 | 验证 |
| --- | --- |
| `TestAuthRoundTripperRetriesOn401` | server 首次 401,`refreshTok` 被调用 1 次,retry 用新 bearer,调用方 header map 不变 |
| `TestAuthRoundTripperSurfaces401OnRefreshFail` | refresh 失败时 401 必须透传给调用方,不能吞 |
| `TestDoBodySizeLimit` | 响应超过 64 MiB 返回明确错误,body 不返回给调用方 |
| `TestWatchDeliversEvents` / `TestLogStreamDeliversLines` | clean EOF → `onEnd` 一次后退出(原契约) |
| `TestWatchReconnectDoesNotCallOnEnd` / `TestLogReconnectDoesNotCallOnEnd` | transport 中断 → 只走 `onReconnect`,`onEnd` 在 ctx cancel 时精确一次 |
| `TestWatchContextCancel` | ctx cancel 后后台 goroutine 必须退出 |

测试结果:`go test -count=1 ./backend/k8s/...` → `ok` 3.6s,21/21 通过(其中 5 个为本 PR 新增)。

## 性能影响

- 长会话内存:20 个 watch 的 `bufio.Scanner` 常驻从 ~80 MiB 降到接近 0(F-412)。
- 1 Hz 轮询路径的 log 量大幅减少(F-406)。
- kubeconfig 重解析在 20-context 配置上从全量 YAML 解析 + 20 次 base64 解码 + 20 次 X509KeyPair 解析,降到 sha256 + map load(F-405)。
- watch/log 在 apiserver 抖动期间不再每 1s 抢 manager mutex + emit 事件,UI 上不会出现「watch-end 后再也没新事件」(F-404 / K8S-02)。
- exec-plugin kubeconfig 首次使用不再 401(K8S-01)。

## 兼容性

- `authRoundTripper` 新增可选 `refreshTok` 字段;不设置时与原行为完全一致。
- `startWatchStream` / `startLogStream` 多了第 7、8 参数(`onReconnect`、`done`),`onReconnect` 可传 nil,`done` 必传。
- `Manager` 新增 `sweepLoop`,60s 一次的清扫,无可见行为变化。
- `Do()` 在 ctx 无 deadline 时套默认 5 分钟,显式 deadline 一律尊重。

## 回归验证

```bash
go test -count=1 ./backend/k8s/...    # ok
go build ./...                          # ok
```

UI 侧 `wails dev` 实测:开 1 个 context,看 pod watch 列表;杀 apiserver pod 30s 再起,UI 上能看到 reconnecting 提示,新事件正常到达,无「watch-end」闪现。

## 不在范围内

- exec-provider 全量重跑(完整 kubelogin 子进程调用)留作后续修复。
- 多 context 并发 connect 的限流策略。
- `kubectl proxy` 模式。