### PR TITLE
fix(x11): skip X11 auth replacement when no local cookie is available

### DIFF
--- a/backend/session/x11_forward.go
+++ b/backend/session/x11_forward.go
@@ -269,6 +269,14 @@ func (f *x11Forwarder) handleX11(ch ssh.NewChannel, display string) {
 	}
 	defer local.Close()
 
+	// Skip auth replacement when no real local cookie is available
+	// (e.g. Windows VcXsrv with access control disabled). Bridge
+	// directly to avoid unnecessary X11 handshake interception.
+	if f.realProto == "" || len(f.realCookie) == 0 {
+		bridge(local, ch2)
+		return
+	}
+
 	// Replace the X11 connection setup's auth with the real local cookie
 	// before bridging. If the setup read/write fails the channel is
 	// dropped — the X application will see a connection error and may


### PR DESCRIPTION
## Summary

The X11 desktop flickering issue was introduced in PR #508, which added dedicated VcXsrv per desktop session plus X11 connection-setup interception (`forwardX11Setup` + response parsing). On Windows, VcXsrv runs with access control disabled — there is no real Xauthority cookie — so the auth-replacement code was forwarding every X11 handshake packet unmodified through `forwardX11Setup`, causing desktop flickering.

## Root Cause

When `realProto` is empty and `realCookie` has zero length (Windows VcXsrv without access control), `handleX11` was still calling `forwardX11Setup` to read, parse, and rewrite every X11 connection-request packet before bridging. This unnecessary interception interfered with the data flow and caused the desktop to flicker.

## Fix

Add an early return in `handleX11`: when no real cookie is available, bridge the channel directly with `bridge(local, ch2)` and return, matching the pre-PR-#508 behavior. Linux/macOS with Xauthority cookies continue through the full auth-replacement path unchanged.

### Change

- `backend/session/x11_forward.go`: +8 lines

### Behavior by platform

| Platform | Xauthority | realCookie | Path |
|----------|-----------|------------|------|
| Windows (VcXsrv) | None | Empty | `bridge` directly |
| Linux (Xorg) | Present | Non-empty | `forwardX11Setup` + auth replacement |
| macOS (XQuartz) | Present | Non-empty | `forwardX11Setup` + auth replacement |

---

## 问题

X11 desktop 闪烁问题由 PR #508 引入。该 PR 为每个 X11 Desktop 会话启动独立 VcXsrv，同时新增了 X11 握手拦截逻辑（`forwardX11Setup` + 响应解析）。Windows 上 VcXsrv 无访问控制，没有 Xauthority cookie，但 `handleX11` 仍会调用 `forwardX11Setup` 逐包读写 X11 握手数据再透传，导致数据流被不必要地拦截，引发桌面闪烁。

## 根因

`realProto` 为空且 `realCookie` 长度为 0（Windows VcXsrv 场景）时，代码仍走完整的 X11 握手拦截路径，对每个 X11 连接请求包进行无意义的读写和透传。

## 修复

在 `handleX11` 中增加 early return：当没有真实 cookie 时直接 `bridge(local, ch2)` 并返回，恢复 PR #508 之前的行为。Linux/macOS 有 Xauthority 的场景不受影响。