### PR TITLE
fix(k8s): add confirmation prompts for cordon/uncordon and fix drain icon

### DIFF
--- a/frontend/src/components/K8sResourceList.vue
+++ b/frontend/src/components/K8sResourceList.vue
@@ -99,7 +99,7 @@
             <component :is="row.spec?.unschedulable ? CircleCheck : Ban" :size="14" />
           </button>
           <button v-if="has('drain')" class="btn btn-ghost btn-icon btn-sm" :title="t('k8s.actionDrain')" @click.stop="onCommand('drain', row)">
-            <Download :size="14" />
+            <CirclePower :size="14" />
           </button>
           <button v-if="has('delete')" class="btn btn-ghost btn-icon btn-sm danger" :title="t('k8s.actionDelete')" @click.stop="onCommand('delete', row)">
             <Trash2 :size="14" />
@@ -127,7 +127,7 @@ import {
 } from 'element-plus'
 import { Refresh, Plus } from '@element-plus/icons-vue'
 import {
-  Pencil, ScrollText, SquareTerminal, Box, Repeat, ArrowUpDown, Ban, CircleCheck, Download, Trash2,
+  Pencil, ScrollText, SquareTerminal, Box, Repeat, ArrowUpDown, Ban, CircleCheck, CirclePower, Trash2,
 } from '@lucide/vue'
 import { useK8sStore } from '../stores/k8sStore'
 import { useI18n } from '../i18n'
@@ -357,7 +357,9 @@ async function onCommand(cmd: string, row: any) {
       const { value } = await ElMessageBox.prompt(t('k8s.scaleReplicas'), t('k8s.scaleTitle'), { inputPattern: /^\d+$/, inputValue: String(row.spec?.replicas ?? 1), confirmButtonText: t('common.confirm'), cancelButtonText: t('common.cancel') })
       await scaleWorkload(props.connId, scaleApiBase(row), row.metadata?.namespace, row.metadata?.name, Number(value)); ElMessage.success(t('k8s.scaled'))
     } else if (cmd === 'cordon') {
-      await cordonNode(props.connId, row.metadata?.name, !row.spec?.unschedulable); ElMessage.success(t('k8s.done')); emit('changed')
+      const unschedulable = !row.spec?.unschedulable
+      await ElMessageBox.confirm(t(unschedulable ? 'k8s.cordonConfirm' : 'k8s.uncordonConfirm', { name: row.metadata?.name }), t('k8s.confirmTitle'), { type: 'warning', confirmButtonText: t('common.confirm'), cancelButtonText: t('common.cancel') })
+      await cordonNode(props.connId, row.metadata?.name, unschedulable); ElMessage.success(t('k8s.done')); emit('changed')
     } else if (cmd === 'drain') {
       await ElMessageBox.confirm(t('k8s.drainConfirm', { name: row.metadata?.name }), t('k8s.confirmTitle'), { type: 'warning', confirmButtonText: t('common.confirm'), cancelButtonText: t('common.cancel') })
       const r = await drainNode(props.connId, row.metadata?.name); ElMessage.success(t('k8s.drained', { evicted: r.evicted, skipped: r.skipped }) + (r.errors.length ? t('k8s.drainErrors', { count: r.errors.length }) : ''))

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -855,6 +855,8 @@
   "k8s.scaled": "Skaliert",
   "k8s.done": "Fertig",
   "k8s.drainConfirm": "Node {name} drainen? Pods werden verdrängt.",
+  "k8s.cordonConfirm": "Node {name} cordonen? Er wird keine neuen Pods mehr annehmen.",
+  "k8s.uncordonConfirm": "Node {name} uncordonen? Er wird wieder neue Pods annehmen.",
   "k8s.drained": "{evicted} verdrängt, {skipped} übersprungen",
   "k8s.drainErrors": ", Fehler: {count}",
   "k8s.created": "Erstellt",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -855,6 +855,8 @@
   "k8s.scaled": "Scaled",
   "k8s.done": "Done",
   "k8s.drainConfirm": "Drain node {name}? Pods will be evicted.",
+  "k8s.cordonConfirm": "Cordon node {name}? It will stop accepting new pods.",
+  "k8s.uncordonConfirm": "Uncordon node {name}? It will start accepting new pods again.",
   "k8s.drained": "Evicted {evicted}, skipped {skipped}",
   "k8s.drainErrors": ", errors: {count}",
   "k8s.created": "Created",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -855,6 +855,8 @@
   "k8s.scaled": "Escalado",
   "k8s.done": "Hecho",
   "k8s.drainConfirm": "¿Drenar nodo {name}? Los Pods serán desalojados.",
+  "k8s.cordonConfirm": "¿Aislar nodo {name}? Dejará de aceptar nuevos Pods.",
+  "k8s.uncordonConfirm": "¿Desaislar nodo {name}? Volverá a aceptar nuevos Pods.",
   "k8s.drained": "Desalojados {evicted}, omitidos {skipped}",
   "k8s.drainErrors": ", errores: {count}",
   "k8s.created": "Creado",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -855,6 +855,8 @@
   "k8s.scaled": "Mis à l'échelle",
   "k8s.done": "Terminé",
   "k8s.drainConfirm": "Drainer le nœud {name} ? Les Pods seront évincés.",
+  "k8s.cordonConfirm": "Cordonner le nœud {name} ? Il cessera d'accepter de nouveaux Pods.",
+  "k8s.uncordonConfirm": "Décordonner le nœud {name} ? Il acceptera à nouveau de nouveaux Pods.",
   "k8s.drained": "{evicted} évincés, {skipped} ignorés",
   "k8s.drainErrors": ", erreurs : {count}",
   "k8s.created": "Créé",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -855,6 +855,8 @@
   "k8s.scaled": "スケールしました",
   "k8s.done": "完了",
   "k8s.drainConfirm": "ノード {name} を Drain しますか？Pod が退避されます。",
+  "k8s.cordonConfirm": "ノード {name} を Cordon しますか？新しい Pod を受け付けなくなります。",
+  "k8s.uncordonConfirm": "ノード {name} を Uncordon しますか？新しい Pod を再び受け付けるようになります。",
   "k8s.drained": "退避 {evicted}、スキップ {skipped}",
   "k8s.drainErrors": "、エラー {count}",
   "k8s.created": "作成しました",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -855,6 +855,8 @@
   "k8s.scaled": "스케일 조정됨",
   "k8s.done": "완료",
   "k8s.drainConfirm": "노드 {name}을(를) Drain하시겠습니까? Pod가 축출됩니다.",
+  "k8s.cordonConfirm": "노드 {name}을(를) Cordon하시겠습니까? 새 Pod를 받지 않습니다.",
+  "k8s.uncordonConfirm": "노드 {name}을(를) Uncordon하시겠습니까? 새 Pod를 다시 받습니다.",
   "k8s.drained": "축출 {evicted}, 건너뜀 {skipped}",
   "k8s.drainErrors": ", 오류 {count}",
   "k8s.created": "생성됨",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -855,6 +855,8 @@
   "k8s.scaled": "Масштабировано",
   "k8s.done": "Готово",
   "k8s.drainConfirm": "Drain узла {name}? Pod'ы будут вытеснены.",
+  "k8s.cordonConfirm": "Cordon узла {name}? Он перестанет принимать новые Pod'ы.",
+  "k8s.uncordonConfirm": "Uncordon узла {name}? Он снова будет принимать новые Pod'ы.",
   "k8s.drained": "Вытеснено {evicted}, пропущено {skipped}",
   "k8s.drainErrors": ", ошибок: {count}",
   "k8s.created": "Создано",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -855,6 +855,8 @@
   "k8s.scaled": "已伸缩",
   "k8s.done": "完成",
   "k8s.drainConfirm": "确定驱逐节点 {name}？其上的 Pod 将被驱逐。",
+  "k8s.cordonConfirm": "确定封禁节点 {name}？它将停止接受新 Pod。",
+  "k8s.uncordonConfirm": "确定解禁节点 {name}？它将恢复接受新 Pod。",
   "k8s.drained": "已驱逐 {evicted}，跳过 {skipped}",
   "k8s.drainErrors": "，错误 {count}",
   "k8s.created": "已创建",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -855,6 +855,8 @@
   "k8s.scaled": "已伸縮",
   "k8s.done": "完成",
   "k8s.drainConfirm": "確定驅逐節點 {name}？其上的 Pod 將被驅逐。",
+  "k8s.cordonConfirm": "確定封禁節點 {name}？它將停止接受新 Pod。",
+  "k8s.uncordonConfirm": "確定解禁節點 {name}？它將恢復接受新 Pod。",
   "k8s.drained": "已驅逐 {evicted}，跳過 {skipped}",
   "k8s.drainErrors": "，錯誤 {count}",
   "k8s.created": "已建立",


### PR DESCRIPTION
## What

- Replace `Download` icon with `CirclePower` for the drain action (UX fix — the download icon didn't convey drain)
- Add confirmation dialog before cordon/uncordon node operations (previously executed immediately without prompting, which could accidentally make a node unschedulable)
- Add i18n strings `k8s.cordonConfirm` / `k8s.uncordonConfirm` across all locales

## Files changed

- `frontend/src/components/K8sResourceList.vue` — icon swap + confirmation prompts
- `frontend/src/i18n/locales/*.json` — new confirmation strings

---

## 改动

- 将 drain 操作的图标从 `Download` 替换为 `CirclePower`（下载图标无法表达驱逐语义）
- 为 cordon/uncordon 节点操作添加确认弹窗（之前直接执行，可能误操作导致节点不可调度）
- 为所有语言添加 `k8s.cordonConfirm` / `k8s.uncordonConfirm` 翻译字符串