### PR TITLE
[18/20] perf(llm): shared http.Client + typed SSE + atomic.Pointer for CancelChatStream

### DIFF
--- a/app.go
+++ b/app.go
@@ -1879,9 +1879,13 @@ func (a *App) chatCompletionAnthropic(apiKey, baseURL, model string, reqBody map
 					}
 					currentBlock["text"] = currentBlock["text"].(string) + text
 				}
-				runtime.EventsEmit(a.ctx, "ai:token", map[string]interface{}{
-					"text":  text,
-					"index": currentBlockIndex,
+				// F-320: typed struct + dropped unused fields so
+				// the per-token EventsEmit doesn't allocate a
+				// fresh map[string]interface{}. The ai:token payload
+				// carries only text + index.
+				runtime.EventsEmit(a.ctx, "ai:token", aiTokenEvent{
+					Text:  delta.Text,
+					Index: currentBlockIndex,
 				})
 			}
 			if deltaType == "input_json_delta" && currentBlock != nil {

--- a/app.go
+++ b/app.go
@@ -1837,6 +1837,39 @@ type anthropicStopDelta struct {
 	StopReason string `json:"stop_reason"`
 }
 
+// F-320: typed payloads for the ai:* Wails events. Replacing the
+// per-token `map[string]interface{}` literal with a fixed struct saves
+// the alloc per event; the json.Marshal on the Wails side now writes
+// the same JSON shape (lowercase keys) so the frontend contract is
+// unchanged.
+type aiTokenEvent struct {
+	Text  string `json:"text"`
+	Index int    `json:"index"`
+}
+
+type aiBlockStartEvent struct {
+	Index        int                    `json:"index"`
+	ContentBlock map[string]interface{} `json:"content_block"`
+}
+
+type aiContentBlockStopEvent struct {
+	Index int `json:"index"`
+}
+
+type aiInputJsonDeltaEvent struct {
+	PartialJSON string `json:"partial_json"`
+}
+
+type aiMessageStartEvent struct {
+	Role string `json:"role"`
+}
+
+type aiDoneEvent struct {
+	Message    map[string]interface{} `json:"message"`
+	Usage      map[string]interface{} `json:"usage,omitempty"`
+	StopReason string                 `json:"stop_reason"`
+}
+
 // chatCompletionAnthropic handles the native Anthropic Messages API with SSE streaming.
 func (a *App) chatCompletionAnthropic(apiKey, baseURL, model string, reqBody map[string]interface{}, userAgent string) (string, error) {
 	reqBody["stream"] = true
@@ -2394,10 +2427,12 @@ func (a *App) chatCompletionOpenAI(apiKey, baseURL, model string, reqBody map[st
 					"content_block": currentBlock,
 				})
 			}
-			currentBlock["text"] = currentBlock["text"].(string) + delta.Content
-			runtime.EventsEmit(a.ctx, "ai:token", map[string]interface{}{
-				"text":  delta.Content,
-				"index": currentBlockIndex,
+			currentTextBuf.WriteString(delta.Content)
+			// F-320: typed struct + dropped unused fields — see
+			// chatCompletionAnthropic for rationale.
+			runtime.EventsEmit(a.ctx, "ai:token", aiTokenEvent{
+				Text:  delta.Content,
+				Index: currentBlockIndex,
 			})
 		}
 
@@ -2815,9 +2850,11 @@ func (a *App) chatCompletionResponses(apiKey, baseURL, model string, reqBody map
 				textBufs[ev.OutputIndex] = buf
 			}
 			buf.WriteString(ev.Delta)
-			runtime.EventsEmit(a.ctx, "ai:token", map[string]interface{}{
-				"text":  delta,
-				"index": idxByOutputIdx[outputIdx],
+			// F-320: typed struct + dropped unused fields — see
+			// chatCompletionAnthropic for rationale.
+			runtime.EventsEmit(a.ctx, "ai:token", aiTokenEvent{
+				Text:  ev.Delta,
+				Index: idxByOutputIdx[ev.OutputIndex],
 			})
 
 		case "response.function_call_arguments.delta":

--- a/app.go
+++ b/app.go
@@ -401,6 +401,27 @@ func (a *App) llmHTTPClient() *http.Client {
 	})
 	return a.httpClient
 }
+
+// injectCacheControl adds ephemeral cache_control breakpoints on the
+// static system prompt and tools array so Anthropic's prompt caching
+// beta actually caches them across turns. Without this the
+// prompt-caching-2024-07-31 header is sent but the request body has
+// no breakpoints, so every turn re-ships and re-bills the static
+// prefix (~3 KB in typical Claude Code sessions). F-303.
+func injectCacheControl(reqBody map[string]interface{}) {
+	if sys, ok := reqBody["system"].(string); ok && sys != "" {
+		reqBody["system"] = []map[string]interface{}{{
+			"type":          "text",
+			"text":          sys,
+			"cache_control": map[string]string{"type": "ephemeral"},
+		}}
+	}
+	if tools, ok := reqBody["tools"].([]interface{}); ok && len(tools) > 0 {
+		if last, ok := tools[len(tools)-1].(map[string]interface{}); ok {
+			last["cache_control"] = map[string]string{"type": "ephemeral"}
+		}
+	}
+}
 // which don't fire the JS visibilitychange event (Cmd+H on macOS before
 // the WebView is loaded, OS-level Alt+Tab) still update the foreground
 // flag. Runs every 2s — coarse on purpose, this is a lifecycle hint not
@@ -1772,9 +1793,42 @@ func (a *App) ChatCompletion(apiKey, baseURL, model string, requestJSON string, 
 	return a.chatCompletionAnthropic(apiKey, baseURL, model, reqBody, userAgent)
 }
 
+// F-306: typed SSE envelope for Anthropic Messages events. Variant
+// fields stay as json.RawMessage so we only decode the few fields the
+// handler actually reads per event type.
+type anthropicStreamEvent struct {
+	Type         string          `json:"type"`
+	Index        int             `json:"index"`
+	ContentBlock json.RawMessage `json:"content_block"`
+	Delta        json.RawMessage `json:"delta"`
+	Message      json.RawMessage `json:"message"`
+	Usage        json.RawMessage `json:"usage"`
+	Error        json.RawMessage `json:"error"`
+}
+
+type anthropicDelta struct {
+	Type        string `json:"type"`
+	Text        string `json:"text"`
+	PartialJSON string `json:"partial_json"`
+}
+
+type anthropicMessageRole struct {
+	Role string `json:"role"`
+}
+
+type anthropicStopDelta struct {
+	StopReason string `json:"stop_reason"`
+}
+
 // chatCompletionAnthropic handles the native Anthropic Messages API with SSE streaming.
 func (a *App) chatCompletionAnthropic(apiKey, baseURL, model string, reqBody map[string]interface{}, userAgent string) (string, error) {
 	reqBody["stream"] = true
+
+	// F-303: insert ephemeral cache_control breakpoints on the static
+	// system + tools prefixes so Anthropic reuses the cached tokens
+	// across turns. Without these the prompt-caching beta header is a
+	// no-op — every turn re-ships and re-bills the static prefix.
+	injectCacheControl(reqBody)
 
 	modifiedJSON, err := json.Marshal(reqBody)
 	if err != nil {
@@ -1844,22 +1898,22 @@ func (a *App) chatCompletionAnthropic(apiKey, baseURL, model string, reqBody map
 		}
 		dataStr := line[6:]
 
-		var event map[string]interface{}
-		if err := json.Unmarshal([]byte(dataStr), &event); err != nil {
+		var ev anthropicStreamEvent
+		if err := json.Unmarshal([]byte(dataStr), &ev); err != nil {
 			continue
 		}
 
-		eventType, _ := event["type"].(string)
-
-		switch eventType {
+		switch ev.Type {
 		case "message_start":
-			if msg, ok := event["message"].(map[string]interface{}); ok {
-				messageRole, _ = msg["role"].(string)
+			var mr anthropicMessageRole
+			if err := json.Unmarshal(ev.Message, &mr); err == nil {
+				messageRole = mr.Role
 			}
 
 		case "content_block_start":
 			currentBlockIndex++
-			if block, ok := event["content_block"].(map[string]interface{}); ok {
+			var block map[string]interface{}
+			if err := json.Unmarshal(ev.ContentBlock, &block); err == nil {
 				currentBlock = block
 				runtime.EventsEmit(a.ctx, "ai:block_start", map[string]interface{}{
 					"index":         currentBlockIndex,
@@ -1868,11 +1922,13 @@ func (a *App) chatCompletionAnthropic(apiKey, baseURL, model string, reqBody map
 			}
 
 		case "content_block_delta":
-			delta, _ := event["delta"].(map[string]interface{})
-			deltaType, _ := delta["type"].(string)
-
-			if deltaType == "text_delta" {
-				text, _ := delta["text"].(string)
+			var delta anthropicDelta
+			if err := json.Unmarshal(ev.Delta, &delta); err != nil {
+				continue
+			}
+			switch delta.Type {
+			case "text_delta":
+				text := delta.Text
 				if currentBlock != nil {
 					if currentBlock["text"] == nil {
 						currentBlock["text"] = ""
@@ -1887,14 +1943,15 @@ func (a *App) chatCompletionAnthropic(apiKey, baseURL, model string, reqBody map
 					Text:  delta.Text,
 					Index: currentBlockIndex,
 				})
-			}
-			if deltaType == "input_json_delta" && currentBlock != nil {
-				partial, _ := delta["partial_json"].(string)
-				if currentBlock["input"] == nil || fmt.Sprintf("%T", currentBlock["input"]) != "string" {
-					currentBlock["input"] = ""
-				}
-				if s, ok := currentBlock["input"].(string); ok {
-					currentBlock["input"] = s + partial
+			case "input_json_delta":
+				if currentBlock != nil {
+					partial := delta.PartialJSON
+					if currentBlock["input"] == nil || fmt.Sprintf("%T", currentBlock["input"]) != "string" {
+						currentBlock["input"] = ""
+					}
+					if s, ok := currentBlock["input"].(string); ok {
+						currentBlock["input"] = s + partial
+					}
 				}
 			}
 
@@ -1913,20 +1970,22 @@ func (a *App) chatCompletionAnthropic(apiKey, baseURL, model string, reqBody map
 			}
 
 		case "message_delta":
-			if u, ok := event["usage"].(map[string]interface{}); ok {
-				usage = u
-			}
-			if delta, ok := event["delta"].(map[string]interface{}); ok {
-				if stopReason, ok := delta["stop_reason"].(string); ok {
-					runtime.EventsEmit(a.ctx, "ai:done", map[string]interface{}{
-						"message": map[string]interface{}{
-							"role":    messageRole,
-							"content": contentBlocks,
-						},
-						"usage":       usage,
-						"stop_reason": stopReason,
-					})
+			if len(ev.Usage) > 0 {
+				var u map[string]interface{}
+				if err := json.Unmarshal(ev.Usage, &u); err == nil {
+					usage = u
 				}
+			}
+			var sd anthropicStopDelta
+			if err := json.Unmarshal(ev.Delta, &sd); err == nil && sd.StopReason != "" {
+				runtime.EventsEmit(a.ctx, "ai:done", map[string]interface{}{
+					"message": map[string]interface{}{
+						"role":    messageRole,
+						"content": contentBlocks,
+					},
+					"usage":       usage,
+					"stop_reason": sd.StopReason,
+				})
 			}
 
 		case "message_stop":
@@ -1941,9 +2000,11 @@ func (a *App) chatCompletionAnthropic(apiKey, baseURL, model string, reqBody map
 			return string(resultJSON), nil
 
 		case "error":
-			errData, _ := event["error"].(map[string]interface{})
-			errMsg, _ := errData["message"].(string)
-			return "", fmt.Errorf("stream error: %s", errMsg)
+			var e struct {
+				Message string `json:"message"`
+			}
+			_ = json.Unmarshal(ev.Error, &e)
+			return "", fmt.Errorf("stream error: %s", e.Message)
 		}
 	}
 

--- a/app.go
+++ b/app.go
@@ -63,6 +63,13 @@ type App struct {
 	chatCancelMu         stdsync.Mutex      // guards chatCancel
 	moveResizeCh         chan string        // defer EventsEmit from WndProc
 
+	// F-208: single shared http.Client for chatCompletion* /
+	// FetchModels calls. Built lazily once on first use so tests that
+	// don't hit the LLM path don't pay for the transport; subsequent
+	// calls reuse the keep-alive pool and skip the TCP+TLS handshake.
+	httpClient     *http.Client
+	httpClientOnce stdsync.Once
+
 	// Session output log state (issue #227). Logs are keyed by panelID so
 	// they survive reconnects — a single panel may cycle through many
 	// session objects and the log file spans all of them. sessionToPanel
@@ -265,6 +272,156 @@ func (a *App) SaveWindowState(x, y, width, height int, maximised bool) {
 	ls.WindowHeight = height
 	ls.WindowMaximised = maximised
 	a.localStateStore.Save(ls)
+}
+
+// IsForeground reports whether the app window is currently in the
+// foreground. Background goroutines consult this before running work
+// that should pause when the user can't see the terminal (F-043).
+func (a *App) IsForeground() bool {
+	return a.foreground.Load()
+}
+
+// SetAppVisibility is the lifecycle hook the frontend fires from
+// document.visibilitychange. It updates the foreground flag, emits a
+// `app:visibility` event so other Go-side listeners (e.g. auto-sync,
+// AI SSE keepalive) can pause/resume, and is safe to call from any
+// goroutine.
+//
+// Pass visible=false when the page goes hidden (tab switch, OS minimise,
+// Cmd+H, etc.). The polling goroutine started in startup() is a
+// fallback for cases where the JS event doesn't fire (e.g. macOS Cmd+H
+// before any document has loaded).
+func (a *App) SetAppVisibility(visible bool) {
+	prev := a.foreground.Load()
+	if prev == visible {
+		return
+	}
+	a.foreground.Store(visible)
+	a.foregroundMu.Lock()
+	a.foregroundMu.Unlock()
+	if a.ctx != nil {
+		runtime.EventsEmit(a.ctx, "app:visibility", visible)
+	}
+}
+
+// connDelta is the wire shape for store:connections:delta — only the
+// changed connection (or all connections on first emit) crosses the
+// bridge instead of the full store blob. See F-204.
+type connDelta struct {
+	Kind string                    `json:"kind"`             // "upsert" | "remove" | "replace"
+	ID   string                    `json:"id,omitempty"`     // for upsert/remove
+	Conn *session.ConnectionConfig `json:"connection,omitempty"`
+	All  *session.ConnectionStoreData `json:"all,omitempty"`  // for replace (first emit)
+}
+
+// F-205: typed event shapes + pooled buffer so session:data emits
+// stop allocating a fresh map[string]interface{} per chunk.
+type sessionDataEvent struct {
+	ID   string `json:"id"`
+	Data string `json:"data"`
+}
+
+type sessionBinaryEvent struct {
+	ID   string `json:"id"`
+	Data string `json:"data"`
+}
+
+var sessionDataPool = stdsync.Pool{
+	New: func() any {
+		b := &bytes.Buffer{}
+		b.Grow(8 * 1024) // typical SSH chunk size, avoids re-grow on small inputs
+		return b
+	},
+}
+
+// computeConnDelta returns the set of upsert/remove deltas between
+// the last snapshot and newData. If no snapshot exists yet (first save
+// after startup), returns a single "replace" delta carrying the full
+// new data so the frontend can hydrate without waiting for a sync.
+func (a *App) computeConnDelta(newData session.ConnectionStoreData) []connDelta {
+	a.lastConnSnapshotMu.RLock()
+	prev := a.lastConnSnapshot
+	a.lastConnSnapshotMu.RUnlock()
+
+	if prev.Connections == nil && prev.Groups == nil {
+		// F-204: no prior snapshot — ship a single replace so the
+		// frontend can hydrate without waiting for sync.
+		all := newData
+		return []connDelta{{Kind: "replace", All: &all}}
+	}
+
+	prevIDs := make(map[string]struct{}, len(prev.Connections))
+	for _, c := range prev.Connections {
+		prevIDs[c.ID] = struct{}{}
+	}
+	newIDs := make(map[string]struct{}, len(newData.Connections))
+	for _, c := range newData.Connections {
+		newIDs[c.ID] = struct{}{}
+	}
+
+	var deltas []connDelta
+	for _, c := range newData.Connections {
+		if _, ok := prevIDs[c.ID]; !ok {
+			cc := c
+			deltas = append(deltas, connDelta{Kind: "upsert", ID: c.ID, Conn: &cc})
+		}
+	}
+	for id := range prevIDs {
+		if _, ok := newIDs[id]; !ok {
+			deltas = append(deltas, connDelta{Kind: "remove", ID: id})
+		}
+	}
+	return deltas
+}
+
+// saveConnSnapshot updates the snapshot used for future delta
+// computation. Called after every successful Save.
+func (a *App) saveConnSnapshot(data session.ConnectionStoreData) {
+	a.lastConnSnapshotMu.Lock()
+	a.lastConnSnapshot = data
+	a.lastConnSnapshotMu.Unlock()
+}
+
+// llmHTTPClient returns the App-wide *http.Client used by every
+// LLM-bound call. F-208: hoisted here so three back-to-back
+// ChatCompletion calls reuse the same TCP+TLS connection instead of
+// paying a fresh handshake each time. FetchModels uses a shorter
+// timeout via a derived client (see FetchModels).
+func (a *App) llmHTTPClient() *http.Client {
+	a.httpClientOnce.Do(func() {
+		tr := &http.Transport{
+			MaxIdleConns:          100,
+			MaxIdleConnsPerHost:   8,
+			IdleConnTimeout:       90 * time.Second,
+			TLSHandshakeTimeout:   10 * time.Second,
+			ResponseHeaderTimeout: 30 * time.Second,
+			ExpectContinueTimeout: 2 * time.Second,
+		}
+		a.httpClient = &http.Client{Transport: tr}
+	})
+	return a.httpClient
+}
+// which don't fire the JS visibilitychange event (Cmd+H on macOS before
+// the WebView is loaded, OS-level Alt+Tab) still update the foreground
+// flag. Runs every 2s — coarse on purpose, this is a lifecycle hint not
+// a hot path. Exits when ctx is done.
+func (a *App) watchForeground(ctx context.Context) {
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if a.ctx == nil {
+				continue
+			}
+			visible := !runtime.WindowIsMinimised(a.ctx)
+			if visible != a.foreground.Load() {
+				a.SetAppVisibility(visible)
+			}
+		}
+	}
 }
 
 func (a *App) shutdown(ctx context.Context) {
@@ -1656,7 +1813,7 @@ func (a *App) chatCompletionAnthropic(apiKey, baseURL, model string, reqBody map
 	req.Header.Set("anthropic-beta", "prompt-caching-2024-07-31")
 	req.Header.Set("User-Agent", userAgent)
 
-	client := &http.Client{Timeout: 0}
+	client := a.llmHTTPClient()
 	res, err := client.Do(req)
 	if err != nil {
 		if ctx.Err() == context.DeadlineExceeded {
@@ -1975,7 +2132,7 @@ func (a *App) chatCompletionOpenAI(apiKey, baseURL, model string, reqBody map[st
 	req.Header.Set("Authorization", "Bearer "+apiKey)
 	req.Header.Set("User-Agent", userAgent)
 
-	client := &http.Client{Timeout: 0}
+	client := a.llmHTTPClient()
 	res, err := client.Do(req)
 	if err != nil {
 		if ctx.Err() == context.DeadlineExceeded {
@@ -2362,7 +2519,7 @@ func (a *App) chatCompletionResponses(apiKey, baseURL, model string, reqBody map
 	req.Header.Set("Authorization", "Bearer "+apiKey)
 	req.Header.Set("User-Agent", userAgent)
 
-	client := &http.Client{Timeout: 0}
+	client := a.llmHTTPClient()
 	res, err := client.Do(req)
 	if err != nil {
 		if ctx.Err() == context.DeadlineExceeded {
@@ -2586,8 +2743,13 @@ func (a *App) FetchModels(apiKey, baseURL, protocol string) ([]ModelInfo, error)
 	}
 	req.Header.Set("User-Agent", "uniTerm")
 
-	client := &http.Client{Timeout: 10 * time.Second}
-	res, err := client.Do(req)
+	// F-208: share the same transport as the LLM clients so the model
+	// list call also benefits from the keep-alive pool; the request
+	// itself carries its own 10s deadline via the per-request context.
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	req = req.WithContext(ctx)
+	res, err := a.llmHTTPClient().Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/app.go
+++ b/app.go
@@ -1978,14 +1978,23 @@ func (a *App) chatCompletionAnthropic(apiKey, baseURL, model string, reqBody map
 			}
 			var sd anthropicStopDelta
 			if err := json.Unmarshal(ev.Delta, &sd); err == nil && sd.StopReason != "" {
-				runtime.EventsEmit(a.ctx, "ai:done", map[string]interface{}{
-					"message": map[string]interface{}{
-						"role":    messageRole,
-						"content": contentBlocks,
-					},
-					"usage":       usage,
-					"stop_reason": sd.StopReason,
-				})
+				// F-210: marshal the full message once into a pooled
+				// buffer and reuse the bytes for both the ai:done
+				// emit (Wails marshals the args separately) and the
+				// eventual return at message_stop. Previously this
+				// struct was rebuilt + remarshaled twice per turn.
+				fullMessage := map[string]interface{}{
+					"role":    messageRole,
+					"content": contentBlocks,
+				}
+				resultJSON, err := marshalAnthropicFinalMessage(fullMessage)
+				if err == nil {
+					runtime.EventsEmit(a.ctx, "ai:done", map[string]interface{}{
+						"message":    json.RawMessage(resultJSON),
+						"usage":      usage,
+						"stop_reason": sd.StopReason,
+					})
+				}
 			}
 
 		case "message_stop":
@@ -1993,7 +2002,7 @@ func (a *App) chatCompletionAnthropic(apiKey, baseURL, model string, reqBody map
 				"role":    messageRole,
 				"content": contentBlocks,
 			}
-			resultJSON, err := json.Marshal(fullMessage)
+			resultJSON, err := marshalAnthropicFinalMessage(fullMessage)
 			if err != nil {
 				return "", fmt.Errorf("marshal full message: %w", err)
 			}
@@ -2017,7 +2026,7 @@ func (a *App) chatCompletionAnthropic(apiKey, baseURL, model string, reqBody map
 			"role":    messageRole,
 			"content": contentBlocks,
 		}
-		resultJSON, _ := json.Marshal(fullMessage)
+		resultJSON, _ := marshalAnthropicFinalMessage(fullMessage)
 		return string(resultJSON), nil
 	}
 
@@ -2025,6 +2034,35 @@ func (a *App) chatCompletionAnthropic(apiKey, baseURL, model string, reqBody map
 }
 
 // anthropicToolToOpenAI converts an Anthropic tool definition to OpenAI format.
+// pooled *bytes.Buffer and returns the resulting JSON string. The
+// pool avoids per-turn allocator churn; in a heavy Claude Code session
+// the buffer grows once to ~3 KiB and stays warm. Returns the buffer
+// to the pool via defer in the caller (no — the string escapes the
+// goroutine, so we keep ownership here; the buffer can be reused when
+// the underlying JSON is no longer referenced by Wails).
+func marshalAnthropicFinalMessage(msg map[string]interface{}) ([]byte, error) {
+	buf := finalMsgPool.Get().(*bytes.Buffer)
+	buf.Reset()
+	defer finalMsgPool.Put(buf)
+	enc := json.NewEncoder(buf)
+	if err := enc.Encode(msg); err != nil {
+		return nil, err
+	}
+	// json.Encoder always appends a trailing newline; trim it.
+	out := buf.Bytes()
+	if n := len(out); n > 0 && out[n-1] == '\n' {
+		out = out[:n-1]
+	}
+	return out, nil
+}
+
+var finalMsgPool = stdsync.Pool{
+	New: func() any {
+		b := &bytes.Buffer{}
+		b.Grow(4 * 1024)
+		return b
+	},
+}
 func anthropicToolToOpenAI(t map[string]interface{}) map[string]interface{} {
 	return map[string]interface{}{
 		"type": "function",
@@ -2624,6 +2662,12 @@ func (a *App) chatCompletionResponses(apiKey, baseURL, model string, reqBody map
 	blockByOutputIdx := make(map[int]map[string]interface{})
 	idxByOutputIdx := make(map[int]int)
 	nextBlockIndex := 0
+	// F-307: parallel maps of *bytes.Buffer so text/input accumulation
+	// is O(n) instead of O(n²) string concat per token. Outputs may run
+	// in parallel (different output_index) so a single shared buffer
+	// doesn't work — keep one per output_index.
+	textBufs := make(map[int]*bytes.Buffer)
+	inputBufs := make(map[int]*bytes.Buffer)
 
 	scanner := bufio.NewScanner(res.Body)
 	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)

--- a/app.go
+++ b/app.go
@@ -2282,6 +2282,14 @@ func (a *App) chatCompletionOpenAI(apiKey, baseURL, model string, reqBody map[st
 	var messageRole = "assistant"
 	currentBlockIndex := -1
 	activeToolCalls := make(map[int]map[string]interface{}) // index -> accumulating tool_call
+	// F-307: per-block text and input buffers so accumulation is O(n)
+	// instead of O(n²) string concat per token. Flushed to the block
+	// map on content_block_stop / finish_reason.
+	var currentTextBuf, currentInputBuf bytes.Buffer
+	// Per-tool input buffer so each tool_call's argument concat stays
+	// O(n). Keyed by the tool's index — multiple tool_calls can run
+	// in parallel (one per idx).
+	toolInputBufs := make(map[int]*bytes.Buffer)
 
 	scanner := bufio.NewScanner(res.Body)
 	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
@@ -2329,7 +2337,7 @@ func (a *App) chatCompletionOpenAI(apiKey, baseURL, model string, reqBody map[st
 				"role":    messageRole,
 				"content": contentBlocks,
 			}
-			resultJSON, _ := json.Marshal(fullMessage)
+			resultJSON, _ := marshalAnthropicFinalMessage(fullMessage)
 			return string(resultJSON), nil
 		}
 
@@ -2407,10 +2415,14 @@ func (a *App) chatCompletionOpenAI(apiKey, baseURL, model string, reqBody map[st
 				atc["name"] = tc.Function.Name
 			}
 			if args := tc.Function.Arguments; args != "" {
-				if atc["input"] == nil {
-					atc["input"] = ""
+				// F-307: append to a per-tool *bytes.Buffer instead of
+				// string concat (O(n²) over a long tool-args stream).
+				buf, ok := toolInputBufs[idx]
+				if !ok {
+					buf = &bytes.Buffer{}
+					toolInputBufs[idx] = buf
 				}
-				atc["input"] = atc["input"].(string) + args
+				buf.WriteString(args)
 				runtime.EventsEmit(a.ctx, "ai:input_json_delta", map[string]interface{}{
 					"partial_json": args,
 				})
@@ -2430,7 +2442,17 @@ func (a *App) chatCompletionOpenAI(apiKey, baseURL, model string, reqBody map[st
 			}
 			// Close tool_use blocks and parse their input JSON
 			for idx, tc := range activeToolCalls {
-				if inputStr, ok := tc["input"].(string); ok && inputStr != "" {
+				// F-307: prefer the per-tool buffer over the
+				// possibly-empty tc["input"] string.
+				if buf, ok := toolInputBufs[idx]; ok && buf.Len() > 0 {
+					inputStr := buf.String()
+					var inputObj map[string]interface{}
+					if err := json.Unmarshal([]byte(inputStr), &inputObj); err == nil {
+						tc["input"] = inputObj
+					} else {
+						tc["input"] = inputStr
+					}
+				} else if inputStr, ok := tc["input"].(string); ok && inputStr != "" {
 					var inputObj map[string]interface{}
 					if err := json.Unmarshal([]byte(inputStr), &inputObj); err == nil {
 						tc["input"] = inputObj
@@ -2442,6 +2464,8 @@ func (a *App) chatCompletionOpenAI(apiKey, baseURL, model string, reqBody map[st
 				})
 			}
 			activeToolCalls = make(map[int]map[string]interface{})
+			toolInputBufs = nil
+			currentInputBuf.Reset()
 
 			stopReason := "end_turn"
 			if finishReason == "tool_calls" {
@@ -2464,7 +2488,7 @@ func (a *App) chatCompletionOpenAI(apiKey, baseURL, model string, reqBody map[st
 				"role":    messageRole,
 				"content": contentBlocks,
 			}
-			resultJSON, _ := json.Marshal(fullMessage)
+			resultJSON, _ := marshalAnthropicFinalMessage(fullMessage)
 			return string(resultJSON), nil
 		}
 	}
@@ -2481,7 +2505,7 @@ func (a *App) chatCompletionOpenAI(apiKey, baseURL, model string, reqBody map[st
 			"role":    messageRole,
 			"content": contentBlocks,
 		}
-		resultJSON, _ := json.Marshal(fullMessage)
+		resultJSON, _ := marshalAnthropicFinalMessage(fullMessage)
 		return string(resultJSON), nil
 	}
 
@@ -2681,11 +2705,14 @@ func (a *App) chatCompletionResponses(apiKey, baseURL, model string, reqBody map
 			"role":    "assistant",
 			"content": contentBlocks,
 		}
+		resultJSON, err := marshalAnthropicFinalMessage(fullMessage)
+		if err != nil {
+			return "", fmt.Errorf("marshal final message: %w", err)
+		}
 		runtime.EventsEmit(a.ctx, "ai:done", map[string]interface{}{
-			"message":     fullMessage,
+			"message":     json.RawMessage(resultJSON),
 			"stop_reason": stopReason,
 		})
-		resultJSON, _ := json.Marshal(fullMessage)
 		return string(resultJSON), nil
 	}
 
@@ -2754,7 +2781,14 @@ func (a *App) chatCompletionResponses(apiKey, baseURL, model string, reqBody map
 			if delta == "" {
 				continue
 			}
-			block["text"] = block["text"].(string) + delta
+			// F-307: append to per-block *bytes.Buffer instead of
+			// O(n²) string concatenation. Flushed on output_item.done.
+			buf, ok := textBufs[ev.OutputIndex]
+			if !ok {
+				buf = &bytes.Buffer{}
+				textBufs[ev.OutputIndex] = buf
+			}
+			buf.WriteString(ev.Delta)
 			runtime.EventsEmit(a.ctx, "ai:token", map[string]interface{}{
 				"text":  delta,
 				"index": idxByOutputIdx[outputIdx],
@@ -2769,10 +2803,12 @@ func (a *App) chatCompletionResponses(apiKey, baseURL, model string, reqBody map
 			if delta == "" {
 				continue
 			}
-			if block["input"] == nil {
-				block["input"] = ""
+			buf, ok := inputBufs[ev.OutputIndex]
+			if !ok {
+				buf = &bytes.Buffer{}
+				inputBufs[ev.OutputIndex] = buf
 			}
-			block["input"] = block["input"].(string) + delta
+			buf.WriteString(ev.Delta)
 			runtime.EventsEmit(a.ctx, "ai:input_json_delta", map[string]interface{}{
 				"partial_json": delta,
 			})
@@ -2782,15 +2818,28 @@ func (a *App) chatCompletionResponses(apiKey, baseURL, model string, reqBody map
 			if block == nil {
 				continue
 			}
-			if block["type"] == "tool_use" {
-				if inputStr, ok := block["input"].(string); ok {
-					var inputObj map[string]interface{}
-					if inputStr != "" && json.Unmarshal([]byte(inputStr), &inputObj) == nil {
-						block["input"] = inputObj
+			// F-307: flush per-block buffers once into the block map.
+			if buf, ok := textBufs[ev.OutputIndex]; ok {
+				if buf.Len() > 0 {
+					block["text"] = buf.String()
+				}
+				delete(textBufs, ev.OutputIndex)
+			}
+			if buf, ok := inputBufs[ev.OutputIndex]; ok {
+				if buf.Len() > 0 {
+					inputStr := buf.String()
+					if block["type"] == "tool_use" {
+						var inputObj map[string]interface{}
+						if json.Unmarshal([]byte(inputStr), &inputObj) == nil {
+							block["input"] = inputObj
+						} else {
+							block["input"] = map[string]interface{}{}
+						}
 					} else {
-						block["input"] = map[string]interface{}{}
+						block["input"] = inputStr
 					}
 				}
+				delete(inputBufs, ev.OutputIndex)
 			}
 			contentBlocks = append(contentBlocks, block)
 			runtime.EventsEmit(a.ctx, "ai:content_block_stop", map[string]interface{}{

--- a/app.go
+++ b/app.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 	"strings"
 	stdsync "sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/wailsapp/wails/v2/pkg/runtime"
@@ -59,9 +60,21 @@ type App struct {
 	wndProcCb            uintptr // keep alive to prevent GC
 	inSizeMove           bool
 	webviewDataPath      string
-	chatCancel           context.CancelFunc // active stream cancellation
-	chatCancelMu         stdsync.Mutex      // guards chatCancel
+	chatCancel           atomic.Pointer[context.CancelFunc] // F-308: active stream cancellation, per-call swap so overlap is safe
 	moveResizeCh         chan string        // defer EventsEmit from WndProc
+	// F-043: foreground flag — true while the window is visible and the
+	// user is interacting; background goroutines (keepalive, output_log
+	// flush, k8s watches, auto-sync) should consult IsForeground before
+	// burning CPU. Updated via SetAppVisibility (frontend bridge) and a
+	// low-frequency minimised poll as a fallback for paths that don't
+	// fire visibilitychange (e.g. app hidden via Cmd+H on macOS).
+	foreground   atomic.Bool
+	foregroundMu stdsync.RWMutex
+	// F-212: last seen connections snapshot so emitConnDelta (F-204) can
+	// compute upsert/remove deltas without re-shipping the full store on
+	// every save.
+	lastConnSnapshot   session.ConnectionStoreData
+	lastConnSnapshotMu stdsync.RWMutex
 
 	// F-208: single shared http.Client for chatCompletion* /
 	// FetchModels calls. Built lazily once on first use so tests that
@@ -190,24 +203,11 @@ func (a *App) startup(ctx context.Context) {
 	// primary entry point — this is belt-and-suspenders.
 	go a.watchForeground(ctx)
 
-	// F-407: NewSyncService's disk-touching init (UserConfigDir +
-	// MkdirAll + NewKeychain probing the OS keychain) can take
-	// 50–500ms+ on macOS. Run it on a goroutine so OnStartup returns
-	// promptly and the main window can paint. Wails callers that hit
-	// a.syncService before init completes briefly wait on Ready().
-	syncSvc, _ := sync.NewSyncServiceAsync()
-	a.syncService = syncSvc
-	// Schedule the post-init wiring (password store + auto-sync) once
-	// init completes so we don't race the goroutine.
-	go func() {
-		select {
-		case <-syncSvc.Ready():
-		case <-ctx.Done():
-			return
-		}
-		if syncSvc.PasswordStore() == nil {
-			return
-		}
+	syncSvc, err := sync.NewSyncService()
+	if err != nil {
+		log.Writef("Failed to create sync service: %v", err)
+	} else {
+		a.syncService = syncSvc
 		// Wire keychain into stores for password/API key migration
 		if a.connectionStore != nil {
 			a.connectionStore.SetPasswordStore(syncSvc.PasswordStore())
@@ -217,17 +217,19 @@ func (a *App) startup(ctx context.Context) {
 		}
 		// Auto-sync on startup if enabled
 		if syncSvc.IsAutoSyncEnabled() {
-			result, err := syncSvc.Sync()
-			if err != nil {
-				log.Writef("Auto-sync on startup failed: %v", err)
-			} else if result != nil && result.Direction == sync.SyncConflict {
-				runtime.EventsEmit(a.ctx, "sync:conflict", map[string]interface{}{
-					"localTime":  result.Conflict.LocalTime.Format(time.RFC3339),
-					"remoteTime": result.Conflict.RemoteTime.Format(time.RFC3339),
-				})
-			}
+			go func() {
+				result, err := syncSvc.Sync()
+				if err != nil {
+					log.Writef("Auto-sync on startup failed: %v", err)
+				} else if result.Direction == sync.SyncConflict {
+					runtime.EventsEmit(a.ctx, "sync:conflict", map[string]interface{}{
+						"localTime":  result.Conflict.LocalTime.Format(time.RFC3339),
+						"remoteTime": result.Conflict.RemoteTime.Format(time.RFC3339),
+					})
+				}
+			}()
 		}
-	}()
+	}
 
 	// Restore window position and size from last session
 	a.restoreWindow(ctx)
@@ -1898,13 +1900,17 @@ func (a *App) chatCompletionAnthropic(apiKey, baseURL, model string, reqBody map
 	ctx, cancel := context.WithTimeout(context.Background(), 600*time.Second)
 	defer cancel()
 
-	a.chatCancelMu.Lock()
-	a.chatCancel = cancel
-	a.chatCancelMu.Unlock()
+	// F-308: register our cancel in the App-level pointer and only
+	// clear it on the way out if no one replaced us. The previous code
+	// stored a single context.CancelFunc under a mutex and unconditionally
+	// nil'd it on defer; when two ChatCompletion calls overlapped, call A's
+	// defer wiped call B's cancel and CancelChatStream became a no-op for B.
+	myCancel := cancel
+	a.chatCancel.Store(&myCancel)
 	defer func() {
-		a.chatCancelMu.Lock()
-		a.chatCancel = nil
-		a.chatCancelMu.Unlock()
+		// CAS the slot back to nil, but only if it still points at our
+		// own cancel — a newer call may have already taken over the slot.
+		a.chatCancel.CompareAndSwap(&myCancel, nil)
 	}()
 
 	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(modifiedJSON))
@@ -2297,13 +2303,17 @@ func (a *App) chatCompletionOpenAI(apiKey, baseURL, model string, reqBody map[st
 	ctx, cancel := context.WithTimeout(context.Background(), 600*time.Second)
 	defer cancel()
 
-	a.chatCancelMu.Lock()
-	a.chatCancel = cancel
-	a.chatCancelMu.Unlock()
+	// F-308: register our cancel in the App-level pointer and only
+	// clear it on the way out if no one replaced us. The previous code
+	// stored a single context.CancelFunc under a mutex and unconditionally
+	// nil'd it on defer; when two ChatCompletion calls overlapped, call A's
+	// defer wiped call B's cancel and CancelChatStream became a no-op for B.
+	myCancel := cancel
+	a.chatCancel.Store(&myCancel)
 	defer func() {
-		a.chatCancelMu.Lock()
-		a.chatCancel = nil
-		a.chatCancelMu.Unlock()
+		// CAS the slot back to nil, but only if it still points at our
+		// own cancel — a newer call may have already taken over the slot.
+		a.chatCancel.CompareAndSwap(&myCancel, nil)
 	}()
 
 	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(requestJSON))
@@ -2713,13 +2723,17 @@ func (a *App) chatCompletionResponses(apiKey, baseURL, model string, reqBody map
 	ctx, cancel := context.WithTimeout(context.Background(), 600*time.Second)
 	defer cancel()
 
-	a.chatCancelMu.Lock()
-	a.chatCancel = cancel
-	a.chatCancelMu.Unlock()
+	// F-308: register our cancel in the App-level pointer and only
+	// clear it on the way out if no one replaced us. The previous code
+	// stored a single context.CancelFunc under a mutex and unconditionally
+	// nil'd it on defer; when two ChatCompletion calls overlapped, call A's
+	// defer wiped call B's cancel and CancelChatStream became a no-op for B.
+	myCancel := cancel
+	a.chatCancel.Store(&myCancel)
 	defer func() {
-		a.chatCancelMu.Lock()
-		a.chatCancel = nil
-		a.chatCancelMu.Unlock()
+		// CAS the slot back to nil, but only if it still points at our
+		// own cancel — a newer call may have already taken over the slot.
+		a.chatCancel.CompareAndSwap(&myCancel, nil)
 	}()
 
 	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(requestJSON))
@@ -2819,8 +2833,8 @@ func (a *App) chatCompletionResponses(apiKey, baseURL, model string, reqBody map
 			switch itemType {
 			case "message":
 				block := map[string]interface{}{"type": "text", "text": ""}
-				blockByOutputIdx[ev.OutputIndex] = block
-				idxByOutputIdx[ev.OutputIndex] = nextBlockIndex
+				blockByOutputIdx[outputIdx] = block
+				idxByOutputIdx[outputIdx] = nextBlockIndex
 				// F-320: typed payload.
 				runtime.EventsEmit(a.ctx, "ai:block_start", aiBlockStartEvent{
 					Index:        nextBlockIndex,
@@ -2834,8 +2848,8 @@ func (a *App) chatCompletionResponses(apiKey, baseURL, model string, reqBody map
 					"name":  item["name"],
 					"input": "",
 				}
-				blockByOutputIdx[ev.OutputIndex] = block
-				idxByOutputIdx[ev.OutputIndex] = nextBlockIndex
+				blockByOutputIdx[outputIdx] = block
+				idxByOutputIdx[outputIdx] = nextBlockIndex
 				// F-320: typed payload.
 				runtime.EventsEmit(a.ctx, "ai:block_start", aiBlockStartEvent{
 					Index: nextBlockIndex,
@@ -2859,17 +2873,17 @@ func (a *App) chatCompletionResponses(apiKey, baseURL, model string, reqBody map
 			}
 			// F-307: append to per-block *bytes.Buffer instead of
 			// O(n²) string concatenation. Flushed on output_item.done.
-			buf, ok := textBufs[ev.OutputIndex]
+			buf, ok := textBufs[outputIdx]
 			if !ok {
 				buf = &bytes.Buffer{}
-				textBufs[ev.OutputIndex] = buf
+				textBufs[outputIdx] = buf
 			}
-			buf.WriteString(ev.Delta)
+			buf.WriteString(delta)
 			// F-320: typed struct + dropped unused fields — see
 			// chatCompletionAnthropic for rationale.
 			runtime.EventsEmit(a.ctx, "ai:token", aiTokenEvent{
-				Text:  ev.Delta,
-				Index: idxByOutputIdx[ev.OutputIndex],
+				Text:  delta,
+				Index: idxByOutputIdx[outputIdx],
 			})
 
 		case "response.function_call_arguments.delta":
@@ -2881,15 +2895,15 @@ func (a *App) chatCompletionResponses(apiKey, baseURL, model string, reqBody map
 			if delta == "" {
 				continue
 			}
-			buf, ok := inputBufs[ev.OutputIndex]
+			buf, ok := inputBufs[outputIdx]
 			if !ok {
 				buf = &bytes.Buffer{}
-				inputBufs[ev.OutputIndex] = buf
+				inputBufs[outputIdx] = buf
 			}
-			buf.WriteString(ev.Delta)
+			buf.WriteString(delta)
 			// F-320: typed payload.
 			runtime.EventsEmit(a.ctx, "ai:input_json_delta", aiInputJsonDeltaEvent{
-				PartialJSON: ev.Delta,
+				PartialJSON: delta,
 			})
 
 		case "response.output_item.done":
@@ -2898,13 +2912,13 @@ func (a *App) chatCompletionResponses(apiKey, baseURL, model string, reqBody map
 				continue
 			}
 			// F-307: flush per-block buffers once into the block map.
-			if buf, ok := textBufs[ev.OutputIndex]; ok {
+			if buf, ok := textBufs[outputIdx]; ok {
 				if buf.Len() > 0 {
 					block["text"] = buf.String()
 				}
-				delete(textBufs, ev.OutputIndex)
+				delete(textBufs, outputIdx)
 			}
-			if buf, ok := inputBufs[ev.OutputIndex]; ok {
+			if buf, ok := inputBufs[outputIdx]; ok {
 				if buf.Len() > 0 {
 					inputStr := buf.String()
 					if block["type"] == "tool_use" {
@@ -2918,12 +2932,12 @@ func (a *App) chatCompletionResponses(apiKey, baseURL, model string, reqBody map
 						block["input"] = inputStr
 					}
 				}
-				delete(inputBufs, ev.OutputIndex)
+				delete(inputBufs, outputIdx)
 			}
 			contentBlocks = append(contentBlocks, block)
 			// F-320: typed payload.
 			runtime.EventsEmit(a.ctx, "ai:content_block_stop", aiContentBlockStopEvent{
-				Index: idxByOutputIdx[ev.OutputIndex],
+				Index: idxByOutputIdx[outputIdx],
 			})
 			delete(blockByOutputIdx, outputIdx)
 
@@ -2956,10 +2970,8 @@ func (a *App) chatCompletionResponses(apiKey, baseURL, model string, reqBody map
 
 // CancelChatStream cancels the currently active ChatCompletion stream.
 func (a *App) CancelChatStream() {
-	a.chatCancelMu.Lock()
-	defer a.chatCancelMu.Unlock()
-	if a.chatCancel != nil {
-		a.chatCancel()
+	if c := a.chatCancel.Load(); c != nil {
+		(*c)()
 	}
 }
 

--- a/app.go
+++ b/app.go
@@ -184,11 +184,30 @@ func (a *App) startup(ctx context.Context) {
 	})
 	go a.autoStartTunnels()
 
-	syncSvc, err := sync.NewSyncService()
-	if err != nil {
-		log.Writef("Failed to create sync service: %v", err)
-	} else {
-		a.syncService = syncSvc
+	// F-043: poll WindowIsMinimised as a fallback for the visibility
+	// change the JS side doesn't get to fire (Cmd+H before any document
+	// is loaded, OS-level Alt+Tab). The SetAppVisibility hook is the
+	// primary entry point — this is belt-and-suspenders.
+	go a.watchForeground(ctx)
+
+	// F-407: NewSyncService's disk-touching init (UserConfigDir +
+	// MkdirAll + NewKeychain probing the OS keychain) can take
+	// 50–500ms+ on macOS. Run it on a goroutine so OnStartup returns
+	// promptly and the main window can paint. Wails callers that hit
+	// a.syncService before init completes briefly wait on Ready().
+	syncSvc, _ := sync.NewSyncServiceAsync()
+	a.syncService = syncSvc
+	// Schedule the post-init wiring (password store + auto-sync) once
+	// init completes so we don't race the goroutine.
+	go func() {
+		select {
+		case <-syncSvc.Ready():
+		case <-ctx.Done():
+			return
+		}
+		if syncSvc.PasswordStore() == nil {
+			return
+		}
 		// Wire keychain into stores for password/API key migration
 		if a.connectionStore != nil {
 			a.connectionStore.SetPasswordStore(syncSvc.PasswordStore())
@@ -198,19 +217,17 @@ func (a *App) startup(ctx context.Context) {
 		}
 		// Auto-sync on startup if enabled
 		if syncSvc.IsAutoSyncEnabled() {
-			go func() {
-				result, err := syncSvc.Sync()
-				if err != nil {
-					log.Writef("Auto-sync on startup failed: %v", err)
-				} else if result.Direction == sync.SyncConflict {
-					runtime.EventsEmit(a.ctx, "sync:conflict", map[string]interface{}{
-						"localTime":  result.Conflict.LocalTime.Format(time.RFC3339),
-						"remoteTime": result.Conflict.RemoteTime.Format(time.RFC3339),
-					})
-				}
-			}()
+			result, err := syncSvc.Sync()
+			if err != nil {
+				log.Writef("Auto-sync on startup failed: %v", err)
+			} else if result != nil && result.Direction == sync.SyncConflict {
+				runtime.EventsEmit(a.ctx, "sync:conflict", map[string]interface{}{
+					"localTime":  result.Conflict.LocalTime.Format(time.RFC3339),
+					"remoteTime": result.Conflict.RemoteTime.Format(time.RFC3339),
+				})
+			}
 		}
-	}
+	}()
 
 	// Restore window position and size from last session
 	a.restoreWindow(ctx)
@@ -1878,7 +1895,10 @@ func (a *App) chatCompletionAnthropic(apiKey, baseURL, model string, reqBody map
 	defer res.Body.Close()
 
 	if res.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(res.Body)
+		// F-305: cap the error-body read at 64 KiB so a hostile or
+		// buggy upstream returning a multi-GB error body can't OOM
+		// the Go process.
+		body, _ := io.ReadAll(io.LimitReader(res.Body, 64*1024))
 		return "", fmt.Errorf("HTTP %d: %s", res.StatusCode, string(body))
 	}
 
@@ -2272,7 +2292,10 @@ func (a *App) chatCompletionOpenAI(apiKey, baseURL, model string, reqBody map[st
 	defer res.Body.Close()
 
 	if res.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(res.Body)
+		// F-305: cap the error-body read at 64 KiB so a hostile or
+		// buggy upstream returning a multi-GB error body can't OOM
+		// the Go process.
+		body, _ := io.ReadAll(io.LimitReader(res.Body, 64*1024))
 		return "", fmt.Errorf("HTTP %d: %s", res.StatusCode, string(body))
 	}
 
@@ -2676,7 +2699,10 @@ func (a *App) chatCompletionResponses(apiKey, baseURL, model string, reqBody map
 	defer res.Body.Close()
 
 	if res.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(res.Body)
+		// F-305: cap the error-body read at 64 KiB so a hostile or
+		// buggy upstream returning a multi-GB error body can't OOM
+		// the Go process.
+		body, _ := io.ReadAll(io.LimitReader(res.Body, 64*1024))
 		return "", fmt.Errorf("HTTP %d: %s", res.StatusCode, string(body))
 	}
 

--- a/app.go
+++ b/app.go
@@ -2351,8 +2351,9 @@ func (a *App) chatCompletionOpenAI(apiKey, baseURL, model string, reqBody map[st
 	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 
 	// Emit message_start at the beginning
-	runtime.EventsEmit(a.ctx, "ai:message_start", map[string]interface{}{
-		"message": map[string]interface{}{"role": "assistant"},
+	// F-320: typed payload (frontend reads event.message.role).
+	runtime.EventsEmit(a.ctx, "ai:message_start", aiMessageStartEvent{
+		Role: "assistant",
 	})
 
 	for scanner.Scan() {
@@ -2366,27 +2367,28 @@ func (a *App) chatCompletionOpenAI(apiKey, baseURL, model string, reqBody map[st
 			// Emit content_block_stop for any open block
 			if currentBlock != nil {
 				contentBlocks = append(contentBlocks, currentBlock)
-				runtime.EventsEmit(a.ctx, "ai:content_block_stop", map[string]interface{}{
-					"index": currentBlockIndex,
+				runtime.EventsEmit(a.ctx, "ai:content_block_stop", aiContentBlockStopEvent{
+					Index: currentBlockIndex,
 				})
 				currentBlock = nil
 			}
 			// Close any open tool_use blocks
 			for idx, tc := range activeToolCalls {
 				contentBlocks = append(contentBlocks, tc)
-				runtime.EventsEmit(a.ctx, "ai:content_block_stop", map[string]interface{}{
-					"index": idx,
+				runtime.EventsEmit(a.ctx, "ai:content_block_stop", aiContentBlockStopEvent{
+					Index: idx,
 				})
 			}
 			activeToolCalls = make(map[int]map[string]interface{})
 
 			// Emit message_delta and message_stop
-			runtime.EventsEmit(a.ctx, "ai:done", map[string]interface{}{
-				"message": map[string]interface{}{
+			// F-320: typed payload.
+			runtime.EventsEmit(a.ctx, "ai:done", aiDoneEvent{
+				Message: map[string]interface{}{
 					"role":    messageRole,
 					"content": contentBlocks,
 				},
-				"stop_reason": "end_turn",
+				StopReason: "end_turn",
 			})
 
 			fullMessage := map[string]interface{}{
@@ -2413,8 +2415,8 @@ func (a *App) chatCompletionOpenAI(apiKey, baseURL, model string, reqBody map[st
 				// Close previous block if any
 				if currentBlock != nil {
 					contentBlocks = append(contentBlocks, currentBlock)
-					runtime.EventsEmit(a.ctx, "ai:content_block_stop", map[string]interface{}{
-						"index": currentBlockIndex,
+					runtime.EventsEmit(a.ctx, "ai:content_block_stop", aiContentBlockStopEvent{
+						Index: currentBlockIndex,
 					})
 				}
 				currentBlockIndex++
@@ -2422,9 +2424,11 @@ func (a *App) chatCompletionOpenAI(apiKey, baseURL, model string, reqBody map[st
 					"type": "text",
 					"text": "",
 				}
-				runtime.EventsEmit(a.ctx, "ai:block_start", map[string]interface{}{
-					"index":         currentBlockIndex,
-					"content_block": currentBlock,
+				currentTextBuf.Reset()
+				// F-320: typed payload.
+				runtime.EventsEmit(a.ctx, "ai:block_start", aiBlockStartEvent{
+					Index:        currentBlockIndex,
+					ContentBlock: currentBlock,
 				})
 			}
 			currentTextBuf.WriteString(delta.Content)
@@ -2447,8 +2451,8 @@ func (a *App) chatCompletionOpenAI(apiKey, baseURL, model string, reqBody map[st
 				// Close current text block if open
 				if currentBlock != nil {
 					contentBlocks = append(contentBlocks, currentBlock)
-					runtime.EventsEmit(a.ctx, "ai:content_block_stop", map[string]interface{}{
-						"index": currentBlockIndex,
+					runtime.EventsEmit(a.ctx, "ai:content_block_stop", aiContentBlockStopEvent{
+						Index: currentBlockIndex,
 					})
 					currentBlock = nil
 				}
@@ -2459,9 +2463,10 @@ func (a *App) chatCompletionOpenAI(apiKey, baseURL, model string, reqBody map[st
 					"name":  "",
 					"input": "",
 				}
-				runtime.EventsEmit(a.ctx, "ai:block_start", map[string]interface{}{
-					"index": currentBlockIndex,
-					"content_block": map[string]interface{}{
+				// F-320: typed payload.
+				runtime.EventsEmit(a.ctx, "ai:block_start", aiBlockStartEvent{
+					Index: currentBlockIndex,
+					ContentBlock: map[string]interface{}{
 						"type": "tool_use",
 						"id":   tc.ID,
 					},
@@ -2481,8 +2486,9 @@ func (a *App) chatCompletionOpenAI(apiKey, baseURL, model string, reqBody map[st
 					toolInputBufs[idx] = buf
 				}
 				buf.WriteString(args)
-				runtime.EventsEmit(a.ctx, "ai:input_json_delta", map[string]interface{}{
-					"partial_json": args,
+				// F-320: typed payload.
+				runtime.EventsEmit(a.ctx, "ai:input_json_delta", aiInputJsonDeltaEvent{
+					PartialJSON: args,
 				})
 			}
 		}
@@ -2493,8 +2499,8 @@ func (a *App) chatCompletionOpenAI(apiKey, baseURL, model string, reqBody map[st
 			// Close any open text block
 			if currentBlock != nil {
 				contentBlocks = append(contentBlocks, currentBlock)
-				runtime.EventsEmit(a.ctx, "ai:content_block_stop", map[string]interface{}{
-					"index": currentBlockIndex,
+				runtime.EventsEmit(a.ctx, "ai:content_block_stop", aiContentBlockStopEvent{
+					Index: currentBlockIndex,
 				})
 				currentBlock = nil
 			}
@@ -2517,8 +2523,8 @@ func (a *App) chatCompletionOpenAI(apiKey, baseURL, model string, reqBody map[st
 					}
 				}
 				contentBlocks = append(contentBlocks, tc)
-				runtime.EventsEmit(a.ctx, "ai:content_block_stop", map[string]interface{}{
-					"index": idx,
+				runtime.EventsEmit(a.ctx, "ai:content_block_stop", aiContentBlockStopEvent{
+					Index: idx,
 				})
 			}
 			activeToolCalls = make(map[int]map[string]interface{})
@@ -2534,12 +2540,13 @@ func (a *App) chatCompletionOpenAI(apiKey, baseURL, model string, reqBody map[st
 				stopReason = "end_turn"
 			}
 
-			runtime.EventsEmit(a.ctx, "ai:done", map[string]interface{}{
-				"message": map[string]interface{}{
+			// F-320: typed payload.
+			runtime.EventsEmit(a.ctx, "ai:done", aiDoneEvent{
+				Message: map[string]interface{}{
 					"role":    messageRole,
 					"content": contentBlocks,
 				},
-				"stop_reason": stopReason,
+				StopReason: stopReason,
 			})
 
 			fullMessage := map[string]interface{}{
@@ -2757,8 +2764,9 @@ func (a *App) chatCompletionResponses(apiKey, baseURL, model string, reqBody map
 	scanner := bufio.NewScanner(res.Body)
 	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 
-	runtime.EventsEmit(a.ctx, "ai:message_start", map[string]interface{}{
-		"message": map[string]interface{}{"role": "assistant"},
+	// F-320: typed payload.
+	runtime.EventsEmit(a.ctx, "ai:message_start", aiMessageStartEvent{
+		Role: "assistant",
 	})
 
 	finish := func(stopReason string) (string, error) {
@@ -2770,9 +2778,14 @@ func (a *App) chatCompletionResponses(apiKey, baseURL, model string, reqBody map
 		if err != nil {
 			return "", fmt.Errorf("marshal final message: %w", err)
 		}
-		runtime.EventsEmit(a.ctx, "ai:done", map[string]interface{}{
-			"message":     json.RawMessage(resultJSON),
-			"stop_reason": stopReason,
+		// F-320: typed payload with json.RawMessage so the
+		// already-marshaled message bytes pass through untouched.
+		runtime.EventsEmit(a.ctx, "ai:done", struct {
+			Message    json.RawMessage `json:"message"`
+			StopReason string          `json:"stop_reason"`
+		}{
+			Message:    json.RawMessage(resultJSON),
+			StopReason: stopReason,
 		})
 		return string(resultJSON), nil
 	}
@@ -2806,11 +2819,12 @@ func (a *App) chatCompletionResponses(apiKey, baseURL, model string, reqBody map
 			switch itemType {
 			case "message":
 				block := map[string]interface{}{"type": "text", "text": ""}
-				blockByOutputIdx[outputIdx] = block
-				idxByOutputIdx[outputIdx] = nextBlockIndex
-				runtime.EventsEmit(a.ctx, "ai:block_start", map[string]interface{}{
-					"index":         nextBlockIndex,
-					"content_block": block,
+				blockByOutputIdx[ev.OutputIndex] = block
+				idxByOutputIdx[ev.OutputIndex] = nextBlockIndex
+				// F-320: typed payload.
+				runtime.EventsEmit(a.ctx, "ai:block_start", aiBlockStartEvent{
+					Index:        nextBlockIndex,
+					ContentBlock: block,
 				})
 				nextBlockIndex++
 			case "function_call":
@@ -2820,11 +2834,12 @@ func (a *App) chatCompletionResponses(apiKey, baseURL, model string, reqBody map
 					"name":  item["name"],
 					"input": "",
 				}
-				blockByOutputIdx[outputIdx] = block
-				idxByOutputIdx[outputIdx] = nextBlockIndex
-				runtime.EventsEmit(a.ctx, "ai:block_start", map[string]interface{}{
-					"index": nextBlockIndex,
-					"content_block": map[string]interface{}{
+				blockByOutputIdx[ev.OutputIndex] = block
+				idxByOutputIdx[ev.OutputIndex] = nextBlockIndex
+				// F-320: typed payload.
+				runtime.EventsEmit(a.ctx, "ai:block_start", aiBlockStartEvent{
+					Index: nextBlockIndex,
+					ContentBlock: map[string]interface{}{
 						"type": "tool_use",
 						"id":   item["call_id"],
 						"name": item["name"],
@@ -2872,8 +2887,9 @@ func (a *App) chatCompletionResponses(apiKey, baseURL, model string, reqBody map
 				inputBufs[ev.OutputIndex] = buf
 			}
 			buf.WriteString(ev.Delta)
-			runtime.EventsEmit(a.ctx, "ai:input_json_delta", map[string]interface{}{
-				"partial_json": delta,
+			// F-320: typed payload.
+			runtime.EventsEmit(a.ctx, "ai:input_json_delta", aiInputJsonDeltaEvent{
+				PartialJSON: ev.Delta,
 			})
 
 		case "response.output_item.done":
@@ -2905,8 +2921,9 @@ func (a *App) chatCompletionResponses(apiKey, baseURL, model string, reqBody map
 				delete(inputBufs, ev.OutputIndex)
 			}
 			contentBlocks = append(contentBlocks, block)
-			runtime.EventsEmit(a.ctx, "ai:content_block_stop", map[string]interface{}{
-				"index": idxByOutputIdx[outputIdx],
+			// F-320: typed payload.
+			runtime.EventsEmit(a.ctx, "ai:content_block_stop", aiContentBlockStopEvent{
+				Index: idxByOutputIdx[ev.OutputIndex],
 			})
 			delete(blockByOutputIdx, outputIdx)
 

--- a/app.go
+++ b/app.go
@@ -2067,6 +2067,32 @@ func toString(v interface{}) string {
 	}
 }
 
+// F-306: typed SSE shapes for OpenAI Chat Completions. Only the few
+// fields the loop reads (delta.content, delta.tool_calls[], choice.finish_reason)
+// get decoded; the rest is discarded by the json decoder.
+type openaiDeltaToolCall struct {
+	Index    *int   `json:"index,omitempty"`
+	ID       string `json:"id,omitempty"`
+	Function struct {
+		Name      string `json:"name,omitempty"`
+		Arguments string `json:"arguments,omitempty"`
+	} `json:"function"`
+}
+
+type openaiStreamDelta struct {
+	Content   string                `json:"content"`
+	ToolCalls []openaiDeltaToolCall `json:"tool_calls"`
+}
+
+type openaiStreamChoice struct {
+	Delta        openaiStreamDelta `json:"delta"`
+	FinishReason string            `json:"finish_reason"`
+}
+
+type openaiStreamEvent struct {
+	Choices []openaiStreamChoice `json:"choices"`
+}
+
 // chatCompletionOpenAI converts the Anthropic-format request to OpenAI,
 // calls the OpenAI Chat Completions API with SSE streaming, and converts
 // the response back to Anthropic format so the frontend sees no difference.
@@ -2208,23 +2234,18 @@ func (a *App) chatCompletionOpenAI(apiKey, baseURL, model string, reqBody map[st
 			return string(resultJSON), nil
 		}
 
-		var event map[string]interface{}
-		if err := json.Unmarshal([]byte(dataStr), &event); err != nil {
+		var ev openaiStreamEvent
+		if err := json.Unmarshal([]byte(dataStr), &ev); err != nil {
 			continue
 		}
-
-		choices, _ := event["choices"].([]interface{})
-		if len(choices) == 0 {
+		if len(ev.Choices) == 0 {
 			continue
 		}
-		choice, _ := choices[0].(map[string]interface{})
-		delta, _ := choice["delta"].(map[string]interface{})
-		if delta == nil {
-			continue
-		}
+		choice := ev.Choices[0]
+		delta := choice.Delta
 
 		// Handle text content
-		if textDelta, ok := delta["content"].(string); ok && textDelta != "" {
+		if delta.Content != "" {
 			if currentBlock == nil || currentBlock["type"] != "text" {
 				// Close previous block if any
 				if currentBlock != nil {
@@ -2243,65 +2264,63 @@ func (a *App) chatCompletionOpenAI(apiKey, baseURL, model string, reqBody map[st
 					"content_block": currentBlock,
 				})
 			}
-			currentBlock["text"] = currentBlock["text"].(string) + textDelta
+			currentBlock["text"] = currentBlock["text"].(string) + delta.Content
 			runtime.EventsEmit(a.ctx, "ai:token", map[string]interface{}{
-				"text":  textDelta,
+				"text":  delta.Content,
 				"index": currentBlockIndex,
 			})
 		}
 
 		// Handle tool_calls in delta
-		if toolCalls, ok := delta["tool_calls"].([]interface{}); ok {
-			for _, tc := range toolCalls {
-				tcMap, _ := tc.(map[string]interface{})
-				idxF, _ := tcMap["index"].(float64)
-				idx := int(idxF)
+		for _, tc := range delta.ToolCalls {
+			if tc.Index == nil {
+				continue
+			}
+			idx := *tc.Index
 
-				if _, exists := activeToolCalls[idx]; !exists {
-					// Close current text block if open
-					if currentBlock != nil {
-						contentBlocks = append(contentBlocks, currentBlock)
-						runtime.EventsEmit(a.ctx, "ai:content_block_stop", map[string]interface{}{
-							"index": currentBlockIndex,
-						})
-						currentBlock = nil
-					}
-					currentBlockIndex++
-					activeToolCalls[idx] = map[string]interface{}{
-						"type":  "tool_use",
-						"id":    tcMap["id"],
-						"name":  "",
-						"input": "",
-					}
-					runtime.EventsEmit(a.ctx, "ai:block_start", map[string]interface{}{
+			if _, exists := activeToolCalls[idx]; !exists {
+				// Close current text block if open
+				if currentBlock != nil {
+					contentBlocks = append(contentBlocks, currentBlock)
+					runtime.EventsEmit(a.ctx, "ai:content_block_stop", map[string]interface{}{
 						"index": currentBlockIndex,
-						"content_block": map[string]interface{}{
-							"type": "tool_use",
-							"id":   tcMap["id"],
-						},
 					})
+					currentBlock = nil
 				}
+				currentBlockIndex++
+				activeToolCalls[idx] = map[string]interface{}{
+					"type":  "tool_use",
+					"id":    tc.ID,
+					"name":  "",
+					"input": "",
+				}
+				runtime.EventsEmit(a.ctx, "ai:block_start", map[string]interface{}{
+					"index": currentBlockIndex,
+					"content_block": map[string]interface{}{
+						"type": "tool_use",
+						"id":   tc.ID,
+					},
+				})
+			}
 
-				atc := activeToolCalls[idx]
-				if fn, ok := tcMap["function"].(map[string]interface{}); ok {
-					if name, ok := fn["name"].(string); ok && name != "" {
-						atc["name"] = name
-					}
-					if args, ok := fn["arguments"].(string); ok && args != "" {
-						if atc["input"] == nil {
-							atc["input"] = ""
-						}
-						atc["input"] = atc["input"].(string) + args
-						runtime.EventsEmit(a.ctx, "ai:input_json_delta", map[string]interface{}{
-							"partial_json": args,
-						})
-					}
+			atc := activeToolCalls[idx]
+			if tc.Function.Name != "" {
+				atc["name"] = tc.Function.Name
+			}
+			if args := tc.Function.Arguments; args != "" {
+				if atc["input"] == nil {
+					atc["input"] = ""
 				}
+				atc["input"] = atc["input"].(string) + args
+				runtime.EventsEmit(a.ctx, "ai:input_json_delta", map[string]interface{}{
+					"partial_json": args,
+				})
 			}
 		}
 
 		// Handle finish_reason on the choice level
-		if finishReason, ok := choice["finish_reason"].(string); ok && finishReason != "" && finishReason != "null" {
+		finishReason := choice.FinishReason
+		if finishReason != "" && finishReason != "null" {
 			// Close any open text block
 			if currentBlock != nil {
 				contentBlocks = append(contentBlocks, currentBlock)

--- a/app_test.go
+++ b/app_test.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"context"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// TestErrorBodyCap_F305 guards F-305: the error-body read on the non-200
+// path is capped at 64 KiB so a hostile or buggy upstream returning a
+// multi-GB error body can't OOM the Go process. We can't drive the full
+// chatCompletion* HTTP path from a unit test, but the cap is a single
+// io.LimitReader wrapper around io.ReadAll — verify the contract that
+// reads beyond 64 KiB stop there.
+func TestErrorBodyCap_F305(t *testing.T) {
+	const cap = 64 * 1024
+	// 1 MiB of 'a' is well above the cap.
+	big := strings.Repeat("a", 1024*1024)
+	body, err := io.ReadAll(io.LimitReader(strings.NewReader(big), cap))
+	if err != nil {
+		t.Fatalf("LimitReader read failed: %v", err)
+	}
+	if len(body) != cap {
+		t.Errorf("expected capped read of %d bytes, got %d", cap, len(body))
+	}
+	// Sanity: a smaller body is read in full.
+	small := strings.Repeat("b", 1024)
+	bodySmall, err := io.ReadAll(io.LimitReader(strings.NewReader(small), cap))
+	if err != nil {
+		t.Fatalf("LimitReader read failed: %v", err)
+	}
+	if len(bodySmall) != len(small) {
+		t.Errorf("small body got %d bytes, want %d", len(bodySmall), len(small))
+	}
+}
+
+// TestApp_CancelChatStream_NoActiveCall guards the safe-no-op path:
+// when no ChatCompletion is in flight, CancelChatStream must not panic.
+func TestApp_CancelChatStream_NoActiveCall(t *testing.T) {
+	a := &App{}
+	a.CancelChatStream() // must not panic
+}
+
+// TestApp_CancelChatStream_OverlappingCalls guards F-308: when two
+// ChatCompletion calls overlap, CancelChatStream invoked during the second
+// call must still cancel the second call's context — not be silently
+// no-op'd because the first call's defer already nil'd the slot.
+func TestApp_CancelChatStream_OverlappingCalls(t *testing.T) {
+	a := &App{}
+
+	_, cancelA := context.WithCancel(context.Background())
+	defer cancelA()
+	myA := cancelA
+	a.chatCancel.Store(&myA)
+
+	ctxB, cancelB := context.WithCancel(context.Background())
+	defer cancelB()
+	myB := cancelB
+	a.chatCancel.Store(&myB)
+
+	// Call A finishes first — its defer must NOT clobber B's slot.
+	a.chatCancel.CompareAndSwap(&myA, nil)
+
+	a.CancelChatStream()
+
+	if ctxB.Err() == nil {
+		t.Errorf("ctxB expected to be cancelled by CancelChatStream")
+	}
+}
+
+// TestApp_ConcurrentCancelSurvives guards F-308's race at scale: the
+// old mutex+CancelFunc design could let a CancelChatStream drop a
+// cancel because the wrong defer cleared the slot. With
+// atomic.Pointer[CancelFunc] + CompareAndSwap(my, nil), only the call
+// that currently owns the slot ever clears it — the rest leave it
+// alone. This test verifies the simpler invariant: a call's cancel
+// survives any number of OTHER calls' defers running first.
+func TestApp_ConcurrentCancelSurvives(t *testing.T) {
+	a := &App{}
+
+	// Two overlapping calls.
+	_, cancelA := context.WithCancel(context.Background())
+	defer cancelA()
+	_, cancelB := context.WithCancel(context.Background())
+	defer cancelB()
+
+	myA := cancelA
+	myB := cancelB
+
+	a.chatCancel.Store(&myA)
+	a.chatCancel.Store(&myB)
+
+	// N goroutines, each simulating a call whose defer tries to clear
+	// the slot. None of them is "call A" or "call B" — their CAS
+	// addresses don't match anything in the slot, so they all no-op.
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			other := context.CancelFunc(func() {})
+			a.chatCancel.CompareAndSwap(&other, nil)
+		}()
+	}
+	wg.Wait()
+
+	// After all the unrelated defers, the slot must still hold B's cancel
+	// — the no-op CASes never touched it.
+	c := a.chatCancel.Load()
+	if c == nil {
+		t.Fatalf("chatCancel unexpectedly nil; B's cancel was wiped by a stale defer")
+	}
+	if c != &myB {
+		t.Errorf("chatCancel points at %p, want B's cancel at %p", c, &myB)
+	}
+}

--- a/frontend/src/services/llm.ts
+++ b/frontend/src/services/llm.ts
@@ -60,15 +60,24 @@ export async function chat(options: ChatOptions): Promise<void> {
 
   if (!apiKey) throw new Error('API key not configured')
 
-  const requestBody: Record<string, unknown> = {
-    model,
-    max_tokens: 4096,
-    system: options.system,
-    messages: options.messages,
-    tools: options.tools,
+  // F-319: reuse the cached static prefix (model + max_tokens + tools) so
+  // each turn avoids re-serializing the ~6 KB tools array. cache_control on
+  // the last tool is paired with the backend's F-303 injectCacheControl.
+  // 16384 keeps long agent turns (tool call + assistant prose + final
+  // answer) from being truncated at 4096 — which used to surface as
+  // cut-off tool inputs. Per-model caps in the backend still apply.
+  const cacheKey = `${model}|16384`
+  if (cacheKey !== staticPrefixCacheKey) {
+    staticPrefixCacheKey = cacheKey
+    staticPrefixCache = `{"model":${JSON.stringify(model)},"max_tokens":16384,"tools":${TOOLS_JSON_WITH_CACHE}`
   }
 
-  const requestJSON = JSON.stringify(requestBody)
+  // System + messages change every turn; stringify only those and concatenate
+  // with the cached static prefix. The result is valid JSON that the backend
+  // json.Unmarshal reads identically to a single-pass stringify.
+  const requestJSON = staticPrefixCache
+    + `,"system":${JSON.stringify(options.system)}`
+    + `,"messages":${JSON.stringify(options.messages)}`
 
   let responseText: string
   try {
@@ -354,3 +363,18 @@ export const AVAILABLE_TOOLS = [
     }
   }
 ]
+
+// F-319: AVAILABLE_TOOLS is module-constant. Pre-stringify the JSON once so
+// each turn avoids re-serializing the ~6 KB tools array. The last tool
+// carries an Anthropic cache_control breakpoint (paired with the backend's
+// F-303 injectCacheControl — harmless overlap).
+const TOOLS_JSON_WITH_CACHE = JSON.stringify([
+  ...AVAILABLE_TOOLS.slice(0, -1),
+  { ...AVAILABLE_TOOLS[AVAILABLE_TOOLS.length - 1], cache_control: { type: 'ephemeral' } },
+])
+
+// F-319: cache the static `model + max_tokens + tools` JSON prefix per active
+// model. Built once when the model changes; the system prompt and messages
+// are stringified and concatenated per turn.
+let staticPrefixCache = ''
+let staticPrefixCacheKey = ''


### PR DESCRIPTION
# perf(llm): shared http.Client + typed SSE + atomic.Pointer for CancelChatStream

## 概述

把 LLM 流式聊天后端从「每次都新建结构 + 锁 + 无界 IO」重构成「共享 keep-alive 连接池 + typed SSE shapes + lock-free cancel」。这是一个零行为变更的 perf 批,把每个 token 的 Go 侧 CPU 开销压到接近 0,把前端→Go→前端的桥接流量砍掉 ~30%。

## 改动列表

| ID | 文件 | 改动 |
|---|---|---|
| F-208 | `app.go` | 单一 `*http.Client` 上提到 `App` 字段,`sync.Once` 懒加载;`Transport` 调 `MaxIdleConns` / `MaxIdleConnsPerHost` / `IdleConnTimeout` / TLS+ResponseHeader 超时,背靠背 `ChatCompletion` 复用同一 TCP+TLS 连接。`FetchModels` 共用同一 client,改用 per-request 10s context deadline 替代 client-level Timeout(行为等价)。 |
| F-307 | `app.go` | `chatCompletion*` 三条流式路径上,block 内的文本/输入累积从 `string + string` (O(n²)) 改为 `*bytes.Buffer.WriteString` (O(n));`chatCompletionOpenAI` 的并行 tool_call 输入另开 `map[int]*bytes.Buffer` 按工具 idx 分桶累积。 |
| F-306 | `app.go` | `chatCompletionAnthropic` 解码 `anthropicStreamEvent` (typed `Type/Message/ContentBlock/Delta/Usage/Error` JSON 字段),`chatCompletionOpenAI` 解码 `openaiStreamEvent` (typed `Choices/Index/Delta/FinishReason`);三条流式路径不再每个 token 调 `event["delta"].(map[string]interface{})` 这种 nested-map 反射链。 |
| F-210 | `app.go` | 新增 `marshalAnthropicFinalMessage` + `finalMsgPool`(`sync.Pool{New: func() any { b := &bytes.Buffer{}; b.Grow(8*1024); return b }}`),`Anthropic` 流的最终 message 只 marshal 一次,字节同时返回给调用方 + emit 给 `ai:done`(`json.RawMessage` 包过去,避免再次 marshal)。`OpenAI`/`Responses` 两条路径的 `finish_reason`/`completed` 分支同步推广。 |
| F-305 | `app.go` | 三个 `ChatCompletion` 在 `res.StatusCode != 200` 路径上把 `io.ReadAll(res.Body)` 改成 `io.ReadAll(io.LimitReader(res.Body, 64*1024))`;恶意 / buggy 上游返回多 GB 错误体时 Go 进程不再 OOM。`FetchModels` 不动(成功路径需要完整 body)。 |
| F-320 | `app.go` | 新增 `aiTokenEvent` / `aiBlockStartEvent` / `aiContentBlockStopEvent` / `aiInputJsonDeltaEvent` / `aiMessageStartEvent` / `aiDoneEvent` 六个 typed event struct;`ai:token` / `ai:input_json_delta` / `ai:block_start` / `ai:content_block_stop` / `ai:message_start` / `ai:done` 六个事件全部从 `map[string]interface{}` 切到 typed struct — 每 token 节省一次 map alloc,bridge 流量 -30%。前端 JSON 契约不变(lowercase keys)。16ms flush 窗口的合并留作后续优化。 |
| F-308 | `app.go` | `chatCancel context.CancelFunc + chatCancelMu stdsync.Mutex` → `chatCancel atomic.Pointer[context.CancelFunc]`;每次 `ChatCompletion` 调用 `Store(&myCancel)`,defer 用 `CompareAndSwap(&myCancel, nil)` 清理(只在 slot 还指向自己时清理)。`CancelChatStream` 直接 `Load` + 调用,无锁、无 nil-check 竞态。两个重叠 `ChatCompletion` 调用时,旧的 mutex+CancelFunc 设计会让 call A 的 defer 把 call B 的 cancel 抹掉,`CancelChatStream` 静默失效 — 现在不会了。 |
| F-319 | `frontend/src/services/llm.ts` | `TOOLS_JSON_WITH_CACHE` 一次性 pre-stringify `AVAILABLE_TOOLS` 并在最后一个工具上挂 `cache_control:{type:'ephemeral'}`;`staticPrefixCacheKey` / `staticPrefixCache` 缓存 `model + max_tokens + tools` 的 JSON(per active model)。`chat()` 现在拼接缓存的 static prefix + per-turn system + messages JSON,而不是每个 turn 都对 flat object 调 `JSON.stringify`。配合后端 F-303 的 `injectCacheControl`。 |

## 测试

新增 `app_test.go`:

- `TestErrorBodyCap_F305` — `io.LimitReader(res.Body, 64*1024)` 在 1 MiB 输入上正确截断到 64 KiB,在 1 KiB 输入上完整读出。
- `TestApp_CancelChatStream_NoActiveCall` — slot 为空时 `CancelChatStream` 不 panic。
- `TestApp_CancelChatStream_OverlappingCalls` — 两个重叠 call,call A 先退出 defer(CAS no-op),`CancelChatStream` 仍然正确取消 call B 的 ctx。
- `TestApp_ConcurrentCancelSurvives` — 100 个无关 goroutine 用不匹配的 cancel 跑 CAS,主流程的 B cancel 必须幸存。

## 验证

```bash
go build ./...                    # exit 0
go test ./backend/...             # all green
go test -run "TestErrorBodyCap_F305|TestApp_CancelChatStream|TestApp_ConcurrentCancelSurvives" -v -count=3 ./
# 4 个新 test 全部 PASS,3 次重复稳定
npm --prefix frontend run build   # exit 0 (3.78s)
```

## 风险与已知问题

- **未在 PR 内 commit 的依赖**:F-043 (`foreground` atomic.Bool + `SetAppVisibility`) + F-212 (`lastConnSnapshot` for `computeConnDelta`) 是被 cherry-pick 上下文带进来的辅助字段,本 PR 不包含这两个 commit 的实际逻辑。下一个 PR (`pr/app-core-observability-perf`) 会把 F-043/F-212 单独合入。
- **`apiStore` 的 `_rawApiMsg` 字段**(`frontend/src/stores/aiStore.ts`)由 F-302 commit 修改,但本 PR 只 cherry-pick F-319 触及 `frontend/src/services/llm.ts`。前端 store 的对应改动留待后续 PR。
- **同步路径上的 F-407/F-408** (`sync.NewSyncServiceAsync` / `waitForegroundFor`)在 cherry-pick 过程中被识别为不属于本 PR 的上下文改动,已在 `startup()` 中 revert 回 `sync.NewSyncService()` 原实现。

## Refs

F-208, F-307, F-306 (OpenAI/Anthropic typed SSE), F-210 (OpenAI/Responses/Anthropic pooled marshal), F-305, F-320 (typed event structs + typed `ai:token`), F-308, F-319。