### PR TITLE
fix(terminal): restore bottom-up prompt scanning for reliable history recording, add independent AI transcription toggle

### DIFF
--- a/backend/store/settings_store.go
+++ b/backend/store/settings_store.go
@@ -21,6 +21,7 @@ type TerminalSettings struct {
 	RightClickAction string `json:"rightClickAction"`
 	MaxHistoryLines  int    `json:"maxHistoryLines"`
 	SmartCompletion  *bool  `json:"smartCompletion"`
+	AiTranscription  *bool  `json:"aiTranscription"`
 	HighlightEnabled *bool  `json:"highlightEnabled"`
 	// CursorBlink controls xterm.js's cursor blink. Pointer + omitempty so
 	// settings.json written by older builds (which lack this field) still

--- a/frontend/src/components/BaseTerminal.vue
+++ b/frontend/src/components/BaseTerminal.vue
@@ -996,7 +996,7 @@ onMounted(() => {
           const isPrintable = data.length === 1 && data >= ' '
           if (!wasVisible && !isPrintable) return
           if (terminalInput.isAtLineEnd() && terminalInput.currentToken.value && !terminalInput.isPasswordMode()) {
-            suggestions.updateSuggestions(terminalInput.currentToken.value)
+            suggestions.updateSuggestions(terminalInput.currentToken.value, settingsStore.settings.terminal.aiTranscription)
           } else {
             suggestions.close()
           }

--- a/frontend/src/components/SettingsTab.vue
+++ b/frontend/src/components/SettingsTab.vue
@@ -339,6 +339,16 @@
 
           <div class="setting-card">
             <div class="setting-info">
+              <div class="setting-title">{{ t('settings.aiTranscription') }}</div>
+              <div class="setting-desc">{{ t('settings.aiTranscriptionDesc') }}</div>
+            </div>
+            <div class="setting-control">
+              <el-switch :model-value="settingsStore.settings.terminal.aiTranscription ?? true" @update:model-value="(v: boolean) => { settingsStore.settings.terminal.aiTranscription = v; settingsStore.save() }" />
+            </div>
+          </div>
+
+          <div class="setting-card">
+            <div class="setting-info">
               <div class="setting-title">{{ t('settings.highlight') }}</div>
               <div class="setting-desc">{{ t('settings.highlightDesc') }}</div>
             </div>

--- a/frontend/src/composables/useSuggestions.ts
+++ b/frontend/src/composables/useSuggestions.ts
@@ -350,7 +350,7 @@ export function useSuggestions() {
     }
   }
 
-  async function updateSuggestions(token: string) {
+  async function updateSuggestions(token: string, aiTranscriptionEnabled?: boolean) {
     if (debounceTimer) {
       clearTimeout(debounceTimer)
     }
@@ -364,12 +364,14 @@ export function useSuggestions() {
       const historyItems = getHistorySuggestions(token)
       const quickCommandItems = getQuickCommandSuggestions(token)
       const items: SuggestionItem[] = [...quickCommandItems, ...historyItems]
-      items.push({
-        type: 'ai-preview',
-        label: t('terminal.aiTranscribing'),
-        value: '',
-        description: 'AI',
-      })
+      if (aiTranscriptionEnabled !== false) {
+        items.push({
+          type: 'ai-preview',
+          label: t('terminal.aiTranscribing'),
+          value: '',
+          description: 'AI',
+        })
+      }
       state.value.items = items
       state.value.selectedIndex = -1
       state.value.visible = items.length > 0

--- a/frontend/src/composables/useTerminalInput.ts
+++ b/frontend/src/composables/useTerminalInput.ts
@@ -52,8 +52,9 @@ export function useTerminalInput(terminal: Terminal | null, options: UseTerminal
       // Prompt endings: $ # > ] plus common zsh/oh-my-zsh/powerline glyphs
       const PROMPT_RE = /(.+?[$#>\]❯➜→»λ])(?:\s+|$)(.*)/
       const rows = (terminal as any).rows || 24
-      // Cursor row first: running command lives where the cursor sits.
-      const cursorY = (buffer.y ?? 0) + (buffer.baseY ?? 0)
+      // Scan visible area from bottom to top — always finds the latest
+      // prompt regardless of cursor position. (Cursor-based scanning was
+      // tried in e4d31b7 but proved unreliable for prompt detection.)
       const tryLine = (y: number): string | null => {
         if (y < 0) return null
         const line = buffer.getLine(y)
@@ -63,22 +64,15 @@ export function useTerminalInput(terminal: Terminal | null, options: UseTerminal
         const cleanText = stripAnsi(rawText)
         const match = cleanText.match(PROMPT_RE)
         if (!match) return null
-        const promptPart = match[1]
-        const lastChar = promptPart.charAt(promptPart.length - 1)
-        const isUnicodePrompt = /[❯➜→»λ]/.test(lastChar)
-        if (!promptPart.includes('@') && !promptPart.includes('~') &&
-            promptPart !== '$' && promptPart !== '#' && !isUnicodePrompt) return null
         const command = match[2].trim()
         if (command && !command.includes('__AI_DONE_') && command.length <= MAX_COMMAND_LENGTH) {
           return command
         }
         return null
       }
-      const fromCursor = tryLine(cursorY)
-      if (fromCursor !== null) return fromCursor
-      // Walk up until we find a prompt — stop at the first match.
-      for (let dy = 1; dy < rows; dy++) {
-        const y = cursorY - dy
+      const bottomY = (buffer.baseY ?? 0) + rows - 1
+      for (let dy = 0; dy < rows; dy++) {
+        const y = bottomY - dy
         if (y < 0) break
         const hit = tryLine(y)
         if (hit !== null) return hit

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -344,6 +344,8 @@
   "settings.maxHistoryDesc": "Maximale Anzahl ausgegebener Zeilen im Terminal",
   "settings.smartCompletion": "Intelligente Vervollständigung",
   "settings.smartCompletionDesc": "Verlaufs- und KI-Vorschläge beim Tippen anzeigen",
+  "settings.aiTranscription": "KI-Transkription",
+  "settings.aiTranscriptionDesc": "KI-basierte Befehlsvorschläge beim Tippen (API-Key erforderlich)",
   "settings.fetchModels": "Modelle abrufen",
   "settings.fetchModelsSuccess": "{connCount} Modelle abgerufen",
   "settings.fetchModelsFailed": "Modelle konnten nicht abgerufen werden",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -344,6 +344,8 @@
   "settings.maxHistoryDesc": "Maximum output lines to keep in terminal",
   "settings.smartCompletion": "Smart Completion",
   "settings.smartCompletionDesc": "Show history and AI suggestions while typing",
+  "settings.aiTranscription": "AI Transcription",
+  "settings.aiTranscriptionDesc": "Suggest command rewrites via AI when typing (requires API key configured)",
   "settings.fetchModels": "Fetch Models",
   "settings.fetchModelsSuccess": "Fetched {count} models",
   "settings.fetchModelsFailed": "Failed to fetch models",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -344,6 +344,8 @@
   "settings.maxHistoryDesc": "Máximo de líneas de salida a conservar en la terminal",
   "settings.smartCompletion": "Autocompletado Inteligente",
   "settings.smartCompletionDesc": "Mostrar sugerencias del historial y de la IA mientras escribe",
+  "settings.aiTranscription": "Transcripción IA",
+  "settings.aiTranscriptionDesc": "Sugerir reescrituras de comandos mediante IA mientras escribe (requiere clave API)",
   "settings.fetchModels": "Obtener modelos",
   "settings.fetchModelsSuccess": "{connCount} modelos obtenidos",
   "settings.fetchModelsFailed": "Error al obtener modelos",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -344,6 +344,8 @@
   "settings.maxHistoryDesc": "Nombre maximum de lignes de sortie conservées dans le terminal",
   "settings.smartCompletion": "Complétion intelligente",
   "settings.smartCompletionDesc": "Afficher les suggestions d'historique et de IA pendant la saisie",
+  "settings.aiTranscription": "Transcription IA",
+  "settings.aiTranscriptionDesc": "Suggérer des réécritures de commandes via IA pendant la saisie (clé API requise)",
   "settings.fetchModels": "Récupérer les modèles",
   "settings.fetchModelsSuccess": "{connCount} modèles récupérés",
   "settings.fetchModelsFailed": "Échec de la récupération des modèles",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -344,6 +344,8 @@
   "settings.maxHistoryDesc": "ターミナルに保持する出力行数の上限",
   "settings.smartCompletion": "スマート補完",
   "settings.smartCompletionDesc": "入力中に履歴と AI の候補を表示",
+  "settings.aiTranscription": "AI 文字起こし",
+  "settings.aiTranscriptionDesc": "入力中に AI によるコマンドの書き換え候補を表示（API キーの設定が必要）",
   "settings.fetchModels": "モデルを取得",
   "settings.fetchModelsSuccess": "{connCount}件のモデルを取得しました",
   "settings.fetchModelsFailed": "モデルの取得に失敗しました",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -344,6 +344,8 @@
   "settings.maxHistoryDesc": "터미널에 유지할 최대 출력 줄 수",
   "settings.smartCompletion": "스마트 완성",
   "settings.smartCompletionDesc": "입력 중에 기록 및 AI 제안 표시",
+  "settings.aiTranscription": "AI 트랜스크라이빙",
+  "settings.aiTranscriptionDesc": "입력 중 AI 명령어 재작성 제안 표시 (API 키 필요)",
   "settings.fetchModels": "모델 가져오기",
   "settings.fetchModelsSuccess": "{connCount}개의 모델을 가져왔습니다",
   "settings.fetchModelsFailed": "모델을 가져오지 못했습니다",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -344,6 +344,8 @@
   "settings.maxHistoryDesc": "Максимальное количество строк вывода в терминале",
   "settings.smartCompletion": "Умное автодополнение",
   "settings.smartCompletionDesc": "Показывать историю и подсказки ИИ при вводе",
+  "settings.aiTranscription": "Транскрипция ИИ",
+  "settings.aiTranscriptionDesc": "Предлагать переписанные команды через ИИ при вводе (требуется API-ключ)",
   "settings.fetchModels": "Получить модели",
   "settings.fetchModelsSuccess": "Получено моделей: {connCount}",
   "settings.fetchModelsFailed": "Не удалось получить модели",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -344,6 +344,8 @@
   "settings.maxHistoryDesc": "终端保留的最大输出行数",
   "settings.smartCompletion": "智能补全",
   "settings.smartCompletionDesc": "输入时显示历史命令和 AI 补全建议",
+  "settings.aiTranscription": "AI 转写",
+  "settings.aiTranscriptionDesc": "输入时通过 AI 提供命令改写建议（需先配置 API Key）",
   "settings.fetchModels": "拉取模型列表",
   "settings.fetchModelsSuccess": "已拉取 {count} 个模型",
   "settings.fetchModelsFailed": "拉取模型列表失败",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -344,6 +344,8 @@
   "settings.maxHistoryDesc": "終端機保留的最大輸出行數",
   "settings.smartCompletion": "智慧補全",
   "settings.smartCompletionDesc": "輸入時顯示歷史命令和 AI 補全建議",
+  "settings.aiTranscription": "AI 轉寫",
+  "settings.aiTranscriptionDesc": "輸入時透過 AI 提供命令改寫建議（需先設定 API Key）",
   "settings.fetchModels": "拉取模型列表",
   "settings.fetchModelsSuccess": "已拉取 {connCount} 個模型",
   "settings.fetchModelsFailed": "拉取模型列表失敗",

--- a/frontend/src/types/settings.ts
+++ b/frontend/src/types/settings.ts
@@ -50,6 +50,7 @@ export interface TerminalSettings {
   middleClickAction: 'none' | 'paste'
   maxHistoryLines: number
   smartCompletion: boolean
+  aiTranscription: boolean
   highlightEnabled: boolean
   cursorBlink: boolean
   // Override for the session output log directory. Empty means the
@@ -170,6 +171,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
     middleClickAction: 'paste',
     maxHistoryLines: 2500,
     smartCompletion: true,
+    aiTranscription: true,
     highlightEnabled: true,
     cursorBlink: true,
     sessionLogDir: '',

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -1478,6 +1478,7 @@ export namespace store {
 	    rightClickAction: string;
 	    maxHistoryLines: number;
 	    smartCompletion?: boolean;
+	    aiTranscription?: boolean;
 	    highlightEnabled?: boolean;
 	    cursorBlink?: boolean;
 	    sessionLogDir?: string;
@@ -1496,6 +1497,7 @@ export namespace store {
 	        this.rightClickAction = source["rightClickAction"];
 	        this.maxHistoryLines = source["maxHistoryLines"];
 	        this.smartCompletion = source["smartCompletion"];
+	        this.aiTranscription = source["aiTranscription"];
 	        this.highlightEnabled = source["highlightEnabled"];
 	        this.cursorBlink = source["cursorBlink"];
 	        this.sessionLogDir = source["sessionLogDir"];


### PR DESCRIPTION
## Summary

### 1. Fix: command history not being recorded

**Root cause:** Commit `e4d31b7` changed `getCurrentCommandFromTerminal()` scan order from bottom-up (`buffer.baseY + rows - 1`) to cursor-based (`buffer.y + buffer.baseY`). When `buffer.y` is inaccurate in certain xterm.js states, the scan starts from the wrong line and fails to extract the typed command.

**Fix:** Restore the bottom-up scanning order, which always finds the latest prompt regardless of cursor position. Also remove the overly strict prompt character validation that rejected prompts without `@` or `~` characters (e.g. `bash-5.1$`, `sh-4.2$`).

### 2. Independent AI transcription toggle

Previously the `smartCompletion` toggle controlled both history suggestions and AI transcription together. This adds a separate `aiTranscription` boolean in `TerminalSettings` so users can keep fast, private history suggestions on while turning off AI-powered command rewrites.

### Changes

| File | Change |
|------|--------|
| `useTerminalInput.ts` | Restore bottom-up prompt scanning; remove strict prompt char validation |
| `useSuggestions.ts` | Accept `aiTranscriptionEnabled` param to conditionally show AI row |
| `BaseTerminal.vue` | Pass `aiTranscription` setting to `updateSuggestions()` |
| `SettingsTab.vue` | Add AI transcription toggle in settings UI |
| `settings.ts` | Add `aiTranscription: boolean` field with default `true` |
| `settings_store.go` | Add `AiTranscription *bool` field |
| 9 locale files | Add `settings.aiTranscription` / `settings.aiTranscriptionDesc` keys |

Fixes #495

---

## 摘要

### 1. 修复：历史命令未被记录

**根因：** `e4d31b7` 将命令提取的扫描顺序从底部向上（`buffer.baseY + rows - 1`）改为基于光标位置（`buffer.y + buffer.baseY`）。当 xterm.js 的 `buffer.y` 不准确时，扫描从错误行开始，无法提取到输入的命令。

**修复：** 恢复从底部向上的扫描顺序，不依赖光标位置。同时移除对 prompt 中必须包含 `@` 或 `~` 的过严校验。

### 2. AI 转写独立开关

原先 `smartCompletion`（智能补全）一个开关同时控制历史建议和 AI 转写。现在新增 `aiTranscription` 独立开关，用户可保留快速、隐私的历史建议，同时关闭消耗 API token 的 AI 命令改写。

修复 #495