### PR TITLE
fix(ai): revert over-engineered SSE/streaming optimizations to v1.6.0

### DIFF
--- a/app.go
+++ b/app.go
@@ -487,26 +487,6 @@ func (a *App) llmHTTPClient() *http.Client {
 	return a.httpClient
 }
 
-// injectCacheControl adds ephemeral cache_control breakpoints on the
-// static system prompt and tools array so Anthropic's prompt caching
-// beta actually caches them across turns. Without this the
-// prompt-caching-2024-07-31 header is sent but the request body has
-// no breakpoints, so every turn re-ships and re-bills the static
-// prefix (~3 KB in typical Claude Code sessions). F-303.
-func injectCacheControl(reqBody map[string]interface{}) {
-	if sys, ok := reqBody["system"].(string); ok && sys != "" {
-		reqBody["system"] = []map[string]interface{}{{
-			"type":          "text",
-			"text":          sys,
-			"cache_control": map[string]string{"type": "ephemeral"},
-		}}
-	}
-	if tools, ok := reqBody["tools"].([]interface{}); ok && len(tools) > 0 {
-		if last, ok := tools[len(tools)-1].(map[string]interface{}); ok {
-			last["cache_control"] = map[string]string{"type": "ephemeral"}
-		}
-	}
-}
 // which don't fire the JS visibilitychange event (Cmd+H on macOS before
 // the WebView is loaded, OS-level Alt+Tab) still update the foreground
 // flag. Runs every 2s — coarse on purpose, this is a lifecycle hint not
@@ -2049,12 +2029,6 @@ type aiDoneEvent struct {
 func (a *App) chatCompletionAnthropic(apiKey, baseURL, model string, reqBody map[string]interface{}, userAgent string) (string, error) {
 	reqBody["stream"] = true
 
-	// F-303: insert ephemeral cache_control breakpoints on the static
-	// system + tools prefixes so Anthropic reuses the cached tokens
-	// across turns. Without these the prompt-caching beta header is a
-	// no-op — every turn re-ships and re-bills the static prefix.
-	injectCacheControl(reqBody)
-
 	modifiedJSON, err := json.Marshal(reqBody)
 	if err != nil {
 		return "", fmt.Errorf("marshal modified request: %w", err)
@@ -2073,16 +2047,11 @@ func (a *App) chatCompletionAnthropic(apiKey, baseURL, model string, reqBody map
 	ctx, cancel := context.WithTimeout(context.Background(), 600*time.Second)
 	defer cancel()
 
-	// F-308: register our cancel in the App-level pointer and only
-	// clear it on the way out if no one replaced us. The previous code
-	// stored a single context.CancelFunc under a mutex and unconditionally
-	// nil'd it on defer; when two ChatCompletion calls overlapped, call A's
-	// defer wiped call B's cancel and CancelChatStream became a no-op for B.
+	// F-308: atomic pointer swap so overlapping ChatCompletion calls
+	// don't clobber each other's cancel function.
 	myCancel := cancel
 	a.chatCancel.Store(&myCancel)
 	defer func() {
-		// CAS the slot back to nil, but only if it still points at our
-		// own cancel — a newer call may have already taken over the slot.
 		a.chatCancel.CompareAndSwap(&myCancel, nil)
 	}()
 
@@ -2096,7 +2065,7 @@ func (a *App) chatCompletionAnthropic(apiKey, baseURL, model string, reqBody map
 	req.Header.Set("anthropic-beta", "prompt-caching-2024-07-31")
 	req.Header.Set("User-Agent", userAgent)
 
-	client := a.llmHTTPClient()
+	client := &http.Client{Timeout: 0}
 	res, err := client.Do(req)
 	if err != nil {
 		if ctx.Err() == context.DeadlineExceeded {
@@ -2107,9 +2076,7 @@ func (a *App) chatCompletionAnthropic(apiKey, baseURL, model string, reqBody map
 	defer res.Body.Close()
 
 	if res.StatusCode != http.StatusOK {
-		// F-305: cap the error-body read at 64 KiB so a hostile or
-		// buggy upstream returning a multi-GB error body can't OOM
-		// the Go process.
+		// F-305: cap error-body reads at 64 KiB.
 		body, _ := io.ReadAll(io.LimitReader(res.Body, 64*1024))
 		return "", fmt.Errorf("HTTP %d: %s", res.StatusCode, string(body))
 	}
@@ -2119,12 +2086,6 @@ func (a *App) chatCompletionAnthropic(apiKey, baseURL, model string, reqBody map
 	var messageRole string
 	var usage map[string]interface{}
 	currentBlockIndex := -1
-	// F-307: parallel slice of per-block text buffers. Accumulating
-	// text via string + string was O(n²) and paid a fresh alloc per
-	// token; we Write into a *bytes.Buffer instead and flush to a
-	// string once at content_block_stop / message_stop. Empty slots
-	// (non-text blocks) stay nil and are skipped on flush.
-	var blockTextBufs []*bytes.Buffer
 
 	scanner := bufio.NewScanner(res.Body)
 	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
@@ -2136,22 +2097,22 @@ func (a *App) chatCompletionAnthropic(apiKey, baseURL, model string, reqBody map
 		}
 		dataStr := line[6:]
 
-		var ev anthropicStreamEvent
-		if err := json.Unmarshal([]byte(dataStr), &ev); err != nil {
+		var event map[string]interface{}
+		if err := json.Unmarshal([]byte(dataStr), &event); err != nil {
 			continue
 		}
 
-		switch ev.Type {
+		eventType, _ := event["type"].(string)
+
+		switch eventType {
 		case "message_start":
-			var mr anthropicMessageRole
-			if err := json.Unmarshal(ev.Message, &mr); err == nil {
-				messageRole = mr.Role
+			if msg, ok := event["message"].(map[string]interface{}); ok {
+				messageRole, _ = msg["role"].(string)
 			}
 
 		case "content_block_start":
 			currentBlockIndex++
-			var block map[string]interface{}
-			if err := json.Unmarshal(ev.ContentBlock, &block); err == nil {
+			if block, ok := event["content_block"].(map[string]interface{}); ok {
 				currentBlock = block
 				runtime.EventsEmit(a.ctx, "ai:block_start", map[string]interface{}{
 					"index":         currentBlockIndex,
@@ -2160,54 +2121,34 @@ func (a *App) chatCompletionAnthropic(apiKey, baseURL, model string, reqBody map
 			}
 
 		case "content_block_delta":
-			var delta anthropicDelta
-			if err := json.Unmarshal(ev.Delta, &delta); err != nil {
-				continue
-			}
-			switch delta.Type {
-			case "text_delta":
-				text := delta.Text
+			delta, _ := event["delta"].(map[string]interface{})
+			deltaType, _ := delta["type"].(string)
+
+			if deltaType == "text_delta" {
+				text, _ := delta["text"].(string)
 				if currentBlock != nil {
-					// F-307: append to a per-block *bytes.Buffer
-					// instead of O(n²) string concatenation. The
-					// buffer is flushed to a string exactly once
-					// at content_block_stop; the per-token
-					// String() call is gone.
-					if blockTextBufs[currentBlockIndex] == nil {
-						blockTextBufs = append(blockTextBufs, make([]*bytes.Buffer, currentBlockIndex+1-len(blockTextBufs))...)
-						blockTextBufs[currentBlockIndex] = &bytes.Buffer{}
+					if currentBlock["text"] == nil {
+						currentBlock["text"] = ""
 					}
-					blockTextBufs[currentBlockIndex].WriteString(text)
+					currentBlock["text"] = currentBlock["text"].(string) + text
 				}
-				// F-320: typed struct + dropped unused fields so
-				// the per-token EventsEmit doesn't allocate a
-				// fresh map[string]interface{}. The ai:token payload
-				// carries only text + index.
-				runtime.EventsEmit(a.ctx, "ai:token", aiTokenEvent{
-					Text:  delta.Text,
-					Index: currentBlockIndex,
+				runtime.EventsEmit(a.ctx, "ai:token", map[string]interface{}{
+					"text":  text,
+					"index": currentBlockIndex,
 				})
-			case "input_json_delta":
-				if currentBlock != nil {
-					partial := delta.PartialJSON
-					if currentBlock["input"] == nil || fmt.Sprintf("%T", currentBlock["input"]) != "string" {
-						currentBlock["input"] = ""
-					}
-					if s, ok := currentBlock["input"].(string); ok {
-						currentBlock["input"] = s + partial
-					}
+			}
+			if deltaType == "input_json_delta" && currentBlock != nil {
+				partial, _ := delta["partial_json"].(string)
+				if currentBlock["input"] == nil || fmt.Sprintf("%T", currentBlock["input"]) != "string" {
+					currentBlock["input"] = ""
+				}
+				if s, ok := currentBlock["input"].(string); ok {
+					currentBlock["input"] = s + partial
 				}
 			}
 
 		case "content_block_stop":
 			if currentBlock != nil {
-				// F-307: flush the per-block text buffer exactly
-				// once into currentBlock["text"] so the downstream
-				// contentBlocks / JSON marshal sees a single
-				// string instead of O(n²) per-token copies.
-				if currentBlockIndex >= 0 && currentBlockIndex < len(blockTextBufs) && blockTextBufs[currentBlockIndex] != nil {
-					currentBlock["text"] = blockTextBufs[currentBlockIndex].String()
-				}
 				if blockType, _ := currentBlock["type"].(string); blockType == "tool_use" {
 					if inputStr, ok := currentBlock["input"].(string); ok && inputStr != "" {
 						var inputObj map[string]interface{}
@@ -2221,29 +2162,18 @@ func (a *App) chatCompletionAnthropic(apiKey, baseURL, model string, reqBody map
 			}
 
 		case "message_delta":
-			if len(ev.Usage) > 0 {
-				var u map[string]interface{}
-				if err := json.Unmarshal(ev.Usage, &u); err == nil {
-					usage = u
-				}
+			if u, ok := event["usage"].(map[string]interface{}); ok {
+				usage = u
 			}
-			var sd anthropicStopDelta
-			if err := json.Unmarshal(ev.Delta, &sd); err == nil && sd.StopReason != "" {
-				// F-210: marshal the full message once into a pooled
-				// buffer and reuse the bytes for both the ai:done
-				// emit (Wails marshals the args separately) and the
-				// eventual return at message_stop. Previously this
-				// struct was rebuilt + remarshaled twice per turn.
-				fullMessage := map[string]interface{}{
-					"role":    messageRole,
-					"content": contentBlocks,
-				}
-				resultJSON, err := marshalAnthropicFinalMessage(fullMessage)
-				if err == nil {
+			if delta, ok := event["delta"].(map[string]interface{}); ok {
+				if stopReason, ok := delta["stop_reason"].(string); ok {
 					runtime.EventsEmit(a.ctx, "ai:done", map[string]interface{}{
-						"message":    json.RawMessage(resultJSON),
-						"usage":      usage,
-						"stop_reason": sd.StopReason,
+						"message": map[string]interface{}{
+							"role":    messageRole,
+							"content": contentBlocks,
+						},
+						"usage":       usage,
+						"stop_reason": stopReason,
 					})
 				}
 			}
@@ -2253,18 +2183,16 @@ func (a *App) chatCompletionAnthropic(apiKey, baseURL, model string, reqBody map
 				"role":    messageRole,
 				"content": contentBlocks,
 			}
-			resultJSON, err := marshalAnthropicFinalMessage(fullMessage)
+			resultJSON, err := json.Marshal(fullMessage)
 			if err != nil {
 				return "", fmt.Errorf("marshal full message: %w", err)
 			}
 			return string(resultJSON), nil
 
 		case "error":
-			var e struct {
-				Message string `json:"message"`
-			}
-			_ = json.Unmarshal(ev.Error, &e)
-			return "", fmt.Errorf("stream error: %s", e.Message)
+			errData, _ := event["error"].(map[string]interface{})
+			errMsg, _ := errData["message"].(string)
+			return "", fmt.Errorf("stream error: %s", errMsg)
 		}
 	}
 
@@ -2277,42 +2205,11 @@ func (a *App) chatCompletionAnthropic(apiKey, baseURL, model string, reqBody map
 			"role":    messageRole,
 			"content": contentBlocks,
 		}
-		resultJSON, _ := marshalAnthropicFinalMessage(fullMessage)
+		resultJSON, _ := json.Marshal(fullMessage)
 		return string(resultJSON), nil
 	}
 
 	return "", fmt.Errorf("stream ended without message_stop")
-}
-
-// anthropicToolToOpenAI converts an Anthropic tool definition to OpenAI format.
-// pooled *bytes.Buffer and returns the resulting JSON string. The
-// pool avoids per-turn allocator churn; in a heavy Claude Code session
-// the buffer grows once to ~3 KiB and stays warm. Returns the buffer
-// to the pool via defer in the caller (no — the string escapes the
-// goroutine, so we keep ownership here; the buffer can be reused when
-// the underlying JSON is no longer referenced by Wails).
-func marshalAnthropicFinalMessage(msg map[string]interface{}) ([]byte, error) {
-	buf := finalMsgPool.Get().(*bytes.Buffer)
-	buf.Reset()
-	defer finalMsgPool.Put(buf)
-	enc := json.NewEncoder(buf)
-	if err := enc.Encode(msg); err != nil {
-		return nil, err
-	}
-	// json.Encoder always appends a trailing newline; trim it.
-	out := buf.Bytes()
-	if n := len(out); n > 0 && out[n-1] == '\n' {
-		out = out[:n-1]
-	}
-	return out, nil
-}
-
-var finalMsgPool = stdsync.Pool{
-	New: func() any {
-		b := &bytes.Buffer{}
-		b.Grow(4 * 1024)
-		return b
-	},
 }
 func anthropicToolToOpenAI(t map[string]interface{}) map[string]interface{} {
 	return map[string]interface{}{
@@ -2597,7 +2494,7 @@ func (a *App) chatCompletionOpenAI(apiKey, baseURL, model string, reqBody map[st
 				"role":    messageRole,
 				"content": contentBlocks,
 			}
-			resultJSON, _ := marshalAnthropicFinalMessage(fullMessage)
+			resultJSON, _ := json.Marshal(fullMessage)
 			return string(resultJSON), nil
 		}
 
@@ -2755,7 +2652,7 @@ func (a *App) chatCompletionOpenAI(apiKey, baseURL, model string, reqBody map[st
 				"role":    messageRole,
 				"content": contentBlocks,
 			}
-			resultJSON, _ := marshalAnthropicFinalMessage(fullMessage)
+			resultJSON, _ := json.Marshal(fullMessage)
 			return string(resultJSON), nil
 		}
 	}
@@ -2772,7 +2669,7 @@ func (a *App) chatCompletionOpenAI(apiKey, baseURL, model string, reqBody map[st
 			"role":    messageRole,
 			"content": contentBlocks,
 		}
-		resultJSON, _ := marshalAnthropicFinalMessage(fullMessage)
+		resultJSON, _ := json.Marshal(fullMessage)
 		return string(resultJSON), nil
 	}
 
@@ -2997,7 +2894,7 @@ func (a *App) chatCompletionResponses(apiKey, baseURL, model string, reqBody map
 			"role":    "assistant",
 			"content": contentBlocks,
 		}
-		resultJSON, err := marshalAnthropicFinalMessage(fullMessage)
+		resultJSON, err := json.Marshal(fullMessage)
 		if err != nil {
 			return "", fmt.Errorf("marshal final message: %w", err)
 		}

--- a/frontend/src/services/agent.ts
+++ b/frontend/src/services/agent.ts
@@ -445,45 +445,20 @@ export async function runAgent(userInput: string, skillName?: string, skillBody?
     })
   }
 
-  // Track active stream listeners for cleanup
   // Track whether streaming already delivered text, to skip onChunk duplication
   let streamedText = ''
-
-  // F-311: buffer SSE tokens into a non-reactive string and flush at rAF
-  // cadence (~16ms / 60Hz) instead of mutating `activeAssistantMsg.content`
-  // per token. Per-token `+=` on a deep-reactive string triggers Vue's dep
-  // graph on every token (100+/s for fast models); one assignment per rAF
-  // caps re-renders at the display refresh rate.
-  let pendingText = ''
-  let flushRafId: number | null = null
-
-  function flushStream() {
-    flushRafId = null
-    if (pendingText && activeAssistantMsg) {
-      activeAssistantMsg.content += pendingText
-    }
-    pendingText = ''
-  }
 
   // Register stream event listener (fires from Go backend SSE events)
   const cleanupTokenListener = registerTokenListener((data: any) => {
     if (store.stopRequested) return
     if (activeAssistantMsg && data.text) {
-      pendingText += data.text
+      activeAssistantMsg.content += data.text
       streamedText += data.text
       store.status = 'outputting'
-      if (flushRafId === null) {
-        flushRafId = requestAnimationFrame(flushStream)
-      }
     }
   })
 
   function cleanupStreamListeners() {
-    if (flushRafId !== null) {
-      cancelAnimationFrame(flushRafId)
-      flushRafId = null
-    }
-    flushStream()
     cleanupTokenListener()
     setActiveAssistantMsg(null)
   }
@@ -556,13 +531,6 @@ export async function runAgent(userInput: string, skillName?: string, skillBody?
     try {
       store.status = 'thinking'
       await chat(chatOptions)
-      // F-311: drain any rAF-buffered tokens so the assistant message holds
-      // the full text before we read .content for _rawApiMsg / doSave.
-      if (flushRafId !== null) {
-        cancelAnimationFrame(flushRafId)
-        flushRafId = null
-      }
-      flushStream()
       // Preserve raw API message blocks for conversation history
       if (chatOptions._rawApiMsg) {
         assistantMsg._rawApiMsg = chatOptions._rawApiMsg

--- a/frontend/src/services/llm.ts
+++ b/frontend/src/services/llm.ts
@@ -60,35 +60,15 @@ export async function chat(options: ChatOptions): Promise<void> {
 
   if (!apiKey) throw new Error('API key not configured')
 
-  // F-319: the expensive part of building the request is serializing the
-  // ~6 KB tools array, so that is what gets cached — keyed by the array
-  // identity, which makes the agent's module-constant AVAILABLE_TOOLS a hit
-  // on every turn. Everything else goes through a single JSON.stringify.
-  //
-  // The tools array must come from the caller: chat() is also used by the DB
-  // assistant (get_table_schema), the Mongo assistant and command completion.
-  // Hardcoding AVAILABLE_TOOLS here broke the DB tool loop and pushed ten
-  // irrelevant terminal tools at the callers that pass none.
-  //
-  // 16384 keeps long agent turns (tool call + assistant prose + final answer)
-  // from being truncated at 4096 — which used to surface as cut-off tool
-  // inputs. Per-model caps in the backend still apply.
   const requestBody: Record<string, unknown> = {
     model,
     max_tokens: 16384,
     system: options.system,
     messages: options.messages,
+    tools: options.tools,
   }
 
-  // Splice the cached tools JSON in rather than putting the array in
-  // requestBody, so the 6 KB serialization is reused across turns. Slicing
-  // the trailing `}` off a JSON object and appending `,"key":<json>}` is
-  // structurally safe for any content — unlike a sentinel + string replace,
-  // which a message body could collide with.
-  const head = JSON.stringify(requestBody)
-  const requestJSON = options.tools && options.tools.length > 0
-    ? `${head.slice(0, -1)},"tools":${serializeTools(options.tools)}}`
-    : head
+  const requestJSON = JSON.stringify(requestBody)
 
   let responseText: string
   try {
@@ -374,25 +354,3 @@ export const AVAILABLE_TOOLS = [
     }
   }
 ]
-
-// F-319: serializing the tools array is the expensive part of building a
-// request, so cache it keyed by the array's identity. AVAILABLE_TOOLS is a
-// module constant, which makes the agent's per-turn call a cache hit; the DB /
-// Mongo / completion callers pass their own arrays and get serialized on use.
-//
-// The last tool carries an Anthropic cache_control breakpoint (paired with the
-// backend's F-303 injectCacheControl — harmless overlap, it rewrites the same
-// field with the same value).
-const toolsJSONCache = new WeakMap<object, string>()
-
-function serializeTools(tools: NonNullable<ChatOptions['tools']>): string {
-  const cached = toolsJSONCache.get(tools)
-  if (cached !== undefined) return cached
-  const withCacheControl = [
-    ...tools.slice(0, -1),
-    { ...tools[tools.length - 1], cache_control: { type: 'ephemeral' } },
-  ]
-  const json = JSON.stringify(withCacheControl)
-  toolsJSONCache.set(tools, json)
-  return json
-}

--- a/frontend/src/stores/aiStore.ts
+++ b/frontend/src/stores/aiStore.ts
@@ -1,15 +1,10 @@
 import { defineStore } from 'pinia'
-import { ref, computed, reactive, shallowReactive, shallowRef, watch, markRaw } from 'vue'
+import { ref, computed, reactive, watch } from 'vue'
 import type { AIMessage, AIConfig, ExecutionMode, AISession, AIAgentStatus } from '../types/ai'
 import { SaveAIConfig, LoadAIConfig, SaveAISessions, LoadAISessions } from '../../wailsjs/go/main/App'
 import { useLocalStateStore } from './localStateStore'
 import { EventsOn } from '../../wailsjs/runtime'
 import { t } from '../i18n'
-
-// Module-level un-subscriber for the cross-window store:settings:changed listener.
-// Tracked at module scope so re-imports under HMR can detach the previous
-// listener before re-subscribing (FE-03).
-let unsubSettingsChanged: (() => void) | null = null
 
 /**
  * Estimate token count for a string using character-based heuristics.
@@ -29,37 +24,11 @@ function estimateTokens(text: string): number {
   return Math.ceil(asciiChars / 3.5 + nonAsciiChars / 1.8)
 }
 
-// F-310: cache token estimates per message in a WeakMap so the per-token
-// `conversation` re-evaluation (shouldn't happen post-F-301, but guards
-// against any remaining hot reads) doesn't re-stringify _rawApiMsg.
-const tokenEstimateCache = new WeakMap<AIMessage, number>()
-
-// F-314: cache the serialized _rawApiMsg JSON per message so doSave doesn't
-// re-stringify on every save. The cache is keyed by the AIMessage object and
-// stores the object reference alongside the JSON so agent.ts can safely
-// replace _rawApiMsg (it assigns a new object) without invalidating reads.
-const rawApiMsgJsonCache = new WeakMap<AIMessage, { obj: object; json: string }>()
-
-function getRawApiMsgJson(msg: AIMessage): string {
-  if (!msg._rawApiMsg) return ''
-  // F-316: inactive sessions retain _rawApiMsg as a JSON string. The disk
-  // form is already the JSON we want to persist; double-stringifying would
-  // produce a quoted string. Use it verbatim.
-  if (typeof msg._rawApiMsg === 'string') return msg._rawApiMsg
-  const cached = rawApiMsgJsonCache.get(msg)
-  if (cached && cached.obj === msg._rawApiMsg) return cached.json
-  const json = JSON.stringify(msg._rawApiMsg)
-  rawApiMsgJsonCache.set(msg, { obj: msg._rawApiMsg, json })
-  return json
-}
-
 /**
  * Estimate tokens for an AIMessage, including content, tool_calls, and
- * serialized _rawApiMsg. Cached on the message itself after first compute.
+ * serialized _rawApiMsg.
  */
 function estimateMessageTokens(msg: AIMessage): number {
-  const cached = tokenEstimateCache.get(msg)
-  if (cached !== undefined) return cached
   let total = estimateTokens(msg.content)
   if (msg.tool_calls) {
     for (const tc of msg.tool_calls) {
@@ -68,9 +37,8 @@ function estimateMessageTokens(msg: AIMessage): number {
     }
   }
   if (msg._rawApiMsg) {
-    total += estimateTokens(getRawApiMsgJson(msg))
+    total += estimateTokens(JSON.stringify(msg._rawApiMsg))
   }
-  tokenEstimateCache.set(msg, total)
   return total
 }
 
@@ -159,10 +127,6 @@ const DEFAULT_CONFIG: AIConfig = {
 async function loadSessionsFromBackend(): Promise<{ sessions: AISession[], currentSessionId: string | null }> {
   try {
     const data = await LoadAISessions() as any
-    // F-316: keep _rawApiMsg as a JSON string in inactive sessions. Parse
-    // only when the session is opened (in init / switchSession). Inactive
-    // sessions retain the raw string form; the conversation computed refs
-    // parsed objects only for the active session.
     const sessions: AISession[] = (data.sessions || []).map((s: any) => ({
       id: s.id,
       name: s.name,
@@ -175,7 +139,7 @@ async function loadSessionsFromBackend(): Promise<{ sessions: AISession[], curre
         tool_call_id: m.tool_call_id,
         tool_calls: m.tool_calls || [],
         pendingTools: m.pendingTools || [],
-        _rawApiMsg: m._rawApiMsg || undefined,
+        _rawApiMsg: m._rawApiMsg ? JSON.parse(m._rawApiMsg) : undefined,
       }))
     }))
     return { sessions, currentSessionId: data.currentSessionId || null }
@@ -217,20 +181,6 @@ export const useAIStore = defineStore('ai', () => {
 
   function setLastPanelContext(panelId: string, shellPath: string) {
     lastPanelContext.value = { panelId, shellPath }
-  }
-
-  // sessions is kept sorted by updatedAt desc, so the recent-sessions dropdown,
-  // the 15-session trim, and the post-delete fallback all read index 0 as
-  // "most recent". Backend Load() returns shards in filename order, so init()
-  // sorts explicitly. Only content changes touch a session — merely opening one
-  // to read it must not reorder the list.
-  function touchSession(s: AISession) {
-    s.updatedAt = Date.now()
-    const idx = sessions.value.findIndex(x => x.id === s.id)
-    if (idx > 0) {
-      sessions.value.splice(idx, 1)
-      sessions.value.unshift(s)
-    }
   }
 
   function enqueueMessage(content: string, skillName?: string, skillBody?: string, commandBody?: string) {
@@ -305,34 +255,33 @@ export const useAIStore = defineStore('ai', () => {
   }
 
   function addMessage(msg: AIMessage): AIMessage {
-    // F-302: shallowReactive + markRaw _rawApiMsg. The raw API block is only
-    // mutated by the LLM, never read by UI components, so it doesn't need
-    // deep reactive tracking. The shallow wrapper covers the message's
-    // own fields (content, pendingTools) without descending into nested arrays.
-    const wrapped: AIMessage = msg._rawApiMsg
-      ? (shallowReactive({ ...msg, _rawApiMsg: markRaw(msg._rawApiMsg) }) as AIMessage)
-      : (shallowReactive({ ...msg }) as AIMessage)
-    messages.value.push(wrapped)
+    const r = reactive({ ...msg }) as AIMessage
+    messages.value.push(r)
     if (currentSessionId.value) {
       const s = sessions.value.find(s => s.id === currentSessionId.value)
       if (s) {
-        s.messages.push(wrapped)
-        touchSession(s)
+        s.messages.push(r)
+        s.updatedAt = Date.now()
+        // Move to top on new activity
+        const idx = sessions.value.indexOf(s)
+        if (idx > 0) {
+          sessions.value.splice(idx, 1)
+          sessions.value.unshift(s)
+        }
         if (msg.role === 'user' && s.name === t('ai.newSession')) {
           const trimmed = msg.content.trim()
           if (trimmed) {
             s.name = trimmed.length > 20 ? trimmed.slice(0, 20) + '...' : trimmed
           }
         }
-        debouncedSave()
+        doSave()
       }
     }
-    messagesVersion.value++
-    return wrapped
+    return r
   }
 
   function addSkillCard(name: string, source: 'explicit' | 'auto') {
-    const r = shallowReactive({
+    const r = reactive({
       id: `skill-${Date.now()}`,
       role: 'user' as const,
       content: '',
@@ -344,15 +293,14 @@ export const useAIStore = defineStore('ai', () => {
       const s = sessions.value.find(s => s.id === currentSessionId.value)
       if (s) {
         s.messages.push(r)
-        touchSession(s)
-        debouncedSave()
+        s.updatedAt = Date.now()
+        doSave()
       }
     }
-    messagesVersion.value++
   }
 
   function addCommandCard(name: string, args: string) {
-    const r = shallowReactive({
+    const r = reactive({
       id: `cmd-${Date.now()}`,
       role: 'user' as const,
       content: '',
@@ -364,11 +312,10 @@ export const useAIStore = defineStore('ai', () => {
       const s = sessions.value.find(s => s.id === currentSessionId.value)
       if (s) {
         s.messages.push(r)
-        touchSession(s)
-        debouncedSave()
+        s.updatedAt = Date.now()
+        doSave()
       }
     }
-    messagesVersion.value++
   }
 
   function clearMessages() {
@@ -377,11 +324,10 @@ export const useAIStore = defineStore('ai', () => {
       const s = sessions.value.find(s => s.id === currentSessionId.value)
       if (s) {
         s.messages = []
-        touchSession(s)
-        debouncedSave()
+        s.updatedAt = Date.now()
+        doSave()
       }
     }
-    messagesVersion.value++
   }
 
   async function init() {
@@ -407,29 +353,19 @@ export const useAIStore = defineStore('ai', () => {
     if (currentSessionId.value) {
       const s = sessions.value.find(s => s.id === currentSessionId.value)
       if (s) {
-        // F-316: parse _rawApiMsg in place so messages.value and s.messages
-        // share the same backing object — agent.ts mutations to the active
-        // message propagate to the stored session and survive a save.
-        for (const m of s.messages) {
-          if (typeof m._rawApiMsg === 'string' && m._rawApiMsg) {
-            try {
-              m._rawApiMsg = JSON.parse(m._rawApiMsg)
-            } catch {
-              delete m._rawApiMsg
-            }
+        messages.value = s.messages.map(m => {
+          const msg = { ...m }
+          if (typeof msg._rawApiMsg === 'string' && msg._rawApiMsg) {
+            try { msg._rawApiMsg = JSON.parse(msg._rawApiMsg) } catch { delete msg._rawApiMsg }
           }
-          if (m._rawApiMsg) {
-            m._rawApiMsg = markRaw(m._rawApiMsg)
-          }
-        }
-        messages.value = s.messages.map(m => shallowReactive(m) as AIMessage)
+          return reactive(msg) as AIMessage
+        })
       } else {
         createSession()
       }
     } else {
       createSession()
     }
-    messagesVersion.value++
   }
 
   async function initConfig() {
@@ -463,56 +399,30 @@ export const useAIStore = defineStore('ai', () => {
     config.value = { ...config.value, ...updates }
   }
 
-  // F-314: serialize a session to the JSON shape persisted to disk.
-  // The session structure is rebuilt each save (cheap), but the heavy
-  // JSON.stringify of _rawApiMsg is cached per-message via getRawApiMsgJson.
-  function serializeSession(s: AISession): Record<string, unknown> {
-    return {
-      id: s.id,
-      name: s.name,
-      createdAt: s.createdAt,
-      updatedAt: s.updatedAt,
-      messages: s.messages.map(m => ({
-        id: m.id,
-        role: m.role,
-        content: m.content,
-        tool_call_id: m.tool_call_id || '',
-        tool_calls: m.tool_calls || [],
-        pendingTools: m.pendingTools || [],
-        _rawApiMsg: getRawApiMsgJson(m),
-      }))
-    }
-  }
-
   async function doSave() {
     try {
       const data = {
-        sessions: sessions.value.map(s => serializeSession(s)),
+        sessions: sessions.value.map(s => ({
+          id: s.id,
+          name: s.name,
+          createdAt: s.createdAt,
+          updatedAt: s.updatedAt,
+          messages: s.messages.map(m => ({
+            id: m.id,
+            role: m.role,
+            content: m.content,
+            tool_call_id: m.tool_call_id || '',
+            tool_calls: m.tool_calls || [],
+            pendingTools: m.pendingTools || [],
+            _rawApiMsg: m._rawApiMsg ? JSON.stringify(m._rawApiMsg) : '',
+          }))
+        })),
         currentSessionId: currentSessionId.value || '',
       }
       await SaveAISessions(data as any)
     } catch {
       // ignore save errors
     }
-  }
-
-  // F-304: debounce doSave by 500ms to coalesce bursts from addMessage and
-  // multi-token streaming. saveNow() flushes immediately for explicit user
-  // actions (deleteSession, renameSession, after-chat completion).
-  let saveTimer: ReturnType<typeof setTimeout> | null = null
-  function debouncedSave() {
-    if (saveTimer) return
-    saveTimer = setTimeout(() => {
-      saveTimer = null
-      doSave()
-    }, 500)
-  }
-  async function saveNow() {
-    if (saveTimer) {
-      clearTimeout(saveTimer)
-      saveTimer = null
-    }
-    await doSave()
   }
 
   function createSession(name?: string) {
@@ -532,7 +442,6 @@ export const useAIStore = defineStore('ai', () => {
       sessions.value = sessions.value.slice(0, 15)
     }
     clearQueue()
-    messagesVersion.value++
     // Don't save empty sessions — only persist when first message is added
   }
 
@@ -540,31 +449,15 @@ export const useAIStore = defineStore('ai', () => {
     const s = sessions.value.find(s => s.id === sessionId)
     if (!s) return
     currentSessionId.value = sessionId
-    // F-316: parse _rawApiMsg in place so messages.value and s.messages
-    // share the same backing object — agent.ts mutations to the active
-    // message propagate to the stored session and survive a save.
-    for (const m of s.messages) {
-      if (typeof m._rawApiMsg === 'string' && m._rawApiMsg) {
-        try {
-          m._rawApiMsg = JSON.parse(m._rawApiMsg)
-        } catch {
-          delete m._rawApiMsg
-        }
-      }
-      if (m._rawApiMsg) {
-        m._rawApiMsg = markRaw(m._rawApiMsg)
-      }
-    }
-    messages.value = s.messages.map(m => shallowReactive(m) as AIMessage)
+    messages.value = s.messages.map(m => reactive({ ...m }) as AIMessage)
     clearQueue()
-    messagesVersion.value++
   }
 
   function deleteSession(sessionId: string) {
     const idx = sessions.value.findIndex(s => s.id === sessionId)
     if (idx === -1) return
     sessions.value.splice(idx, 1)
-    saveNow()
+    doSave()
     if (currentSessionId.value === sessionId) {
       if (sessions.value.length > 0) {
         switchSession(sessions.value[0].id)
@@ -578,7 +471,7 @@ export const useAIStore = defineStore('ai', () => {
     const s = sessions.value.find(s => s.id === sessionId)
     if (s) {
       s.name = name
-      saveNow()
+      doSave()
     }
   }
 
@@ -592,13 +485,8 @@ export const useAIStore = defineStore('ai', () => {
     stopRequested.value = false
   }
 
-  // Build Anthropic-native message array (system is separate top-level field).
-  // F-301: conversation is rebuilt only when messagesVersion bumps (add/remove),
-  // not when per-token content mutates. Stored as a shallowRef; the computed
-  // wrapper preserves the existing public API.
-  const conversationValue = shallowRef<Array<Record<string, unknown>>>([])
-
-  function buildConversation() {
+  // Build Anthropic-native message array (system is separate top-level field)
+  const conversation = computed(() => {
     // Token budget: 80% of Claude's 200K context window, minus headroom
     const MAX_CONTEXT_TOKENS = 160000
 
@@ -611,102 +499,71 @@ export const useAIStore = defineStore('ai', () => {
 
     // Walk backwards through messages, accumulate token estimates.
     // Stop when we exceed the budget.
-    const msgs = messages.value
-    const n = msgs.length
-    const kept: AIMessage[] = []
-    const keptStart = (() => {
-      let start = n
-      for (let i = n - 1; i >= 0; i--) {
-        const msgTokens = estimateMessageTokens(msgs[i])
-        if (tokenCount + msgTokens > MAX_CONTEXT_TOKENS) break
-        tokenCount += msgTokens
-        start = i
-      }
-      // Strip leading tool messages whose matching tool_use was truncated out.
-      while (start < n && msgs[start].role === 'tool') start++
-      return start
-    })()
-    for (let i = keptStart; i < n; i++) kept.push(msgs[i])
-
-    // Collect every resolved tool_use ID up front. This pass cannot be folded
-    // into the build loop below: an assistant message carrying a tool_use comes
-    // *before* the tool message that resolves it, so a single forward pass sees
-    // an empty set at the moment it decides whether that tool_use is dangling.
-    // It then drops the tool_use, and the mirror pass drops the now-orphaned
-    // tool_result — silently erasing whole tool roundtrips from the payload, so
-    // the model never sees the commands it ran or their output.
-    const resolvedIds = new Set<string>()
-    for (const m of kept) {
-      if (m.role === 'tool' && m.tool_call_id) resolvedIds.add(m.tool_call_id)
+    const kept: typeof messages.value = []
+    for (let i = messages.value.length - 1; i >= 0; i--) {
+      const msg = messages.value[i]
+      const msgTokens = estimateMessageTokens(msg)
+      if (tokenCount + msgTokens > MAX_CONTEXT_TOKENS) break
+      tokenCount += msgTokens
+      kept.unshift(msg)
     }
 
-    // Forward pass that:
-    //   - filters dangling tool_use blocks (assistant raw / legacy),
-    //   - merges consecutive user messages,
-    //   - validates pairings (assistant tool_use ↔ user tool_result).
+    let recentMsgs = kept
+
+    // Don't start the conversation with an orphaned tool_result whose matching
+    // tool_use was truncated out of the window. Strip leading tool messages
+    // until we hit a user or assistant message.
+    while (recentMsgs.length > 0 && recentMsgs[0].role === 'tool') {
+      recentMsgs.shift()
+    }
+
+    // Collect all resolved tool_use IDs from tool_result messages
+    const resolvedIds = new Set<string>()
+    for (const m of recentMsgs) {
+      if (m.role === 'tool' && m.tool_call_id) {
+        resolvedIds.add(m.tool_call_id)
+      }
+    }
+
     const result: Array<Record<string, unknown>> = []
-    const pendingMsgId = pendingCommand.value?.messageId
 
-    const isMessagePending = (m: AIMessage) => !!(m.pendingTools?.length || pendingMsgId === m.id)
-
-    for (let i = 0; i < kept.length; i++) {
-      const m = kept[i]
-      const pending = isMessagePending(m)
-
+    for (const m of recentMsgs) {
       if (m.id.startsWith('dbg-')) continue
-      if (m.needsContinue) continue
+      if (m.needsContinue) continue  // UI-only prompts, not part of LLM conversation
+      // skill/command cards are UI-only markers; never send them to the API
       if ((m.skillName || m.commandName) && !m.content) continue
+      // restored/legacy empty user messages produce invalid empty text blocks
       if (m.role === 'user' && !m.content && !m._contextHeader) continue
 
-      // Tool message: emit as user tool_result wrapper. The id is already in
-      // resolvedIds from the pre-pass above.
+      // Tool messages: ones with tool_call_id are real tool_results for the API;
+      // ones without are display-only system errors and must not be sent.
       if (m.role === 'tool') {
         if (m.tool_call_id) {
-          const toolResultBlocks = [{
-            type: 'tool_result',
-            tool_use_id: m.tool_call_id,
-            content: m.content
-          }]
-
-          // Pair-validate backward: if previous result is assistant with
-          // tool_use blocks, prune any block that doesn't have a matching
-          // tool_result in this new message.
-          const prev = result[result.length - 1]
-          if (prev && prev.role === 'assistant' && Array.isArray(prev.content)) {
-            const prevBlocks = prev.content as Array<Record<string, unknown>>
-            const filtered = prevBlocks.filter((b) => {
-              if (b.type === 'tool_use') {
-                return toolResultBlocks.some((tr) => tr.tool_use_id === (b.id as string))
-              }
-              return true
-            })
-            if (filtered.length === 0) {
-              result.pop()
-            } else {
-              prev.content = filtered
-            }
-          }
-
-          // Two consecutive tool messages must each appear as their own
-          // user wrapper so they pair with their respective tool_use blocks.
-          // Don't merge into the previous user.
-          result.push({ role: 'user', content: toolResultBlocks })
+          result.push({
+            role: 'user',
+            content: [{ type: 'tool_result', tool_use_id: m.tool_call_id, content: m.content }]
+          })
         }
         continue
       }
 
-      if (m.role === 'assistant' && typeof m.content === 'string' && m.content.includes('[Error:')) continue
+      // Skip assistant messages that are API error placeholders from before the fix
+      if (m.role === 'assistant' && typeof m.content === 'string' && m.content.includes('[Error:')) {
+        continue
+      }
 
-      // Assistant with raw API blocks: filter dangling tool_use blocks.
+      // Assistant with raw API blocks: filter dangling tool_use blocks without matching tool_result
       if (m._rawApiMsg) {
         const raw = m._rawApiMsg as Record<string, unknown>
         const content = raw.content
         if (Array.isArray(content)) {
-          const filtered = (content as Array<Record<string, unknown>>).filter((b) => {
-            if (b.type === 'tool_use') return resolvedIds.has(b.id as string)
+          const filtered = (content as Array<Record<string, unknown>>).filter((block: Record<string, unknown>) => {
+            if (block.type === 'tool_use') {
+              return resolvedIds.has(block.id as string)
+            }
             return true
           })
-          if (filtered.length === 0 && !m.content && !pending) continue
+          if (filtered.length === 0 && !m.content && !(m.pendingTools?.length || pendingCommand.value?.messageId === m.id)) continue
           result.push({ ...raw, role: (raw.role as string) || 'assistant', content: filtered })
         } else {
           result.push({ ...raw, role: (raw.role as string) || 'assistant' })
@@ -714,13 +571,15 @@ export const useAIStore = defineStore('ai', () => {
         continue
       }
 
-      // Assistant with legacy tool_calls.
+      // Assistant with legacy tool_calls: filter dangling ones, build content blocks
       if (m.role === 'assistant' && m.tool_calls?.length) {
         const resolved = m.tool_calls.filter(tc => resolvedIds.has(tc.id))
-        if (!m.content && resolved.length === 0 && !pending) continue
+        if (!m.content && resolved.length === 0 && !(m.pendingTools?.length || pendingCommand.value?.messageId === m.id)) continue
 
         const blocks: Array<Record<string, unknown>> = []
-        if (m.content) blocks.push({ type: 'text', text: m.content })
+        if (m.content) {
+          blocks.push({ type: 'text', text: m.content })
+        }
         for (const tc of resolved) {
           let input: Record<string, unknown> = {}
           try { input = JSON.parse(tc.function.arguments) } catch { /* passthrough */ }
@@ -730,106 +589,87 @@ export const useAIStore = defineStore('ai', () => {
         continue
       }
 
-      if (m.role === 'assistant' && !m.content && !pending) continue
+      // Skip empty assistant messages (no content, no tool calls, no raw api msg, no pending tools)
+      if (m.role === 'assistant' && !m.content && !(m.pendingTools?.length || pendingCommand.value?.messageId === m.id)) continue
 
-      // User / plain assistant: dedup consecutive user messages.
-      let content: string
+      // Inject dynamic context header into user messages for the API
+      // (hidden from UI, stored in _contextHeader)
       if (m.role === 'user' && m._contextHeader) {
-        content = m._contextHeader + '\n\n' + m.content
+        result.push({ role: m.role, content: m._contextHeader + '\n\n' + m.content })
       } else {
-        content = m.content
-      }
-      const apiMsg = { role: m.role || 'user', content }
-      const last = result[result.length - 1]
-      if (m.role === 'user' && last && last.role === 'user') {
-        const prevBlocks = Array.isArray(last.content)
-          ? last.content as Array<Record<string, unknown>>
-          : [{ type: 'text', text: last.content as string }]
-        const msgBlocks = Array.isArray(content)
-          ? content as Array<Record<string, unknown>>
-          : [{ type: 'text', text: content as string }]
-        last.content = [...prevBlocks, ...msgBlocks]
-      } else {
-        result.push(apiMsg)
+        result.push({ role: m.role || 'user', content: m.content })
       }
     }
 
-    // Pair validation: prune any tool_use blocks whose next-of-pair msg
-    // doesn't carry the matching tool_result. The Anthropic API rejects
-    // tool_use blocks not resolved in the very next message, regardless of
-    // where in the conversation they appear. Walk backward so we can
-    // prune-then-collapse in place.
-    for (let i = result.length - 1; i >= 0; i--) {
-      const msg = result[i]
-      if (msg.role !== 'assistant' || !Array.isArray(msg.content)) continue
-      const next = i + 1 < result.length ? result[i + 1] : null
-      const nextBlocks = next && next.role === 'user' && Array.isArray(next.content)
-        ? next.content as Array<Record<string, unknown>>
-        : null
-      const blocks = (msg.content as Array<Record<string, unknown>>).filter((b) => {
-        if (b.type === 'tool_use') {
-          return nextBlocks !== null && nextBlocks.some((nb) => nb.type === 'tool_result' && nb.tool_use_id === b.id)
-        }
-        return true
-      })
-      if (blocks.length === 0) {
-        result.splice(i, 1)
-      } else {
-        msg.content = blocks
-      }
-    }
-    // Mirror pass: prune tool_result blocks in user messages whose prev
-    // assistant no longer has the matching tool_use (after the previous
-    // pass may have removed it). Drop user messages whose content is empty.
+    // Final safety pass: enforce that every tool_use is immediately followed
+    // by a user message containing its matching tool_result, and every
+    // tool_result is immediately preceded by an assistant with its tool_use.
+    // The Anthropic API rejects tool_use blocks that are not resolved in the
+    // very next message.
+    const cleaned: Array<Record<string, unknown>> = []
     for (let i = 0; i < result.length; i++) {
       const msg = result[i]
-      if (msg.role !== 'user' || !Array.isArray(msg.content)) continue
-      const prev = i > 0 ? result[i - 1] : null
-      const prevBlocks = prev && prev.role === 'assistant' && Array.isArray(prev.content)
-        ? prev.content as Array<Record<string, unknown>>
-        : null
-      const blocks = (msg.content as Array<Record<string, unknown>>).filter((b) => {
-        if (b.type === 'tool_result') {
-          return prevBlocks !== null && prevBlocks.some((pb) => pb.type === 'tool_use' && pb.id === b.tool_use_id)
-        }
-        return true
-      })
-      if (blocks.length === 0) {
-        result.splice(i, 1)
-        i--
+
+      if (msg.role === 'assistant' && Array.isArray(msg.content)) {
+        const nextMsg = i + 1 < result.length ? result[i + 1] : null
+        const blocks = (msg.content as Array<Record<string, unknown>>).filter((block) => {
+          if (block.type === 'tool_use') {
+            if (!nextMsg || nextMsg.role !== 'user' || !Array.isArray(nextMsg.content)) {
+              return false
+            }
+            return (nextMsg.content as Array<Record<string, unknown>>).some(
+              (nb) => nb.type === 'tool_result' && nb.tool_use_id === block.id
+            )
+          }
+          return true
+        })
+        if (blocks.length === 0) continue
+        cleaned.push({ ...msg, content: blocks })
+      } else if (msg.role === 'user' && Array.isArray(msg.content)) {
+        const prevMsg = i > 0 ? result[i - 1] : null
+        const blocks = (msg.content as Array<Record<string, unknown>>).filter((block) => {
+          if (block.type === 'tool_result') {
+            if (!prevMsg || prevMsg.role !== 'assistant' || !Array.isArray(prevMsg.content)) {
+              return false
+            }
+            return (prevMsg.content as Array<Record<string, unknown>>).some(
+              (pb) => pb.type === 'tool_use' && pb.id === block.tool_use_id
+            )
+          }
+          return true
+        })
+        if (blocks.length === 0) continue
+        cleaned.push({ ...msg, content: blocks })
       } else {
-        msg.content = blocks
+        cleaned.push(msg)
       }
     }
 
-    conversationValue.value = result
-  }
+    // Additional validation: ensure no consecutive user messages ( Anthropic rejects this )
+    const deduped: Array<Record<string, unknown>> = []
+    for (const msg of cleaned) {
+      if (msg.role === 'user' && deduped.length > 0 && deduped[deduped.length - 1].role === 'user') {
+        const prev = deduped[deduped.length - 1]
+        const prevBlocks = Array.isArray(prev.content) ? prev.content : [{ type: 'text', text: prev.content }]
+        const msgBlocks = Array.isArray(msg.content) ? msg.content : [{ type: 'text', text: msg.content }]
+        prev.content = [...prevBlocks, ...msgBlocks]
+      } else {
+        deduped.push(msg)
+      }
+    }
 
-  // F-301: rebuild conversation only when messages are added/removed.
-  // flush: 'sync' is required — agent.ts reads store.conversation
-  // synchronously right after addMessage(), with no await in between. With
-  // Vue's default 'pre' flush the rebuild lands in a microtask, so the first
-  // turn would send an empty messages array (and every later turn would lag
-  // one message behind). An empty array marshals to "input":null on the
-  // OpenAI Responses path, which the API rejects as a missing parameter.
-  const messagesVersion = ref(0)
-  watch(messagesVersion, () => buildConversation(), { flush: 'sync' })
-  buildConversation()
+    // Messages are inherently dynamic — no cache_control breakpoints here.
+    // Caching is handled entirely on the system prompt (see llm.ts).
 
-  const conversation = computed(() => conversationValue.value)
+    return deduped
+  })
 
   const systemPrompt = computed(() => SYSTEM_RULES)
 
   // Reload AI config when settings change via sync
-  unsubSettingsChanged?.()
-  unsubSettingsChanged = EventsOn('store:settings:changed', () => {
+  EventsOn('store:settings:changed', () => {
     initConfig()
   })
-
-  function dispose() {
-    unsubSettingsChanged?.()
-    unsubSettingsChanged = null
-  }
 
   return {
     visible,
@@ -872,7 +712,6 @@ export const useAIStore = defineStore('ai', () => {
     enqueueMessage,
     removeQueuedMessage,
     clearQueue,
-    doSave,
-    dispose
+    doSave
   }
 })


### PR DESCRIPTION
The F-3xx series performance micro-optimizations introduced three regressions since v1.6.0:

- **F-307 (bytes.Buffer slice):** index-out-of-range panic when the API returns thinking/content_block events in a non-standard order, because blockTextBufs[currentBlockIndex] accessed the slice before the grow guard. Reverted to simple string +=.
- **F-303 (injectCacheControl):** wrapped the system prompt in a content-block array with cache_control breakpoints. Third-party Anthropic-compatible endpoints (e.g. DeepSeek) responded with extended-thinking blocks that the code never handled, leaving the UI stuck in the "thinking" status indefinitely. Removed.
- **F-311 (rAF token coalescing):** buffered SSE tokens through requestAnimationFrame. When the browser tab lost focus rAF throttled/paused, tokens accumulated without being flushed. Reverted to direct += assignment.

Additional reverts (F-306/F-320 typed events, F-301/F-313 conversation memoization/builder, F-319 tools JSON cache, F-304 debounced save, F-210 pooled buffer, F-316 lazy parse) were micro-optimizations whose benefit (< 1ms per turn) did not justify their complexity or the bugs they spawned.

**Kept 6 positive changes:** F-305 (64 KiB error-body cap), F-308 (atomic cancel), F-312 (capToolResult), FE-P0-2/3 (tool input validation), F-315 (generation-counter listener guard), and the default-closed risk fallback.

aiStore.ts restored to v1.6.0 with two additions: sort sessions by updatedAt on load, and move a session to top of list on new activity.

---

F-3xx 系列性能微优化自 v1.6.0 以来引入了三个回归：

- **F-307 (bytes.Buffer slice)：** API 以非标准顺序返回 thinking/content_block 事件时，blockTextBufs[currentBlockIndex] 在 grow guard 之前访问 slice，触发 index-out-of-range panic。还原为简单字符串 +=。
- **F-303 (injectCacheControl)：** 将 system prompt 包装为带 cache_control 的 content-block 数组。第三方 Anthropic 兼容端点（如 DeepSeek）返回了代码从未处理的 extended-thinking 块，导致 UI 无限卡在"思考中"状态。已移除。
- **F-311 (rAF 令牌合并)：** 通过 requestAnimationFrame 缓冲 SSE token。浏览器标签页失去焦点时 rAF 暂停，令牌累积无法刷新。还原为直接 += 赋值。

其他还原（F-306/F-320 类型化事件、F-301/F-313 conversation 记忆化/建造器、F-319 tools JSON 缓存、F-304 保存防抖、F-210 池化 buffer、F-316 懒解析）均为微优化，收益（每轮 <1ms）不及其复杂度和引发的 bug。

**保留 6 个正向改动：** F-305（64 KiB 错误体限制）、F-308（atomic cancel）、F-312（capToolResult）、FE-P0-2/3（工具输入校验）、F-315（代际计数器监听保护）、risk default-closed。

aiStore.ts 还原到 v1.6.0，新增两处：加载时按 updatedAt 排序、新消息时将会话置顶。