### PR TITLE
fix(ssh): add legacy CBC/3DES cipher and MAC support for old servers

### DIFF
--- a/backend/session/monitor_session.go
+++ b/backend/session/monitor_session.go
@@ -134,9 +134,7 @@ func (s *MonitorSession) Connect(config ConnectionConfig) error {
 		Auth:            authMethods,
 		Timeout:         30 * time.Second,
 		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
-		Config: ssh.Config{
-			KeyExchanges: sshKeyExchanges(),
-		},
+		Config: sshAlgorithms(),
 	}
 
 	client, err := ssh.Dial("tcp", fmt.Sprintf("%s:%d", config.Host, config.Port), clientConfig)

--- a/backend/session/mosh_session.go
+++ b/backend/session/mosh_session.go
@@ -61,9 +61,7 @@ func (s *MoshSession) Connect(config ConnectionConfig) error {
 		Auth:            authMethods,
 		Timeout:         30 * time.Second,
 		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
-		Config: ssh.Config{
-			KeyExchanges: sshKeyExchanges(),
-		},
+		Config: sshAlgorithms(),
 	}
 
 	conn, err := net.DialTimeout("tcp", addr, clientConfig.Timeout)

--- a/backend/session/sftp_session.go
+++ b/backend/session/sftp_session.go
@@ -81,9 +81,7 @@ func (s *SFTPSession) Connect(config ConnectionConfig) error {
 		Auth:            authMethods,
 		Timeout:         30 * time.Second,
 		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
-		Config: ssh.Config{
-			KeyExchanges: sshKeyExchanges(),
-		},
+		Config: sshAlgorithms(),
 	}
 
 	client, err := ssh.Dial("tcp", fmt.Sprintf("%s:%d", config.Host, config.Port), clientConfig)

--- a/backend/session/ssh_config.go
+++ b/backend/session/ssh_config.go
@@ -6,7 +6,6 @@ import "golang.org/x/crypto/ssh"
 // including legacy algorithms for compatibility with older servers.
 func sshKeyExchanges() []string {
 	return []string{
-		// Default safe algorithms
 		"mlkem768x25519-sha256",
 		"curve25519-sha256",
 		"curve25519-sha256@libssh.org",
@@ -20,5 +19,43 @@ func sshKeyExchanges() []string {
 		ssh.InsecureKeyExchangeDH14SHA1,
 		ssh.InsecureKeyExchangeDHGEXSHA1,
 		ssh.InsecureKeyExchangeDH1SHA1,
+	}
+}
+
+// sshCiphers returns the cipher list, including legacy CBC/3DES ciphers
+// for compatibility with old servers (issue #497).
+func sshCiphers() []string {
+	return []string{
+		ssh.CipherAES128GCM,
+		ssh.CipherAES256GCM,
+		ssh.CipherChaCha20Poly1305,
+		ssh.CipherAES128CTR,
+		ssh.CipherAES192CTR,
+		ssh.CipherAES256CTR,
+		// Legacy CBC/3DES ciphers for old servers (issue #497)
+		ssh.InsecureCipherAES128CBC,
+		ssh.InsecureCipherTripleDESCBC,
+	}
+}
+
+// sshMACs returns the MAC list, including legacy algorithms
+// for compatibility with old servers (issue #497).
+func sshMACs() []string {
+	return []string{
+		ssh.HMACSHA256ETM,
+		ssh.HMACSHA512ETM,
+		ssh.HMACSHA256,
+		ssh.HMACSHA512,
+		ssh.HMACSHA1,
+		ssh.InsecureHMACSHA196,
+	}
+}
+
+// sshAlgorithms returns the full algorithm configuration for SSH connections.
+func sshAlgorithms() ssh.Config {
+	return ssh.Config{
+		KeyExchanges: sshKeyExchanges(),
+		Ciphers:      sshCiphers(),
+		MACs:         sshMACs(),
 	}
 }

--- a/backend/session/ssh_dial.go
+++ b/backend/session/ssh_dial.go
@@ -22,7 +22,7 @@ func DialSSHClient(config ConnectionConfig) (*ssh.Client, error) {
 		Auth:            authMethods,
 		Timeout:         30 * time.Second,
 		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
-		Config:          ssh.Config{KeyExchanges: sshKeyExchanges()},
+		Config:          sshAlgorithms(),
 	}
 	conn, err := net.DialTimeout("tcp", addr, clientConfig.Timeout)
 	if err != nil {

--- a/backend/session/ssh_session.go
+++ b/backend/session/ssh_session.go
@@ -181,9 +181,7 @@ func (s *SSHSession) Connect(config ConnectionConfig) error {
 		Auth:            authMethods,
 		Timeout:         30 * time.Second,
 		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
-		Config: ssh.Config{
-			KeyExchanges: sshKeyExchanges(),
-		},
+		Config: sshAlgorithms(),
 	}
 
 	conn, err := net.DialTimeout("tcp", addr, clientConfig.Timeout)

--- a/backend/session/tunnel_forward.go
+++ b/backend/session/tunnel_forward.go
@@ -228,6 +228,7 @@ func (ts *TunnelService) dialChain(chain []ConnectionConfig, upstream *SocksProx
 			Auth:            makeSSHAuthMethods(cfg, nil),
 			Timeout:         30 * time.Second,
 			HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+			Config:          sshAlgorithms(),
 		}
 		sshConn, chans, reqs, err := ssh.NewClientConn(raw, addr, clientConfig)
 		if err != nil {

--- a/backend/session/tunnel_service.go
+++ b/backend/session/tunnel_service.go
@@ -60,9 +60,7 @@ func (ts *TunnelService) Start(sessionID string, sshConfig ConnectionConfig, tar
 		Auth:            authMethods,
 		Timeout:         30 * time.Second,
 		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
-		Config: ssh.Config{
-			KeyExchanges: sshKeyExchanges(),
-		},
+		Config: sshAlgorithms(),
 	}
 
 	conn, err := net.DialTimeout("tcp", addr, clientConfig.Timeout)


### PR DESCRIPTION
Extend SSH algorithm negotiation with legacy CBC/3DES ciphers (aes128-cbc, 3des-cbc) and hmac-sha1-96 MAC for compatibility with old servers (routers, switches, legacy Linux) that don't support modern AEAD/CTR ciphers.

### Changes
- Add `sshCiphers()` — modern ciphers + legacy CBC/3DES
- Add `sshMACs()` — modern MACs + legacy `hmac-sha1-96`
- Add `sshAlgorithms()` helper aggregating KEX + Ciphers + MACs
- Replace all 7 `ssh.ClientConfig` sites with unified `Config: sshAlgorithms()`
- Fix `tunnel_forward.go` which previously had no algorithm config at all

Cipher negotiation auto-selects the strongest mutually-supported algorithm — modern servers won't downgrade.

Fixes #497

---

SSH 算法协商扩展，加入 legacy CBC/3DES 加密（aes128-cbc、3des-cbc）和 hmac-sha1-96 MAC，兼容只支持旧算法的老设备（交换机/路由器/老旧 Linux）。

- 新增 `sshCiphers()` / `sshMACs()` / `sshAlgorithms()` 三个辅助函数
- 7 处 `ssh.ClientConfig` 统一改为 `Config: sshAlgorithms()`
- 修复 `tunnel_forward.go` 此前完全没有算法配置的问题

算法协商自动选择双方都支持的最强算法，不影响现代服务器。

Fixes #497