### PR TITLE
fix(container): hide console window when running docker/nerdctl on Windows

### DIFF
--- a/backend/container/runner_local.go
+++ b/backend/container/runner_local.go
@@ -10,6 +10,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"syscall"
 )
 
 type LocalRunner struct{}
@@ -58,6 +59,9 @@ func (r *LocalRunner) command(ctx context.Context, argv []string) (*exec.Cmd, er
 		argv[0] = p
 	}
 	cmd := exec.CommandContext(ctx, argv[0], argv[1:]...)
+	if runtime.GOOS == "windows" {
+		cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
+	}
 	return cmd, nil
 }
 


### PR DESCRIPTION
Add `SysProcAttr{HideWindow: true}` to local container runner commands on Windows, preventing brief console window flashes when the container panel queries Docker/Podman/nerdctl.

Same pattern as the WSL fix in b6254c3.

---

为本地容器 runner 在 Windows 下添加 `SysProcAttr{HideWindow: true}`，防止容器面板查询 Docker/Podman/nerdctl 时短暂弹出命令行窗口。

与 b6254c3 修复 WSL 窗口闪烁的方式一致。