### PR TITLE
fix(x11): probe /tmp/.X11-unix when $DISPLAY is empty on macOS/Linux

### DIFF
--- a/backend/session/x11.go
+++ b/backend/session/x11.go
@@ -58,6 +58,40 @@ func ParseDisplay(s string) (host string, display, screen int, err error) {
 	return host, display, screen, nil
 }
 
+// resolveLocalDisplay returns a usable X11 display string. A non-empty raw
+// value (normally $DISPLAY) is used verbatim. When it's empty on macOS/Linux
+// — a GUI-launched app often doesn't inherit $DISPLAY, and a macOS .app opened
+// from Finder/Dock has its environment stripped entirely — it probes the
+// standard socket dir /tmp/.X11-unix/Xn and returns ":n" for the lowest live
+// socket (XQuartz/Xorg both listen there). Returns "" if nothing is found.
+func resolveLocalDisplay(raw string) string {
+	if raw != "" || runtime.GOOS == "windows" {
+		return raw
+	}
+	entries, err := os.ReadDir("/tmp/.X11-unix")
+	if err != nil {
+		return ""
+	}
+	best := -1
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasPrefix(name, "X") {
+			continue
+		}
+		n, aerr := strconv.Atoi(name[1:])
+		if aerr != nil || n < 0 {
+			continue
+		}
+		if best == -1 || n < best {
+			best = n
+		}
+	}
+	if best == -1 {
+		return ""
+	}
+	return ":" + strconv.Itoa(best)
+}
+
 // DialLocalX connects to the X server pointed to by `display`.
 //   - ":N" / "unix:N"                         → unix socket /tmp/.X11-unix/XN
 //     on Linux/macOS, with a parallel TCP fallback to 127.0.0.1:6000+N.

--- a/backend/session/x11_forward.go
+++ b/backend/session/x11_forward.go
@@ -108,12 +108,17 @@ func startX11Forward(client *ssh.Client, session *ssh.Session, xauthPath, displa
 	if display == "" {
 		// Windows convenience: VcXsrv is standard at localhost:0;
 		// assume that's what the user has and skip the empty-DISPLAY error.
-		// macOS / Linux keep the strict behavior — their DISPLAY is normally
-		// set by the session, and a missing one is usually intentional.
 		if runtime.GOOS == "windows" {
 			display = "localhost:0"
 		} else {
-			return nil, errX11DisplayEmpty
+			// macOS / Linux: a GUI-launched app (esp. a Finder-launched
+			// .app with its env stripped) often has no $DISPLAY even when
+			// XQuartz/Xorg is running. Probe /tmp/.X11-unix for a live
+			// socket before giving up.
+			display = resolveLocalDisplay(display)
+			if display == "" {
+				return nil, errX11DisplayEmpty
+			}
 		}
 	}
 

--- a/backend/session/x11_test.go
+++ b/backend/session/x11_test.go
@@ -3,6 +3,7 @@ package session
 import (
 	"net"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"testing"
 )
@@ -82,6 +83,33 @@ func TestDialLocalX_DisplayUnset(t *testing.T) {
 	_, err := DialLocalX("")
 	if err == nil {
 		t.Fatal("expected error for empty DISPLAY")
+	}
+}
+
+func TestResolveLocalDisplay(t *testing.T) {
+	// A non-empty value is always used verbatim, regardless of OS.
+	if got := resolveLocalDisplay(":3"); got != ":3" {
+		t.Errorf("non-empty passthrough: got %q, want %q", got, ":3")
+	}
+	if got := resolveLocalDisplay("host:0"); got != "host:0" {
+		t.Errorf("non-empty passthrough: got %q, want %q", got, "host:0")
+	}
+
+	// Empty-value probing is platform-specific.
+	got := resolveLocalDisplay("")
+	switch runtime.GOOS {
+	case "windows":
+		// No socket probing on Windows — empty stays empty.
+		if got != "" {
+			t.Errorf("windows empty: got %q, want \"\"", got)
+		}
+	default:
+		// macOS/Linux: either no live socket ("") or a well-formed ":n"
+		// discovered from /tmp/.X11-unix. Assert the shape, not a fixed
+		// value, so the test doesn't depend on whether an X server runs.
+		if got != "" && !regexp.MustCompile(`^:\d+$`).MatchString(got) {
+			t.Errorf("probed display %q is not empty or \":n\"", got)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary / 摘要
X11 forwarding fails with `x11: $DISPLAY is empty` on macOS even when XQuartz is running.
即便 XQuartz 已运行，macOS 上 X11 转发仍报 `x11: $DISPLAY is empty`。

## Root cause / 根因
The backend reads only `os.Getenv("DISPLAY")`, but a Finder/Dock-launched `.app` has its environment stripped by macOS, so `$DISPLAY` is always empty there — the local X server is reachable, but the app never sees the variable. (Note: `launchctl getenv DISPLAY` is often empty too, since XQuartz only `setenv`s it at login.)
后端只读 `os.Getenv("DISPLAY")`，而从 Finder/Dock 启动的 `.app` 环境变量被 macOS 剥离，`$DISPLAY` 恒为空——本机 X server 明明可连，app 却拿不到该变量。（注：`launchctl getenv DISPLAY` 也常为空，因为 XQuartz 仅在登录时 `setenv`。）

## Changes / 改动
Add `resolveLocalDisplay()` in `x11.go`:
- A non-empty value (or Windows) is used verbatim.
- On macOS/Linux an empty value probes `/tmp/.X11-unix/Xn` and falls back to the lowest `:n` (usually `:0`), returning `""` only if no live socket exists.

Wired into `startX11Forward`'s empty-DISPLAY branch, mirroring the existing Windows `localhost:0` fallback.

在 `x11.go` 新增 `resolveLocalDisplay()`：非空值（或 Windows）原样使用；macOS/Linux 空值时扫描 `/tmp/.X11-unix/Xn`，回落到最小编号 `:n`（通常 `:0`），只有无存活 socket 时才返回 `""`。接入 `startX11Forward` 的空 DISPLAY 分支，与现有 Windows `localhost:0` 兜底同构。

## Validation / 验证
- Backend builds; x11 tests pass including the new `TestResolveLocalDisplay`. / 后端编译通过，x11 测试（含新增 `TestResolveLocalDisplay`）全过。
- End-to-end needs on-device verification: XQuartz running + a **packaged `.app`** (not `wails dev`, which doesn't reproduce the env stripping) running `xeyes`/`xclock` over SSH. / 端到端需真机验证：XQuartz 已启动 + **打包版 `.app`**（非 `wails dev`，其不复现 env 剥离）经 SSH 运行 `xeyes`/`xclock`。

## Note / 说明
Users must still start XQuartz first — this fixes the case where the X server *is* running but the GUI app can't see `$DISPLAY`. / 用户仍需先启动 XQuartz——本 PR 修的是「X server 已在跑、但 GUI app 读不到 `$DISPLAY`」这一场景。
