### PR TITLE
fix(terminal): persist cursorBlink setting across restarts

### DIFF
--- a/backend/store/settings_store.go
+++ b/backend/store/settings_store.go
@@ -20,6 +20,11 @@ type TerminalSettings struct {
 	MaxHistoryLines  int    `json:"maxHistoryLines"`
 	SmartCompletion  *bool  `json:"smartCompletion"`
 	HighlightEnabled *bool  `json:"highlightEnabled"`
+	// CursorBlink controls xterm.js's cursor blink. Pointer + omitempty so
+	// settings.json written by older builds (which lack this field) still
+	// load; the frontend falls back to `true` when nil, matching the
+	// pre-existing default behaviour.
+	CursorBlink *bool `json:"cursorBlink,omitempty"`
 	// SessionLogDir overrides the default directory used for session
 	// output logs (issue #227). Empty means: use the OS-appropriate
 	// default under ~/Documents/uniTerm/logs.


### PR DESCRIPTION
The cursorBlink toggle only existed on the frontend type, so SaveSettings silently dropped it on the Go side and the value reset to the default (true) on every restart. Add the field to store.TerminalSettings so it round-trips through settings.json; pointer + omitempty keeps backward compatibility with settings.json written by older builds.
