### PR TITLE
feat(build): split macOS DMG into amd64 and arm64 packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,8 +33,8 @@ jobs:
             slug: linux-arm64
             artifact: uniTerm
           - os: macos-latest
-            platform: darwin/universal
-            slug: darwin-universal
+            platform: darwin
+            slug: darwin
             artifact: uniTerm.app
 
     runs-on: ${{ matrix.os }}
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Free disk space (macOS)
-        if: matrix.platform == 'darwin/universal'
+        if: startsWith(matrix.platform, 'darwin')
         run: |
           sudo rm -rf /Library/Developer/CoreSimulator
           sudo rm -rf /Applications/Xcode_*.app 2>/dev/null || true
@@ -111,35 +111,39 @@ jobs:
           fi
           echo "PATH=$PATH"
 
-          BUILD_ARGS="-platform $PLATFORM -ldflags \"-s -w -X main.Version=${{ env.VERSION }}\" -skipbindings"
+          if [ "$PLATFORM" = "darwin" ]; then
+            for ARCH in amd64 arm64; do
+              echo "Building darwin/$ARCH..."
+              eval wails build -platform "darwin/$ARCH" -ldflags "-s -w -X main.Version=${{ env.VERSION }}" -skipbindings
+              mv build/bin/uniTerm.app "build/bin/uniTerm-${ARCH}.app"
+            done
+          else
+            BUILD_ARGS="-platform $PLATFORM -ldflags \"-s -w -X main.Version=${{ env.VERSION }}\" -skipbindings"
 
-          if [[ "$PLATFORM" == windows/* ]]; then
-            BUILD_ARGS="$BUILD_ARGS"
+            if [ "${PLATFORM%/*}" = "linux" ]; then
+              BUILD_ARGS="$BUILD_ARGS -upx -upxflags=\"--best --lzma\" -tags webkit2_41"
+            fi
+
+            echo "BUILD_ARGS=$BUILD_ARGS"
+            eval wails build $BUILD_ARGS
           fi
-
-          if [ "${PLATFORM%/*}" = "linux" ]; then
-            BUILD_ARGS="$BUILD_ARGS -upx -upxflags=\"--best --lzma\""
-          fi
-
-          if [ "${PLATFORM%/*}" = "linux" ]; then
-            BUILD_ARGS="$BUILD_ARGS -tags webkit2_41"
-          fi
-
-          echo "BUILD_ARGS=$BUILD_ARGS"
-          eval wails build $BUILD_ARGS
 
       - name: Package (macOS)
-        if: matrix.platform == 'darwin/universal'
+        if: startsWith(matrix.platform, 'darwin')
         run: |
-          chmod +x build/bin/uniTerm.app/Contents/MacOS/uniTerm
-          codesign --force --deep --sign - build/bin/uniTerm.app
+          for ARCH in amd64 arm64; do
+            APP="build/bin/uniTerm-${ARCH}.app"
+            chmod +x "$APP/Contents/MacOS/uniTerm"
+            codesign --force --deep --sign - "$APP"
 
-          cd build/bin
-          mkdir -p dmg_staging
-          cp -R uniTerm.app dmg_staging/
-          ln -s /Applications dmg_staging/Applications
-          hdiutil create -volname uniTerm -srcfolder dmg_staging -ov -format UDZO ../../uniterm-darwin-universal-${VERSION}.dmg
-          rm -rf dmg_staging
+            cd build/bin
+            mkdir -p dmg_staging
+            cp -R "uniTerm-${ARCH}.app" dmg_staging/uniTerm.app
+            ln -s /Applications dmg_staging/Applications
+            hdiutil create -volname uniTerm -srcfolder dmg_staging -ov -format UDZO "../../uniterm-darwin-${ARCH}-${VERSION}.dmg"
+            rm -rf dmg_staging
+            cd ../..
+          done
 
       - name: Download VcXsrv (Windows)
         if: startsWith(matrix.platform, 'windows')

--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -26,17 +26,20 @@ jobs:
           echo "VERSION=$VERSION" >> $GITHUB_ENV
           echo "TAG=$TAG" >> $GITHUB_ENV
 
-      - name: Download macOS DMG and compute hash
+      - name: Download macOS DMGs and compute hashes
         run: |
-          URL="https://github.com/ys-ll/uniterm/releases/download/$TAG/uniterm-darwin-universal-$TAG.dmg"
-          curl -sLo /tmp/uniterm.dmg "$URL"
-          SHA256=$(sha256sum /tmp/uniterm.dmg | cut -d' ' -f1)
-          echo "SHA256=$SHA256" >> $GITHUB_ENV
+          for ARCH in amd64 arm64; do
+            URL="https://github.com/ys-ll/uniterm/releases/download/$TAG/uniterm-darwin-${ARCH}-$TAG.dmg"
+            curl -sLo "/tmp/uniterm-${ARCH}.dmg" "$URL"
+            SHA256=$(sha256sum "/tmp/uniterm-${ARCH}.dmg" | cut -d' ' -f1)
+            echo "SHA256_${ARCH}=$SHA256" >> $GITHUB_ENV
+          done
 
       - name: Update formula
         run: |
           sed -i "s/version \".*\"/version \"$VERSION\"/" Casks/uniterm.rb
-          sed -i "s/sha256 \".*\"/sha256 \"$SHA256\"/" Casks/uniterm.rb
+          sed -i "s/sha256_amd64 \".*\"/sha256_amd64 \"$SHA256_amd64\"/" Casks/uniterm.rb
+          sed -i "s/sha256_arm64 \".*\"/sha256_arm64 \"$SHA256_arm64\"/" Casks/uniterm.rb
 
       - name: Commit and push
         run: |


### PR DESCRIPTION
Replace darwin/universal with separate darwin/amd64 and darwin/arm64 builds. The universal binary causes compatibility warnings on macOS 26+ and will likely be unsupported in future macOS versions.

## Changes

- **build.yml**: build macOS for both amd64 and arm64 in a loop, produce two DMGs (`uniterm-darwin-amd64-*.dmg` + `uniterm-darwin-arm64-*.dmg`)
- **update-homebrew.yml**: download both DMGs and compute separate SHA256 hashes per arch
- **README / docs**: update download instructions to list both architectures

---

将 macOS 的 universal 合包拆分为独立的 amd64 和 arm64 DMG。macOS 26+ 已开始对 x86_64 兼容性弹警告，后续版本大概率不再支持 universal binary。

- **build.yml**: macOS 构建改为循环编译 amd64 + arm64，产出两个独立 DMG
- **update-homebrew.yml**: 分别下载两个 DMG 并计算各自的 SHA256
- **README / 文档**: 下载说明改为两个架构分列