### PR TITLE
feat(terminal): configurable double-click word separator

### DIFF
--- a/backend/store/settings_store.go
+++ b/backend/store/settings_store.go
@@ -24,6 +24,10 @@ type TerminalSettings struct {
 	// output logs (issue #227). Empty means: use the OS-appropriate
 	// default under ~/Documents/uniTerm/logs.
 	SessionLogDir string `json:"sessionLogDir,omitempty"`
+	// WordSeparator overrides xterm.js's double-click word-selection
+	// separators. Empty means the frontend falls back to its built-in
+	// default. Mirrors the `wordSeparator` Terminal option.
+	WordSeparator string `json:"wordSeparator,omitempty"`
 }
 
 // TerminalThemeColors mirrors xterm.js's ITheme shape: the 4 base colors

--- a/frontend/src/components/BaseTerminal.vue
+++ b/frontend/src/components/BaseTerminal.vue
@@ -1502,6 +1502,12 @@ watch(() => settingsStore.settings.terminal, (ts) => {
     // Force-reset by feeding the cursor a DECRST 12 sequence.
     if (!ts.cursorBlink) terminal.write('\x1b[?12l')
   }
+  if (ts.wordSeparator) {
+    // xterm reads wordSeparator on each selection via rawOptions; assigning
+    // here is enough to change the next double-click selection without
+    // recreating the terminal.
+    terminal.options.wordSeparator = ts.wordSeparator
+  }
   resize()
 }, { deep: true })
 

--- a/frontend/src/components/SettingsTab.vue
+++ b/frontend/src/components/SettingsTab.vue
@@ -271,6 +271,21 @@
 
           <div class="setting-card">
             <div class="setting-info">
+              <div class="setting-title">{{ t('settings.wordSeparator') }}</div>
+              <div class="setting-desc">{{ t('settings.wordSeparatorDesc') }}</div>
+            </div>
+            <div class="setting-control setting-control-wide">
+              <el-input
+                v-model="settingsStore.settings.terminal.wordSeparator"
+                :placeholder="defaultWordSeparator"
+                clearable
+                @change="settingsStore.save()"
+              />
+            </div>
+          </div>
+
+          <div class="setting-card">
+            <div class="setting-info">
               <div class="setting-title">{{ t('settings.rightClick') }}</div>
               <div class="setting-desc">{{ t('settings.rightClickDesc') }}</div>
             </div>
@@ -798,6 +813,11 @@ onMounted(async () => {
 // default plus any current override (so if the user cleared their
 // override, the placeholder shows the fallback path).
 const defaultLogDir = ref('')
+
+// Default word separator for xterm's double-click selection; shown in
+// the settings input as a placeholder so the user can see what to
+// reset to.
+const defaultWordSeparator = '\\ :;~`!@#$%^&*()=+|[]{}\'",<>?'
 
 async function pickLogDir() {
   try {

--- a/frontend/src/composables/useTerminal.ts
+++ b/frontend/src/composables/useTerminal.ts
@@ -356,6 +356,7 @@ export function useTerminal(
       scrollback: ts.maxHistoryLines || 2500,
       allowProposedApi: true,
       allowTransparency: true,
+      wordSeparator: ts.wordSeparator || '\\ :;~`!@#$%^&*()=+|[]{}\'",<>?',
     }
   }
 

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -332,6 +332,8 @@
   "settings.defaultLocalShell": "Default Local Shell",
   "settings.defaultLocalShellDesc": "Shell used when clicking the Local Terminal button on the start page",
   "settings.selectionActionDesc": "Standardaktion nach Textauswahl",
+  "settings.wordSeparator": "Worttrenner",
+  "settings.wordSeparatorDesc": "Zeichen, die bei Doppelklick als Wortgrenzen gelten. Leer lassen, um die Vorgabe zu verwenden.",
   "settings.rightClickDesc": "Rechtsklick-Verhalten im Terminal",
   "settings.middleClick": "Mittelklick-Aktion",
   "settings.middleClickDesc": "Verhalten bei Mittelklick im Terminal",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -335,6 +335,8 @@
   "settings.defaultLocalShell": "Default Local Shell",
   "settings.defaultLocalShellDesc": "Shell used when clicking the Local Terminal button on the start page",
   "settings.selectionActionDesc": "Default action after selecting text",
+  "settings.wordSeparator": "Word Separator",
+  "settings.wordSeparatorDesc": "Characters that separate words on double-click. Leave empty to use the default.",
   "settings.rightClickDesc": "Right-click behavior in terminal",
   "settings.middleClick": "Middle Click Action",
   "settings.middleClickDesc": "Middle-click behavior in terminal",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -332,6 +332,8 @@
   "settings.defaultLocalShell": "Default Local Shell",
   "settings.defaultLocalShellDesc": "Shell used when clicking the Local Terminal button on the start page",
   "settings.selectionActionDesc": "Acción predeterminada después de seleccionar texto",
+  "settings.wordSeparator": "Separador de palabras",
+  "settings.wordSeparatorDesc": "Caracteres que separan palabras al hacer doble clic. Déjelo vacío para usar el valor predeterminado.",
   "settings.rightClickDesc": "Comportamiento del clic derecho en la terminal",
   "settings.middleClick": "Accion clic medio",
   "settings.middleClickDesc": "Comportamiento del clic medio en la terminal",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -332,6 +332,8 @@
   "settings.defaultLocalShell": "Default Local Shell",
   "settings.defaultLocalShellDesc": "Shell used when clicking the Local Terminal button on the start page",
   "settings.selectionActionDesc": "Action par défaut après la sélection de texte",
+  "settings.wordSeparator": "Séparateur de mots",
+  "settings.wordSeparatorDesc": "Caractères servant de frontière entre les mots lors d'un double-clic. Laisser vide pour utiliser la valeur par défaut.",
   "settings.rightClickDesc": "Comportement du clic droit dans le terminal",
   "settings.middleClick": "Action clic milieu",
   "settings.middleClickDesc": "Comportement du clic milieu dans le terminal",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -332,6 +332,8 @@
   "settings.defaultLocalShell": "Default Local Shell",
   "settings.defaultLocalShellDesc": "Shell used when clicking the Local Terminal button on the start page",
   "settings.selectionActionDesc": "テキスト選択後の既定アクション",
+  "settings.wordSeparator": "単語区切り文字",
+  "settings.wordSeparatorDesc": "ダブルクリックで単語選択するときの区切り文字。空欄の場合は既定値を使用。",
   "settings.rightClickDesc": "ターミナル内での右クリックの動作",
   "settings.middleClick": "中ボタン機能",
   "settings.middleClickDesc": "端末内での中ボタンクリックの動作",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -332,6 +332,8 @@
   "settings.defaultLocalShell": "Default Local Shell",
   "settings.defaultLocalShellDesc": "Shell used when clicking the Local Terminal button on the start page",
   "settings.selectionActionDesc": "텍스트 선택 후 기본 동작",
+  "settings.wordSeparator": "단어 구분 문자",
+  "settings.wordSeparatorDesc": "더블 클릭으로 단어를 선택할 때 사용되는 구분 문자입니다. 비워 두면 기본값을 사용합니다.",
   "settings.rightClickDesc": "터미널에서 오른쪽 클릭 동작",
   "settings.middleClick": "가운데 클릭 동작",
   "settings.middleClickDesc": "터미널에서 가운데 클릭 동작",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -332,6 +332,8 @@
   "settings.defaultLocalShell": "Default Local Shell",
   "settings.defaultLocalShellDesc": "Shell used when clicking the Local Terminal button on the start page",
   "settings.selectionActionDesc": "Действие по умолчанию после выделения текста",
+  "settings.wordSeparator": "Разделитель слов",
+  "settings.wordSeparatorDesc": "Символы-разделители слов при двойном щелчке. Оставьте пустым, чтобы использовать значение по умолчанию.",
   "settings.rightClickDesc": "Поведение правой кнопки мыши в терминале",
   "settings.middleClick": "Действие средней кнопки",
   "settings.middleClickDesc": "Поведение средней кнопки в терминале",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -335,6 +335,8 @@
   "settings.defaultLocalShell": "默认本地终端",
   "settings.defaultLocalShellDesc": "在起始页点击本地终端按钮时使用的 Shell",
   "settings.selectionActionDesc": "选中文字后的默认操作",
+  "settings.wordSeparator": "选词分隔符",
+  "settings.wordSeparatorDesc": "双击选词时作为分词边界的字符。留空使用默认值。",
   "settings.rightClickDesc": "右键点击终端的行为",
   "settings.middleClick": "中键功能",
   "settings.middleClickDesc": "中键点击终端的行为",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -332,6 +332,8 @@
   "settings.defaultLocalShell": "Default Local Shell",
   "settings.defaultLocalShellDesc": "Shell used when clicking the Local Terminal button on the start page",
   "settings.selectionActionDesc": "選取文字後的預設操作",
+  "settings.wordSeparator": "選詞分隔符",
+  "settings.wordSeparatorDesc": "雙擊選詞時作為分詞邊界的字元。留空使用預設值。",
   "settings.rightClickDesc": "右鍵點擊終端機的行為",
   "settings.middleClick": "中鍵功能",
   "settings.middleClickDesc": "中鍵點擊終端的行為",

--- a/frontend/src/services/terminalManager.ts
+++ b/frontend/src/services/terminalManager.ts
@@ -67,6 +67,8 @@ export function acquireTerminal(
     managed.isNew = false
   } else {
     const cursorBlink = useSettingsStore().settings.terminal.cursorBlink ?? true
+    const wordSeparator = useSettingsStore().settings.terminal.wordSeparator
+      || '\\ :;~`!@#$%^&*()=+|[]{}\'",<>?'
     const ls = useLocalStateStore()
     const theme = getXtermTheme(options.themeName ?? 'dark', customThemes)
     if (ls.state.backgroundEnabled && ls.state.backgroundImage) {
@@ -81,6 +83,7 @@ export function acquireTerminal(
       scrollback: options.scrollback ?? 2500,
       allowProposedApi: true,
       allowTransparency: true,
+      wordSeparator,
     })
 
     const fitAddon = new FitAddon()

--- a/frontend/src/types/settings.ts
+++ b/frontend/src/types/settings.ts
@@ -55,6 +55,11 @@ export interface TerminalSettings {
   // Override for the session output log directory. Empty means the
   // OS default under ~/Documents/uniTerm/logs.
   sessionLogDir: string
+  // Characters that act as word boundaries for xterm.js's double-click
+  // word selection. Default mirrors the built-in xterm separators
+  // extended with the most common shell / path punctuation, so that
+  // e.g. `foo;bar` selects only `foo` on double-click.
+  wordSeparator: string
 }
 
 export interface AIModelConfig {
@@ -167,7 +172,8 @@ export const DEFAULT_SETTINGS: AppSettings = {
     smartCompletion: true,
     highlightEnabled: true,
     cursorBlink: true,
-    sessionLogDir: ''
+    sessionLogDir: '',
+    wordSeparator: '\\ :;~`!@#$%^&*()=+|[]{}\'",<>?'
   },
   ai: {
     maxTurns: 20,

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -1450,6 +1450,7 @@ export namespace store {
 	    smartCompletion?: boolean;
 	    highlightEnabled?: boolean;
 	    sessionLogDir?: string;
+	    wordSeparator?: string;
 	
 	    static createFrom(source: any = {}) {
 	        return new TerminalSettings(source);
@@ -1466,6 +1467,7 @@ export namespace store {
 	        this.smartCompletion = source["smartCompletion"];
 	        this.highlightEnabled = source["highlightEnabled"];
 	        this.sessionLogDir = source["sessionLogDir"];
+	        this.wordSeparator = source["wordSeparator"];
 	    }
 	}
 	export class AppSettings {


### PR DESCRIPTION
Add a 'Word Separator' setting so users can change which characters xterm.js treats as word boundaries on double-click selection. Default expands the built-in xterm separators with common shell / path punctuation, e.g. selecting 'foo' from 'foo;bar' on a double-click.

Changes:
- Persist via new TerminalSettings.WordSeparator (Go) so the value survives restart; wailsjs/go/models.ts regenerated accordingly.
- Pass wordSeparator when creating Terminal, and update terminal.options.wordSeparator on settings change for live effect.
- Add 'Word Separator' input in Settings → Terminal, with placeholder showing the default; clearing the field falls back to the default.
- Add settings.wordSeparator / settings.wordSeparatorDesc i18n keys for all 9 locales.
