### PR TITLE
feat(session): add terminal encoding support to telnet

### DIFF
--- a/app.go
+++ b/app.go
@@ -1317,9 +1317,12 @@ func (a *App) CreateSession(sessionType string, config session.ConnectionConfig)
 			sz.SetPendingSize(config.InitialCols, config.InitialRows)
 		}
 	}
-	// Apply terminal character encoding (SSH only). No-op for utf-8/empty.
+	// Apply terminal character encoding (SSH / Telnet). No-op for utf-8/empty.
 	if ssh, ok := s.(*session.SSHSession); ok {
 		ssh.SetEncoding(config.Encoding)
+	}
+	if telnet, ok := s.(*session.TelnetSession); ok {
+		telnet.SetEncoding(config.Encoding)
 	}
 
 	// Apply serial config; connection itself is handled by the async goroutine

--- a/backend/session/telnet_session.go
+++ b/backend/session/telnet_session.go
@@ -8,6 +8,9 @@ import (
 	"strconv"
 	"sync"
 	"time"
+
+	"golang.org/x/text/encoding"
+	"golang.org/x/text/transform"
 )
 
 const (
@@ -38,6 +41,13 @@ type TelnetSession struct {
 	cancel   context.CancelFunc
 	quit     chan struct{}
 	quitOnce sync.Once
+
+	enc            encoding.Encoding    // input(write) codec; nil = utf-8 passthrough
+	encoder        transform.Transformer // cached encoder; nil = utf-8 passthrough
+	decoder        *encoding.Decoder     // persistent streaming decoder for output(read)
+	decodeLeftover []byte                // trailing partial multibyte bytes between reads
+	decodeScratch  []byte                // reusable src buffer for decodeOutput
+	encScratch     []byte                // reusable dst buffer for encodeInput
 }
 
 func NewTelnetSession(id string) *TelnetSession {
@@ -125,7 +135,7 @@ func (s *TelnetSession) readLoop(ctx context.Context) {
 func (s *TelnetSession) handleRead(data []byte) {
 	filtered := s.filterIAC(data)
 	if len(filtered) > 0 {
-		s.emitData(filtered)
+		s.emitData(s.decodeOutput(filtered))
 	}
 }
 
@@ -279,7 +289,7 @@ func (s *TelnetSession) Write(data []byte) error {
 	if s.conn == nil {
 		return fmt.Errorf("not connected")
 	}
-	_, err := s.conn.Write(data)
+	_, err := s.conn.Write(s.encodeInput(data))
 	return err
 }
 
@@ -308,4 +318,73 @@ func (s *TelnetSession) Resize(cols, rows int) error {
 
 func (s *TelnetSession) IsConnected() bool {
 	return s.Status() == StatusConnected
+}
+
+// SetEncoding configures the character encoding for this session.
+// name: "" / "utf-8" (passthrough) | "gbk" | "gb2312" | "gb18030" |
+// "big5" | "shift-jis" | "euc-jp" | "euc-kr".
+func (s *TelnetSession) SetEncoding(name string) {
+	enc := encodingByName(name)
+	s.mu.Lock()
+	s.enc = enc
+	if enc == nil {
+		s.decoder = nil
+		s.encoder = nil
+	} else {
+		s.decoder = enc.NewDecoder()
+		s.encoder = enc.NewEncoder()
+	}
+	s.decodeLeftover = nil
+	s.mu.Unlock()
+}
+
+// decodeOutput converts a chunk of remote bytes to UTF-8 using the configured
+// decoder. Partial trailing multibyte sequences are buffered until the next
+// call. Must only be called from the single readLoop goroutine.
+func (s *TelnetSession) decodeOutput(data []byte) []byte {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.decoder == nil {
+		return data
+	}
+	s.decodeScratch = s.decodeScratch[:0]
+	s.decodeScratch = append(s.decodeScratch, s.decodeLeftover...)
+	s.decodeScratch = append(s.decodeScratch, data...)
+	src := s.decodeScratch
+
+	var out []byte
+	dst := make([]byte, 8192)
+	for {
+		nDst, nSrc, err := s.decoder.Transform(dst, src, false)
+		out = append(out, dst[:nDst]...)
+		src = src[nSrc:]
+		if err == transform.ErrShortDst {
+			continue
+		}
+		break
+	}
+	if len(src) > 0 {
+		s.decodeLeftover = append(s.decodeLeftover[:0], src...)
+	} else {
+		s.decodeLeftover = src[:0]
+	}
+	return out
+}
+
+// encodeInput converts user keystrokes (UTF-8) to the configured encoding
+// before writing to the remote. Each call handles a complete UTF-8 input.
+func (s *TelnetSession) encodeInput(data []byte) []byte {
+	s.mu.RLock()
+	encoder := s.encoder
+	s.mu.RUnlock()
+	if encoder == nil {
+		return data
+	}
+	encoder.Reset()
+	s.encScratch = s.encScratch[:0]
+	nDst, _, err := encoder.Transform(s.encScratch, data, true)
+	if err != nil && err != transform.ErrShortSrc {
+		return data
+	}
+	return s.encScratch[:nDst]
 }

--- a/frontend/src/components/ConnectionForm.vue
+++ b/frontend/src/components/ConnectionForm.vue
@@ -340,7 +340,7 @@
               </div>
             </el-form-item>
             <el-form-item
-              v-if="form.type === 'ssh'"
+              v-if="form.type === 'ssh' || form.type === 'telnet'"
               :label="t('conn.encoding')"
             >
               <el-select v-model="form.encoding" placeholder="Unicode (UTF-8)">

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -1457,6 +1457,7 @@ export namespace store {
 	    maxHistoryLines: number;
 	    smartCompletion?: boolean;
 	    highlightEnabled?: boolean;
+	    cursorBlink?: boolean;
 	    sessionLogDir?: string;
 	    wordSeparator?: string;
 	
@@ -1474,6 +1475,7 @@ export namespace store {
 	        this.maxHistoryLines = source["maxHistoryLines"];
 	        this.smartCompletion = source["smartCompletion"];
 	        this.highlightEnabled = source["highlightEnabled"];
+	        this.cursorBlink = source["cursorBlink"];
 	        this.sessionLogDir = source["sessionLogDir"];
 	        this.wordSeparator = source["wordSeparator"];
 	    }


### PR DESCRIPTION
## Summary

Add terminal character encoding support to Telnet sessions, mirroring the existing SSH implementation. Connections to non-UTF-8 devices (e.g. GBK, GB2312, Big5, Shift-JIS) will now render Chinese / Japanese text instead of tofu blocks.

### Changes

- **`backend/session/telnet_session.go`**: port `SetEncoding` / `decodeOutput` / `encodeInput` from `ssh_session.go`. `encodeInput` is applied in `Write`; `decodeOutput` is applied after `filterIAC` in `handleRead` (avoids feeding IAC bytes into the codec). Thread safety via `baseSession.mu` matches the SSH implementation. Reuses the package-private `encodingByName` helper.
- **`app.go`**: apply `SetEncoding` on `*TelnetSession` alongside the existing SSH branch in the session setup path.
- **`frontend/src/components/ConnectionForm.vue`**: show the existing encoding dropdown for both `ssh` and `telnet` connection types. No new i18n keys needed (`conn.encoding` already exists in all locales).
- **`frontend/wailsjs/go/models.ts`**: regenerated by `wails dev`.

### Notes

- `sendAutoLogin` (username / password) is still written as UTF-8 raw bytes; SSH behaves the same. Configured credentials are typically ASCII, so this is consistent with the existing SSH behavior and out of scope for this fix.
- Proper RFC 2066 CHARSET negotiation was not implemented — the post-hoc codec approach matches what SSH does and is sufficient for the issue's symptom.

Fixes #455

### Test plan

- `go build ./...`
- `go test ./backend/session/...`
- `npm --prefix frontend run build`
- Manual: create a Telnet connection, set encoding to `GBK` / `GB2312` / `Big5` / `Shift-JIS`, connect to a server that emits those encodings, and verify the terminal renders Chinese / Japanese characters correctly instead of tofu blocks.
- Manual: verify the default `Unicode (UTF-8)` Telnet behavior is unchanged.

---

## 概要

给 Telnet 加上和 SSH 一样的终端字符编码支持。连接到非 UTF-8 设备（如 GBK、GB2312、Big5、Shift-JIS）时，终端将正常渲染中文 / 日文字符，而不是显示方块。

### 改动

- **`backend/session/telnet_session.go`**：从 `ssh_session.go` 移植 `SetEncoding` / `decodeOutput` / `encodeInput`。`encodeInput` 在 `Write` 里套用；`decodeOutput` 在 `handleRead` 里 `filterIAC` 之后套用（避免 IAC 字节混进 codec）。通过 `baseSession.mu` 保证并发安全，与 SSH 实现一致。复用包内私有 `encodingByName` 函数。
- **`app.go`**：在 session 创建路径的 SSH 分支后，增加对 `*TelnetSession` 调用 `SetEncoding`。
- **`frontend/src/components/ConnectionForm.vue`**：现有 encoding 下拉框现在在 `ssh` 和 `telnet` 两种连接类型下都显示。不需要新增 i18n key（`conn.encoding` 在各语言里都已有）。
- **`frontend/wailsjs/go/models.ts`**：由 `wails dev` 重新生成。

### 说明

- `sendAutoLogin`（用户名 / 密码）仍以 UTF-8 裸字节写入，与 SSH 行为一致；典型配置凭据是 ASCII，此处与 SSH 保持一致，不在本次修复范围内。
- 未实现 RFC 2066 CHARSET 协商；采用 SSH 同款的后置 codec 方案，对应 issue 描述的症状已经够用。

修复 #455

### 测试

- `go build ./...`
- `go test ./backend/session/...`
- `npm --prefix frontend run build`
- 手动：建一个 Telnet 连接，编码设为 `GBK` / `GB2312` / `Big5` / `Shift-JIS`，连到对应编码的服务器，确认中文 / 日文能正常显示而不是方块。
- 手动：确认默认 `Unicode (UTF-8)` 下 Telnet 行为不变。
