### PR TITLE
feat: add X11 desktop support over SSH with X11 forwarding

### DIFF
--- a/app.go
+++ b/app.go
@@ -4606,6 +4606,48 @@ func (a *App) ContainerDisconnect(connectionID string) {
 	}
 }
 
+// X11DesktopConnect starts an x11-desktop session: looks up the saved
+// connection config (which carries its own SSH credentials), opens an
+// SSH connection with X11 forwarding, and runs the chosen desktop
+// command on the remote host. connectionID and sessionID are distinct
+// UUIDs (the connection is the user's saved record; the session is the
+// live runtime object created via CreateSession).
+func (a *App) X11DesktopConnect(connectionID string, sessionID string) error {
+	if a.connectionStore == nil || a.sessionManager == nil {
+		return fmt.Errorf("connection store or session manager not initialized")
+	}
+	data, err := a.connectionStore.Load()
+	if err != nil {
+		return err
+	}
+	var cfg *session.ConnectionConfig
+	for i := range data.Connections {
+		if data.Connections[i].ID == connectionID {
+			cfg = &data.Connections[i]
+			break
+		}
+	}
+	if cfg == nil {
+		return fmt.Errorf("connection not found: %s", connectionID)
+	}
+	if cfg.Type != "x11-desktop" {
+		return fmt.Errorf("connection %s is not an x11-desktop", connectionID)
+	}
+
+	sess, ok := a.sessionManager.Get(sessionID)
+	if !ok {
+		return fmt.Errorf("session not found: %s", sessionID)
+	}
+	x11Sess, ok := sess.(*session.X11DesktopSession)
+	if !ok {
+		return fmt.Errorf("session %s is not x11-desktop", sessionID)
+	}
+	if err := x11Sess.ConnectX11Desktop(*cfg); err != nil {
+		return err
+	}
+	return nil
+}
+
 func (a *App) ContainerList(connectionID string) ([]container.Container, error) {
 	p, err := a.containerManager.Provider(connectionID)
 	if err != nil {

--- a/backend/session/manager.go
+++ b/backend/session/manager.go
@@ -75,6 +75,9 @@ func (sm *SessionManager) Create(sessionType string, config ConnectionConfig) (S
 	case "mongodb":
 		s = NewMongoSession(config.ID)
 
+	case "x11-desktop":
+		s = NewX11DesktopSession(config.ID)
+
 	default:
 		return nil, fmt.Errorf("unsupported session type: %s", sessionType)
 	}

--- a/backend/session/session.go
+++ b/backend/session/session.go
@@ -179,6 +179,19 @@ type ConnectionConfig struct {
 	// a session. It has no effect on later reconnects — a manually
 	// stopped log stays stopped for the life of the panel.
 	LogOnConnect bool `json:"logOnConnect,omitempty"`
+	// X11Desktop fields. Used when Type == "x11-desktop".
+	// This type carries its own SSH credentials (Host, Port, User,
+	// AuthType, Password, KeyPath) and connects directly — it no
+	// longer references a separate SSH connection. X11 forward is
+	// forced on automatically (this type is meaningless without it).
+	//   DesktopType — "gnome" | "kde" | "xfce" | "mate" | "cinnamon" |
+	//                 "openbox" | "custom". Mapped to a built-in command or
+	//                 to CustomCmd verbatim.
+	//   CustomCmd   — only used when DesktopType == "custom". The string is
+	//                 passed to sshd verbatim (so it goes through
+	//                 /bin/sh -c on the remote).
+	X11DesktopDesktopType string `json:"x11DesktopDesktopType,omitempty"`
+	X11DesktopCustomCmd   string `json:"x11DesktopCustomCmd,omitempty"`
 }
 
 // ConnectionStoreData is the top-level structure persisted to connections.json.

--- a/backend/session/x11.go
+++ b/backend/session/x11.go
@@ -138,7 +138,15 @@ func tryStartLocalXServer() bool {
 		if _, err := os.Stat(path); err != nil {
 			continue
 		}
-		cmd := exec.Command(path, ":0", "-ac", "-multiwindow", "-clipboard", "-silent-dup-error")
+		// Minimal VcXsrv args per user: ":0 -clipboard". No -screen
+		// (VcXsrv defaults to the primary monitor), no -multiwindow (XWin's
+		// default is "windowed" single-window mode, same as XLaunch's
+		// "One large window"). Dir must be set to a writable path (the user's
+		// home) because VcXsrv writes its XWin.log to the cwd and aborts
+		// with "Cannot open log file XWin.log" if cwd is not writable.
+		cmd := exec.Command(path, ":0", "-clipboard")
+		home, _ := os.UserHomeDir()
+		cmd.Dir = home
 		if err := cmd.Start(); err != nil {
 			return false
 		}

--- a/backend/session/x11_desktop_session.go
+++ b/backend/session/x11_desktop_session.go
@@ -1,0 +1,199 @@
+package session
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"runtime"
+	"strings"
+	"sync"
+
+	"golang.org/x/crypto/ssh"
+
+	"github.com/ys-ll/uniterm/backend/log"
+)
+
+// "custom" is handled separately below — it is not a preset key.
+// SSH sessions don't get DBus session bus injected (pam_systemd only
+// does that for graphical logins), so presets are wrapped in
+// `dbus-run-session --` to give the DE a working DBUS_SESSION_BUS_ADDRESS.
+// Plain commands like xterm don't need it; the wrapper is harmless.
+// xsetroot -name sets the root window's WM_NAME so it shows up in the
+// Windows taskbar (VcXsrv multiwindow mode creates a Windows window
+// per X client; MATE's root window has no title by default and is
+// therefore hidden from the taskbar. xsetroot sets the title before
+// the DE starts; MATE may or may not override it, but it's harmless
+// either way).
+var desktopCommands = map[string]string{
+	"gnome":    `dbus-run-session -- sh -c 'xsetroot -name "X11 Desktop" || true; exec gnome-session'`,
+	"kde":      `dbus-run-session -- sh -c 'xsetroot -name "X11 Desktop" || true; exec startkde'`,
+	"xfce":     `dbus-run-session -- sh -c 'xsetroot -name "X11 Desktop" || true; exec startxfce4'`,
+	"mate":     `dbus-run-session -- sh -c 'xsetroot -name "X11 Desktop" || true; exec mate-session'`,
+	"cinnamon": `dbus-run-session -- sh -c 'xsetroot -name "X11 Desktop" || true; exec cinnamon-session'`,
+	"openbox":  `dbus-run-session -- sh -c 'xsetroot -name "X11 Desktop" || true; exec openbox-session'`,
+}
+
+func resolveDesktopCommand(cfg ConnectionConfig) (string, error) {
+	if cfg.X11DesktopDesktopType == "custom" {
+		cmd := strings.TrimSpace(cfg.X11DesktopCustomCmd)
+		if cmd == "" {
+			return "", fmt.Errorf("x11-desktop: custom command is empty")
+		}
+		return cmd, nil
+	}
+	cmd, ok := desktopCommands[cfg.X11DesktopDesktopType]
+	if !ok {
+		return "", fmt.Errorf("x11-desktop: unknown desktop type %q", cfg.X11DesktopDesktopType)
+	}
+	return cmd, nil
+}
+
+// X11DesktopSession opens an SSH connection to a remote host with X11
+// forwarding enabled and runs the chosen desktop command. The remote X
+// clients are bridged to the local X server (VcXsrv/XQuartz/Xorg) over
+// SSH's x11 channel — the actual desktop is rendered outside uniTerm.
+// The session represents the lifecycle of that desktop process:
+// Connected while the command is running, Disconnected when it exits.
+type X11DesktopSession struct {
+	baseSession
+	sshClient  *ssh.Client
+	sshSession *ssh.Session
+	x11Fwd     *x11Forwarder
+	quit       chan struct{}
+	quitOnce   sync.Once
+}
+
+func NewX11DesktopSession(id string) *X11DesktopSession {
+	return &X11DesktopSession{
+		baseSession: baseSession{id: id, sessionType: "x11-desktop", status: StatusDisconnected},
+		quit:        make(chan struct{}),
+	}
+}
+
+// Connect is the Session-interface stub. The real entry point is
+// ConnectX11Desktop below, which X11DesktopConnect in app.go invokes.
+// The frontend sets deferConnect: true at create time so the generic
+// launch goroutine never calls this method. It exists only to satisfy
+// the Session interface; any direct call here is a programming error.
+func (s *X11DesktopSession) Connect(config ConnectionConfig) error {
+	return fmt.Errorf("x11-desktop: use X11DesktopConnect (not Session.Connect); set deferConnect: true at create time")
+}
+
+// ConnectX11Desktop opens an SSH connection with X11 forwarding and runs
+// the desktop command on the remote host. Blocks until the remote command
+// exits (or the SSH connection drops).
+func (s *X11DesktopSession) ConnectX11Desktop(cfg ConnectionConfig) error {
+	s.setStatus(StatusConnecting)
+
+	cmd, err := resolveDesktopCommand(cfg)
+	if err != nil {
+		s.setStatus(StatusError)
+		return err
+	}
+
+	// X11 forward is mandatory for this type.
+	cfg.X11Forwarding = true
+
+	// Make sure a local X server is running. On Windows $DISPLAY is normally
+	// unset or set to a placeholder like "needs-to-be-defined"; VcXsrv/Xming
+	// listen at localhost:0 by convention, so fall back to that. macOS/Linux
+	// keep strict validation.
+	display := os.Getenv("DISPLAY")
+	if runtime.GOOS == "windows" {
+		if _, _, _, perr := ParseDisplay(display); perr != nil {
+			display = "localhost:0"
+		}
+	} else if display == "" {
+		display = resolveLocalDisplay(display)
+	}
+	if _, derr := DialLocalX(display); derr != nil {
+		if !tryStartLocalXServer() {
+			s.setStatus(StatusError)
+			return fmt.Errorf("x11-desktop: local X server unreachable: %w", derr)
+		}
+		// After starting VcXsrv, try localhost:0 (not the original
+		// possibly-broken DISPLAY).
+		retryDisplay := display
+		if runtime.GOOS == "windows" {
+			retryDisplay = "localhost:0"
+		}
+		if _, derr2 := DialLocalX(retryDisplay); derr2 != nil {
+			s.setStatus(StatusError)
+			return fmt.Errorf("x11-desktop: local X server unreachable after start: %w", derr2)
+		}
+	}
+
+	client, err := DialSSHClient(cfg)
+	if err != nil {
+		s.setStatus(StatusError)
+		return fmt.Errorf("x11-desktop: %w", err)
+	}
+	s.sshClient = client
+
+	sess, err := client.NewSession()
+	if err != nil {
+		client.Close()
+		s.setStatus(StatusError)
+		return fmt.Errorf("x11-desktop: new session: %w", err)
+	}
+	s.sshSession = sess
+
+	xauthPath := os.Getenv("XAUTHORITY")
+	if xauthPath == "" {
+		if home, herr := os.UserHomeDir(); herr == nil {
+			xauthPath = home + "/.Xauthority"
+		}
+	}
+	fwd, ferr := startX11Forward(client, sess, xauthPath, os.Getenv("DISPLAY"))
+	switch {
+	case ferr == nil, errors.Is(ferr, errX11TrustedFallback):
+		s.x11Fwd = fwd
+	default:
+		sess.Close()
+		client.Close()
+		s.setStatus(StatusError)
+		return fmt.Errorf("x11-desktop: x11 forward: %w", ferr)
+	}
+
+	s.title = fmt.Sprintf("%s @ %s (%s)", cfg.X11DesktopDesktopType, cfg.Host, "X11")
+	s.setStatus(StatusConnected)
+
+	// Block until remote command exits; report back via status change.
+	go func() {
+		werr := sess.Run(cmd)
+		log.Writef("x11-desktop: command %q exited: %v", cmd, werr)
+		s.Disconnect()
+	}()
+
+	return nil
+}
+
+// Disconnect tears down the X11 forwarder, SSH session, and SSH client.
+// Idempotent: sync.Once guarantees the cleanup runs once even if the
+// underlying resources are nil (e.g. Disconnect called before Connect,
+// or after a partial failure).
+func (s *X11DesktopSession) Disconnect() error {
+	s.quitOnce.Do(func() {
+		if s.x11Fwd != nil {
+			s.x11Fwd.stop()
+			s.x11Fwd = nil
+		}
+		if s.sshSession != nil {
+			s.sshSession.Close()
+		}
+		if s.sshClient != nil {
+			s.sshClient.Close()
+		}
+		s.setStatus(StatusDisconnected)
+	})
+	return nil
+}
+
+// Write/Resize are not applicable: X11 data flows directly between
+// remote X clients and the local X server, bypassing this session.
+// Resize is a no-op because the remote desktop's size is determined by
+// the X server, not by xterm.js dimensions.
+func (s *X11DesktopSession) Write(_ []byte) error { return fmt.Errorf("x11-desktop: not a terminal session") }
+func (s *X11DesktopSession) Resize(_, _ int) error { return nil }
+
+func (s *X11DesktopSession) IsConnected() bool { return s.Status() == StatusConnected }

--- a/backend/session/x11_desktop_session_test.go
+++ b/backend/session/x11_desktop_session_test.go
@@ -1,0 +1,161 @@
+package session
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestDesktopCommandMapping covers the six built-in desktop environment
+// presets. Each maps to a command on the remote wrapped in
+// `dbus-run-session --` so the DE has a working DBUS_SESSION_BUS_ADDRESS
+// (SSH sessions don't get one injected; see x11_desktop_session.go).
+func TestDesktopCommandMapping(t *testing.T) {
+	cases := []struct {
+		desktopType string
+		want        string
+	}{
+		{"gnome", `dbus-run-session -- sh -c 'xsetroot -name "X11 Desktop" || true; exec gnome-session'`},
+		{"kde", `dbus-run-session -- sh -c 'xsetroot -name "X11 Desktop" || true; exec startkde'`},
+		{"xfce", `dbus-run-session -- sh -c 'xsetroot -name "X11 Desktop" || true; exec startxfce4'`},
+		{"mate", `dbus-run-session -- sh -c 'xsetroot -name "X11 Desktop" || true; exec mate-session'`},
+		{"cinnamon", `dbus-run-session -- sh -c 'xsetroot -name "X11 Desktop" || true; exec cinnamon-session'`},
+		{"openbox", `dbus-run-session -- sh -c 'xsetroot -name "X11 Desktop" || true; exec openbox-session'`},
+	}
+	for _, c := range cases {
+		t.Run(c.desktopType, func(t *testing.T) {
+			cfg := ConnectionConfig{X11DesktopDesktopType: c.desktopType}
+			got, err := resolveDesktopCommand(cfg)
+			if err != nil {
+				t.Fatalf("resolveDesktopCommand(%q): unexpected error: %v", c.desktopType, err)
+			}
+			if got != c.want {
+				t.Errorf("resolveDesktopCommand(%q) = %q, want %q", c.desktopType, got, c.want)
+			}
+		})
+	}
+}
+
+func TestResolveCustomPassthrough(t *testing.T) {
+	cfg := ConnectionConfig{
+		X11DesktopDesktopType: "custom",
+		X11DesktopCustomCmd:   "mycommand --foo bar",
+	}
+	got, err := resolveDesktopCommand(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "mycommand --foo bar" {
+		t.Errorf("got %q, want %q", got, "mycommand --foo bar")
+	}
+}
+
+func TestResolveCustomWhitespaceTrim(t *testing.T) {
+	cfg := ConnectionConfig{
+		X11DesktopDesktopType: "custom",
+		X11DesktopCustomCmd:   "   startxfce4   ",
+	}
+	got, err := resolveDesktopCommand(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "startxfce4" {
+		t.Errorf("got %q, want trimmed %q", got, "startxfce4")
+	}
+	if strings.TrimSpace(got) != got {
+		t.Errorf("result still has surrounding whitespace: %q", got)
+	}
+}
+
+func TestResolveCustomEmpty(t *testing.T) {
+	cfg := ConnectionConfig{
+		X11DesktopDesktopType: "custom",
+		X11DesktopCustomCmd:   "",
+	}
+	_, err := resolveDesktopCommand(cfg)
+	if err == nil {
+		t.Fatal("expected error for empty custom command, got nil")
+	}
+}
+
+func TestResolveUnknownType(t *testing.T) {
+	cfg := ConnectionConfig{
+		X11DesktopDesktopType: "windows-xp",
+	}
+	_, err := resolveDesktopCommand(cfg)
+	if err == nil {
+		t.Fatal("expected error for unknown desktop type, got nil")
+	}
+}
+
+func TestResolveEmptyType(t *testing.T) {
+	cfg := ConnectionConfig{}
+	_, err := resolveDesktopCommand(cfg)
+	if err == nil {
+		t.Fatal("expected error for empty desktop type, got nil")
+	}
+}
+
+// TestX11DesktopSession_NotConnectedByDefault checks that a freshly
+// constructed session reports IsConnected() == false and Status() ==
+// StatusDisconnected, before Connect is ever called.
+func TestX11DesktopSession_NotConnectedByDefault(t *testing.T) {
+	s := NewX11DesktopSession("test-x11-id")
+	if s == nil {
+		t.Fatal("NewX11DesktopSession returned nil")
+	}
+	if s.IsConnected() {
+		t.Error("IsConnected() = true, want false before Connect")
+	}
+	if s.Status() != StatusDisconnected {
+		t.Errorf("Status() = %v, want %v", s.Status(), StatusDisconnected)
+	}
+	if s.Type() != "x11-desktop" {
+		t.Errorf("Type() = %q, want %q", s.Type(), "x11-desktop")
+	}
+	if s.ID() != "test-x11-id" {
+		t.Errorf("ID() = %q, want %q", s.ID(), "test-x11-id")
+	}
+}
+
+// TestX11DesktopSession_WriteReturnsError checks that Write always
+// rejects data: this session represents an X11-forwarded desktop, not a
+// terminal pipe, so there is no stdin to write to.
+func TestX11DesktopSession_WriteReturnsError(t *testing.T) {
+	s := NewX11DesktopSession("test-x11-id")
+	if err := s.Write([]byte("hello")); err == nil {
+		t.Error("Write() = nil, want non-nil error (X11 desktop is not a terminal)")
+	}
+}
+
+// TestX11DesktopSession_ResizeIsNoop checks that Resize is a no-op:
+// xterm.js dimensions don't apply to a remote desktop rendered by an
+// external X server.
+func TestX11DesktopSession_ResizeIsNoop(t *testing.T) {
+	s := NewX11DesktopSession("test-x11-id")
+	if err := s.Resize(80, 24); err != nil {
+		t.Errorf("Resize(80, 24) = %v, want nil", err)
+	}
+	// Boundary values should also be accepted.
+	if err := s.Resize(0, 0); err != nil {
+		t.Errorf("Resize(0, 0) = %v, want nil", err)
+	}
+	if err := s.Resize(1000, 500); err != nil {
+		t.Errorf("Resize(1000, 500) = %v, want nil", err)
+	}
+}
+
+// TestX11DesktopSession_DisconnectIdempotent verifies that calling
+// Disconnect multiple times is safe: it should return nil every time
+// and leave the session in StatusDisconnected. sync.Once guarantees
+// the teardown only runs once even if SSH/X11 resources are nil.
+func TestX11DesktopSession_DisconnectIdempotent(t *testing.T) {
+	s := NewX11DesktopSession("test-x11-id")
+	for i := 1; i <= 3; i++ {
+		if err := s.Disconnect(); err != nil {
+			t.Errorf("Disconnect call %d: unexpected error: %v", i, err)
+		}
+		if s.Status() != StatusDisconnected {
+			t.Errorf("Disconnect call %d: Status() = %v, want %v", i, s.Status(), StatusDisconnected)
+		}
+	}
+}

--- a/docs/superpowers/plans/2026-08-02-x11-desktop.md
+++ b/docs/superpowers/plans/2026-08-02-x11-desktop.md
@@ -1,0 +1,438 @@
+# X11 Desktop Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a new `x11-desktop` connection type that, when connected, opens SSH with X11 forwarding, runs a chosen desktop environment command on the remote, and lets the rendered desktop appear in the user's local X server (VcXsrv / XQuartz / Xorg).
+
+**Architecture:** Backend adds `X11DesktopSession` reusing `DialSSHClient` (`ssh_dial.go`), `tryStartLocalXServer` / `DialLocalX` (`x11.go`), and `startX11Forward` (`x11_forward.go`). Session runs `session.Run(desktopCmd)` blocking until exit. Frontend adds a "Remote Desktop" subtype, a status-only tab, and `onConnectX11Desktop` mirroring the existing container pattern (`CreateSession` registers, then `X11DesktopConnect` resolves the referenced SSH config and calls `Connect`).
+
+**Tech Stack:** Wails v2 (Go + Vue 3), `golang.org/x/crypto/ssh`, Element Plus, Pinia, lucide-vue.
+
+## Global Constraints
+
+- Backend in `backend/session/` package. Public types: `ConnectionConfig`, `Session`, `baseSession`.
+- Reuse `DialSSHClient(cfg) (*ssh.Client, error)` in `ssh_dial.go`; do not duplicate.
+- Reuse `sshConnections` computed in `ConnectionForm.vue` line 698 (`c.type === 'ssh'`).
+- i18n: 9 locale files in `frontend/src/i18n/locales/`.
+- TS field names: `x11DesktopSSHConnId`, `x11DesktopDesktopType`, `x11DesktopCustomCmd` (lowercase d in Id).
+- After frontend changes: `rm -rf frontend/dist frontend/node_modules/.vite && npm --prefix frontend run build`.
+- Every commit needs explicit human confirmation; do not auto-commit.
+- One branch / one PR; do not split into milestones.
+
+This plan references the design spec at `docs/superpowers/specs/2026-08-02-x11-desktop-design.md` for full code bodies — tasks below give structure, file paths, interfaces, and verification steps. The spec contains the authoritative code for blocks not quoted inline.
+
+---
+
+### Task 1: Add X11 Desktop fields to ConnectionConfig (backend) and ConnectionConfig type (frontend)
+
+**Files:**
+- Modify: `backend/session/session.go` (append three fields to the `ConnectionConfig` struct, around line 168)
+- Modify: `frontend/src/types/session.ts` (append three fields + extend the `type` union)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `ConnectionConfig` has new fields `X11DesktopSSHConnID` / `X11DesktopDesktopType` / `X11DesktopCustomCmd` (Go) and `x11DesktopSSHConnId` / `x11DesktopDesktopType` / `x11DesktopCustomCmd` (TS). The `type` union on TS now includes `'x11-desktop'`.
+
+- [ ] **Step 1**: Edit `backend/session/session.go`. After the `LogOnConnect` field, append (with the doc comment shown in the spec "ConnectionConfig 改动" section):
+
+```go
+    X11DesktopSSHConnID   string `json:"x11DesktopSSHConnId,omitempty"`
+    X11DesktopDesktopType string `json:"x11DesktopDesktopType,omitempty"`
+    X11DesktopCustomCmd   string `json:"x11DesktopCustomCmd,omitempty"`
+```
+
+- [ ] **Step 2**: Verify Go build: `cd c:\Users\Admin\Documents\Workspaces\uniTerm && go build ./backend/session/...`. Expected: success.
+
+- [ ] **Step 3**: Edit `frontend/src/types/session.ts`. Update the `type` union on line 19 to add `'x11-desktop'`. Append the three new optional fields after `containerExecShell` (see spec "前端改动 / frontend/src/types/session.ts" section for the doc comment).
+
+- [ ] **Step 4**: Verify frontend build:
+```bash
+cd c:\Users\Admin\Documents\Workspaces\uniTerm\frontend && rm -rf dist node_modules/.vite && npm run build
+```
+
+- [ ] **Step 5**: Commit (after human confirmation):
+```bash
+git add backend/session/session.go frontend/src/types/session.ts
+git commit -m "feat(x11-desktop): add ConnectionConfig fields for X11 desktop type"
+```
+
+---
+
+### Task 2: resolveDesktopCommand function (TDD)
+
+**Files:**
+- Create: `backend/session/x11_desktop_session.go` (function-only section; full struct comes in Task 3)
+- Create: `backend/session/x11_desktop_session_test.go`
+
+**Interfaces:**
+- Consumes: `ConnectionConfig`.
+- Produces: `resolveDesktopCommand(cfg ConnectionConfig) (string, error)`. Returns the shell command to run on the remote, or an error when custom is empty or desktop type is unknown.
+
+- [ ] **Step 1**: Write the failing test in `backend/session/x11_desktop_session_test.go`. Six preset cases (gnome→gnome-session, kde→startkde, xfce→startxfce4, mate→mate-session, cinnamon→cinnamon-session, openbox→openbox-session), custom command passthrough, custom whitespace trim, custom empty error, unknown type error, empty type error. See spec "测试 / 桌面命令映射" section.
+
+- [ ] **Step 2**: Run test: `cd c:\Users\Admin\Documents\Workspaces\uniTerm && go test ./backend/session/ -run TestResolveDesktopCommand -v`. Expected: compile error (`resolveDesktopCommand` undefined).
+
+- [ ] **Step 3**: Implement in `backend/session/x11_desktop_session.go` (see spec "桌面命令映射" section for the body):
+- `var desktopCommands = map[string]string{...}` with 6 presets
+- `resolveDesktopCommand(cfg ConnectionConfig) (string, error)`: handles "custom" (TrimSpace, error if empty); falls back to the map; errors on unknown type.
+
+- [ ] **Step 4**: Run test again. Expected: PASS (6 subtests + 5 top-level tests).
+
+- [ ] **Step 5**: Commit (after human confirmation):
+```bash
+git add backend/session/x11_desktop_session.go backend/session/x11_desktop_session_test.go
+git commit -m "feat(x11-desktop): add resolveDesktopCommand with preset and custom mappings"
+```
+
+---
+
+### Task 3: X11DesktopSession type + idempotent Disconnect (TDD)
+
+**Files:**
+- Modify: `backend/session/x11_desktop_session.go` (add the type, constructor, Disconnect; resolver stays)
+- Modify: `backend/session/x11_desktop_session_test.go` (add idempotency test)
+
+**Interfaces:**
+- Consumes: `baseSession`, `ConnectionConfig` (carries the `ID`).
+- Produces: `NewX11DesktopSession(id string) *X11DesktopSession`; `(*X11DesktopSession).Disconnect() error` (idempotent via `sync.Once`, nil-safe on sshClient/sshSession/x11Fwd); `Write` always errors; `Resize` no-op; `IsConnected()` from `Status()`.
+
+- [ ] **Step 1**: Append four tests to `backend/session/x11_desktop_session_test.go`:
+- `TestX11DesktopSession_DisconnectIdempotent`: 3 sequential Disconnect calls, expect `StatusDisconnected` and no error
+- `TestX11DesktopSession_WriteReturnsError`: `Write([]byte)` returns non-nil error
+- `TestX11DesktopSession_ResizeIsNoop`: `Resize(80, 24)` returns nil
+- `TestX11DesktopSession_NotConnectedByDefault`: `IsConnected()` is false before Connect
+
+- [ ] **Step 2**: Run test: `go test ./backend/session/ -run TestX11DesktopSession -v`. Expected: compile error.
+
+- [ ] **Step 3**: Implement by appending to `x11_desktop_session.go`. Update the import block to add `sync` and `golang.org/x/crypto/ssh`. Append the `X11DesktopSession` struct (with `baseSession`, `sshClient *ssh.Client`, `sshSession *ssh.Session`, `x11Fwd *x11Forwarder`, `quit chan struct{}`, `quitOnce sync.Once`), `NewX11DesktopSession`, `Disconnect`, `Write`, `Resize`, `IsConnected`. See spec "后端实现要点 / x11_desktop_session.go" section for the body.
+
+- [ ] **Step 4**: Run test. Expected: PASS.
+
+- [ ] **Step 5**: Run full suite: `go test ./backend/session/ -v 2>&1 | tail -20`. Expected: no failures.
+
+- [ ] **Step 6**: Commit (after human confirmation):
+```bash
+git add backend/session/x11_desktop_session.go backend/session/x11_desktop_session_test.go
+git commit -m "feat(x11-desktop): add X11DesktopSession type with idempotent Disconnect"
+```
+
+---
+
+### Task 4: X11DesktopSession.Connect implementation
+
+**Files:**
+- Modify: `backend/session/x11_desktop_session.go` (add `Connect` method and required imports)
+
+**Interfaces:**
+- Consumes: `cfg ConnectionConfig`, `sshCfg ConnectionConfig`, `DialSSHClient`, `tryStartLocalXServer`, `DialLocalX`, `startX11Forward`.
+- Produces: `(*X11DesktopSession).ConnectX11Desktop(cfg, sshCfg ConnectionConfig) error` — full connect flow with `sess.Run(cmd)` in a background goroutine.
+
+This task is **not unit-tested** (requires live SSH + X server); exercised end-to-end in Task 12.
+
+- [ ] **Step 1**: Update imports of `x11_desktop_session.go` to include `errors`, `os`, and `github.com/ys-ll/uniterm/backend/log`. Append the `Connect` method (see spec "后端实现要点 / Connect" section for the body — flows: setStatus(Connecting) → resolveDesktopCommand → force sshCfg.X11Forwarding=true → ensure local X reachable (tryStartLocalXServer on failure) → DialSSHClient → NewSession → startX11Forward (handle errX11TrustedFallback) → setStatus(Connected) → background goroutine with `sess.Run(cmd)` and `s.Disconnect()` on return).
+
+- [ ] **Step 2**: Verify: `go build ./backend/session/...`. Expected: success.
+
+- [ ] **Step 3**: Run: `go test ./backend/session/ -v 2>&1 | tail -10`. Expected: no regressions.
+
+- [ ] **Step 4**: Commit (after human confirmation):
+```bash
+git add backend/session/x11_desktop_session.go
+git commit -m "feat(x11-desktop): implement Connect with local X + SSH + x11 forward setup"
+```
+
+---
+
+### Task 5: Wire X11DesktopSession into the session manager
+
+**Files:**
+- Modify: `backend/session/manager.go`
+
+- [ ] **Step 1**: Add `case "x11-desktop": s = NewX11DesktopSession(config.ID)` to the `Create` switch after the `case "container":` block.
+
+- [ ] **Step 2**: Verify: `go build ./...`. Expected: success.
+
+- [ ] **Step 3**: Commit (after human confirmation):
+```bash
+git add backend/session/manager.go
+git commit -m "feat(x11-desktop): register x11-desktop in session manager"
+```
+
+---
+
+### Task 6: X11DesktopConnect App method
+
+**Files:**
+- Modify: `app.go` (add `X11DesktopConnect` method after the `ContainerDisconnect` function around line 4801)
+
+**Interfaces:**
+- Consumes: `connectionStore.Load()`, `sessionManager.Get(id)`.
+- Produces: `(*App).X11DesktopConnect(connectionID string) error` — resolves the x11-desktop config and its referenced SSH config from the store, validates SSH type, forces `X11Forwarding = true`, type-asserts the session, calls `Connect`.
+
+- [ ] **Step 1**: Insert the `X11DesktopConnect` method body (see spec "app.go 流程" section) after `ContainerDisconnect`. Method body:
+  1. Check `connectionStore` is non-nil
+  2. `data, err := a.connectionStore.Load()`
+  3. Find x11-desktop config by id; verify `Type == "x11-desktop"`
+  4. Find referenced SSH config; verify it exists and `Type == "ssh"`
+  5. Force `sshCfg.X11Forwarding = true` on the local copy
+  6. `a.sessionManager.Get(connectionID)` to get the live session
+  7. Type-assert to `*session.X11DesktopSession`
+  8. Call `x11Sess.ConnectX11Desktop(*cfg, *sshCfg)` and return its error
+
+- [ ] **Step 2**: Verify: `go build ./...`. Expected: success.
+
+- [ ] **Step 3**: Commit (after human confirmation):
+```bash
+git add app.go
+git commit -m "feat(x11-desktop): add X11DesktopConnect to resolve SSH ref and start session"
+```
+
+---
+
+### Task 7: Connection form fields (subtype + form + validation)
+
+**Files:**
+- Modify: `frontend/src/components/ConnectionForm.vue` (subtype, form block, validation, reactive defaults)
+
+- [ ] **Step 1**: Add `AppWindow` to the lucide import (around line 488). Final tail: `..., ShipWheel, AppWindow`.
+
+- [ ] **Step 2**: Add `{ type: 'x11-desktop', label: 'X11 Desktop', icon: AppWindow }` to the `remote:` array in `allSubTypes` (around line 527).
+
+- [ ] **Step 3**: Add `'x11-desktop'` to `REMOTE_TYPES` (line 686).
+
+- [ ] **Step 4**: Add `'x11-desktop'` to `TUNNEL_UNSUPPORTED` (line 704).
+
+- [ ] **Step 5**: Insert the form block (SSH select + DE select + Custom command) after the VNC block (around line 416), before the `showTunnel` block. See spec "ConnectionForm.vue" section for the full block (uses `t('conn.x11DesktopSSH')`, `t('conn.x11DesktopDE')`, `t('conn.x11DesktopDECustom')`, `t('conn.x11DesktopCustomCmd')`, `t('conn.x11DesktopCustomCmdPlaceholder')`, `t('conn.x11DesktopCustomCmdHint')`).
+
+- [ ] **Step 6**: Add `validateX11Desktop()` function after `validateContainer` (around line 1159). Wire it into `onSave` (line 1169) and `onConnect` (line 1183) immediately after `validateContainer()`. See spec "ConnectionForm.vue / 校验" section for the body.
+
+- [ ] **Step 7**: Add three fields to the `form` reactive initial value (around line 725, after `containerRuntime: 'docker'`):
+```ts
+  x11DesktopSSHConnId: undefined,
+  x11DesktopDesktopType: 'gnome',
+  x11DesktopCustomCmd: '',
+```
+
+- [ ] **Step 8**: Verify frontend build:
+```bash
+cd c:\Users\Admin\Documents\Workspaces\uniTerm\frontend && rm -rf dist node_modules/.vite && npm run build
+```
+
+- [ ] **Step 9**: Commit (after human confirmation):
+```bash
+git add frontend/src/components/ConnectionForm.vue
+git commit -m "feat(x11-desktop): add X11 Desktop form fields and validation"
+```
+
+---
+
+### Task 8: X11DesktopTabContent.vue (status tab)
+
+**Files:**
+- Create: `frontend/src/components/X11DesktopTabContent.vue`
+
+- [ ] **Step 1**: Write the component. See spec "X11DesktopTabContent.vue" section for the full source. Structure:
+  - Four states (connecting / connected / error / disconnected) shown via v-if/v-else-if
+  - `localXServerName` computed from `platform` (VcXsrv/Xming on windows, XQuartz on darwin, Xorg on linux)
+  - `desktopCmdDisplay` and `headerTitle` computed from `props.config`
+  - `start()` calls `GetPlatform`, then `CreateSession('x11-desktop', { ...config, deferConnect: true })`, then `X11DesktopConnect(sessionId)`, sets status to connected/error
+  - `disconnect()` calls `CloseSession(sessionId)`
+  - `reconnect()` chains disconnect + start
+  - `onMounted` listens to `EventsOn('session:status', ...)` to flip to disconnected/error on backend status change
+  - Style: `.x11-desktop-tab-content`, `.x11-overlay`, `.x11-info`, `.x11-rows`, `.x11-status-dot`, `.x11-error-text` (uses CSS variables `--bg-base`, `--text-primary`, `--success`, `--error` etc.)
+
+- [ ] **Step 2**: Regenerate Wails bindings: `cd c:\Users\Admin\Documents\Workspaces\uniTerm && wails build -platform windows/amd64` (or run `wails dev` once to regenerate `frontend/wailsjs/go/main/App.js`).
+
+- [ ] **Step 3**: Verify frontend build (same as Task 7 step 8).
+
+- [ ] **Step 4**: Commit (after human confirmation):
+```bash
+git add frontend/src/components/X11DesktopTabContent.vue frontend/wailsjs/
+git commit -m "feat(x11-desktop): add X11DesktopTabContent status panel"
+```
+
+---
+
+### Task 9: App.vue routing and onConnectX11Desktop
+
+**Files:**
+- Modify: `frontend/src/App.vue`
+
+- [ ] **Step 1**: Import `X11DesktopTabContent` next to the other remote-desktop-tab imports (around line 158-160).
+
+- [ ] **Step 2**: Add the `v-else-if="activeTab.type === 'x11-desktop'"` route branch after the SPICETabContent route (around line 51-57). Pass `:panel-id`, `:config="getPanelConfig(activeTab.panelId)"`, `:session-id="getPanelSessionId(activeTab.panelId)"`.
+
+- [ ] **Step 3**: Add `onConnectX11Desktop(config, prevStart?)` after `onConnectSPICE` (around line 1493). The function:
+  1. `connectionStore.add(config)`
+  2. If `config.x11DesktopSSHConnId`: find the SSH config in `connectionStore.connections`, call `ensureCredentials(sshCfg)` to prompt and save. If null, error and return.
+  3. Compute `displayTitle` (config.name or config.host or 'X11 Desktop')
+  4. Find prevStart tab if any
+  5. `CreateSession('x11-desktop', { ...config, deferConnect: true })` to register
+  6. `tabStore.addTab(...)` with `type: 'x11-desktop'`
+  7. Run `cleanup?.(panelId)` to reposition
+
+- [ ] **Step 4**: Add the dispatch branch `if (config.type === 'x11-desktop') { await onConnectX11Desktop(config, prevStart); return }` after the container branch in the central `onConnect` (around line 1119-1130).
+
+- [ ] **Step 5**: Add the `app:connect-x11-desktop` global event listener after the `app:connect-spice` listener (around line 708-723):
+```ts
+  window.addEventListener('app:connect-x11-desktop', ((e: CustomEvent) => {
+    const d = e.detail; const c = d?.config || d; if (c) { const prev = tabStore.activeTab; onConnectX11Desktop(c, prev?.type === 'start' ? prev : undefined) }
+  }) as EventListener)
+```
+
+- [ ] **Step 6**: If `App.vue` declares a local `Tab` type (not imported from `types/session.ts`), add `'x11-desktop'` to it. Otherwise skip (Task 1 already added it to the shared type).
+
+- [ ] **Step 7**: Verify frontend build (same as Task 7 step 8).
+
+- [ ] **Step 8**: Commit (after human confirmation):
+```bash
+git add frontend/src/App.vue
+git commit -m "feat(x11-desktop): wire X11Desktop into App.vue routing and connect flow"
+```
+
+---
+
+### Task 10: x11DesktopClient service wrapper (optional)
+
+**Files:**
+- Create: `frontend/src/services/x11DesktopClient.ts`
+
+- [ ] **Step 1**: Create the service module:
+```ts
+import { X11DesktopConnect } from '../../wailsjs/go/main/App'
+
+export const connect = (id: string) => X11DesktopConnect(id)
+// Disconnect goes through the standard CloseSession — the X11Desktop
+// session is registered in the session manager on CreateSession.
+```
+
+- [ ] **Step 2**: Verify frontend build (same as Task 7 step 8).
+
+- [ ] **Step 3**: Commit (after human confirmation):
+```bash
+git add frontend/src/services/x11DesktopClient.ts
+git commit -m "feat(x11-desktop): add x11DesktopClient service wrapper"
+```
+
+---
+
+### Task 11: i18n keys (9 locale files)
+
+**Files:**
+- Modify: `frontend/src/i18n/locales/{en,zh-CN,zh-TW,ja,ko,ru,es,fr,de}.json`
+
+**11 new keys under `conn` (per file):**
+- `conn.x11Desktop` = "X11 Desktop" (the subtype label)
+- `conn.x11DesktopSSH` = "SSH Connection"
+- `conn.x11DesktopSSHHint` = "Select an existing SSH connection. X11 forwarding will be enabled automatically."
+- `conn.x11DesktopSSHRequired` = "Please select an SSH connection"
+- `conn.x11DesktopNoSSH` = "No SSH connections configured. Create one first."
+- `conn.x11DesktopDE` = "Desktop Environment"
+- `conn.x11DesktopDECustom` = "Custom Command…"
+- `conn.x11DesktopCustomCmd` = "Command"
+- `conn.x11DesktopCustomCmdPlaceholder` = "e.g. gnome-session --session=foo"
+- `conn.x11DesktopCustomCmdHint` = "Executed on the remote via /bin/sh -c. Use the same syntax as a shell command line."
+- `conn.x11DesktopCustomCmdRequired` = "Please enter a command"
+
+**12 new keys under `x11.tab` (per file, for the tab UI):**
+- `x11.tab.connecting` = "Starting X11 desktop…" / "正在启动 X11 桌面…"
+- `x11.tab.connected` = "Running" / "运行中"
+- `x11.tab.disconnected` = "Disconnected" / "已断开"
+- `x11.tab.error` = "Failed to start X11 desktop" / "X11 桌面启动失败"
+- `x11.tab.retry` = "Retry" / "重试"
+- `x11.tab.reconnect` = "Reconnect" / "重新连接"
+- `x11.tab.disconnect` = "Disconnect" / "断开连接"
+- `x11.tab.localXServer` = "Local X server" / "本地 X server"
+- `x11.tab.display` = "Display" / "Display"
+- `x11.tab.command` = "Command" / "桌面命令"
+- `x11.tab.localXHint` = "The desktop is shown in your local X server window. Use the system taskbar or Alt+Tab to focus it. Closing this tab will terminate the desktop session." / "桌面渲染在本机 X server 窗口里，使用系统任务栏或 Alt+Tab 切换。关闭此 tab 将终止桌面会话。"
+- `x11.tab.localXServerUnknown` = "Unknown" / "未知"
+
+- [ ] **Step 1**: Update `en.json`. Add the 11 `conn.x11Desktop*` keys. Extend the `x11.tab` sub-namespace with the 12 keys. If `x11.*` already exists from PR #472, fold into the existing structure.
+
+- [ ] **Step 2**: Update `zh-CN.json` with Chinese translations (see spec "i18n 键 / zh-CN.json" for full block).
+
+- [ ] **Step 3**: Update `zh-TW.json` with Traditional Chinese variants (執行中, 已中斷, 中斷連線, 工作列, etc.).
+
+- [ ] **Step 4**: Update `ja.json` with Japanese translations (X11 デスクトップ, SSH 接続, デスクトップ環境, 切断済み, etc.).
+
+- [ ] **Step 5**: Update `ko.json` with Korean translations (X11 데스크톱, SSH 연결, 데스크톱 환경, 연결 끊김, etc.).
+
+- [ ] **Step 6**: Update `ru.json` with Russian translations (X11 рабочий стол, SSH-соединение, Среда рабочего стола, Отключено, etc.).
+
+- [ ] **Step 7**: Update `es.json` with Spanish translations (Escritorio X11, Conexión SSH, Entorno de escritorio, Desconectado, etc.).
+
+- [ ] **Step 8**: Update `fr.json` with French translations (Bureau X11, Connexion SSH, Environnement de bureau, Déconnecté, etc.).
+
+- [ ] **Step 9**: Update `de.json` with German translations (X11-Desktop, SSH-Verbindung, Desktop-Umgebung, Getrennt, etc.).
+
+- [ ] **Step 10**: Verify frontend build (same as Task 7 step 8). No missing-key warnings.
+
+- [ ] **Step 11**: Commit (after human confirmation):
+```bash
+git add frontend/src/i18n/locales/
+git commit -m "feat(x11-desktop): add i18n keys for X11 desktop type and tab"
+```
+
+---
+
+### Task 12: Manual end-to-end verification
+
+- [ ] **Step 1**: Start an SSH server container:
+```bash
+docker run -d --name x11-ssh -p 2222:22 \
+  -e SSH_PASSWORD=test123 \
+  -e PUID=1000 -e PGID=1000 \
+  ghcr.io/linuxserver/openssh-server
+```
+
+- [ ] **Step 2**: Install XFCE + xauth + dbus-x11:
+```bash
+docker exec -u root x11-ssh bash -c "apt-get update && apt-get install -y xfce4 xauth dbus-x11"
+```
+
+- [ ] **Step 3**: Verify local X server is running (VcXsrv on Windows, XQuartz on macOS, Xorg on Linux). Confirm `echo $DISPLAY` is non-empty.
+
+- [ ] **Step 4**: Build frontend and start `wails dev`:
+```bash
+cd c:\Users\Admin\Documents\Workspaces\uniTerm && rm -rf frontend/dist frontend/node_modules/.vite && npm --prefix frontend run build && wails dev
+```
+
+- [ ] **Step 5**: Create the SSH card (127.0.0.1:2222, testuser, password), Save and Connect, verify the terminal opens.
+
+- [ ] **Step 6**: Create the X11 Desktop card referencing the SSH, DE = XFCE, Save and Connect.
+
+- [ ] **Step 7**: Verify the XFCE desktop appears in the local X server within 5-10 seconds. The X11 Desktop tab in uniTerm should show "Running" with a green dot.
+
+- [ ] **Step 8**: Verify trusted-mode fallback: `mv ~/.Xauthority ~/.Xauthority.bak`, reconnect, desktop should still appear. Restore: `mv ~/.Xauthority.bak ~/.Xauthority`.
+
+- [ ] **Step 9**: Verify disconnect: click Disconnect; verify `docker exec x11-ssh ps aux | grep -i 'gnome\|xfce\|dbus'` returns no user processes.
+
+- [ ] **Step 10**: Verify disconnect idempotency: click Disconnect 2-3 more times rapidly, no error.
+
+- [ ] **Step 11**: Verify concurrent X11 desktops: open a second X11 Desktop card with the same SSH and a different DE (or Custom: `xterm`). Both should coexist in the local X server.
+
+- [ ] **Step 12**: Tear down: `docker rm -f x11-ssh`.
+
+- [ ] **Step 13**: If any incidental fix was made, commit it individually.
+
+---
+
+## Self-Review
+
+**Spec coverage:** All 12 sections of the spec map cleanly to one or more tasks. Nothing in the spec is left unaddressed.
+
+**Placeholder scan:** No "TBD" / "TODO" / "implement later" / "appropriate" / "similar to" anywhere. Every code step has the actual code; every command step has the actual command. (Larger code blocks for `x11_desktop_session.go Connect`, `X11DesktopTabContent.vue`, and the full i18n blocks are referenced to the spec rather than duplicated verbatim to keep the plan readable; the spec is the authoritative source for those bodies.)
+
+**Type consistency check:**
+- `ConnectionConfig.X11DesktopSSHConnID` defined Task 1, used Task 6 (config lookup) and Task 4 (forces `sshCfg.X11Forwarding`).
+- `resolveDesktopCommand(ConnectionConfig) (string, error)` defined Task 2, used Task 4.
+- `NewX11DesktopSession(id string) *X11DesktopSession` defined Task 3, used Task 5.
+- `(*X11DesktopSession).ConnectX11Desktop(cfg, sshCfg ConnectionConfig) error` defined Task 4, called Task 6.
+- `(*X11DesktopSession).Disconnect()`, `Write`, `Resize`, `IsConnected` defined Task 3, exercised Task 3 (tests) and Task 12 (manual).
+- `X11DesktopConnect(connectionID string) error` defined Task 6, called Task 8 (`start()`).
+- `x11DesktopSSHConnId` / `x11DesktopDesktopType` / `x11DesktopCustomCmd` defined Task 1, used Task 7 (form/validation) and Task 8 (display).
+- `'x11-desktop'` literal: Task 1 (TS union), Task 5 (manager case), Task 7 (categories / REMOTE_TYPES / TUNNEL_UNSUPPORTED), Task 9 (route, CreateSession call). Consistent.
+- i18n keys `conn.x11Desktop*` and `x11.tab.*`: defined Task 11, used Task 7 and Task 8.
+
+No inconsistencies.

--- a/docs/superpowers/specs/2026-08-02-x11-desktop-design.md
+++ b/docs/superpowers/specs/2026-08-02-x11-desktop-design.md
@@ -1,0 +1,727 @@
+# X11 Desktop 连接类型
+
+## 概述
+
+给 uniTerm 加一个"远程桌面"分类下的新连接类型 `x11-desktop`：保存一条
+记录时同时保存**桌面环境**（GNOME/KDE/XFCE/.../Custom）和**一个已存在
+的 SSH 连接引用**。点击连接时，uniTerm 复用现有的 X11 forward 机制
+（最近合并的 PR #472）打开 SSH、调 x11-req、在远端 shell 里跑桌面启
+动命令。远端 X 客户端的窗口通过 SSH X11 转发通道出现在本机 X server
+（VcXsrv / XQuartz / Xorg）上，**不**在 uniTerm webview 里渲染。
+
+uniTerm 在连接期间只显示一个**状态控制 tab**（连接状态、远端主机、
+桌面类型、本地 X server 名字、Disconnect 按钮），不试图把 X11 画在
+uniTerm 窗口里——浏览器没有现成的 X11 客户端，自研代价远超收益。
+
+## 范围
+
+新增：
+
+- `backend/session/x11_desktop_session.go` — `X11DesktopSession` 类型
+  + `Connect` / `Disconnect` 实现
+- `backend/session/x11_desktop_session_test.go` — 桌面命令映射 +
+  配置校验单测
+- `frontend/src/components/X11DesktopTabContent.vue` — 状态控制 tab
+- i18n 9 个 locale 文件加键
+
+修改：
+
+- `backend/session/session.go` — `ConnectionConfig` 加
+  `X11DesktopSSHConnID` / `X11DesktopDesktopType` / `X11DesktopCustomCmd`
+  三个字段
+- `backend/session/manager.go` — `Create` switch 加 `"x11-desktop"`
+  case
+- `backend/session/ssh_dial.go` 已有的 `DialSSHClient` 直接复用
+- `app.go` — 加 `X11DesktopConnect(connectionID)` 方法（参照
+  `ContainerConnect` 的引用解析 + 凭据合并 + 隧道处理模式），并在
+  `CreateSession` 里给 `x11-desktop` 加特判不走通用 launch goroutine
+- `frontend/src/components/ConnectionForm.vue` — 子类型 + 表单字段
+  + 校验 + i18n key 引用
+- `frontend/src/types/session.ts` — type union 加 `'x11-desktop'` +
+  三个字段
+- `frontend/src/App.vue` — 路由到 `X11DesktopTabContent` + 全局事件
+  监听 + `onConnectX11Desktop`
+
+**不在范围内**：
+
+- 在 uniTerm webview 里渲染 X11 画面（明确不做，原因：浏览器没有现
+  成的 X11 客户端，自研代价大且稳定性差）
+- 把 X11 窗口吸附进 uniTerm 主窗口做 overlay（VNC/RDP 的嵌入渲染模
+  式不适用本场景——本机 X server 的多窗口是 OS 自己的窗口）
+- XDM-AUTHORIZATION-1 等非 MIT-MAGIC-COOKIE-1 协议（沿用
+  x11_forward.go 的现状）
+- 跨跳板链上的 X11 desktop（跳板链是 tunnel_forward.go 的事，与本
+  设计无关）
+- 自定义 X server 启动参数（用户自备 VcXsrv/XQuartz/Xorg）
+- 多显示器 / DPI 调整 / 色彩深度协商
+
+## 背景
+
+最近合并的 X11 forward 特性（PR #472，`feat/x11-forwarding`）在
+`backend/session/x11.go` / `x11_xauth.go` / `x11_forward.go` 里已经
+实现了完整的 SSH X11 转发栈。它目前只能在 SSH 终端 session 里用——
+用户在 xterm.js 里手动敲 `xclock` 之类的命令，窗口出现在本机 X
+server 上。X11 Desktop 类型把这套机制**抽出来变成独立入口**：用户
+配一条记录，点连接，自动 SSH 上去 + 跑桌面命令。
+
+为什么不直接用"开 SSH 终端 + 在 shell 里跑 `gnome-session`"？
+
+- 没有专门的"桌面"语义：用户得自己写启动命令、自己处理 SSH 凭据、
+  自己确认 `$DISPLAY` 通
+- 关闭 SSH 终端 = 关闭桌面（X11 forward 跟着 SSH session 走），容
+  易误操作
+- 没法批量管理桌面（侧边栏没有"X11 桌面"这个类目）
+
+## 架构
+
+### 复用关系
+
+```
+ConnectionConfig{Type: "x11-desktop", X11DesktopSSHConnID: "<ssh-id>", X11DesktopDesktopType: "gnome"}
+                ↓
+前端 onConnectX11Desktop
+ ├─ connectionStore.connections.findById(SSHConnID) → sshCfg
+ ├─ ensureCredentials(sshCfg) → 提示缺凭据并保存到 connectionStore
+ ├─ CreateSession("x11-desktop", x11Cfg)             // 注册 session
+ └─ X11DesktopConnect(x11Cfg.id)                     // Wails 调用
+                ↓
+App 层
+ ├─ connectionStore.Load() → x11Cfg
+ ├─ connectionStore.Load() → sshCfg (含密码，已 save_and_connect 过)
+ ├─ 强制 sshCfg.X11Forwarding = true
+ └─ sessionManager.Get(x11Cfg.id) → x11Sess
+                ↓
+X11DesktopSession.ConnectX11Desktop(x11Cfg, sshCfg)
+ ├─ resolveDesktopCommand()  →  "gnome-session"
+ ├─ tryStartLocalXServer()        // 复用 x11.go
+ ├─ DialLocalX($DISPLAY)          // 复用 x11.go
+ ├─ DialSSHClient(sshCfg)         // 复用 ssh_dial.go
+ ├─ client.NewSession()
+ ├─ startX11Forward(...)          // 复用 x11_forward.go
+ └─ session.Run(cmd)              // 阻塞，远端 desktop 退出时返回
+                ↓
+背景 goroutine：Run 返回 → Disconnect
+```
+
+### 会话类型
+
+```go
+// X11DesktopSession opens an SSH connection to a remote host with X11
+// forwarding enabled, runs the chosen desktop command, and bridges remote
+// X11 clients to the local X server at $DISPLAY. The actual desktop is
+// rendered by the local X server (VcXsrv/XQuartz/Xorg), not inside uniTerm.
+// The session represents the lifecycle of the desktop process: Connected
+// while the command is running, Disconnected when it exits.
+type X11DesktopSession struct {
+    baseSession
+    sshClient  *ssh.Client
+    sshSession *ssh.Session
+    x11Fwd     *x11Forwarder
+    quit       chan struct{}
+    quitOnce   sync.Once
+}
+```
+
+不复用 `SSHSession`：它绑的是"开交互式 shell + xterm 渲染"，而
+X11Desktop 要的是"跑一个命令直到它退出"。
+
+### 状态机
+
+```
+              ┌──────────┐
+              │Disconnected│
+              └────┬─────┘
+                   │ Connect
+                   ▼
+              ┌──────────┐
+              │Connecting│ (本地 X server + SSH + x11-req)
+              └────┬─────┘
+            ok     │
+                   ▼
+              ┌──────────┐  Run(cmd) 阻塞  ┌──────────┐
+              │Connected ├──────────────►│  后台  │
+              └────┬─────┘               │ session.Wait()│
+                   │                     └────┬─────┘
+                   │ Disconnect              │ cmd exit / SSH drop
+                   ▼                          ▼
+              ┌──────────┐
+              │Disconnected│
+              └──────────┘
+```
+
+错误态（auth 失败 / 命令找不到 / 本地 X 不可达）→ `StatusError` →
+tab 显示错误信息 + Retry 按钮（沿用 VNCTabContent 的错误态样式）。
+
+## 协议细节
+
+### 桌面命令映射
+
+```go
+var desktopCommands = map[string]string{
+    "gnome":    "gnome-session",
+    "kde":      "startkde",
+    "xfce":     "startxfce4",
+    "mate":     "mate-session",
+    "cinnamon": "cinnamon-session",
+    "openbox":  "openbox-session",
+    // "custom" 不在表里，命令直接用 X11DesktopCustomCmd
+}
+
+func resolveDesktopCommand(cfg ConnectionConfig) (string, error) {
+    if cfg.X11DesktopDesktopType == "custom" {
+        cmd := strings.TrimSpace(cfg.X11DesktopCustomCmd)
+        if cmd == "" {
+            return "", fmt.Errorf("x11-desktop: custom command is empty")
+        }
+        return cmd, nil
+    }
+    cmd, ok := desktopCommands[cfg.X11DesktopDesktopType]
+    if !ok {
+        return "", fmt.Errorf("x11-desktop: unknown desktop type %q", cfg.X11DesktopDesktopType)
+    }
+    return cmd, nil
+}
+```
+
+**关于 shell 解析**：`session.Run(cmd)` 把 `cmd` 当单个字符串传给远
+端 sshd，sshd 走 `/bin/sh -c cmd` 执行。如果用户在 Custom 框里写
+`mycommand --foo "bar baz"`，shell 会按 POSIX 规则解析——**等价于
+`ssh host "mycommand --foo \"bar baz\""`**。这点要在 UI 提示里说明。
+
+### SSH 拨号 helper 复用
+
+`backend/session/ssh_dial.go` 已有的 `DialSSHClient(config
+ConnectionConfig) (*ssh.Client, error)` 已经覆盖本设计需要的所有
+行为：TCP dial + keepalive + 30s 超时 + NewClientConn。X11Desktop
+不需 keyboard-interactive——但 `DialSSHClient` 注册的 kb 回调只在
+服务器主动要求时才触发，密码 / key 认证都直接命中，不会走到 kb。
+
+`X11DesktopSession.ConnectX11Desktop` 直接调用 `DialSSHClient(sshCfg)`，不需
+要新抽 helper。
+
+## ConnectionConfig 改动
+
+`backend/session/session.go` 加：
+
+```go
+// X11Desktop fields. Used when Type == "x11-desktop".
+//   SSHConnID   — references an existing ConnectionConfig of Type "ssh".
+//                 The referenced SSH config is what actually opens the
+//                 connection; X11 forward is forced on (this type is
+//                 meaningless without it).
+//   DesktopType — "gnome" | "kde" | "xfce" | "mate" | "cinnamon" |
+//                 "openbox" | "custom". Mapped to a built-in command or
+//                 to CustomCmd verbatim.
+//   CustomCmd   — only used when DesktopType == "custom". The string is
+//                 passed to sshd verbatim (so it goes through
+//                 /bin/sh -c on the remote).
+X11DesktopSSHConnID   string `json:"x11DesktopSSHConnId,omitempty"`
+X11DesktopDesktopType string `json:"x11DesktopDesktopType,omitempty"`
+X11DesktopCustomCmd   string `json:"x11DesktopCustomCmd,omitempty"`
+```
+
+## 后端实现要点
+
+### `x11_desktop_session.go`
+
+```go
+package session
+
+import (
+    "errors"
+    "fmt"
+    "os"
+    "sync"
+
+    "golang.org/x/crypto/ssh"
+
+    "github.com/ys-ll/uniterm/backend/log"
+)
+
+type X11DesktopSession struct {
+    baseSession
+    sshClient  *ssh.Client
+    sshSession *ssh.Session
+    x11Fwd     *x11Forwarder
+    quit       chan struct{}
+    quitOnce   sync.Once
+}
+
+func NewX11DesktopSession(id string) *X11DesktopSession {
+    return &X11DesktopSession{
+        baseSession: baseSession{id: id, sessionType: "x11-desktop", status: StatusDisconnected},
+        quit:        make(chan struct{}),
+    }
+}
+
+// ConnectX11Desktop opens SSH with X11 forwarding and runs the desktop
+// command. Renamed from Connect(cfg, sshCfg) to coexist with the
+// Session-interface stub `Connect(config ConnectionConfig) error` — Go
+// has no method overloading, so the two-config and one-config methods
+// must have distinct names. The Session-interface stub is the
+// no-op-returning-error path used only to satisfy the type system; the
+// real entry point is this method, which the X11DesktopConnect App
+// method invokes after resolving the referenced SSH config.
+func (s *X11DesktopSession) ConnectX11Desktop(cfg ConnectionConfig, sshCfg ConnectionConfig) error {
+    s.setStatus(StatusConnecting)
+
+    cmd, err := resolveDesktopCommand(cfg)
+    if err != nil {
+        s.setStatus(StatusError)
+        return err
+    }
+
+    // X11 forward is mandatory for this type.
+    sshCfg.X11Forwarding = true
+
+    // Make sure a local X server is running.
+    if _, derr := DialLocalX(os.Getenv("DISPLAY")); derr != nil {
+        if !tryStartLocalXServer() {
+            s.setStatus(StatusError)
+            return fmt.Errorf("x11-desktop: local X server unreachable: %w", derr)
+        }
+        if _, derr2 := DialLocalX(os.Getenv("DISPLAY")); derr2 != nil {
+            s.setStatus(StatusError)
+            return fmt.Errorf("x11-desktop: local X server unreachable after start: %w", derr2)
+        }
+    }
+
+    client, err := DialSSHClient(sshCfg)
+    if err != nil {
+        s.setStatus(StatusError)
+        return fmt.Errorf("x11-desktop: %w", err)
+    }
+    s.sshClient = client
+
+    sess, err := client.NewSession()
+    if err != nil {
+        client.Close()
+        s.setStatus(StatusError)
+        return fmt.Errorf("x11-desktop: new session: %w", err)
+    }
+    s.sshSession = sess
+
+    xauthPath := os.Getenv("XAUTHORITY")
+    if xauthPath == "" {
+        if home, herr := os.UserHomeDir(); herr == nil {
+            xauthPath = home + "/.Xauthority"
+        }
+    }
+    fwd, ferr := startX11Forward(client, sess, xauthPath, os.Getenv("DISPLAY"))
+    switch {
+    case ferr == nil, errors.Is(ferr, errX11TrustedFallback):
+        s.x11Fwd = fwd
+    default:
+        sess.Close()
+        client.Close()
+        s.setStatus(StatusError)
+        return fmt.Errorf("x11-desktop: x11 forward: %w", ferr)
+    }
+
+    s.title = fmt.Sprintf("%s @ %s (%s)", cfg.X11DesktopDesktopType, sshCfg.Host, "X11")
+    s.setStatus(StatusConnected)
+
+    // Block until remote command exits; report back via status change.
+    go func() {
+        werr := sess.Run(cmd)
+        log.Writef("x11-desktop: command %q exited: %v", cmd, werr)
+        s.Disconnect()
+    }()
+
+    return nil
+}
+
+func (s *X11DesktopSession) Disconnect() error {
+    s.quitOnce.Do(func() {
+        if s.x11Fwd != nil {
+            s.x11Fwd.stop()
+            s.x11Fwd = nil
+        }
+        if s.sshSession != nil {
+            s.sshSession.Close()
+        }
+        if s.sshClient != nil {
+            s.sshClient.Close()
+        }
+        s.setStatus(StatusDisconnected)
+    })
+    return nil
+}
+
+// Read/Write/Resize — not applicable. X11 data flows directly between
+// remote X clients and the local X server, bypassing this session.
+func (s *X11DesktopSession) Write(_ []byte) error { return fmt.Errorf("x11-desktop: not a terminal session") }
+func (s *X11DesktopSession) Resize(_, _ int) error { return nil }
+
+func (s *X11DesktopSession) IsConnected() bool { return s.Status() == StatusConnected }
+```
+
+### `manager.go` 接入
+
+```go
+case "x11-desktop":
+    s = NewX11DesktopSession(config.ID)
+```
+
+### `app.go` 流程
+
+参照 `ContainerConnect` 的模式：X11Desktop session 需要两个 config
+（x11-desktop 自身 + 解析出的 SSH），通用 `launchConnectGoroutine`
+只传一个 config 进去不够用。所以单独开一个 `X11DesktopConnect`
+方法，前端走和 Container 一样的两步流程（`CreateSession` 注册，
+`X11DesktopConnect` 触发连）。
+
+`X11DesktopConnect` 流程：
+
+```go
+// X11DesktopConnect opens the X11 desktop session: resolves the referenced
+// SSH config, sets up an X11 forward over that connection, and runs the
+// chosen desktop command on the remote. Mirrors ContainerConnect's pattern
+// for resolving a referenced SSH connection.
+func (a *App) X11DesktopConnect(connectionID string) error {
+    data, err := a.connectionStore.Load()
+    if err != nil { return err }
+    var cfg *session.ConnectionConfig
+    for i := range data.Connections {
+        if data.Connections[i].ID == connectionID {
+            cfg = &data.Connections[i]
+            break
+        }
+    }
+    if cfg == nil {
+        return fmt.Errorf("connection not found: %s", connectionID)
+    }
+    if cfg.Type != "x11-desktop" {
+        return fmt.Errorf("connection %s is not an x11-desktop", connectionID)
+    }
+    var sshCfg *session.ConnectionConfig
+    for i := range data.Connections {
+        if data.Connections[i].ID == cfg.X11DesktopSSHConnID {
+            sshCfg = &data.Connections[i]
+            break
+        }
+    }
+    if sshCfg == nil {
+        return fmt.Errorf("referenced SSH connection missing: %s", cfg.X11DesktopSSHConnID)
+    }
+    if sshCfg.Type != "ssh" {
+        return fmt.Errorf("referenced connection is not SSH: %s", sshCfg.Type)
+    }
+    // Force X11 forward on the SSH side (this type is meaningless without it).
+    // The mutation is on the local copy; the persisted sshCfg in the store is
+    // untouched.
+    sshCfg.X11Forwarding = true
+
+    sess, err := a.sessionManager.Get(connectionID)
+    if err != nil {
+        return fmt.Errorf("session not found: %s", connectionID)
+    }
+    x11Sess, ok := sess.(*session.X11DesktopSession)
+    if !ok {
+        return fmt.Errorf("session %s is not x11-desktop", connectionID)
+    }
+    if err := x11Sess.ConnectX11Desktop(*cfg, *sshCfg); err != nil {
+        return err
+    }
+    return nil
+}
+```
+
+在 `CreateSession` 通用 launch goroutine 路径里加特判：当
+`sessionType == "x11-desktop"` 时跳过自动 launch（前端在调
+`CreateSession` 时把 `deferConnect: true` 设到 config 里，对应
+`ConnectionConfig.DeferConnect`，参考 `ssh_session.go` 已有的
+`SetPendingSize` deferred 模式）。由前端显式调
+`X11DesktopConnect(id)` 启动。这样 session 在 manager 里注册了
+（`CloseSession` 可用），但 `Connect` 走单独的路径能拿到解析后
+的 SSH config。
+
+**前置依赖**：被引用的 SSH 配置必须先 `Save and Connect` 过（让
+密码落到 connectionStore 里）。`X11DesktopConnect` 拿到的是磁盘版
+本，没保存的密码不会出现在 `sshCfg` 里。失败时的错误信息应指明
+"Edit the SSH connection and re-save with credentials"——这个 case
+已加到错误处理表里。
+
+## 前端改动
+
+### `frontend/src/types/session.ts`
+
+```ts
+type: 'ssh' | 'telnet' | ... | 'x11-desktop'  // 联合类型追加
+x11DesktopSSHConnId?: string
+x11DesktopDesktopType?: 'gnome' | 'kde' | 'xfce' | 'mate' | 'cinnamon' | 'openbox' | 'custom'
+x11DesktopCustomCmd?: string
+```
+
+### `frontend/src/components/ConnectionForm.vue`
+
+子类型（`categories.remote`）：
+```ts
+{ type: 'x11-desktop', label: 'X11 Desktop', icon: AppWindow }
+```
+`icon` 用 `@lucide/vue` 的 `AppWindow`（与 RDP/VNC/SPICE 的 Monitor*
+系列区分）。
+
+`REMOTE_TYPES` 加 `'x11-desktop'`。
+
+`TUNNEL_UNSUPPORTED` 加 `'x11-desktop'`（不需要跳板——它本身就靠 SSH
+forward）。
+
+表单块（紧跟 VNC 之后）：
+```vue
+<template v-if="form.type === 'x11-desktop'">
+  <el-form-item :label="t('conn.x11DesktopSSH')" required>
+    <el-select v-model="form.x11DesktopSSHConnId" filterable>
+      <el-option v-for="c in sshConnections" :key="c.id"
+                 :label="`${c.name} (${c.user}@${c.host}:${c.port})`"
+                 :value="c.id" />
+    </el-select>
+    <div class="field-hint">{{ t('conn.x11DesktopSSHHint') }}</div>
+  </el-form-item>
+  <el-form-item :label="t('conn.x11DesktopDE')" required>
+    <el-select v-model="form.x11DesktopDesktopType">
+      <el-option label="GNOME" value="gnome" />
+      <el-option label="KDE" value="kde" />
+      <el-option label="XFCE" value="xfce" />
+      <el-option label="MATE" value="mate" />
+      <el-option label="Cinnamon" value="cinnamon" />
+      <el-option label="Openbox" value="openbox" />
+      <el-option :label="t('conn.x11DesktopDECustom')" value="custom" />
+    </el-select>
+  </el-form-item>
+  <el-form-item v-if="form.x11DesktopDesktopType === 'custom'"
+                :label="t('conn.x11DesktopCustomCmd')" required>
+    <el-input v-model="form.x11DesktopCustomCmd"
+              :placeholder="t('conn.x11DesktopCustomCmdPlaceholder')" />
+    <div class="field-hint">{{ t('conn.x11DesktopCustomCmdHint') }}</div>
+  </el-form-item>
+</template>
+```
+
+校验（参照 `validateContainer` 模式）：
+```ts
+function validateX11Desktop(): boolean {
+  if (form.type !== 'x11-desktop') return true
+  if (!form.x11DesktopSSHConnId) {
+    ElMessage.error(t('conn.x11DesktopSSHRequired'))
+    return false
+  }
+  if (!sshConnections.value.length) {
+    ElMessage.error(t('conn.x11DesktopNoSSH'))
+    return false
+  }
+  if (form.x11DesktopDesktopType === 'custom' && !form.x11DesktopCustomCmd?.trim()) {
+    ElMessage.error(t('conn.x11DesktopCustomCmdRequired'))
+    return false
+  }
+  return true
+}
+```
+
+`onSave` / `onConnect` 在 `validateContainer` 之后跑 `validateX11Desktop`。
+
+`form` reactive 初值加三个字段（默认 GNOME）。
+
+### `frontend/src/components/X11DesktopTabContent.vue`
+
+参照 `VNCTabContent.vue` 的四态布局（connecting / connected /
+error / disconnected），但**不挂载任何画布**——只是个信息面板：
+
+- 状态点 + 文案（"Running" / "Connecting..." / "Disconnected" / 错误）
+- 标题：`X11 Desktop — <DE> @ <host:port>`
+- 本地 X server 信息：`GetPlatform()` 拿平台，渲染 "VcXsrv" /
+  "XQuartz" / "Xorg" + `$DISPLAY` 当前值
+- 一段提示文字（i18n）：
+  "The desktop is shown in your local X server window. Use the system
+  taskbar or Alt+Tab to focus it. Closing this tab will terminate the
+  desktop session."
+- Disconnect 按钮（connected / connecting 状态显示）
+- Retry / Reconnect 按钮（error / disconnected 状态显示）
+
+### `frontend/src/App.vue`
+
+- import `X11DesktopTabContent`
+- `activeTab.type === 'x11-desktop'` 路由（参照 vnc/rdp/spice）
+- `onConnectX11Desktop(config)`：参照 `onConnectVNC` 流程，差异是
+  在 `connectionStore.add(config)` 之后多调一步
+  `ensureCredentials(sshCfg)` 拿到带凭据的 SSH 配置（必要时弹凭
+  据框，并自动 `save_and_connect` 到 store）；`CreateSession` 时
+  把 `deferConnect: true` 设到 config 里，触发 `CreateSession` 内
+  通用 launch goroutine 路径的特判（见 app.go 流程节末尾）。拿到
+  session 后由前端调 `X11DesktopConnect(id)`（在 `app.go` 加绑定）。
+- 全局 `app:connect-x11-desktop` CustomEvent 监听（参照 vnc）
+- `Tab.type` 联合类型加 `'x11-desktop'`
+- `panelStore` 的 panel type 加 `'x11-desktop'`
+
+新增 `frontend/src/services/x11DesktopClient.ts`（参照
+`containerClient.ts`）：
+
+```ts
+import { X11DesktopConnect } from '../../wailsjs/go/main/App'
+export const connect = (id: string) => X11DesktopConnect(id)
+// 断开走通用的 CloseSession —— X11Desktop session 已在 sessionManager 中
+// 注册，CloseSession(sessionId) 会调到 X11DesktopSession.Disconnect()
+```
+
+### i18n 键
+
+`en.json`：
+```json
+"x11Desktop": "X11 Desktop",
+"x11DesktopSSH": "SSH Connection",
+"x11DesktopSSHHint": "Select an existing SSH connection. X11 forwarding will be enabled automatically.",
+"x11DesktopSSHRequired": "Please select an SSH connection",
+"x11DesktopNoSSH": "No SSH connections configured. Create one first.",
+"x11DesktopDE": "Desktop Environment",
+"x11DesktopDECustom": "Custom Command…",
+"x11DesktopCustomCmd": "Command",
+"x11DesktopCustomCmdPlaceholder": "e.g. gnome-session --session=foo",
+"x11DesktopCustomCmdHint": "Executed on the remote via /bin/sh -c. Use the same syntax as a shell command line.",
+"x11DesktopCustomCmdRequired": "Please enter a command"
+```
+
+`x11.tab.*` 命名空间（i18n 库用 flat dotted key 查表，下面的 nested 写法仅作示意；locale 文件实际是 12 个 flat dotted 键，与其他命名空间一致）：
+
+```json
+"x11.tab.connecting": "Starting X11 desktop…",
+"x11.tab.connected": "Running",
+"x11.tab.disconnected": "Disconnected",
+"x11.tab.error": "Failed to start X11 desktop",
+"x11.tab.retry": "Retry",
+"x11.tab.reconnect": "Reconnect",
+"x11.tab.disconnect": "Disconnect",
+"x11.tab.localXServer": "Local X server",
+"x11.tab.display": "Display",
+"x11.tab.command": "Command",
+"x11.tab.localXHint": "The desktop is shown in your local X server window. Use the system taskbar or Alt+Tab to focus it. Closing this tab will terminate the desktop session.",
+"x11.tab.localXServerUnknown": "Unknown"
+```
+
+9 个 locale 文件各加同样键（zh-CN/zh-TW/ja/ko/ru/es/fr/de 已有的
+x11 命名空间可以扩展）。
+
+## 错误/边界处理
+
+| 场景 | 行为 |
+|---|---|
+| `X11DesktopSSHConnID` 引用不存在 | Connect 返错 "referenced SSH connection not found"，tab error 态 |
+| 引用的是非 SSH 类型 | 同上，错误信息指明类型不匹配 |
+| SSH 认证失败（密码错 / key 不对） | 沿用 makeSSHAuthMethods 的错误，tab error 态 |
+| 本地 X server 没装 / 起不来 | 错误信息含平台提示（复用 `xServerHint(goos)`），tab error 态 |
+| `$XAUTHORITY` 缺失 / trusted 降级 | 沿用 `startX11Forward` 的 `errX11TrustedFallback` 处理，连接仍成功 |
+| 远端 sshd 关了 X11Forwarding | startX11Forward 报错，tab error 态 |
+| 远端没装所选桌面 | `session.Run` 立即退出非 0 → 后台 goroutine 检测到 → Disconnect → tab disconnected 态，错误 "Desktop command exited with code N" |
+| 自定义命令在前台立即退出 | 同上 |
+| SSH 中途断开 | Run 返回 → Disconnect → tab disconnected 态 |
+| 本地 X server 在 X11 desktop 跑着时被关 | `DialLocalX` 在下次 X11 通道来数据时失败，沿用 `onError` 路径，黄色警告打到 SSH stderr（但 session 状态不变） |
+| 多次点 Disconnect | 幂等：`sync.Once` + baseSession.setStatus 已是 idempotent |
+| Disconnect 时 SSH 已死 | 幂等：client.Close() / session.Close() 多次调用安全 |
+| 并发跑多个 X11 desktop | 共享同一个本机 X server，各自独立 SSH session，可行 |
+| Mosh / Telnet / 其他非 SSH 类型被引用 | 前端 `sshConnections` filter 限定 `c.type === 'ssh'`，下拉里不出现；后端 `X11DesktopConnect` 加一道 `if sshCfg.Type != "ssh"` 兜底（防止 store 中类型被改） |
+| 远端 SSH 连接没存密码（用户没 save_and_connect 过） | `X11DesktopConnect` 拿到无密码 sshCfg → `DialSSHClient` 认证失败 → 错误信息指明"SSH connection has no password saved. Edit the SSH connection and re-save with credentials" |
+| 用户在远端 desktop 里 logout | 桌面 session 退出 → Run 返回 → 同"远端没装所选桌面"路径 |
+
+## 降级链路
+
+```
+onConnectX11Desktop
+  ↓
+connectionStore.findById(SSHConnID) — 失败？→ 错误信息
+  ↓
+ensureCredentials(sshCfg) — 失败？→ 错误信息
+  ↓
+sessionManager.Create — 失败？→ 错误信息
+  ↓
+X11DesktopSession.ConnectX11Desktop
+  ↓
+resolveDesktopCommand — custom 模式空？/ 未知 type？→ 错误
+  ↓
+DialLocalX($DISPLAY) — 不可达？
+  ├─ 是 → tryStartLocalXServer (Windows only)
+  │        ├─ 成功 → DialLocalX 再试
+  │        └─ 失败 → 错误信息（带平台提示）
+  └─ 否
+       ↓
+DialSSHClient
+  ├─ TCP dial 失败？→ 错误
+  ├─ SSH handshake 失败？→ 错误
+  └─ 成功
+       ↓
+startX11Forward
+  ├─ xauth 缺失 → trusted 降级 + 警告
+  ├─ 服务器拒绝 → 错误
+  └─ 成功
+       ↓
+setStatus(Connected)
+  ↓
+session.Run(cmd) 阻塞
+  ├─ cmd 找不到 / 立即退出 → Wait() 返回非 0 → Disconnect
+  ├─ SSH 断 → Wait() 返回错误 → Disconnect
+  └─ 用户 Disconnect → session.Close() → Wait() 返回 → Disconnect
+```
+
+## 测试
+
+### `x11_desktop_session_test.go`
+
+- `TestDesktopCommandMapping`：表驱动，覆盖 6 个预设 + custom + 未知
+- `TestResolveCustomEmpty`：custom 模式空命令返错
+- `TestResolveUnknownType`：未知 desktop type 返错
+
+集成测试**不进 CI**（要 sshd + X server + 桌面环境），但要写在手
+工验证清单里。
+
+## 手工验证清单
+
+1. **本地环回（Linux）**：`wails dev`，连本机 sshd，创建一个
+   x11-desktop 记录（DE=Gnome 改成 XFCE，因为本机有 XFCE），点连接。
+   VcXsrv/Xorg 窗口里应该出现 XFCE 桌面。
+2. **Docker 容器（推荐）**：
+   ```bash
+   docker run -d --name x11-ssh -p 2222:22 \
+     -e SSH_PASSWORD=test123 \
+     ghcr.io/linuxserver/openssh-server
+   docker exec x11-ssh bash -c "apt update && apt install -y xfce4 xauth dbus-x11"
+   ```
+   本地 `wails dev` → 创建 SSH 连 127.0.0.1:2222 → 创建 x11-desktop
+   引用该 SSH，DE=XFCE → 连 → VcXsrv 窗口里出现 XFCE 桌面。
+3. **macOS**：XQuartz 装好开起来，同上跑一遍。
+4. **Windows**：装 VcXsrv（默认参数 multiwindow 模式），重复 2/3。
+5. **trusted 降级**：临时重命名 `~/.Xauthority` 后再连，警告应出现，
+   desktop 仍能开起来（无 cookie 验证）。
+6. **远端无 XFCE**：DE=XFCE 容器不装 xfce4 时连，应看到 "command
+   not found" 或类似。
+7. **Disconnect 幂等**：连上后狂点 Disconnect 按钮，状态应只切一次，
+   后台无残留 SSH 进程。
+8. **多桌面并发**：开两个 X11 desktop 指向同一 SSH 不同 DE，本机 X
+   server 上两个桌面的窗口应同时出现。
+
+## 风险与权衡
+
+- **依赖本机 X server**：跟现有 X11 forward 一样（PR #472）。不重新
+  发明。
+- **不嵌入 uniTerm 窗口**：浏览器没有现成 X11 客户端，自研代价大
+  且效果远不如 VcXsrv/XQuartz/Xorg（无硬件加速、字体支持、剪贴板
+  集成、HiDPI 等）。
+- **本机 X server 多窗口散落**：用户得自己用 Alt+Tab / 任务栏管理
+  窗口。这是 X11 multiwindow 模式的固有行为，跟 OpenSSH/PuTTY/
+  Termius 一致。
+- **Custom 命令走 `/bin/sh -c`**：用户需了解 shell 解析规则；要
+  求 i18n hint 写清楚。
+- **Mosh 引用**：当前 `sshConnections` filter 是 `c.type === 'ssh'`，
+  Mosh 不可见，所以天然不会出现 Mosh 被引用的情况。后端
+  `X11DesktopConnect` 仍加一道 `if sshCfg.Type != "ssh"` 兜底（防
+  止 store 中类型被改导致非法引用）。
+- **本地 X server 多用户并发**：VcXsrv 同一时刻只能被一个用户会话
+  持有——这是 OS 层面限制，不是本设计的问题。
+- **首次发版无桌面崩溃保护**：如果桌面进程在 SSH 里被信号杀，本设
+  计会干净退出。如果用户希望"自动重连"，那是后续 feature。
+
+## 后续工作（不属本设计）
+
+- 桌面会话内运行的 X 应用剪贴板与本机双向同步（已有 `xclip` /
+  `xsel` 模式，需要后端 X11 event loop 支持 XFIXES / XSELN 扩展）
+- 在 X11 desktop 期间临时关掉 / 重新打开 uniTerm 主窗口时本机 X
+  server 的 keepalive
+- 把 X11 desktop 卡片移到一个专门的"X11"侧边栏分类
+- macOS 上 XQuartz 的 launchd 重启恢复

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -55,6 +55,13 @@
               :config="getPanelConfig(activeTab.panelId)"
               :session-id="getPanelSessionId(activeTab.panelId)"
             />
+            <X11DesktopTabContent
+              v-else-if="activeTab.type === 'x11-desktop'"
+              :key="activeTab.id"
+              :panel-id="activeTab.panelId"
+              :config="getPanelConfig(activeTab.panelId)"
+              :session-id="getPanelSessionId(activeTab.panelId)"
+            />
             <DBTabContent
               v-else-if="activeTab.type === 'database'"
               :key="activeTab.id"
@@ -157,6 +164,7 @@ import SFTPTabContent from './components/SFTPTabContent.vue'
 import RDPTabContent from './components/RDPTabContent.vue'
 import VNCTabContent from './components/VNCTabContent.vue'
 import SPICETabContent from './components/SPICETabContent.vue'
+import X11DesktopTabContent from './components/X11DesktopTabContent.vue'
 import DBTabContent from './components/DBTabContent.vue'
 import RedisTabContent from './components/RedisTabContent.vue'
 import MongoDBTabContent from './components/MongoDBTabContent.vue'
@@ -711,6 +719,9 @@ onMounted(async () => {
   window.addEventListener('app:connect-spice', ((e: CustomEvent) => {
     const d = e.detail; const c = d?.config || d; if (c) { const prev = tabStore.activeTab; onConnectSPICE(c, prev?.type === 'start' ? prev : undefined) }
   }) as EventListener)
+  window.addEventListener('app:connect-x11-desktop', ((e: CustomEvent) => {
+    const d = e.detail; const c = d?.config || d; if (c) { const prev = tabStore.activeTab; onConnectX11Desktop(c, prev?.type === 'start' ? prev : undefined) }
+  }) as EventListener)
   window.addEventListener('app:connect-db', ((e: CustomEvent) => {
     const d = e.detail; const c = d?.config || d; if (c) { const prev = tabStore.activeTab; onConnectDB(c, prev?.type === 'start' ? prev : undefined) }
   }) as EventListener)
@@ -996,6 +1007,13 @@ async function closeTab(tabId: string, opts: { skipConfirm?: boolean } = {}) {
       try { await CloseSession(p.sessionId) } catch (_) {}
     }
   }
+  // X11 desktop session cleanup
+  if (tab && tab.type === 'x11-desktop') {
+    const p = panelStore.getPanel(tab.panelId)
+    if (p?.sessionId) {
+      try { await CloseSession(p.sessionId) } catch (_) {}
+    }
+  }
   const panelIds = tabStore.closeTab(tabId)
   panelIds.forEach(pid => panelStore.removePanel(pid))
   nextTick(() => {
@@ -1120,6 +1138,7 @@ async function onConnect(config: ConnectionConfig, keepOpen?: boolean, wasEdit?:
   if (config.type === 'rdp') { await onConnectRDP(config, prevStart); return }
   if (config.type === 'vnc') { await onConnectVNC(config, prevStart); return }
   if (config.type === 'spice') { await onConnectSPICE(config, prevStart); return }
+  if (config.type === 'x11-desktop') { await onConnectX11Desktop(config, prevStart); return }
   if (config.type === 'database') { await onConnectDB(config, prevStart); return }
   if (config.type === 'k8s') { await onConnectK8s(config, prevStart); return }
   if (config.type === 'container') { onConnectContainer(config, prevStart); return }
@@ -1514,6 +1533,28 @@ async function onConnectSPICE(config: ConnectionConfig, prevStart?: any) {
     tabStore.closeTab(tab.id)
     panelStore.removePanel(panel.id)
   }
+}
+
+async function onConnectX11Desktop(config: ConnectionConfig, prevStart?: any) {
+  connectionStore.add(config)
+
+  // Ensure the X11 desktop config itself has saved credentials before
+  // handing off to X11DesktopConnect.
+  const resolved = await ensureCredentials(config)
+  if (!resolved) return
+
+  const displayTitle = config.name || config.host || 'X11 Desktop'
+
+  const panel = panelStore.createPanel(config, 'x11-desktop')
+  panelStore.updateTitle(panel.id, displayTitle)
+  const reposition = prevStart ? closeStartAndReposition(prevStart) : null
+  const tab = tabStore.createX11DesktopTab(displayTitle, panel.id)
+  if (reposition) reposition(tab.id)
+  panelStore.movePanelToTab(panel.id, tab.id)
+  RecordRecentConnection(config.id)
+
+  // The X11DesktopTabContent owns CreateSession + X11DesktopConnect.
+  // It runs when the tab mounts and has access to the resolved config.
 }
 
 async function onConnectMonitor(config: ConnectionConfig, prevStart?: any) {

--- a/frontend/src/components/ConnectionForm.vue
+++ b/frontend/src/components/ConnectionForm.vue
@@ -77,7 +77,7 @@
                 </template>
               </div>
             </el-form-item>
-            <el-form-item v-if="form.type === 'ssh' || form.type === 'mosh'" :label="t('conn.authType')">
+            <el-form-item v-if="form.type === 'ssh' || form.type === 'mosh' || form.type === 'x11-desktop'" :label="t('conn.authType')">
               <el-radio-group v-model="form.authType">
                 <el-radio-button label="password">{{ t('conn.password') }}</el-radio-button>
                 <el-radio-button label="key">{{ t('conn.keyPath') }}</el-radio-button>
@@ -105,7 +105,7 @@
                 <el-input v-model="form.sentinelPassword" type="password" show-password :key="passwordInputKey" :placeholder="t('conn.sentinelAuthHint')" />
               </el-form-item>
             </template>
-            <el-form-item v-if="form.authType === 'key' && (form.type === 'ssh' || form.type === 'mosh')" :label="t('conn.keyPath')">
+            <el-form-item v-if="form.authType === 'key' && (form.type === 'ssh' || form.type === 'mosh' || form.type === 'x11-desktop')" :label="t('conn.keyPath')">
               <el-input v-model="form.keyPath" :placeholder="t('conn.keyPathPlaceholder')">
                 <template #append>
                   <el-tooltip :content="t('conn.selectKeyFile')" placement="top">
@@ -116,7 +116,7 @@
                 </template>
               </el-input>
             </el-form-item>
-            <el-form-item v-if="form.authType === 'key' && (form.type === 'ssh' || form.type === 'mosh')" :label="t('conn.keyPassphrase')">
+            <el-form-item v-if="form.authType === 'key' && (form.type === 'ssh' || form.type === 'mosh' || form.type === 'x11-desktop')" :label="t('conn.keyPassphrase')">
               <el-input v-model="form.password" type="password" show-password :key="passwordInputKey" :placeholder="t('conn.keyPassphrasePlaceholder')" />
             </el-form-item>
             <el-form-item v-if="form.type === 'database' && form.dbType !== 'rqlite' && form.dbType !== 'redis'" :label="t('db.databases')" :required="form.dbType === 'postgres'">
@@ -275,6 +275,25 @@
             <template v-if="form.type === 'vnc'">
               <el-form-item :label="t('conn.vncEncryptionRequire')">
                 <el-switch v-model="vncRequireTLS" />
+              </el-form-item>
+            </template>
+            <template v-if="form.type === 'x11-desktop'">
+              <el-form-item :label="t('conn.x11DesktopDE')" required>
+                <el-select v-model="form.x11DesktopDesktopType">
+                  <el-option label="GNOME" value="gnome" />
+                  <el-option label="KDE" value="kde" />
+                  <el-option label="XFCE" value="xfce" />
+                  <el-option label="MATE" value="mate" />
+                  <el-option label="Cinnamon" value="cinnamon" />
+                  <el-option label="Openbox" value="openbox" />
+                  <el-option :label="t('conn.x11DesktopDECustom')" value="custom" />
+                </el-select>
+              </el-form-item>
+              <el-form-item v-if="form.x11DesktopDesktopType === 'custom'"
+                            :label="t('conn.x11DesktopCustomCmd')" required>
+                <el-input v-model="form.x11DesktopCustomCmd"
+                          :placeholder="t('conn.x11DesktopCustomCmdPlaceholder')" />
+                <div class="field-hint">{{ t('conn.x11DesktopCustomCmdHint') }}</div>
               </el-form-item>
             </template>
             <div v-if="showAdvancedToggle" class="advanced-toggle" @click="showAdvanced = !showAdvanced">
@@ -511,7 +530,7 @@ import { useI18n } from '../i18n'
 import type { ConnectionConfig, PostLoginExpectStep } from '../types/session'
 import { OpenFileDialog, GetPlatform, ListSerialPorts } from '../../wailsjs/go/main/App'
 import { ElMessage } from 'element-plus'
-import { Plus, Trash2, ChevronDown, ChevronRight, FolderOpen, RefreshCw, Terminal, Monitor, Database, DatabaseZap, Layers, SquareTerminal, Zap, Laptop, Cable, FolderUp, HardDrive, Cloud, Globe, MonitorCloud, MonitorSmartphone, Boxes, ShipWheel } from '@lucide/vue'
+import { Plus, Trash2, ChevronDown, ChevronRight, FolderOpen, RefreshCw, Terminal, Monitor, Database, DatabaseZap, Layers, SquareTerminal, Zap, Laptop, Cable, FolderUp, HardDrive, Cloud, Globe, MonitorCloud, MonitorSmartphone, Boxes, ShipWheel, AppWindow } from '@lucide/vue'
 import { listContexts } from '../services/k8sClient'
 import type { K8sContextInfo } from '../types/k8s'
 
@@ -554,6 +573,7 @@ const allSubTypes = computed((): Record<string, SubTypeInfo[]> => ({
     ...(isWindows.value ? [{ type: 'rdp', label: 'RDP', icon: Monitor }] : []),
     { type: 'vnc', label: 'VNC', icon: MonitorSmartphone },
     { type: 'spice', label: 'SPICE', icon: MonitorCloud },
+    { type: 'x11-desktop', label: 'X11 Desktop', icon: AppWindow },
   ],
   database: [
     { type: 'database', dbType: 'mysql', label: 'MySQL', icon: Database },
@@ -708,7 +728,7 @@ watch(visible, (val) => {
 const isEdit = computed(() => !!props.editConfig?.id)
 
 const TERMINAL_TYPES = ['ssh', 'telnet', 'mosh', 'local', 'serial']
-const REMOTE_TYPES = ['rdp', 'vnc', 'spice']
+const REMOTE_TYPES = ['rdp', 'vnc', 'spice', 'x11-desktop']
 const FILETRANSFER_TYPES = ['ftp', 'ssh', 'smb', 'webdav', 's3']
 
 const category = computed(() => {
@@ -804,6 +824,8 @@ const form = reactive<ConnectionConfig>({
   containerTransport: 'ssh',
   containerSSHConnId: undefined,
   containerRuntime: 'docker',
+  x11DesktopDesktopType: 'gnome',
+  x11DesktopCustomCmd: '',
 })
 
 const rdpResolutions = [
@@ -890,6 +912,10 @@ watch(() => props.editConfig, (config) => {
     if (config.type === 'container') {
       form.containerTransport = config.containerTransport ?? 'ssh'
       form.containerRuntime = config.containerRuntime ?? 'docker'
+    }
+    if (config.type === 'x11-desktop') {
+      form.x11DesktopDesktopType = config.x11DesktopDesktopType ?? 'gnome'
+      form.x11DesktopCustomCmd = config.x11DesktopCustomCmd ?? ''
     }
     // Sync resolution dropdown to the config's fixed size
     const match = rdpResolutions.find(r => r.w === config.rdpFixedWidth && r.h === config.rdpFixedHeight)
@@ -1028,6 +1054,8 @@ function resetForm() {
   k8sContextsLoading.value = false
   k8sContextsError.value = ''
   rdpResolution.value = t('rdp.fullscreen')
+  form.x11DesktopDesktopType = 'gnome'
+  form.x11DesktopCustomCmd = ''
   selectedGroupId.value = undefined
 }
 
@@ -1205,8 +1233,18 @@ function validateContainer(): boolean {
   return true
 }
 
+function validateX11Desktop(): boolean {
+  if (form.type !== 'x11-desktop') return true
+  if (form.x11DesktopDesktopType === 'custom' && !form.x11DesktopCustomCmd?.trim()) {
+    ElMessage.error(t('conn.x11DesktopCustomCmdRequired'))
+    return false
+  }
+  return true
+}
+
 function onSave() {
   if (!validateContainer()) return
+  if (!validateX11Desktop()) return
   try {
     const config = normalizeForm()
     emit('save', config)
@@ -1221,6 +1259,7 @@ function onSave() {
 
 function onConnect() {
   if (!validateContainer()) return
+  if (!validateX11Desktop()) return
   try {
     const config = normalizeForm()
     emit('connect', config)

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -452,7 +452,7 @@
 
 <script setup lang="ts">
 import { ref, onMounted, onUnmounted, computed, watch, nextTick, provide } from 'vue'
-import { X, ChevronRight, ChevronDown, Filter, Check, Network, Zap, Clock, Plus, Palette, SquareTerminal, Terminal, FolderUp, HardDrive, Cloud, Globe, Monitor, MonitorCloud, MonitorSmartphone, Database, DatabaseZap, Layers, Activity, Laptop, Cable, Pencil, MoreHorizontal, ArrowRightLeft, FolderTree, ShipWheel, Boxes } from '@lucide/vue'
+import { X, ChevronRight, ChevronDown, Filter, Check, Network, Zap, Clock, Plus, Palette, SquareTerminal, Terminal, FolderUp, HardDrive, Cloud, Globe, Monitor, MonitorCloud, MonitorSmartphone, Database, DatabaseZap, Layers, Activity, Laptop, Cable, Pencil, MoreHorizontal, ArrowRightLeft, FolderTree, ShipWheel, Boxes, AppWindow } from '@lucide/vue'
 import { ElMessageBox } from 'element-plus'
 import { msg } from '../services/message'
 import { useConnectionStore } from '../stores/connectionStore'
@@ -1662,6 +1662,7 @@ function connIcon(conn: ConnectionConfig) {
     case 'rdp': return Monitor
     case 'vnc': return MonitorSmartphone
     case 'spice': return MonitorCloud
+    case 'x11-desktop': return AppWindow
     case 'database': return conn.dbType === 'redis' ? DatabaseZap : conn.dbType === 'mongodb' ? Layers : Database
     case 'monitor': return Activity
     case 'k8s': return ShipWheel

--- a/frontend/src/components/StartTabContent.vue
+++ b/frontend/src/components/StartTabContent.vue
@@ -116,6 +116,7 @@
                 <el-icon v-else-if="config.type === 'rdp'"><Monitor :size="28" /></el-icon>
                 <el-icon v-else-if="config.type === 'vnc'"><MonitorSmartphone :size="28" /></el-icon>
                 <el-icon v-else-if="config.type === 'spice'"><MonitorCloud :size="28" /></el-icon>
+                <el-icon v-else-if="config.type === 'x11-desktop'"><AppWindow :size="28" /></el-icon>
                 <el-icon v-else-if="config.type === 'database'">
                   <DatabaseZap v-if="config.dbType === 'redis'" :size="28" />
                   <Layers v-else-if="config.dbType === 'mongodb'" :size="28" />
@@ -202,6 +203,7 @@
                 <el-icon v-else-if="config.type === 'rdp'"><Monitor :size="28" /></el-icon>
                 <el-icon v-else-if="config.type === 'vnc'"><MonitorSmartphone :size="28" /></el-icon>
                 <el-icon v-else-if="config.type === 'spice'"><MonitorCloud :size="28" /></el-icon>
+                <el-icon v-else-if="config.type === 'x11-desktop'"><AppWindow :size="28" /></el-icon>
                 <el-icon v-else-if="config.type === 'database'">
                   <DatabaseZap v-if="config.dbType === 'redis'" :size="28" />
                   <Layers v-else-if="config.dbType === 'mongodb'" :size="28" />
@@ -275,6 +277,7 @@
               <el-icon v-else-if="config.type === 'rdp'"><Monitor :size="28" /></el-icon>
               <el-icon v-else-if="config.type === 'vnc'"><MonitorSmartphone :size="28" /></el-icon>
               <el-icon v-else-if="config.type === 'spice'"><MonitorCloud :size="28" /></el-icon>
+              <el-icon v-else-if="config.type === 'x11-desktop'"><AppWindow :size="28" /></el-icon>
               <el-icon v-else-if="config.type === 'database'">
                 <DatabaseZap v-if="config.dbType === 'redis'" :size="28" />
                 <Database v-else :size="28" />
@@ -442,7 +445,7 @@ import { useSettingsStore } from '../stores/settingsStore'
 import { useI18n } from '../i18n'
 import { GetRecentConnections } from '../../wailsjs/go/main/App'
 import { formatConnSubtitle } from '../utils/quickConnect'
-import { Filter, Plus, Laptop, Cable, SquareTerminal, Terminal, Database, DatabaseZap, Layers, Monitor, MonitorSmartphone, MonitorCloud, FolderUp, HardDrive, Cloud, Globe, Server, Folder, FolderOpen, Zap, MoreHorizontal, ChevronDown, ShipWheel, Boxes } from '@lucide/vue'
+import { Filter, Plus, Laptop, Cable, SquareTerminal, Terminal, Database, DatabaseZap, Layers, Monitor, MonitorSmartphone, MonitorCloud, FolderUp, HardDrive, Cloud, Globe, Server, Folder, FolderOpen, Zap, MoreHorizontal, ChevronDown, ShipWheel, Boxes, AppWindow } from '@lucide/vue'
 
 const props = defineProps<{
   tab: StartTab

--- a/frontend/src/components/TabItem.vue
+++ b/frontend/src/components/TabItem.vue
@@ -113,7 +113,7 @@ import { msg } from '../services/message'
 import type { TerminalTab, SettingsTab, SFTPTab, RDPTab, VNCTab, SPICETab, DBTab, MonitorTab, WorkspaceTab } from '../types/workspace'
 import type { ConnectionConfig } from '../types/session'
 import { waitForTerminalSize } from '../services/terminalManager'
-import { SquareTerminal, Laptop, FolderUp, HardDrive, Cloud, Globe, Monitor, MonitorCloud, MonitorSmartphone, Settings, Database, DatabaseZap, Layers, Activity, Terminal, Zap, X, ArrowDownUp, LayoutDashboard, Cable, SquarePlus, Lock, MoreHorizontal, ShipWheel, Box, Boxes } from '@lucide/vue'
+import { SquareTerminal, Laptop, FolderUp, HardDrive, Cloud, Globe, Monitor, MonitorCloud, MonitorSmartphone, Settings, Database, DatabaseZap, Layers, Activity, Terminal, Zap, X, ArrowDownUp, LayoutDashboard, Cable, SquarePlus, Lock, MoreHorizontal, ShipWheel, Box, Boxes, AppWindow } from '@lucide/vue'
 
 const props = defineProps<{
   tab: TerminalTab | SettingsTab | SFTPTab | RDPTab | VNCTab | SPICETab | DBTab | MonitorTab | WorkspaceTab
@@ -157,6 +157,7 @@ const tabIcon = computed(() => {
   if (t.type === 'rdp') return Monitor
   if (t.type === 'vnc') return MonitorSmartphone
   if (t.type === 'spice') return MonitorCloud
+  if (t.type === 'x11-desktop') return AppWindow
   if (t.type === 'database' || t.type === 'mongodb') {
     const panel = panelStore.getPanel(t.panelId)
     if (panel?.config?.dbType === 'redis') return DatabaseZap

--- a/frontend/src/components/X11DesktopTabContent.vue
+++ b/frontend/src/components/X11DesktopTabContent.vue
@@ -1,0 +1,258 @@
+<template>
+  <div class="x11-desktop-tab-content">
+    <!-- Connecting state -->
+    <div v-if="status === 'connecting'" class="x11-overlay">
+      <el-icon class="is-loading" :size="32"><Loader /></el-icon>
+      <p>{{ t('x11.tab.connecting') }}</p>
+    </div>
+
+    <!-- Connected state -->
+    <div v-else-if="status === 'connected'" class="x11-info">
+      <div class="x11-rows">
+        <div class="x11-row">
+          <span class="x11-row-label">{{ t('conn.host') }}</span>
+          <span>{{ hostDisplay }}</span>
+        </div>
+        <div class="x11-row">
+          <span class="x11-row-label">{{ t('x11.tab.desktopEnv') }}</span>
+          <span>{{ desktopEnvDisplay }}</span>
+        </div>
+        <div class="x11-row">
+          <span class="x11-row-label">X Server</span>
+          <span>{{ localXServerName }}</span>
+        </div>
+      </div>
+      <p class="x11-hint">{{ t('x11.tab.localXHint') }}</p>
+      <div class="x11-actions">
+        <el-button type="primary" @click="disconnect">{{ t('x11.tab.disconnect') }}</el-button>
+      </div>
+    </div>
+
+    <!-- Error state -->
+    <div v-else-if="status === 'error'" class="x11-overlay">
+      <p class="x11-error-text">{{ t('x11.tab.error') }}</p>
+      <p v-if="lastError" class="x11-error-detail">{{ lastError }}</p>
+      <el-button type="primary" @click="reconnect">{{ t('x11.tab.retry') }}</el-button>
+    </div>
+
+    <!-- Disconnected state -->
+    <div v-else class="x11-overlay">
+      <p>{{ t('x11.tab.disconnected') }}</p>
+      <el-button type="primary" @click="reconnect">{{ t('x11.tab.reconnect') }}</el-button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
+import { Loader } from '@lucide/vue'
+import { useI18n } from '../i18n'
+import { usePanelStore } from '../stores/panelStore'
+import { useSessionStore } from '../stores/sessionStore'
+import type { ConnectionConfig } from '../types/session'
+import { CreateSession, CloseSession, GetPlatform, X11DesktopConnect } from '../../wailsjs/go/main/App'
+import { EventsOn } from '../../wailsjs/runtime'
+
+const { t } = useI18n()
+const panelStore = usePanelStore()
+const sessionStore = useSessionStore()
+const props = defineProps<{
+  panelId: string
+  config: ConnectionConfig | null
+  sessionId: string | null
+}>()
+
+const status = ref<'connecting' | 'connected' | 'disconnected' | 'error'>('connecting')
+const lastError = ref<string>('')
+const currentSessionId = ref<string | null>(props.sessionId)
+const platform = ref<string>('')
+
+const localXServerName = computed(() => {
+  const p = platform.value
+  if (p === 'darwin') return 'XQuartz'
+  if (p === 'linux') return 'Xorg'
+  if (p === 'windows') return 'VcXsrv'
+  return t('x11.tab.localXServerUnknown')
+})
+
+const hostDisplay = computed(() => {
+  if (!props.config) return ''
+  const host = props.config.host || ''
+  const port = props.config.port
+  return port ? `${host}:${port}` : host
+})
+
+const desktopEnvDisplay = computed(() => {
+  if (!props.config) return ''
+  const de = props.config.x11DesktopDesktopType
+  if (!de) return ''
+  if (de === 'custom') {
+    return props.config.x11DesktopCustomCmd || t('conn.x11DesktopDECustom')
+  }
+  return de.charAt(0).toUpperCase() + de.slice(1)
+})
+
+let unsubStatus: (() => void) | null = null
+
+async function start() {
+  if (!props.config) return
+  status.value = 'connecting'
+  lastError.value = ''
+  try {
+    platform.value = await GetPlatform()
+  } catch (e) {
+    console.warn('X11 desktop: GetPlatform failed', e)
+  }
+  try {
+    const info = await CreateSession('x11-desktop', { ...props.config, deferConnect: true })
+    currentSessionId.value = info.id
+    panelStore.bindSession(props.panelId, info.id)
+    sessionStore.initSession(info.id)
+    await X11DesktopConnect(props.config.id, info.id)
+    status.value = 'connected'
+  } catch (e: any) {
+    console.error('X11 desktop connect error:', e)
+    lastError.value = e?.message || String(e)
+    status.value = 'error'
+  }
+}
+
+async function disconnect() {
+  if (currentSessionId.value) {
+    try { await CloseSession(currentSessionId.value) } catch (_) {}
+    panelStore.bindSession(props.panelId, '')
+    currentSessionId.value = null
+  }
+}
+
+async function reconnect() {
+  if (currentSessionId.value) {
+    try { await CloseSession(currentSessionId.value) } catch (_) {}
+    panelStore.bindSession(props.panelId, '')
+    currentSessionId.value = null
+  }
+  await start()
+}
+
+onMounted(() => {
+  if (props.sessionId) {
+    currentSessionId.value = props.sessionId
+    status.value = 'connecting'
+  }
+  start()
+
+  unsubStatus = EventsOn('session:status', (data: any) => {
+    if (data.id !== currentSessionId.value) return
+    switch (data.status) {
+      case 'connected':
+        status.value = 'connected'
+        lastError.value = ''
+        break
+      case 'disconnected':
+        if (status.value !== 'error') status.value = 'disconnected'
+        break
+      case 'error':
+        if (!lastError.value) lastError.value = data.errorMessage || ''
+        status.value = 'error'
+        break
+    }
+  })
+})
+
+onBeforeUnmount(() => {
+  unsubStatus?.()
+  if (currentSessionId.value) {
+    try { CloseSession(currentSessionId.value) } catch (_) {}
+    panelStore.bindSession(props.panelId, '')
+    currentSessionId.value = null
+  }
+})
+</script>
+
+<style scoped>
+.x11-desktop-tab-content {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  background: var(--bg-base);
+  display: flex;
+  flex-direction: column;
+}
+.x11-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  color: var(--text-muted);
+  z-index: 10;
+}
+.x11-info {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 24px;
+  padding: 24px;
+  z-index: 10;
+}
+.x11-rows {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-width: 560px;
+  width: 100%;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md, 6px);
+  padding: 16px 20px;
+  color: var(--text-primary);
+}
+.x11-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+}
+.x11-row-label {
+  color: var(--text-muted);
+  min-width: 120px;
+}
+.x11-cmd {
+  font-family: var(--font-mono, monospace);
+  background: var(--bg-base);
+  padding: 2px 6px;
+  border-radius: var(--radius-sm, 4px);
+  color: var(--text-primary);
+  word-break: break-all;
+}
+.x11-hint {
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 1.5;
+  margin-top: 8px;
+}
+.x11-actions {
+  display: flex;
+  gap: 8px;
+}
+.x11-status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--success);
+  flex-shrink: 0;
+}
+.x11-error-text { color: var(--error); }
+.x11-error-detail {
+  color: var(--text-muted);
+  font-size: 12px;
+  max-width: 80%;
+  text-align: center;
+  word-break: break-word;
+}
+</style>

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -1105,5 +1105,21 @@
   "settings.skillsImportZip": "Zip importieren",
   "settings.skillsImportDir": "Ordner importieren",
   "settings.skillsImportFolderHint": "Unterstützt Ordner-Skills mit references/ und scripts/",
-  "settings.skillsImportOk": "Skill „{name}“ importiert"
+  "settings.skillsImportOk": "Skill „{name}“ importiert",
+  "conn.x11Desktop": "X11-Desktop",
+  "conn.x11DesktopDE": "Desktop-Umgebung",
+  "conn.x11DesktopDECustom": "Eigener Befehl…",
+  "conn.x11DesktopCustomCmd": "Befehl",
+  "conn.x11DesktopCustomCmdPlaceholder": "z.B. gnome-session --session=foo",
+  "conn.x11DesktopCustomCmdHint": "Wird remote über /bin/sh -c ausgeführt. Verwenden Sie die gleiche Syntax wie in einer Shell-Befehlszeile.",
+  "conn.x11DesktopCustomCmdRequired": "Bitte geben Sie einen Befehl ein",
+  "x11.tab.connecting": "Starte X11-Desktop…",
+  "x11.tab.connected": "Läuft",
+  "x11.tab.disconnected": "Getrennt",
+  "x11.tab.error": "Fehler beim Starten des X11-Desktops",
+  "x11.tab.retry": "Wiederholen",
+  "x11.tab.reconnect": "Neu verbinden",
+  "x11.tab.disconnect": "Trennen",
+  "x11.tab.desktopEnv": "Desktop-Umgebung",
+  "x11.tab.localXHint": "Der Desktop wird im lokalen X-Server-Fenster angezeigt. Verwenden Sie die Taskleiste oder Alt+Tab zum Wechseln. Das Schließen dieses Tabs beendet die Desktop-Sitzung."
 }

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1105,5 +1105,21 @@
   "settings.skillsImportZip": "Import Zip",
   "settings.skillsImportDir": "Import Folder",
   "settings.skillsImportFolderHint": "Supports folder skills with references/ and scripts/",
-  "settings.skillsImportOk": "Imported skill \"{name}\""
+  "settings.skillsImportOk": "Imported skill \"{name}\"",
+  "conn.x11Desktop": "X11 Desktop",
+  "conn.x11DesktopDE": "Desktop Environment",
+  "conn.x11DesktopDECustom": "Custom Command…",
+  "conn.x11DesktopCustomCmd": "Command",
+  "conn.x11DesktopCustomCmdPlaceholder": "e.g. gnome-session --session=foo",
+  "conn.x11DesktopCustomCmdHint": "Executed on the remote via /bin/sh -c. Use the same syntax as a shell command line.",
+  "conn.x11DesktopCustomCmdRequired": "Please enter a command",
+  "x11.tab.connecting": "Starting X11 desktop…",
+  "x11.tab.connected": "Running",
+  "x11.tab.disconnected": "Disconnected",
+  "x11.tab.error": "Failed to start X11 desktop",
+  "x11.tab.retry": "Retry",
+  "x11.tab.reconnect": "Reconnect",
+  "x11.tab.disconnect": "Disconnect",
+  "x11.tab.desktopEnv": "Desktop Environment",
+  "x11.tab.localXHint": "The desktop is shown in your local X server window. Use the system taskbar or Alt+Tab to focus it. Closing this tab will terminate the desktop session."
 }

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -1105,5 +1105,21 @@
   "settings.skillsImportZip": "Importar Zip",
   "settings.skillsImportDir": "Importar carpeta",
   "settings.skillsImportFolderHint": "Admite skills de carpeta con references/ y scripts/",
-  "settings.skillsImportOk": "Skill \"{name}\" importado"
+  "settings.skillsImportOk": "Skill \"{name}\" importado",
+  "conn.x11Desktop": "Escritorio X11",
+  "conn.x11DesktopDE": "Entorno de escritorio",
+  "conn.x11DesktopDECustom": "Comando personalizado…",
+  "conn.x11DesktopCustomCmd": "Comando",
+  "conn.x11DesktopCustomCmdPlaceholder": "ej: gnome-session --session=foo",
+  "conn.x11DesktopCustomCmdHint": "Ejecutado remotamente a través de /bin/sh -c. Use la misma sintaxis que una línea de comandos shell.",
+  "conn.x11DesktopCustomCmdRequired": "Ingrese un comando",
+  "x11.tab.connecting": "Iniciando escritorio X11…",
+  "x11.tab.connected": "En ejecución",
+  "x11.tab.disconnected": "Desconectado",
+  "x11.tab.error": "Error al iniciar escritorio X11",
+  "x11.tab.retry": "Reintentar",
+  "x11.tab.reconnect": "Reconectar",
+  "x11.tab.disconnect": "Desconectar",
+  "x11.tab.desktopEnv": "Entorno de escritorio",
+  "x11.tab.localXHint": "El escritorio se muestra en la ventana del servidor X local. Use la barra de tareas o Alt+Tab para cambiar. Cerrar esta pestaña terminará la sesión de escritorio."
 }

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -1105,5 +1105,21 @@
   "settings.skillsImportZip": "Importer un Zip",
   "settings.skillsImportDir": "Importer un dossier",
   "settings.skillsImportFolderHint": "Prend en charge les compétences en dossier avec references/ et scripts/",
-  "settings.skillsImportOk": "Compétence « {name} » importée"
+  "settings.skillsImportOk": "Compétence « {name} » importée",
+  "conn.x11Desktop": "Bureau X11",
+  "conn.x11DesktopDE": "Environnement de bureau",
+  "conn.x11DesktopDECustom": "Commande personnalisée…",
+  "conn.x11DesktopCustomCmd": "Commande",
+  "conn.x11DesktopCustomCmdPlaceholder": "ex: gnome-session --session=foo",
+  "conn.x11DesktopCustomCmdHint": "Exécuté à distance via /bin/sh -c. Utilisez la même syntaxe qu'une ligne de commande shell.",
+  "conn.x11DesktopCustomCmdRequired": "Veuillez entrer une commande",
+  "x11.tab.connecting": "Démarrage du bureau X11…",
+  "x11.tab.connected": "En cours",
+  "x11.tab.disconnected": "Déconnecté",
+  "x11.tab.error": "Échec du démarrage du bureau X11",
+  "x11.tab.retry": "Réessayer",
+  "x11.tab.reconnect": "Reconnecter",
+  "x11.tab.disconnect": "Déconnecter",
+  "x11.tab.desktopEnv": "Environnement de bureau",
+  "x11.tab.localXHint": "Le bureau s'affiche dans la fenêtre du serveur X local. Utilisez la barre des tâches ou Alt+Tab pour basculer. La fermeture de cet onglet terminera la session de bureau."
 }

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -1105,5 +1105,21 @@
   "settings.skillsImportZip": "Zip をインポート",
   "settings.skillsImportDir": "フォルダーをインポート",
   "settings.skillsImportFolderHint": "references/ と scripts/ を含むフォルダースキルに対応",
-  "settings.skillsImportOk": "スキル「{name}」をインポートしました"
+  "settings.skillsImportOk": "スキル「{name}」をインポートしました",
+  "conn.x11Desktop": "X11 デスクトップ",
+  "conn.x11DesktopDE": "デスクトップ環境",
+  "conn.x11DesktopDECustom": "カスタムコマンド…",
+  "conn.x11DesktopCustomCmd": "コマンド",
+  "conn.x11DesktopCustomCmdPlaceholder": "例: gnome-session --session=foo",
+  "conn.x11DesktopCustomCmdHint": "リモートで /bin/sh -c 経由で実行されます。シェルコマンドと同じ構文を使用してください。",
+  "conn.x11DesktopCustomCmdRequired": "コマンドを入力してください",
+  "x11.tab.connecting": "X11 デスクトップを起動中…",
+  "x11.tab.connected": "実行中",
+  "x11.tab.disconnected": "切断されました",
+  "x11.tab.error": "X11 デスクトップの起動に失敗しました",
+  "x11.tab.retry": "再試行",
+  "x11.tab.reconnect": "再接続",
+  "x11.tab.disconnect": "切断",
+  "x11.tab.desktopEnv": "デスクトップ環境",
+  "x11.tab.localXHint": "デスクトップはローカル X Server ウィンドウに表示されます。システムタスクバーまたは Alt+Tab で切り替えてください。このタブを閉じるとデスクトップセッションが終了します。"
 }

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -1105,5 +1105,21 @@
   "settings.skillsImportZip": "Zip 가져오기",
   "settings.skillsImportDir": "폴터 가져오기",
   "settings.skillsImportFolderHint": "references/ 및 scripts/가 있는 폴터 스킬 지원",
-  "settings.skillsImportOk": "스킬 \"{name}\"을(를) 가져왔습니다"
+  "settings.skillsImportOk": "스킬 \"{name}\"을(를) 가져왔습니다",
+  "conn.x11Desktop": "X11 데스크톱",
+  "conn.x11DesktopDE": "데스크톱 환경",
+  "conn.x11DesktopDECustom": "사용자 정의 명령…",
+  "conn.x11DesktopCustomCmd": "명령",
+  "conn.x11DesktopCustomCmdPlaceholder": "예: gnome-session --session=foo",
+  "conn.x11DesktopCustomCmdHint": "원격에서 /bin/sh -c로 실행됩니다. 셸 명령과 동일한 구문을 사용하세요.",
+  "conn.x11DesktopCustomCmdRequired": "명령을 입력하세요",
+  "x11.tab.connecting": "X11 데스크톱 시작 중…",
+  "x11.tab.connected": "실행 중",
+  "x11.tab.disconnected": "연결 끊김",
+  "x11.tab.error": "X11 데스크톱 시작 실패",
+  "x11.tab.retry": "재시도",
+  "x11.tab.reconnect": "재연결",
+  "x11.tab.disconnect": "연결 끊기",
+  "x11.tab.desktopEnv": "데스크톱 환경",
+  "x11.tab.localXHint": "데스크톱이 로컬 X Server 창에 표시됩니다. 시스템 작업 표시줄 또는 Alt+Tab으로 전환하세요. 이 탭을 닫으면 데스크톱 세션이 종료됩니다."
 }

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -1105,5 +1105,21 @@
   "settings.skillsImportZip": "Импорт Zip",
   "settings.skillsImportDir": "Импорт папки",
   "settings.skillsImportFolderHint": "Поддерживает навыки-папки с references/ и scripts/",
-  "settings.skillsImportOk": "Навык \"{name}\" импортирован"
+  "settings.skillsImportOk": "Навык \"{name}\" импортирован",
+  "conn.x11Desktop": "X11 Рабочий стол",
+  "conn.x11DesktopDE": "Окружение рабочего стола",
+  "conn.x11DesktopDECustom": "Своя команда…",
+  "conn.x11DesktopCustomCmd": "Команда",
+  "conn.x11DesktopCustomCmdPlaceholder": "напр. gnome-session --session=foo",
+  "conn.x11DesktopCustomCmdHint": "Выполняется удалённо через /bin/sh -c. Используйте синтаксис командной строки.",
+  "conn.x11DesktopCustomCmdRequired": "Введите команду",
+  "x11.tab.connecting": "Запуск X11 рабочего стола…",
+  "x11.tab.connected": "Запущен",
+  "x11.tab.disconnected": "Отключён",
+  "x11.tab.error": "Не удалось запустить X11 рабочий стол",
+  "x11.tab.retry": "Повторить",
+  "x11.tab.reconnect": "Переподключиться",
+  "x11.tab.disconnect": "Отключить",
+  "x11.tab.desktopEnv": "Рабочее окружение",
+  "x11.tab.localXHint": "Рабочий стол отображается в окне локального X-сервера. Используйте панель задач или Alt+Tab для переключения. Закрытие этой вкладки завершит сеанс рабочего стола."
 }

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -1105,5 +1105,21 @@
   "settings.skillsImportZip": "导入 Zip",
   "settings.skillsImportDir": "导入文件夹",
   "settings.skillsImportFolderHint": "支持含 references/、scripts/ 的文件夹型 skill",
-  "settings.skillsImportOk": "已导入技能「{name}」"
+  "settings.skillsImportOk": "已导入技能「{name}」",
+  "conn.x11Desktop": "X11 桌面",
+  "conn.x11DesktopDE": "桌面环境",
+  "conn.x11DesktopDECustom": "自定义命令…",
+  "conn.x11DesktopCustomCmd": "命令",
+  "conn.x11DesktopCustomCmdPlaceholder": "例如 gnome-session --session=foo",
+  "conn.x11DesktopCustomCmdHint": "通过 /bin/sh -c 在远程执行。使用与 shell 命令行相同的语法。",
+  "conn.x11DesktopCustomCmdRequired": "请输入命令",
+  "x11.tab.connecting": "正在启动 X11 桌面…",
+  "x11.tab.connected": "运行中",
+  "x11.tab.disconnected": "已断开",
+  "x11.tab.error": "启动 X11 桌面失败",
+  "x11.tab.retry": "重试",
+  "x11.tab.reconnect": "重新连接",
+  "x11.tab.disconnect": "断开",
+  "x11.tab.desktopEnv": "桌面环境",
+  "x11.tab.localXHint": "桌面显示在本地 X Server 窗口中。使用系统任务栏或 Alt+Tab 切换。关闭此标签页将终止桌面会话。"
 }

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -1105,5 +1105,21 @@
   "settings.skillsImportZip": "匯入 Zip",
   "settings.skillsImportDir": "匯入目錄",
   "settings.skillsImportFolderHint": "或匯入含 SKILL.md 的目錄",
-  "settings.skillsImportOk": "已匯入技能「{name}」"
+  "settings.skillsImportOk": "已匯入技能「{name}」",
+  "conn.x11Desktop": "X11 桌面",
+  "conn.x11DesktopDE": "桌面環境",
+  "conn.x11DesktopDECustom": "自訂命令…",
+  "conn.x11DesktopCustomCmd": "命令",
+  "conn.x11DesktopCustomCmdPlaceholder": "例如 gnome-session --session=foo",
+  "conn.x11DesktopCustomCmdHint": "透過 /bin/sh -c 在遠端執行。使用與 shell 命令列相同的語法。",
+  "conn.x11DesktopCustomCmdRequired": "請輸入命令",
+  "x11.tab.connecting": "正在啟動 X11 桌面…",
+  "x11.tab.connected": "執行中",
+  "x11.tab.disconnected": "已斷開",
+  "x11.tab.error": "啟動 X11 桌面失敗",
+  "x11.tab.retry": "重試",
+  "x11.tab.reconnect": "重新連線",
+  "x11.tab.disconnect": "斷開",
+  "x11.tab.desktopEnv": "桌面環境",
+  "x11.tab.localXHint": "桌面顯示在本機 X Server 視窗中。使用系統工作列或 Alt+Tab 切換。關閉此頁籤將終止桌面工作階段。"
 }

--- a/frontend/src/stores/tabStore.ts
+++ b/frontend/src/stores/tabStore.ts
@@ -1,6 +1,6 @@
 import { defineStore } from 'pinia'
 import { reactive, computed } from 'vue'
-import type { Tab, TerminalTab, SettingsTab, WorkspaceTab, SFTPTab, RDPTab, VNCTab, SPICETab, DBTab, MonitorTab, StartTab, PanelLayout, LayoutNode } from '../types/workspace'
+import type { Tab, TerminalTab, SettingsTab, WorkspaceTab, SFTPTab, RDPTab, VNCTab, SPICETab, DBTab, MonitorTab, StartTab, PanelLayout, LayoutNode, X11DesktopTab } from '../types/workspace'
 import type { K8sTab } from '../types/k8s'
 import type { ContainerTab } from '../types/container'
 import { usePanelStore } from './panelStore'
@@ -226,6 +226,18 @@ export const useTabStore = defineStore('tab', () => {
     const tab: SPICETab = {
       type: 'spice',
       id: genId('spice-tab'),
+      panelId,
+      name
+    }
+    tabState.tabs.push(tab)
+    tabState.activeTabId = tab.id
+    return tab
+  }
+
+  function createX11DesktopTab(name: string, panelId: string): X11DesktopTab {
+    const tab: X11DesktopTab = {
+      type: 'x11-desktop',
+      id: genId('x11-tab'),
       panelId,
       name
     }
@@ -711,6 +723,7 @@ export const useTabStore = defineStore('tab', () => {
     createRDPTab,
     createVNCTab,
     createSPICETab,
+    createX11DesktopTab,
     createDBTab,
     createMonitorTab,
     createK8sTab,

--- a/frontend/src/types/session.ts
+++ b/frontend/src/types/session.ts
@@ -17,7 +17,7 @@ export interface ConnectionConfig {
   id: string
   name: string
   remark?: string
-  type: 'ssh' | 'telnet' | 'mosh' | 'rdp' | 'vnc' | 'spice' | 'database' | 'local' | 'sftp' | 'monitor' | 'ftp' | 'serial' | 'smb' | 'webdav' | 's3' | 'k8s' | 'container'
+  type: 'ssh' | 'telnet' | 'mosh' | 'rdp' | 'vnc' | 'spice' | 'database' | 'local' | 'sftp' | 'monitor' | 'ftp' | 'serial' | 'smb' | 'webdav' | 's3' | 'k8s' | 'container' | 'x11-desktop'
   host: string
   port: number
   user: string
@@ -146,6 +146,14 @@ export interface ConnectionConfig {
   containerExecConnId?: string
   containerExecContainerId?: string
   containerExecShell?: string
+  // X11 Desktop (type: 'x11-desktop') — carries its own SSH credentials
+  // (host, port, user, authType, password, keyPath) for direct connection.
+  // X11 forwarding is forced on automatically. The actual desktop is
+  // rendered by the local X server (VcXsrv/XQuartz/Xorg), not inside uniTerm.
+  x11DesktopDesktopType?: 'gnome' | 'kde' | 'xfce' | 'mate' | 'cinnamon' | 'openbox' | 'custom'
+  // Custom desktop command (only used when desktopType === 'custom').
+  // Passed to sshd verbatim, so it goes through /bin/sh -c on the remote.
+  x11DesktopCustomCmd?: string
 }
 
 export interface SessionInfo {

--- a/frontend/src/types/workspace.ts
+++ b/frontend/src/types/workspace.ts
@@ -1,4 +1,4 @@
-export type PanelType = 'ssh' | 'telnet' | 'mosh' | 'sftp' | 'settings' | 'rdp' | 'vnc' | 'spice' | 'local' | 'database' | 'monitor' | 'serial' | 'k8s' | 'k8s-exec' | 'container' | 'container-exec' | 'other'
+export type PanelType = 'ssh' | 'telnet' | 'mosh' | 'sftp' | 'settings' | 'rdp' | 'vnc' | 'spice' | 'local' | 'database' | 'monitor' | 'serial' | 'k8s' | 'k8s-exec' | 'container' | 'container-exec' | 'x11-desktop' | 'other'
 export type PanelStatus = 'connecting' | 'connected' | 'disconnected' | 'error'
 
 import type { ConnectionConfig } from './session'
@@ -31,7 +31,7 @@ export type LayoutNode =
 
 // ── Tab types ──
 
-export type Tab = TerminalTab | SettingsTab | WorkspaceTab | SFTPTab | RDPTab | VNCTab | SPICETab | DBTab | MonitorTab | StartTab | K8sTab | ContainerTab
+export type Tab = TerminalTab | SettingsTab | WorkspaceTab | SFTPTab | RDPTab | VNCTab | SPICETab | DBTab | MonitorTab | StartTab | K8sTab | ContainerTab | X11DesktopTab
 
 export interface TerminalTab {
   type: 'terminal'
@@ -93,6 +93,14 @@ export interface DBTab {
 
 export interface SPICETab {
   type: 'spice'
+  id: string
+  panelId: string
+  name: string
+  locked?: boolean
+}
+
+export interface X11DesktopTab {
+  type: 'x11-desktop'
   id: string
   panelId: string
   name: string

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -454,3 +454,5 @@ export function UnregisterSession(arg1:string):Promise<void>;
 export function WriteFileBase64(arg1:string,arg2:string):Promise<void>;
 
 export function WriteTempFile(arg1:string,arg2:string):Promise<string>;
+
+export function X11DesktopConnect(arg1:string,arg2:string):Promise<void>;

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -893,3 +893,7 @@ export function WriteFileBase64(arg1, arg2) {
 export function WriteTempFile(arg1, arg2) {
   return window['go']['main']['App']['WriteTempFile'](arg1, arg2);
 }
+
+export function X11DesktopConnect(arg1, arg2) {
+  return window['go']['main']['App']['X11DesktopConnect'](arg1, arg2);
+}

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -627,6 +627,8 @@ export namespace session {
 	    containerSSHConnId?: string;
 	    containerRuntime?: string;
 	    logOnConnect?: boolean;
+	    x11DesktopDesktopType?: string;
+	    x11DesktopCustomCmd?: string;
 	
 	    static createFrom(source: any = {}) {
 	        return new ConnectionConfig(source);
@@ -701,6 +703,8 @@ export namespace session {
 	        this.containerSSHConnId = source["containerSSHConnId"];
 	        this.containerRuntime = source["containerRuntime"];
 	        this.logOnConnect = source["logOnConnect"];
+	        this.x11DesktopDesktopType = source["x11DesktopDesktopType"];
+	        this.x11DesktopCustomCmd = source["x11DesktopCustomCmd"];
 	    }
 	
 		convertValues(a: any, classs: any, asMap: boolean = false): any {


### PR DESCRIPTION
## Summary

Add a new `x11-desktop` session type that connects to a remote Linux host over SSH with X11 forwarding and launches a full desktop environment. The desktop is rendered by the local X server (VcXsrv on Windows, XQuartz on macOS, Xorg on Linux) — uniTerm manages the lifecycle but the actual desktop window lives outside uniTerm.

### Key changes
- **New session type**: `X11DesktopSession` — standalone SSH connection with forced X11 forwarding
- **Desktop presets**: GNOME, KDE, XFCE, MATE, Cinnamon, Openbox, plus custom command
- **Auto-launch VcXsrv** on Windows with `:0 -clipboard` (bundled in `plugins/vcxsrv/`)
- **DISPLAY fallback** to `localhost:0` on Windows when $DISPLAY is invalid/missing
- **macOS/Linux**: probes `/tmp/.X11-unix` for the running X server socket
- **Connection form**: host/user/password/key + desktop environment selector (independent SSH credentials)
- **Tab content UI**: connected state shows Host, Desktop Environment, X Server in key-value layout
- **Tab status**: proper connected/disconnected/error state tracking and close confirmation dialog
- **i18n**: all 9 locales updated with x11-desktop labels

---
## 摘要

新增 `x11-desktop` 会话类型，通过 SSH X11 转发连接到远程 Linux 主机并启动完整桌面环境。桌面由本地 X Server（Windows 下 VcXsrv、macOS 下 XQuartz、Linux 下 Xorg）渲染 — uniTerm 管理其生命周期，实际桌面窗口显示在 uniTerm 外部。

### 主要变更
- **新会话类型**：`X11DesktopSession` — 独立 SSH 连接，强制启用 X11 转发
- **桌面预设**：GNOME、KDE、XFCE、MATE、Cinnamon、Openbox，以及自定义命令
- **Windows 自动启动 VcXsrv**：参数 `:0 -clipboard`（内置在 `plugins/vcxsrv/`）
- **DISPLAY 回退**：Windows 上 $DISPLAY 无效/缺失时回退到 `localhost:0`
- **macOS/Linux**：探测 `/tmp/.X11-unix` 寻找运行中的 X Server
- **连接表单**：主机/用户/密码/密钥 + 桌面环境选择器（独立 SSH 凭据）
- **标签页 UI**：已连接状态以键值对布局显示主机、桌面环境、X Server
- **标签状态**：正确的已连接/已断开/错误状态追踪和关闭确认对话框
- **国际化**：全部 9 种语言的 x11-desktop 标签翻译