### PR TITLE
fix(ci): prevent sed from replacing arch arm with SHA256 hash

### DIFF
--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -38,8 +38,8 @@ jobs:
       - name: Update formula
         run: |
           sed -i "s/version \".*\"/version \"$VERSION\"/" Casks/uniterm.rb
-          sed -i "s/intel: \".*\"/intel: \"$SHA256_amd64\"/" Casks/uniterm.rb
-          sed -i "s/arm: \".*\"/arm: \"$SHA256_arm64\"/" Casks/uniterm.rb
+          sed -i "/sha256/ s/intel: \".*\"/intel: \"$SHA256_amd64\"/" Casks/uniterm.rb
+          sed -i "/sha256/ s/arm: \".*\"/arm: \"$SHA256_arm64\"/" Casks/uniterm.rb
 
       - name: Commit and push
         run: |


### PR DESCRIPTION
## Summary

The `sed` commands in the update-homebrew workflow were too greedy: the pattern `arm: "..."` matched both `arch arm:` and `sha256 arm:` lines, causing the architecture string `"arm64"` to be replaced with the SHA256 hash. This made the cask URL resolve to a non-existent file (404).

## Root Cause

In `update-homebrew.yml`, the sed replacements:
```bash
sed -i "s/arm: \".*\"/arm: \"$SHA256_arm64\"/" Casks/uniterm.rb
```
matched both:
- `arch arm: "arm64"` → incorrectly replaced with hash
- `sha256 arm: "..."` → correctly replaced

## Fix

Add `/sha256/` line filter to sed commands so they only apply to sha256 lines:
```diff
- sed -i "s/arm: \".*\"/arm: \"$SHA256_arm64\"/" Casks/uniterm.rb
+ sed -i "/sha256/ s/arm: \".*\"/arm: \"$SHA256_arm64\"/" Casks/uniterm.rb
```

The corrupted cask in `homebrew-uniterm` has also been manually fixed.

Closes #525

---

## 问题

update-homebrew workflow 中的 `sed` 替换模式 `arm: "..."` 同时匹配了 `arch arm:` 和 `sha256 arm:` 两行，导致架构标识 `"arm64"` 被错误替换为 SHA256 哈希值，cask URL 指向不存在的文件（404）。

## 修复

给 sed 命令加上 `/sha256/` 行过滤，确保只替换 sha256 行。`homebrew-uniterm` 中已污染的 cask 也已手动修复。

Closes #525