### PR TITLE
fix(terminal): input first letter after Caps Lock toggle on macOS beta

### DIFF
--- a/frontend/src/components/BaseTerminal.vue
+++ b/frontend/src/components/BaseTerminal.vue
@@ -653,6 +653,28 @@ function handleTerminalKey(e: KeyboardEvent): boolean {
   // Check global shortcuts first (Ctrl+Shift+/Alt+ combos)
   if (e.type === 'keydown' && !onTerminalKey(e)) return false
 
+  // macOS 26/27 beta: the first letter typed right after toggling Caps Lock
+  // arrives with keyCode 229 (the IME "composing" code) despite no real
+  // composition, so xterm's CompositionHelper swallows it and it only appears
+  // on the next keystroke (upstream xtermjs/xterm.js#5887, issue #483). keyCode
+  // 229 never fires for an ordinary letter key, and we further require Caps Lock
+  // on + an uppercase A–Z so lowercase IME composition (pinyin's first key) is
+  // untouched — re-inject the char through the normal onData pipeline ourselves.
+  if (
+    isMac &&
+    e.type === 'keydown' &&
+    e.keyCode === 229 &&
+    !e.isComposing &&
+    e.getModifierState('CapsLock') &&
+    /^[A-Z]$/.test(e.key) &&
+    !e.ctrlKey && !e.metaKey && !e.altKey &&
+    (props.mode === 'ssh' || props.mode === 'local')
+  ) {
+    e.preventDefault()
+    terminal?.input(e.key)
+    return false
+  }
+
   // Paste via Wails clipboard (xterm's DOM paste is unreliable in WKWebView).
   // Bind to the platform's paste shortcut only — Cmd+V on macOS, Ctrl+Shift+V
   // elsewhere. Plain Ctrl+V is never intercepted, so it passes through to the


### PR DESCRIPTION
## Summary / 摘要
On macOS 26/27 beta the first letter typed right after toggling Caps Lock is swallowed by the terminal and only appears on the next keystroke.
在 macOS 26/27 beta 上，切换 Caps Lock 后按下的第一个字母会被终端吞掉，要再按一次才显示。

## Root cause / 根因
That keydown arrives with `keyCode 229` (the IME "composing" code) despite no real composition, so xterm.js's `CompositionHelper` defers the character (upstream [xtermjs/xterm.js#5887](https://github.com/xtermjs/xterm.js/issues/5887), still present in xterm 6.0.0).
该 keydown 带 `keyCode 229`（IME 组字码）但并无真实组字，xterm.js 的 `CompositionHelper` 因此把字符延后吐出（上游 [xtermjs/xterm.js#5887](https://github.com/xtermjs/xterm.js/issues/5887)，xterm 6.0.0 仍存在）。

## Changes / 改动
Detect the case in `handleTerminalKey` (`isMac` + keydown + `keyCode 229` + `!isComposing` + Caps Lock on + uppercase `A-Z` + no ctrl/meta/alt, ssh/local only) and re-inject the char via `terminal.input()` so it flows through the normal `onData` pipeline (broadcast / backspace translation / encoding all preserved).
在 `handleTerminalKey` 中命中该场景（`isMac` + keydown + `keyCode 229` + 非组字 + Caps Lock 开 + 大写 `A-Z` + 无 ctrl/meta/alt，仅 ssh/local）时，用 `terminal.input()` 经正常 `onData` 管线重新注入字符（广播 / backspace 翻译 / 编码均保留）。

Two guards keep the fix narrow / 两道门槛保证改动收窄:
- `keyCode 229` never fires for an ordinary letter key, so normal macOS input never hits this path (no duplicate characters). / `keyCode 229` 对普通字母键永不触发，正常 macOS 输入不会命中此路径（不会重复输入）。
- Restricting to uppercase `A-Z` leaves IME composition (e.g. pinyin, whose first key is lowercase latin) untouched. / 限定大写 `A-Z` 以避免影响拼音等 IME 组字（其首键是小写 latin）。

## Validation / 验证
- Frontend build passes; terminal input tests 27/27 pass. / 前端构建通过，终端输入测试 27/27 通过。
- Behavior on macOS beta needs on-device verification (not reproducible without macOS beta). Please verify: (1) first uppercase letter after Caps Lock enters on the first press; (2) Chinese pinyin input (especially with Caps Lock on) is unaffected and produces no duplicate characters. / macOS beta 上的行为需真机验证（无 macOS beta 无法复现）。请验证：① Caps Lock 后首个大写字母首次即入；② 中文拼音输入（尤其开着 Caps Lock）不受影响、无重复字符。

Closes #483
