### PR TITLE
feat(connection): add remark field for connection notes

### DIFF
--- a/backend/session/session.go
+++ b/backend/session/session.go
@@ -34,6 +34,7 @@ type ConnectionGroup struct {
 type ConnectionConfig struct {
 	ID       string `json:"id"`
 	Name     string `json:"name"`
+	Remark   string `json:"remark,omitempty"`
 	Type     string `json:"type"`
 	Host     string `json:"host"`
 	Port     int    `json:"port"`

--- a/frontend/src/components/ConnectionForm.vue
+++ b/frontend/src/components/ConnectionForm.vue
@@ -35,10 +35,8 @@
         <div class="conn-fields">
           <el-form :model="form" label-width="90px" @submit.prevent="onSave">
             <el-form-item :label="t('conn.name')">
-              <el-input v-model="form.name" :placeholder="t('conn.namePlaceholder')" />
-            </el-form-item>
-            <el-form-item :label="t('conn.group')">
-              <div style="display:flex;gap:6px;width:100%">
+              <div class="name-group-row">
+                <el-input v-model="form.name" :placeholder="t('conn.namePlaceholder')" class="name-input" />
                 <el-tree-select
                   v-model="selectedGroupId"
                   :data="groupTreeData"
@@ -46,12 +44,15 @@
                   check-strictly
                   clearable
                   :placeholder="t('conn.noGroup')"
-                  style="flex:1;min-width:0"
+                  class="group-select"
                 />
-                <el-button style="flex-shrink:0;width:32px;height:32px;padding:0" @click="onGroupSelect('__new__')" :title="t('conn.newGroup')">
+                <el-button class="new-group-btn" @click="onGroupSelect('__new__')" :title="t('conn.newGroup')">
                   <Plus :size="14" />
                 </el-button>
               </div>
+            </el-form-item>
+            <el-form-item :label="t('conn.remark')">
+              <el-input v-model="form.remark" />
             </el-form-item>
             <el-form-item v-if="form.type === 'database' && form.dbType === 'redis'" :label="t('conn.redisMode')">
               <el-radio-group v-model="form.redisMode">
@@ -724,6 +725,7 @@ const defaultParamsHint = computed(() => {
 const form = reactive<ConnectionConfig>({
   id: '',
   name: '',
+  remark: '',
   type: 'ssh',
   host: '',
   port: 22,
@@ -934,6 +936,7 @@ watch(rdpResolution, (val) => {
 function resetForm() {
   form.id = ''
   form.name = ''
+  form.remark = ''
   form.type = 'ssh'
   form.host = ''
   form.port = 22
@@ -1310,6 +1313,31 @@ function onConnect() {
 /* ── Form fields ── */
 .conn-fields {
   padding-right: 4px;
+}
+
+/* ── Name + group row ── */
+.name-group-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+}
+
+.name-input {
+  flex: 1;
+  min-width: 0;
+}
+
+.group-select {
+  width: 160px;
+  flex-shrink: 0;
+}
+
+.new-group-btn {
+  flex-shrink: 0;
+  width: 32px;
+  height: 32px;
+  padding: 0;
 }
 
 /* ── Host + port row ── */

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -29,6 +29,8 @@
   "conn.newTitle": "Neue Verbindung",
   "conn.name": "Name",
   "conn.namePlaceholder": "z. B. Mein Server",
+  "conn.remark": "Bemerkung",
+  "conn.remarkPlaceholder": "Standort, Zweck oder andere Hinweise",
   "conn.type": "Typ",
   "conn.categoryTerminal": "Terminal",
   "conn.categoryRemote": "Remote-Desktop",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -29,6 +29,8 @@
   "conn.newTitle": "New Connection",
   "conn.name": "Name",
   "conn.namePlaceholder": "e.g. My Server",
+  "conn.remark": "Remark",
+  "conn.remarkPlaceholder": "Location, purpose, or other notes",
   "conn.type": "Type",
   "conn.categoryTerminal": "Terminal",
   "conn.categoryRemote": "Remote Desktop",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -29,6 +29,8 @@
   "conn.newTitle": "Nueva Conexión",
   "conn.name": "Nombre",
   "conn.namePlaceholder": "p. ej. Mi Servidor",
+  "conn.remark": "Nota",
+  "conn.remarkPlaceholder": "Ubicación, propósito u otras notas",
   "conn.type": "Tipo",
   "conn.categoryTerminal": "Terminal",
   "conn.categoryRemote": "Escritorio Remoto",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -29,6 +29,8 @@
   "conn.newTitle": "Nouvelle connexion",
   "conn.name": "Nom",
   "conn.namePlaceholder": "ex. Mon serveur",
+  "conn.remark": "Remarque",
+  "conn.remarkPlaceholder": "Emplacement, usage ou autres notes",
   "conn.type": "Type",
   "conn.categoryTerminal": "Terminal",
   "conn.categoryRemote": "Bureau distant",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -29,6 +29,8 @@
   "conn.newTitle": "新規接続",
   "conn.name": "名前",
   "conn.namePlaceholder": "例: マイサーバー",
+  "conn.remark": "備考",
+  "conn.remarkPlaceholder": "場所、用途など補足情報",
   "conn.type": "種類",
   "conn.categoryTerminal": "ターミナル",
   "conn.categoryRemote": "リモートデスクトップ",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -29,6 +29,8 @@
   "conn.newTitle": "새 연결",
   "conn.name": "이름",
   "conn.namePlaceholder": "예: 내 서버",
+  "conn.remark": "비고",
+  "conn.remarkPlaceholder": "위치, 용도 등 추가 정보",
   "conn.type": "유형",
   "conn.categoryTerminal": "터미널",
   "conn.categoryRemote": "원격 데스크톱",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -29,6 +29,8 @@
   "conn.newTitle": "Новое подключение",
   "conn.name": "Имя",
   "conn.namePlaceholder": "например, Мой сервер",
+  "conn.remark": "Примечание",
+  "conn.remarkPlaceholder": "Расположение, назначение и другие заметки",
   "conn.type": "Тип",
   "conn.categoryTerminal": "Терминал",
   "conn.categoryRemote": "Удаленный рабочий стол",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -29,6 +29,8 @@
   "conn.newTitle": "新建连接",
   "conn.name": "名称",
   "conn.namePlaceholder": "例如 我的服务器",
+  "conn.remark": "备注",
+  "conn.remarkPlaceholder": "服务器位置、用途等补充信息",
   "conn.type": "类型",
   "conn.categoryTerminal": "终端",
   "conn.categoryRemote": "远程桌面",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -29,6 +29,8 @@
   "conn.newTitle": "新增連線",
   "conn.name": "名稱",
   "conn.namePlaceholder": "例如 我的伺服器",
+  "conn.remark": "備註",
+  "conn.remarkPlaceholder": "伺服器位置、用途等補充資訊",
   "conn.type": "類型",
   "conn.categoryTerminal": "終端機",
   "conn.categoryRemote": "遠端桌面",

--- a/frontend/src/types/session.ts
+++ b/frontend/src/types/session.ts
@@ -16,6 +16,7 @@ export interface PostLoginExpectStep {
 export interface ConnectionConfig {
   id: string
   name: string
+  remark?: string
   type: 'ssh' | 'telnet' | 'mosh' | 'rdp' | 'vnc' | 'spice' | 'database' | 'local' | 'sftp' | 'monitor' | 'ftp' | 'serial' | 'smb' | 'webdav' | 's3' | 'k8s' | 'container'
   host: string
   port: number

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -562,6 +562,7 @@ export namespace session {
 	export class ConnectionConfig {
 	    id: string;
 	    name: string;
+	    remark?: string;
 	    type: string;
 	    host: string;
 	    port: number;
@@ -631,6 +632,7 @@ export namespace session {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.id = source["id"];
 	        this.name = source["name"];
+	        this.remark = source["remark"];
 	        this.type = source["type"];
 	        this.host = source["host"];
 	        this.port = source["port"];


### PR DESCRIPTION
## Summary

Add an optional remark field to every connection, so users can annotate where a server is located, what it is used for, or any other notes.

## Changes

- Add `Remark` field to Go `ConnectionConfig` struct and TS type
- Rearrange the connection form: name and group now share the same row, remark sits below them as a full-width input
- Add `conn.remark` / `conn.remarkPlaceholder` i18n keys for all 9 locales

## Screenshot

The remark field is placed right after name/group, before host:port fields, making it easy to add context when creating or editing a connection.

Closes #361

---

## 概要

为所有连接增加备注字段，用户可以记录服务器位置、用途等补充信息。

## 改动

- Go `ConnectionConfig` 和 TS 类型新增 `Remark` 字段
- 调整连接表单布局：名称和分组放在同一行，备注独占一行紧随其后
- 9 种语言均新增 `conn.remark` / `conn.remarkPlaceholder` 翻译键

Closes #361