### PR TITLE
fix(session): translate backspace key to match remote terminal

### DIFF
--- a/backend/session/session.go
+++ b/backend/session/session.go
@@ -116,6 +116,12 @@ type ConnectionConfig struct {
 	// Terminal character encoding for ssh/telnet:
 	// "" / "utf-8"(default) | "gbk" | "gb2312" | "gb18030" | "big5" | "shift-jis" | "euc-jp" | "euc-kr"
 	Encoding string `json:"encoding,omitempty"`
+	// Backspace key byte sequence for terminal-stream types (ssh/telnet/serial).
+	// The translation happens on the frontend in applyBackspaceKey before the
+	// byte hits SessionWrite, so the backend does not read this field — it is
+	// kept here so the Wails binding reflects the full connection contract.
+	// ""(default) | "del"(0x7F) | "bs"(0x08) | "vt220"(ESC[3~)
+	BackspaceKey string `json:"backspaceKey,omitempty"`
 	// K8s-specific fields
 	K8sConfigPath   string `json:"k8sConfigPath,omitempty"`   // File 模式：kubeconfig 文件路径
 	K8sConfigInline string `json:"k8sConfigInline,omitempty"` // Inline 模式：kubeconfig YAML 全文（明文存储，同其他连接密码策略）

--- a/frontend/src/components/BaseTerminal.vue
+++ b/frontend/src/components/BaseTerminal.vue
@@ -101,6 +101,7 @@ import {
 import { getXtermTheme } from '../composables/useTerminal'
 import { resolveXtermBackground, applyTerminalBgVar } from '../composables/useTerminalTheme'
 import { stripCursorBlink } from '../utils/cursor'
+import { applyBackspaceKey } from '../utils/backspaceKey'
 import {
   sanitizeTerminalOutput,
   sanitizeLiveTerminalOutput,
@@ -627,14 +628,25 @@ function writeTerminalInput(data: string, inAlternateScreen: boolean) {
       for (const pid of targets) {
         const p = panelStore.getPanel(pid)
         if (p?.sessionId && (p.type === 'ssh' || p.type === 'local')) {
-          SessionWrite(p.sessionId, filtered)
+          const translated = applyBackspaceKey(
+            filtered,
+            p.config?.backspaceKey,
+            p.config?.type,
+          )
+          SessionWrite(p.sessionId, translated)
         }
       }
       return
     }
   }
 
-  SessionWrite(sid, filtered)
+  const panel = props.panelId ? panelStore.getPanel(props.panelId) : undefined
+  const translated = applyBackspaceKey(
+    filtered,
+    panel?.config?.backspaceKey,
+    panel?.config?.type,
+  )
+  SessionWrite(sid, translated)
 }
 
 function handleTerminalKey(e: KeyboardEvent): boolean {

--- a/frontend/src/components/ConnectionForm.vue
+++ b/frontend/src/components/ConnectionForm.vue
@@ -354,6 +354,16 @@
                 <el-option label="Korean (EUC-KR)" value="euc-kr" />
               </el-select>
             </el-form-item>
+            <el-form-item
+              v-if="form.type === 'ssh' || form.type === 'telnet' || form.type === 'serial' || form.type === 'mosh'"
+              :label="t('conn.backspaceKey')"
+            >
+              <el-select v-model="form.backspaceKey">
+                <el-option label="ASCII Backspace (0x08)" value="bs" />
+                <el-option label="ASCII Delete (0x7F)" value="del" />
+                <el-option label="VT220 Delete (ESC[3~)" value="vt220" />
+              </el-select>
+            </el-form-item>
             <el-form-item v-if="form.type === 'ssh'" :label="t('conn.sftpMaxConcurrency')">
               <el-input-number v-model="form.sftpMaxConcurrency" :min="0" :max="20" />
             </el-form-item>
@@ -706,6 +716,7 @@ const form = reactive<ConnectionConfig>({
   ftpEncoding: 'utf-8',
   ftpSkipVerify: false,
   encoding: 'utf-8',
+  backspaceKey: 'bs',
   shellPath: '',
   smbDomain: 'WORKGROUP',
   smbShare: '',
@@ -910,6 +921,7 @@ function resetForm() {
   form.ftpEncoding = 'utf-8'
   form.ftpSkipVerify = false
   form.encoding = 'utf-8'
+  form.backspaceKey = 'bs'
   form.shellPath = ''
   form.serialPort = ''
   form.serialBaudRate = 115200

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -823,6 +823,7 @@
   "conn.ftpPassive": "Passiver Modus",
   "conn.ftpEncoding": "Zeichenkodierung",
   "conn.encoding": "Kodierung",
+  "conn.backspaceKey": "Rücktaste",
   "quickCommands.quickCommandsTab": "Schnellbefehle",
   "quickCommands.historyTab": "Verlauf",
   "quickCommands.saveAs": "Als Schnellbefehl speichern",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -872,6 +872,7 @@
   "conn.ftpSkipVerify": "Allow insecure TLS (skip verification)",
   "conn.ftpSkipVerifyDesc": "Disables certificate verification for FTPS. Vulnerable to MITM attacks — only enable for trusted self-signed certificates.",
   "conn.encoding": "Encoding",
+  "conn.backspaceKey": "Backspace Key",
   "quickCommands.quickCommandsTab": "Quick Commands",
   "quickCommands.historyTab": "History",
   "quickCommands.saveAs": "Save as Quick Command",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -823,6 +823,7 @@
   "conn.ftpPassive": "Modo pasivo",
   "conn.ftpEncoding": "Codificación",
   "conn.encoding": "Codificación",
+  "conn.backspaceKey": "Tecla de retroceso",
   "quickCommands.quickCommandsTab": "Comandos rápidos",
   "quickCommands.historyTab": "Historial",
   "quickCommands.saveAs": "Guardar como comando rápido",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -823,6 +823,7 @@
   "conn.ftpPassive": "Mode passif",
   "conn.ftpEncoding": "Encodage",
   "conn.encoding": "Encodage",
+  "conn.backspaceKey": "Touche Retour arrière",
   "quickCommands.quickCommandsTab": "Commandes rapides",
   "quickCommands.historyTab": "Historique",
   "quickCommands.saveAs": "Enregistrer comme commande rapide",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -823,6 +823,7 @@
   "conn.ftpPassive": "パッシブモード",
   "conn.ftpEncoding": "文字エンコーディング",
   "conn.encoding": "エンコーディング",
+  "conn.backspaceKey": "バックスペースキー",
   "quickCommands.quickCommandsTab": "クイックコマンド",
   "quickCommands.historyTab": "履歴",
   "quickCommands.saveAs": "クイックコマンドに保存",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -823,6 +823,7 @@
   "conn.ftpPassive": "수동 모드",
   "conn.ftpEncoding": "문자 인코딩",
   "conn.encoding": "인코딩",
+  "conn.backspaceKey": "백스페이스 키",
   "quickCommands.quickCommandsTab": "빠른 명령",
   "quickCommands.historyTab": "명령 기록",
   "quickCommands.saveAs": "빠른 명령으로 저장",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -823,6 +823,7 @@
   "conn.ftpPassive": "Пассивный режим",
   "conn.ftpEncoding": "Кодировка символов",
   "conn.encoding": "Кодировка",
+  "conn.backspaceKey": "Клавиша Backspace",
   "quickCommands.quickCommandsTab": "Быстрые команды",
   "quickCommands.historyTab": "История",
   "quickCommands.saveAs": "Сохранить как быструю команду",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -872,6 +872,7 @@
   "conn.ftpSkipVerify": "允许不安全的 TLS（跳过证书校验）",
   "conn.ftpSkipVerifyDesc": "关闭 FTPS 的证书校验。容易被中间人攻击，仅在自签名证书等可信场景下开启。",
   "conn.encoding": "终端编码",
+  "conn.backspaceKey": "退格键",
   "quickCommands.quickCommandsTab": "快捷命令",
   "quickCommands.historyTab": "历史命令",
   "quickCommands.saveAs": "保存为快捷命令",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -823,6 +823,7 @@
   "conn.ftpPassive": "被動模式",
   "conn.ftpEncoding": "字元編碼",
   "conn.encoding": "終端編碼",
+  "conn.backspaceKey": "退格鍵",
   "quickCommands.quickCommandsTab": "快捷命令",
   "quickCommands.historyTab": "歷史命令",
   "quickCommands.saveAs": "儲存為快捷命令",

--- a/frontend/src/types/session.ts
+++ b/frontend/src/types/session.ts
@@ -89,6 +89,11 @@ export interface ConnectionConfig {
   s3Bucket?: string
   // Terminal encoding (SSH/Telnet)
   encoding?: string // "utf-8" | "gbk" | "gb2312" | "gb18030" | "big5" | "shift-jis" | "euc-jp" | "euc-kr"
+  // Backspace key byte sequence for terminal-stream types (ssh/telnet/serial).
+  // 'del'  = ASCII DEL (0x7F) — xterm.js default
+  // 'bs'   = ASCII BS  (0x08) — Huawei/H3C/Cisco network gear, Windows convention
+  // 'vt220'= VT220 Delete (ESC[3~) — H3C / late Cisco IOS
+  backspaceKey?: 'del' | 'bs' | 'vt220'
   // Enable session output log automatically on first connect. Applies
   // to terminal-stream types (ssh/telnet/serial/mosh/local).
   logOnConnect?: boolean

--- a/frontend/src/utils/backspaceKey.test.ts
+++ b/frontend/src/utils/backspaceKey.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest'
+import { applyBackspaceKey } from './backspaceKey'
+
+const DEL = '\x7f'
+const BS = '\x08'
+const VT220 = '\x1b[3~'
+
+describe('applyBackspaceKey', () => {
+  describe('connection type filtering', () => {
+    it('passes through for non-terminal-stream types', () => {
+      expect(applyBackspaceKey(`a${DEL}b`, 'bs', 'sftp')).toBe(`a${DEL}b`)
+      expect(applyBackspaceKey(`a${DEL}b`, 'bs', 'ftp')).toBe(`a${DEL}b`)
+      expect(applyBackspaceKey(`a${DEL}b`, 'bs', 'database')).toBe(`a${DEL}b`)
+      expect(applyBackspaceKey(`a${DEL}b`, 'bs', 'rdp')).toBe(`a${DEL}b`)
+      expect(applyBackspaceKey(`a${DEL}b`, 'bs', 'vnc')).toBe(`a${DEL}b`)
+      expect(applyBackspaceKey(`a${DEL}b`, 'bs', 'monitor')).toBe(`a${DEL}b`)
+    })
+
+    it('passes through when connType is undefined', () => {
+      expect(applyBackspaceKey(`a${DEL}b`, 'bs', undefined)).toBe(`a${DEL}b`)
+    })
+
+    it('applies for terminal-stream types', () => {
+      for (const t of ['ssh', 'telnet', 'serial', 'mosh', 'local', 'k8s', 'container']) {
+        expect(applyBackspaceKey(`a${DEL}b`, 'bs', t)).toBe(`a${BS}b`)
+        expect(applyBackspaceKey(`a${DEL}b`, 'vt220', t)).toBe(`a${VT220}b`)
+      }
+    })
+  })
+
+  describe('mode handling', () => {
+    it('passes through when mode is "del"', () => {
+      expect(applyBackspaceKey(`a${DEL}b`, 'del', 'ssh')).toBe(`a${DEL}b`)
+    })
+
+    it('defaults to "bs" for terminal-stream types when mode is undefined', () => {
+      expect(applyBackspaceKey(`a${DEL}b`, undefined, 'ssh')).toBe(`a${BS}b`)
+      expect(applyBackspaceKey(`a${DEL}b`, undefined, 'telnet')).toBe(`a${BS}b`)
+      expect(applyBackspaceKey(`a${DEL}b`, undefined, 'serial')).toBe(`a${BS}b`)
+    })
+
+    it('replaces 0x7F with 0x08 when mode is "bs"', () => {
+      expect(applyBackspaceKey(`a${DEL}b`, 'bs', 'ssh')).toBe(`a${BS}b`)
+    })
+
+    it('replaces 0x7F with ESC[3~ when mode is "vt220"', () => {
+      expect(applyBackspaceKey(`a${DEL}b`, 'vt220', 'ssh')).toBe(`a${VT220}b`)
+    })
+  })
+
+  describe('input shape', () => {
+    it('returns data unchanged when no 0x7F is present', () => {
+      const data = 'hello world\r\nls -la'
+      expect(applyBackspaceKey(data, 'bs', 'ssh')).toBe(data)
+      expect(applyBackspaceKey(data, 'vt220', 'ssh')).toBe(data)
+      expect(applyBackspaceKey(data, 'del', 'ssh')).toBe(data)
+    })
+
+    it('replaces every 0x7F in a multi-byte string', () => {
+      expect(applyBackspaceKey(`${DEL}${DEL}${DEL}`, 'bs', 'ssh')).toBe(`${BS}${BS}${BS}`)
+      expect(applyBackspaceKey(`a${DEL}b${DEL}c`, 'bs', 'ssh')).toBe(`a${BS}b${BS}c`)
+    })
+
+    it('replaces every 0x7F with VT220 sequence', () => {
+      expect(applyBackspaceKey(`a${DEL}b${DEL}c`, 'vt220', 'ssh')).toBe(
+        `a${VT220}b${VT220}c`,
+      )
+    })
+
+    it('handles empty string', () => {
+      expect(applyBackspaceKey('', 'bs', 'ssh')).toBe('')
+    })
+
+    it('does not touch other control characters', () => {
+      // Tab (0x09) and Enter (\r) must pass through untouched.
+      const data = `a\tb\rc${DEL}d`
+      expect(applyBackspaceKey(data, 'bs', 'ssh')).toBe(`a\tb\rc${BS}d`)
+    })
+
+    it('preserves escape sequences surrounding the backspace', () => {
+      // e.g. arrow keys from xterm come in as ESC[A — only the bare 0x7F should
+      // be translated, not the escape bytes.
+      const data = `prefix${DEL}ESC${DEL}`
+      expect(applyBackspaceKey(data, 'bs', 'ssh')).toBe(`prefix${BS}ESC${BS}`)
+    })
+  })
+})

--- a/frontend/src/utils/backspaceKey.ts
+++ b/frontend/src/utils/backspaceKey.ts
@@ -1,0 +1,39 @@
+// Translate xterm.js's default backspace byte (ASCII DEL, 0x7F) into the byte
+// sequence the remote end expects. xterm.js always emits 0x7F for the physical
+// Backspace key, which works on most modern Linux/macOS PTYs but is silently
+// dropped on Huawei/H3C/Cisco network gear and some serial consoles. Those
+// devices expect 0x08 (ASCII BS) or ESC[3~ (VT220 Delete).
+//
+// Only applies to terminal-stream connection types. Non-terminal protocols
+// (SFTP, FTP, database, RDP…) never pass through xterm's onData, but the
+// defensive type check makes the function safe to call from any code path.
+//
+// `mode === undefined` falls back to the new default ('bs') to match the
+// behavior the ConnectionForm applies to new connections; this is the
+// intentional behavior change for issue #456 (MobaXterm ships the same
+// default — "Backspace sends ^H" is on by default).
+const TERMINAL_STREAM_TYPES = new Set([
+  'ssh',
+  'telnet',
+  'serial',
+  'mosh',
+  'local',
+  'k8s',
+  'container',
+])
+
+export type BackspaceKeyMode = 'del' | 'bs' | 'vt220'
+
+export function applyBackspaceKey(
+  data: string,
+  mode: BackspaceKeyMode | undefined,
+  connType: string | undefined,
+): string {
+  if (!connType || !TERMINAL_STREAM_TYPES.has(connType)) return data
+  // Undefined → default to 'bs' for terminal-stream types (see file header).
+  const effective: BackspaceKeyMode = mode ?? 'bs'
+  if (effective === 'del') return data
+  if (!data.includes('\x7f')) return data
+  const replacement = effective === 'bs' ? '\x08' : '\x1b[3~'
+  return data.split('\x7f').join(replacement)
+}

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -607,6 +607,7 @@ export namespace session {
 	    s3Region?: string;
 	    s3Bucket?: string;
 	    encoding?: string;
+	    backspaceKey?: string;
 	    k8sConfigPath?: string;
 	    k8sConfigInline?: string;
 	    k8sContext?: string;
@@ -670,6 +671,7 @@ export namespace session {
 	        this.s3Region = source["s3Region"];
 	        this.s3Bucket = source["s3Bucket"];
 	        this.encoding = source["encoding"];
+	        this.backspaceKey = source["backspaceKey"];
 	        this.k8sConfigPath = source["k8sConfigPath"];
 	        this.k8sConfigInline = source["k8sConfigInline"];
 	        this.k8sContext = source["k8sContext"];


### PR DESCRIPTION
xterm.js emits ASCII DEL (0x7F) for the physical Backspace key, which Linux and macOS PTYs accept but Huawei / H3C / Cisco network gear and some serial consoles silently drop. This adds a per-connection `backspaceKey` setting (`"del"` / `"bs"` / `"vt220"`) that translates the byte in `BaseTerminal.writeTerminalInput` before `SessionWrite`.

Defaults to `"bs"` (0x08) to match MobaXterm's "Backspace sends ^H" default — fixing the issue out of the box for users on Huawei routers and similar devices. Existing connections without the field get the new default via `applyBackspaceKey`, which is a deliberate behavior change.

Scope: `ssh` / `telnet` / `serial` / `mosh` show a dropdown in the connection form; the function still applies the translation for `local` / `k8s` / `container` via the form's default but hides the UI for those types since the user can't change what the remote Linux PTY expects.

The three option labels (ASCII Delete / ASCII Backspace / VT220 Delete) are hardcoded English in `ConnectionForm.vue` rather than extracted to the i18n catalog — they are technical byte-value annotations, identical across locales, and the existing encoding dropdown in the same component follows the same pattern.

### Changes
- `backend/session/session.go` — add `BackspaceKey` to `ConnectionConfig` so the Wails binding reflects the full contract (backend does not read the field — translation is purely frontend).
- `frontend/src/types/session.ts` — add `backspaceKey` to TS `ConnectionConfig`.
- `frontend/src/components/ConnectionForm.vue` — `backspaceKey` dropdown for ssh/telnet/serial/mosh; default `'bs'` on new connections; option labels hardcoded English.
- `frontend/src/components/BaseTerminal.vue` — call `applyBackspaceKey` in `writeTerminalInput` (single + broadcast paths), per-panel config.
- `frontend/src/utils/backspaceKey.ts` — pure translate function with type guard for terminal-stream types.
- `frontend/src/utils/backspaceKey.test.ts` — 13 unit tests.
- `frontend/src/i18n/locales/{9 locales}` — `conn.backspaceKey` label only; option keys dropped.
- `frontend/wailsjs/go/models.ts` — regenerated by `wails dev`.

Fixes #456

---

xterm.js 默认对物理 Backspace 键发送 ASCII DEL (0x7F)，Linux/macOS PTY 能识别，但华为 / H3C / Cisco 网络设备以及部分串口控制台会直接丢弃。本 PR 新增 per-connection 的 `backspaceKey` 配置（`del` / `bs` / `vt220`），在 `BaseTerminal.writeTerminalInput` 调 `SessionWrite` 之前翻译字节序列。

默认值设为 `"bs"` (0x08)，对齐 MobaXterm 默认勾选 "Backspace sends ^H" 的行为——华为路由器等设备开箱即用。旧连接没有该字段时由 `applyBackspaceKey` 自动落到新默认，这是一个有意的行为变化。

范围：`ssh` / `telnet` / `serial` / `mosh` 在连接表单里显示下拉；`local` / `k8s` / `container` 因表单默认值同样生效但 UI 隐藏，因为用户改不动对端 Linux PTY 的预期。

三个选项标签（ASCII Delete / ASCII Backspace / VT220 Delete）直接在 `ConnectionForm.vue` 写死英文，不进 i18n 目录——它们是技术性的字节值标注，跨 locale 完全一致，且同一组件里的 encoding 下拉也是相同模式。

### 改动
- `backend/session/session.go` — `ConnectionConfig` 加 `BackspaceKey` 字段，对齐 Wails 绑定契约（后端不读，纯前端翻译）。
- `frontend/src/types/session.ts` — TS `ConnectionConfig` 加 `backspaceKey`。
- `frontend/src/components/ConnectionForm.vue` — ssh/telnet/serial/mosh 显示退格键下拉，新建连接默认 `'bs'`；选项标签直接写死英文。
- `frontend/src/components/BaseTerminal.vue` — `writeTerminalInput` 调 `applyBackspaceKey`（单 panel + 广播两条路径），每个 panel 用自己的 config。
- `frontend/src/utils/backspaceKey.ts` — 纯函数 + terminal-stream 类型守卫。
- `frontend/src/utils/backspaceKey.test.ts` — 13 个单测。
- `frontend/src/i18n/locales/{9 locales}` — 只保留 `conn.backspaceKey` 标签，选项 key 删除。
- `frontend/wailsjs/go/models.ts` — `wails dev` 自动重生成。

修复 #456