### PR TITLE
fix(session): support S3 virtual-hosted style for OSS / COS / OBS (issue #452)

### DIFF
--- a/backend/session/s3_session.go
+++ b/backend/session/s3_session.go
@@ -50,6 +50,14 @@ func (s *S3Session) Connect(config ConnectionConfig) error {
 
 	s3Client := simples3.New(config.S3Region, config.User, config.Password)
 	s3Client.Endpoint = strings.TrimSuffix(config.Host, "/")
+	// S3URLStyle="" or "virtual" uses virtual-hosted URLs
+	// (https://bucket.endpoint/key) — required by Alibaba Cloud OSS, Tencent
+	// COS and Huawei OBS, which reject path-style requests with
+	// "SecondLevelDomainForbidden" (issue #452). "path" keeps the legacy
+	// path-style (https://endpoint/bucket/key) for AWS S3 and MinIO.
+	if config.S3URLStyle != "path" {
+		s3Client.SetVirtualHostedStyle(true)
+	}
 
 	s.s3 = s3Client
 	s.bucket = config.S3Bucket

--- a/backend/session/s3_session_test.go
+++ b/backend/session/s3_session_test.go
@@ -1,0 +1,94 @@
+package session
+
+import (
+	"testing"
+)
+
+// TestS3SessionConnectURLStyle verifies that the S3URLStyle flag from
+// ConnectionConfig is correctly forwarded to the underlying simples3 client.
+// Issue #452: Alibaba Cloud OSS rejects path-style URLs with
+// "SecondLevelDomainForbidden" and only accepts virtual-hosted style
+// (https://bucket.endpoint/key). The flag must reach simples3 so OSS users
+// can switch off path-style addressing without code changes.
+func TestS3SessionConnectURLStyle(t *testing.T) {
+	tests := []struct {
+		name              string
+		urlStyle          string
+		wantVirtualHosted bool
+	}{
+		{
+			name:              "path-style for AWS S3 / MinIO",
+			urlStyle:          "path",
+			wantVirtualHosted: false,
+		},
+		{
+			name:              "virtual-hosted for OSS / COS / OBS",
+			urlStyle:          "virtual",
+			wantVirtualHosted: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := NewS3Session("s3-test")
+			cfg := ConnectionConfig{
+				Type:       "s3",
+				Host:       "oss-cn-hangzhou.aliyuncs.com",
+				User:       "ak",
+				Password:   "sk",
+				S3Region:   "cn-hangzhou",
+				S3Bucket:   "mybucket",
+				S3URLStyle: tt.urlStyle,
+			}
+			if err := s.Connect(cfg); err != nil {
+				t.Fatalf("Connect failed: %v", err)
+			}
+			if s.s3 == nil {
+				t.Fatal("Connect did not set s3 client")
+			}
+			if got := s.s3.UseVirtualHostedStyle; got != tt.wantVirtualHosted {
+				t.Errorf("UseVirtualHostedStyle = %v, want %v", got, tt.wantVirtualHosted)
+			}
+			// Endpoint must be normalised (no trailing slash) regardless
+			// of what the user typed.
+			if s.s3.Endpoint != "oss-cn-hangzhou.aliyuncs.com" {
+				t.Errorf("Endpoint = %q, want %q", s.s3.Endpoint, "oss-cn-hangzhou.aliyuncs.com")
+			}
+		})
+	}
+}
+
+// TestS3SessionConnectDefaultVirtualHosted covers the chosen default for
+// S3URLStyle: empty string (or "virtual") → virtual-hosted style. This is
+// what the project picked for issue #452 to unblock Alibaba Cloud OSS /
+// Tencent COS / Huawei OBS users out of the box. AWS S3 / MinIO users that
+// need the legacy path-style behaviour can opt back in via the S3 form
+// by picking "Path" in the URL style dropdown.
+func TestS3SessionConnectDefaultVirtualHosted(t *testing.T) {
+	cases := []struct {
+		name     string
+		urlStyle string
+	}{
+		{"empty string", ""},
+		{"explicit virtual", "virtual"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			s := NewS3Session("s3-default")
+			cfg := ConnectionConfig{
+				Type:       "s3",
+				Host:       "oss-cn-hangzhou.aliyuncs.com",
+				User:       "ak",
+				Password:   "sk",
+				S3Region:   "cn-hangzhou",
+				S3Bucket:   "mybucket",
+				S3URLStyle: c.urlStyle,
+			}
+			if err := s.Connect(cfg); err != nil {
+				t.Fatalf("Connect failed: %v", err)
+			}
+			if !s.s3.UseVirtualHostedStyle {
+				t.Errorf("default S3URLStyle should enable virtual-hosted, got UseVirtualHostedStyle=false")
+			}
+		})
+	}
+}

--- a/backend/session/session.go
+++ b/backend/session/session.go
@@ -113,6 +113,13 @@ type ConnectionConfig struct {
 	// S3-specific fields
 	S3Region string `json:"s3Region,omitempty"`
 	S3Bucket string `json:"s3Bucket,omitempty"`
+	// S3URLStyle chooses URL addressing for S3 requests against a custom
+	// endpoint. "" / "virtual" (default) uses virtual-hosted style
+	// (https://bucket.endpoint/key) — required by Alibaba Cloud OSS,
+	// Tencent COS and Huawei OBS; they reject path-style requests with
+	// "SecondLevelDomainForbidden" (issue #452). "path" uses path-style
+	// (https://endpoint/bucket/key) for AWS S3 and MinIO.
+	S3URLStyle string `json:"s3UrlStyle,omitempty"`
 	// Terminal character encoding for ssh/telnet:
 	// "" / "utf-8"(default) | "gbk" | "gb2312" | "gb18030" | "big5" | "shift-jis" | "euc-jp" | "euc-kr"
 	Encoding string `json:"encoding,omitempty"`

--- a/frontend/src/components/ConnectionForm.vue
+++ b/frontend/src/components/ConnectionForm.vue
@@ -69,7 +69,7 @@
             </template>
             <el-form-item :label="form.type === 's3' ? 'Endpoint' : form.type === 'webdav' ? 'URL' : t('conn.host')" required v-if="form.type !== 'local' && form.type !== 'serial' && form.type !== 'k8s' && form.type !== 'container' && !isRedisSentinel">
               <div class="host-port-row">
-                <el-input v-model="form.host" class="host-input" :placeholder="form.type === 's3' ? 'e.g. s3.amazonaws.com' : form.type === 'webdav' ? 'https://dav.example.com/dav/' : t('conn.hostPlaceholder')" />
+                <el-input v-model="form.host" class="host-input" :placeholder="form.type === 's3' ? 'e.g. https://s3.amazonaws.com' : form.type === 'webdav' ? 'https://dav.example.com/dav/' : t('conn.hostPlaceholder')" />
                 <template v-if="form.type !== 's3' && form.type !== 'webdav'">
                   <span class="host-port-sep">:</span>
                   <el-input-number v-model="form.port" :min="0" :max="65535" class="port-input" />
@@ -188,6 +188,12 @@
               </el-form-item>
               <el-form-item label="Bucket">
                 <el-input v-model="form.s3Bucket" placeholder="my-bucket (leave empty to list all buckets)" />
+              </el-form-item>
+              <el-form-item label="URL style">
+                <el-select v-model="form.s3UrlStyle">
+                  <el-option label="Virtual-hosted (https://bucket.endpoint/key)" value="virtual" />
+                  <el-option label="Path (https://endpoint/bucket/key)" value="path" />
+                </el-select>
               </el-form-item>
             </template>
             <!-- ── K8s 字段 ── -->
@@ -722,6 +728,7 @@ const form = reactive<ConnectionConfig>({
   smbShare: '',
   s3Region: 'us-east-1',
   s3Bucket: '',
+  s3UrlStyle: 'virtual',
   logOnConnect: false,
   k8sConfigPath: '~/.kube/config',
   k8sConfigInline: '',

--- a/frontend/src/types/session.ts
+++ b/frontend/src/types/session.ts
@@ -87,6 +87,11 @@ export interface ConnectionConfig {
   // S3-specific
   s3Region?: string
   s3Bucket?: string
+  // S3 URL addressing style. "virtual" (default) uses virtual-hosted style
+  // URLs (https://bucket.endpoint/key) — required by Alibaba Cloud OSS /
+  // Tencent COS / Huawei OBS. "path" uses path-style
+  // (https://endpoint/bucket/key) for AWS S3 and MinIO.
+  s3UrlStyle?: 'virtual' | 'path'
   // Terminal encoding (SSH/Telnet)
   encoding?: string // "utf-8" | "gbk" | "gb2312" | "gb18030" | "big5" | "shift-jis" | "euc-jp" | "euc-kr"
   // Backspace key byte sequence for terminal-stream types (ssh/telnet/serial).

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -606,6 +606,7 @@ export namespace session {
 	    smbShare?: string;
 	    s3Region?: string;
 	    s3Bucket?: string;
+	    s3UrlStyle?: string;
 	    encoding?: string;
 	    backspaceKey?: string;
 	    k8sConfigPath?: string;
@@ -670,6 +671,7 @@ export namespace session {
 	        this.smbShare = source["smbShare"];
 	        this.s3Region = source["s3Region"];
 	        this.s3Bucket = source["s3Bucket"];
+	        this.s3UrlStyle = source["s3UrlStyle"];
 	        this.encoding = source["encoding"];
 	        this.backspaceKey = source["backspaceKey"];
 	        this.k8sConfigPath = source["k8sConfigPath"];

--- a/go.mod
+++ b/go.mod
@@ -116,4 +116,4 @@ require (
 
 replace github.com/unixshells/mosh-go v0.5.2 => github.com/ys-ll/mosh-go v0.0.0-20260702130124-e17b92cd9dab
 
-replace github.com/rhnvrm/simples3 v0.11.1 => github.com/ys-ll/simples3 v0.0.0-20260702065557-1d8c6e314ba9
+replace github.com/rhnvrm/simples3 v0.11.1 => github.com/ys-ll/simples3 v0.0.0-20260801154215-9210db974cd6

--- a/go.sum
+++ b/go.sum
@@ -261,8 +261,8 @@ github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 h1:ilQV1hzziu+LLM3zU
 github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78/go.mod h1:aL8wCCfTfSfmXjznFBSZNN13rSJjlIOI1fUNAtF7rmI=
 github.com/ys-ll/mosh-go v0.0.0-20260702130124-e17b92cd9dab h1:Ru8ctnV5xIDpn1oozOXHizeEtwAU/vSCNaND+i7J0ck=
 github.com/ys-ll/mosh-go v0.0.0-20260702130124-e17b92cd9dab/go.mod h1:HZno4DV/XO+yAZ6lC3EmzMk0whPxrfgY5uix7jcUFps=
-github.com/ys-ll/simples3 v0.0.0-20260702065557-1d8c6e314ba9 h1:LwBT1YY3EZTJIIjKuhkBZVHxK6rqpiwlZKaf20d79EE=
-github.com/ys-ll/simples3 v0.0.0-20260702065557-1d8c6e314ba9/go.mod h1:c2xW30bukipkBlWNnXG1wDjq3gykQ6ww2AB/9NHMLMY=
+github.com/ys-ll/simples3 v0.0.0-20260801154215-9210db974cd6 h1:gkPJwm05bhmvktWCmlahZ+7Mo4CLiwodGk76NEdx3y8=
+github.com/ys-ll/simples3 v0.0.0-20260801154215-9210db974cd6/go.mod h1:c2xW30bukipkBlWNnXG1wDjq3gykQ6ww2AB/9NHMLMY=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/zalando/go-keyring v0.2.8 h1:6sD/Ucpl7jNq10rM2pgqTs0sZ9V3qMrqfIIy5YPccHs=
 github.com/zalando/go-keyring v0.2.8/go.mod h1:tsMo+VpRq5NGyKfxoBVjCuMrG47yj8cmakZDO5QGii0=


### PR DESCRIPTION
Fixes #452.

simples3 only emitted path-style URLs (`https://endpoint/bucket/key`), which S3-compatible services such as Alibaba Cloud OSS, Tencent COS and Huawei OBS reject with `SecondLevelDomainForbidden`. They require virtual-hosted style (`https://bucket.endpoint/key`) instead.

### Changes

- **backend**: add `ConnectionConfig.S3URLStyle` (string: `""` / `"virtual"` / `"path"`) and forward it to the simples3 client. Default is `"virtual"` so OSS / COS / OBS users work out of the box; AWS S3 / MinIO users can pick `"path"` in the new URL style dropdown.
- **backend**: bump simples3 fork replace directive to commit `9210db9` (`github.com/ys-ll/simples3`), which adds the `UseVirtualHostedStyle` field and `SetVirtualHostedStyle` setter.
- **backend**: add `s3_session_test.go` covering path / virtual / empty default and endpoint normalisation.
- **frontend**: replace the previous S3 connection form additions with a single `el-select` labelled "URL style" that has the two options inline. Endpoint placeholder also gains the `https://` prefix for consistency with WebDAV.
- **frontend**: regenerate wails bindings so the new `S3URLStyle` field is visible in the TS-side `ConnectionConfig` type.

The simples3 fork change lives in `github.com/ys-ll/simples3` (commit `9210db9`) and is referenced via the `go.mod` replace directive.

---

修复 #452。

simples3 只生成 path-style URL（`https://endpoint/bucket/key`），而阿里云 OSS、腾讯云 COS、华为云 OBS 这类 S3 兼容服务会直接拒绝并返回 `SecondLevelDomainForbidden`，它们要求 virtual-hosted style（`https://bucket.endpoint/key`）。

### 改动

- **后端**：新增 `ConnectionConfig.S3URLStyle` 字段（string：`""` / `"virtual"` / `"path"`），转发给 simples3 客户端。默认 `"virtual"` 让 OSS / COS / OBS 用户开箱即用；AWS S3 / MinIO 用户可从新下拉框选 `"path"`。
- **后端**：`go.mod` 的 simples3 fork replace 指向新提交 `9210db9`（`github.com/ys-ll/simples3`），该提交加了 `UseVirtualHostedStyle` 字段和 `SetVirtualHostedStyle` setter。
- **后端**：新增 `s3_session_test.go`，覆盖 path / virtual / 空值默认三种情况以及 endpoint 归一化。
- **前端**：S3 表单新增单个 `el-select`，label 为 "URL style"，两个选项直接内联、不走 i18n。Endpoint 占位符加上 `https://` 前缀，与 WebDAV 保持一致。
- **前端**：重新生成 wails 绑定，让新 `S3URLStyle` 字段出现在 TS 端的 `ConnectionConfig` 类型里。

simples3 fork 改动位于 `github.com/ys-ll/simples3`（提交 `9210db9`），通过 `go.mod` 的 replace 指令引用。