### PR TITLE
fix(ssh): preserve saved credentials and retry legacy cipher negotiation

### DIFF
--- a/app.go
+++ b/app.go
@@ -1275,6 +1275,17 @@ func (a *App) CreateSession(sessionType string, config session.ConnectionConfig)
 	}
 	log.Writef("[CreateSession] type=%s, dbType=%s, host=%s, port=%d, user=%s, dbName=%s, name=%s",
 		sessionType, config.DBType, config.Host, config.Port, config.User, config.DBName, config.Name)
+	// Defensive credential fallback: the frontend may hold a connection
+	// snapshot taken before passwords were filled (or a stale copy from an
+	// older session). If the password is stored in the OS keychain, resolve
+	// it synchronously so the session never prompts for a password it
+	// already has. No-op when Password is already set, no store is wired,
+	// the keychain has no entry, or the config carries no connection ID.
+	if config.Password == "" && config.ID != "" && a.connectionStore != nil {
+		if pw, err := a.connectionStore.EnsurePassword(config.ID); err == nil && pw != "" {
+			config.Password = pw
+		}
+	}
 	s, err := a.sessionManager.Create(sessionType, config)
 	if err != nil {
 		log.Writef("[CreateSession] manager.Create failed: %v", err)
@@ -1563,6 +1574,15 @@ func (a *App) setupJumpHostTunnel(sessionID string, sessionType string, config *
 		return fmt.Errorf("tunnel SSH connection not found: %s", config.TunnelSSHConnID)
 	}
 
+	// Defensive credential fallback for the jump host: the freshly loaded
+	// config already has passwords filled synchronously (populatePasswords),
+	// but resolve from the keychain anyway if it is somehow still empty.
+	if tunnelSSHConfig.Password == "" && tunnelSSHConfig.ID != "" {
+		if pw, err := a.connectionStore.EnsurePassword(tunnelSSHConfig.ID); err == nil && pw != "" {
+			tunnelSSHConfig.Password = pw
+		}
+	}
+
 	// Apply inline tunnel credentials if the frontend provided them
 	// (e.g. credential prompt "connect" without saving).
 	if config.TunnelSSHUser != "" {
@@ -1610,6 +1630,16 @@ func (a *App) SessionStart(sessionID string, config session.ConnectionConfig) er
 	// carries the real cols/rows the frontend discovered after mount.
 	if config.InitialCols > 0 && config.InitialRows > 0 {
 		s.SetPendingSize(config.InitialCols, config.InitialRows)
+	}
+	// Terminal session types defer Connect() until SessionStart, and the
+	// frontend passes a fresh config here. If that fresh config still has
+	// an empty password (e.g. the Pinia store holds a snapshot from before
+	// keychain passwords were filled), resolve it from the OS keychain now
+	// so the user is not prompted for a password that is already stored.
+	if config.Password == "" && config.ID != "" && a.connectionStore != nil {
+		if pw, err := a.connectionStore.EnsurePassword(config.ID); err == nil && pw != "" {
+			config.Password = pw
+		}
 	}
 	a.launchConnectGoroutine(s, config.Type, config)
 	return nil

--- a/backend/session/ssh_compat_test.go
+++ b/backend/session/ssh_compat_test.go
@@ -1,0 +1,43 @@
+package session
+
+import (
+	"testing"
+
+	"golang.org/x/crypto/ssh"
+)
+
+func TestSavedPasswordChallenge(t *testing.T) {
+	cases := []struct {
+		name      string
+		config    ConnectionConfig
+		questions []string
+		echos     []bool
+		want      bool
+	}{
+		{"single hidden password", ConnectionConfig{AuthType: "password", Password: "pw"}, []string{"Password:"}, []bool{false}, true},
+		{"empty auth defaults to password", ConnectionConfig{Password: "pw"}, []string{"Password:"}, []bool{false}, true},
+		{"private key passphrase", ConnectionConfig{AuthType: "key", Password: "passphrase"}, []string{"Password:"}, []bool{false}, false},
+		{"password plus otp", ConnectionConfig{AuthType: "password", Password: "pw"}, []string{"Password:", "OTP:"}, []bool{false, false}, false},
+		{"visible challenge", ConnectionConfig{AuthType: "password", Password: "pw"}, []string{"Name:"}, []bool{true}, false},
+		{"missing echo metadata", ConnectionConfig{AuthType: "password", Password: "pw"}, []string{"Password:"}, nil, false},
+		{"no saved password", ConnectionConfig{AuthType: "password"}, []string{"Password:"}, []bool{false}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isSavedPasswordChallenge(tc.config, tc.questions, tc.echos); got != tc.want {
+				t.Fatalf("isSavedPasswordChallenge() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSSHCipherPreferences(t *testing.T) {
+	modern := sshCiphers()
+	legacyRetry := sshCiphersCTRFirst()
+	if modern[0] != ssh.CipherAES128GCM {
+		t.Fatalf("default first cipher = %q, want %q", modern[0], ssh.CipherAES128GCM)
+	}
+	if legacyRetry[0] != ssh.CipherAES128CTR {
+		t.Fatalf("retry first cipher = %q, want %q", legacyRetry[0], ssh.CipherAES128CTR)
+	}
+}

--- a/backend/session/ssh_config.go
+++ b/backend/session/ssh_config.go
@@ -25,13 +25,24 @@ func sshKeyExchanges() []string {
 // sshCiphers returns the cipher list, including legacy CBC/3DES ciphers
 // for compatibility with old servers (issue #497).
 //
-// CTR ciphers are listed before GCM ciphers because some old SSH servers
-// (e.g. OpenSSH 6.2) close the connection during key exchange when an
-// AEAD/GCM cipher is negotiated, even though they advertise GCM support
-// in their KEXINIT. Putting CTR first ensures it gets negotiated instead,
-// avoiding the incompatibility while still offering GCM as a fallback for
-// servers that handle it correctly.
+// The default order prefers AEAD ciphers. Some old SSH servers advertise GCM
+// but close the connection when it is negotiated; callers retry those EOF
+// handshakes once with sshAlgorithmsCTRFirst.
 func sshCiphers() []string {
+	return []string{
+		ssh.CipherAES128GCM,
+		ssh.CipherAES256GCM,
+		ssh.CipherChaCha20Poly1305,
+		ssh.CipherAES128CTR,
+		ssh.CipherAES192CTR,
+		ssh.CipherAES256CTR,
+		// Legacy CBC/3DES ciphers for old servers (issue #497)
+		ssh.InsecureCipherAES128CBC,
+		ssh.InsecureCipherTripleDESCBC,
+	}
+}
+
+func sshCiphersCTRFirst() []string {
 	return []string{
 		ssh.CipherAES128CTR,
 		ssh.CipherAES192CTR,
@@ -39,7 +50,6 @@ func sshCiphers() []string {
 		ssh.CipherChaCha20Poly1305,
 		ssh.CipherAES128GCM,
 		ssh.CipherAES256GCM,
-		// Legacy CBC/3DES ciphers for old servers (issue #497)
 		ssh.InsecureCipherAES128CBC,
 		ssh.InsecureCipherTripleDESCBC,
 	}
@@ -65,4 +75,10 @@ func sshAlgorithms() ssh.Config {
 		Ciphers:      sshCiphers(),
 		MACs:         sshMACs(),
 	}
+}
+
+func sshAlgorithmsCTRFirst() ssh.Config {
+	cfg := sshAlgorithms()
+	cfg.Ciphers = sshCiphersCTRFirst()
+	return cfg
 }

--- a/backend/session/ssh_config.go
+++ b/backend/session/ssh_config.go
@@ -24,14 +24,21 @@ func sshKeyExchanges() []string {
 
 // sshCiphers returns the cipher list, including legacy CBC/3DES ciphers
 // for compatibility with old servers (issue #497).
+//
+// CTR ciphers are listed before GCM ciphers because some old SSH servers
+// (e.g. OpenSSH 6.2) close the connection during key exchange when an
+// AEAD/GCM cipher is negotiated, even though they advertise GCM support
+// in their KEXINIT. Putting CTR first ensures it gets negotiated instead,
+// avoiding the incompatibility while still offering GCM as a fallback for
+// servers that handle it correctly.
 func sshCiphers() []string {
 	return []string{
-		ssh.CipherAES128GCM,
-		ssh.CipherAES256GCM,
-		ssh.CipherChaCha20Poly1305,
 		ssh.CipherAES128CTR,
 		ssh.CipherAES192CTR,
 		ssh.CipherAES256CTR,
+		ssh.CipherChaCha20Poly1305,
+		ssh.CipherAES128GCM,
+		ssh.CipherAES256GCM,
 		// Legacy CBC/3DES ciphers for old servers (issue #497)
 		ssh.InsecureCipherAES128CBC,
 		ssh.InsecureCipherTripleDESCBC,

--- a/backend/session/ssh_dial.go
+++ b/backend/session/ssh_dial.go
@@ -1,13 +1,47 @@
 package session
 
 import (
+	"errors"
 	"fmt"
+	"io"
 	"net"
 	"strconv"
 	"time"
 
 	"golang.org/x/crypto/ssh"
 )
+
+type sshConnDialer func() (net.Conn, error)
+
+// dialSSHWithCipherFallback keeps modern AEAD preference, but retries a
+// handshake EOF once with CTR first for servers that falsely advertise GCM.
+func dialSSHWithCipherFallback(addr string, config *ssh.ClientConfig, dial sshConnDialer) (*ssh.Client, error) {
+	algorithms := []ssh.Config{sshAlgorithms(), sshAlgorithmsCTRFirst()}
+	var lastErr error
+	for i, algorithms := range algorithms {
+		conn, err := dial()
+		if err != nil {
+			return nil, fmt.Errorf("tcp dial: %w", err)
+		}
+		if tcpConn, ok := conn.(*net.TCPConn); ok {
+			tcpConn.SetKeepAlive(true)
+			tcpConn.SetKeepAlivePeriod(sshKeepAliveInterval)
+		}
+		attempt := *config
+		attempt.Config = algorithms
+		sshConn, chans, reqs, err := ssh.NewClientConn(conn, addr, &attempt)
+		if err == nil {
+			return ssh.NewClient(sshConn, chans, reqs), nil
+		}
+		conn.Close()
+		lastErr = err
+		if i == 0 && errors.Is(err, io.EOF) {
+			continue
+		}
+		break
+	}
+	return nil, fmt.Errorf("ssh handshake: %w", lastErr)
+}
 
 // DialSSHClient 建立非交互 SSH 连接（容器 runner 用，无 PTY、无键盘交互回显）。
 // 与 ssh_session 的交互式拨号共享认证与密钥交换配置。
@@ -22,20 +56,8 @@ func DialSSHClient(config ConnectionConfig) (*ssh.Client, error) {
 		Auth:            authMethods,
 		Timeout:         30 * time.Second,
 		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
-		Config:          sshAlgorithms(),
 	}
-	conn, err := net.DialTimeout("tcp", addr, clientConfig.Timeout)
-	if err != nil {
-		return nil, fmt.Errorf("tcp dial: %w", err)
-	}
-	if tcpConn, ok := conn.(*net.TCPConn); ok {
-		tcpConn.SetKeepAlive(true)
-		tcpConn.SetKeepAlivePeriod(sshKeepAliveInterval)
-	}
-	sshConn, chans, reqs, err := ssh.NewClientConn(conn, addr, clientConfig)
-	if err != nil {
-		conn.Close()
-		return nil, fmt.Errorf("ssh handshake: %w", err)
-	}
-	return ssh.NewClient(sshConn, chans, reqs), nil
+	return dialSSHWithCipherFallback(addr, clientConfig, func() (net.Conn, error) {
+		return net.DialTimeout("tcp", addr, clientConfig.Timeout)
+	})
 }

--- a/backend/session/ssh_session.go
+++ b/backend/session/ssh_session.go
@@ -131,7 +131,23 @@ func (s *SSHSession) Connect(config ConnectionConfig) error {
 		config.Password = answer
 	}
 
+	// Auto-answer keyboard-interactive challenges with the saved password on
+	// the FIRST challenge. Many servers (e.g. SuSE/NetIQ) advertise only
+	// keyboard-interactive (no "password" method), so the ssh.Password method
+	// above is rejected and the callback gets invoked with a "Password: "
+	// prompt. Without this, the user would be prompted for a password that is
+	// already saved. If the saved password is wrong, the server re-challenges
+	// and we fall through to interactive prompting so the user can type the
+	// correct one.
+	var kbAutoAnswered int32
 	kbCallback := func(user, instruction string, questions []string, echos []bool) ([]string, error) {
+		if config.Password != "" && atomic.CompareAndSwapInt32(&kbAutoAnswered, 0, 1) {
+			answers := make([]string, len(questions))
+			for i := range questions {
+				answers[i] = config.Password
+			}
+			return answers, nil
+		}
 		answers := make([]string, len(questions))
 		for i, q := range questions {
 			s.emitData([]byte("\r\n" + q + " "))

--- a/backend/session/ssh_session.go
+++ b/backend/session/ssh_session.go
@@ -141,7 +141,7 @@ func (s *SSHSession) Connect(config ConnectionConfig) error {
 	// correct one.
 	var kbAutoAnswered int32
 	kbCallback := func(user, instruction string, questions []string, echos []bool) ([]string, error) {
-		if config.Password != "" && atomic.CompareAndSwapInt32(&kbAutoAnswered, 0, 1) {
+		if isSavedPasswordChallenge(config, questions, echos) && atomic.CompareAndSwapInt32(&kbAutoAnswered, 0, 1) {
 			answers := make([]string, len(questions))
 			for i := range questions {
 				answers[i] = config.Password
@@ -197,26 +197,15 @@ func (s *SSHSession) Connect(config ConnectionConfig) error {
 		Auth:            authMethods,
 		Timeout:         30 * time.Second,
 		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
-		Config: sshAlgorithms(),
 	}
 
-	conn, err := net.DialTimeout("tcp", addr, clientConfig.Timeout)
+	client, err := dialSSHWithCipherFallback(addr, clientConfig, func() (net.Conn, error) {
+		return net.DialTimeout("tcp", addr, clientConfig.Timeout)
+	})
 	if err != nil {
 		s.setStatus(StatusError)
-		return fmt.Errorf("tcp dial: %w", err)
+		return err
 	}
-	if tcpConn, ok := conn.(*net.TCPConn); ok {
-		tcpConn.SetKeepAlive(true)
-		tcpConn.SetKeepAlivePeriod(sshKeepAliveInterval)
-	}
-
-	sshConn, chans, reqs, err := ssh.NewClientConn(conn, addr, clientConfig)
-	if err != nil {
-		conn.Close()
-		s.setStatus(StatusError)
-		return fmt.Errorf("ssh handshake: %w", err)
-	}
-	client := ssh.NewClient(sshConn, chans, reqs)
 
 	session, err := client.NewSession()
 	if err != nil {
@@ -325,6 +314,14 @@ func (s *SSHSession) Connect(config ConnectionConfig) error {
 	go s.runPostLoginAutomation(config)
 
 	return nil
+}
+
+// isSavedPasswordChallenge limits automatic answers to an unambiguous
+// password-only prompt. Key passphrases and password+OTP challenges remain
+// interactive so credentials are never sent to the wrong question.
+func isSavedPasswordChallenge(config ConnectionConfig, questions []string, echos []bool) bool {
+	return (config.AuthType == "" || config.AuthType == "password") &&
+		config.Password != "" && len(questions) == 1 && len(echos) == 1 && !echos[0]
 }
 
 func (s *SSHSession) readStderr() {

--- a/backend/store/connection_store.go
+++ b/backend/store/connection_store.go
@@ -76,6 +76,9 @@ func (s *ConnectionStore) Save(data session.ConnectionStoreData) error {
 			if s.passwordStore != nil {
 				_ = s.passwordStore.DeletePassword(conn.ID)
 			}
+			s.pwdMu.Lock()
+			delete(s.pwdCache, conn.ID)
+			s.pwdMu.Unlock()
 			continue
 		}
 		if s.passwordStore == nil {
@@ -86,6 +89,12 @@ func (s *ConnectionStore) Save(data session.ConnectionStoreData) error {
 		if err := s.passwordStore.SetPassword(conn.ID, conn.Password); err != nil {
 			return err
 		}
+		s.pwdMu.Lock()
+		if s.pwdCache == nil {
+			s.pwdCache = map[string]string{}
+		}
+		s.pwdCache[conn.ID] = conn.Password
+		s.pwdMu.Unlock()
 		conn.Password = ""
 	}
 
@@ -179,11 +188,18 @@ func (s *ConnectionStore) populatePasswords(data *session.ConnectionStoreData) e
 		if s.passwordStore != nil {
 			// One-time migration: plaintext JSON password → keychain.
 			if conn.Password != "" {
-				if err := s.passwordStore.SetPassword(conn.ID, conn.Password); err != nil {
+				pw := conn.Password
+				if err := s.passwordStore.SetPassword(conn.ID, pw); err != nil {
 					return err
 				}
 				conn.Password = ""
 				needsSave = true
+				s.pwdMu.Lock()
+				if s.pwdCache == nil {
+					s.pwdCache = map[string]string{}
+				}
+				s.pwdCache[conn.ID] = pw
+				s.pwdMu.Unlock()
 			}
 		}
 
@@ -219,7 +235,15 @@ func (s *ConnectionStore) populatePasswords(data *session.ConnectionStoreData) e
 		// Save cleaned JSON (passwords migrated out)
 		s.mu.Lock()
 		defer s.mu.Unlock()
-		return s.writeJSONLocked(*data)
+		clean := *data
+		clean.Connections = make([]session.ConnectionConfig, len(data.Connections))
+		copy(clean.Connections, data.Connections)
+		for i := range clean.Connections {
+			if clean.Connections[i].AuthType == "password" {
+				clean.Connections[i].Password = ""
+			}
+		}
+		return s.writeJSONLocked(clean)
 	}
 	return nil
 }

--- a/backend/store/connection_store.go
+++ b/backend/store/connection_store.go
@@ -169,7 +169,6 @@ func (s *ConnectionStore) Load() (session.ConnectionStoreData, error) {
 
 func (s *ConnectionStore) populatePasswords(data *session.ConnectionStoreData) error {
 	needsSave := false
-	var toFetch []string
 
 	for i := range data.Connections {
 		conn := &data.Connections[i]
@@ -188,8 +187,13 @@ func (s *ConnectionStore) populatePasswords(data *session.ConnectionStoreData) e
 			}
 		}
 
-		// F-110: serve from cache when available, otherwise schedule an
-		// async keychain fill so Load() does not block on per-connection IPC.
+		// Serve from cache when available; otherwise fill synchronously so
+		// Load() ALWAYS returns complete credentials. The previous F-110
+		// async-only fill left conn.Password empty on the first Load after
+		// process start — the frontend then held a snapshot with empty
+		// passwords and prompted the user for a password that was already
+		// in the keychain. Keychain IPC is cached per connection, so the
+		// cost is paid once and later Loads hit pwdCache.
 		s.pwdMu.RLock()
 		pw, cached := s.pwdCache[conn.ID]
 		s.pwdMu.RUnlock()
@@ -198,12 +202,17 @@ func (s *ConnectionStore) populatePasswords(data *session.ConnectionStoreData) e
 			continue
 		}
 		if s.passwordStore != nil {
-			toFetch = append(toFetch, conn.ID)
+			pw, err := s.passwordStore.GetPassword(conn.ID)
+			if err == nil && pw != "" {
+				conn.Password = pw
+				s.pwdMu.Lock()
+				if s.pwdCache == nil {
+					s.pwdCache = map[string]string{}
+				}
+				s.pwdCache[conn.ID] = pw
+				s.pwdMu.Unlock()
+			}
 		}
-	}
-
-	if len(toFetch) > 0 {
-		go s.asyncFillPasswords(toFetch)
 	}
 
 	if needsSave {
@@ -215,28 +224,11 @@ func (s *ConnectionStore) populatePasswords(data *session.ConnectionStoreData) e
 	return nil
 }
 
-// asyncFillPasswords runs after Load() returns; it fetches each requested
-// password from the keychain and writes the result into pwdCache. A cache
-// hit on the next Load avoids the per-connection IPC entirely.
-func (s *ConnectionStore) asyncFillPasswords(ids []string) {
-	for _, id := range ids {
-		pw, err := s.passwordStore.GetPassword(id)
-		if err != nil || pw == "" {
-			continue
-		}
-		s.pwdMu.Lock()
-		if s.pwdCache == nil {
-			s.pwdCache = map[string]string{}
-		}
-		s.pwdCache[id] = pw
-		s.pwdMu.Unlock()
-	}
-}
-
 // EnsurePassword returns the password for a connection ID, populating from
-// the keychain on cache miss. Callers needing synchronous access (e.g.
-// SSH Connect right after Load) should call this instead of relying on
-// conn.Password, which may be empty for the first Load after process start.
+// the keychain on cache miss. Load() already fills passwords synchronously
+// (see populatePasswords), so this is a defensive fallback for callers that
+// construct configs without going through Load — e.g. the session connect
+// path, which should never prompt for a password that exists in the keychain.
 // Returns "" if no password store is set or the keychain has no entry.
 func (s *ConnectionStore) EnsurePassword(connID string) (string, error) {
 	s.pwdMu.RLock()

--- a/backend/store/connection_store_password_test.go
+++ b/backend/store/connection_store_password_test.go
@@ -122,6 +122,55 @@ func TestConnectionStore_LoadUsesCache(t *testing.T) {
 	}
 }
 
+func TestConnectionStore_SaveUpdatesAndClearsPasswordCache(t *testing.T) {
+	dir := t.TempDir()
+	s := &ConnectionStore{configDir: dir}
+	ps := fakePasswordStore{store: map[string]string{"c1": "old"}}
+	s.SetPasswordStore(ps)
+
+	data := session.ConnectionStoreData{Groups: []session.ConnectionGroup{}, Connections: []session.ConnectionConfig{{ID: "c1", AuthType: "password", Password: "new"}}}
+	if err := s.Save(data); err != nil {
+		t.Fatalf("Save new password: %v", err)
+	}
+	if got, _ := s.EnsurePassword("c1"); got != "new" {
+		t.Fatalf("cached password after update = %q, want new", got)
+	}
+
+	data.Connections[0].Password = ""
+	if err := s.Save(data); err != nil {
+		t.Fatalf("Save cleared password: %v", err)
+	}
+	if got, _ := s.EnsurePassword("c1"); got != "" {
+		t.Fatalf("cached password after clear = %q, want empty", got)
+	}
+}
+
+func TestConnectionStore_MigrationDoesNotPersistPlaintext(t *testing.T) {
+	dir := t.TempDir()
+	s := &ConnectionStore{configDir: dir}
+	if err := s.writeJSONLocked(session.ConnectionStoreData{
+		Groups:      []session.ConnectionGroup{},
+		Connections: []session.ConnectionConfig{{ID: "c1", AuthType: "password", Password: "secret"}},
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	s.SetPasswordStore(fakePasswordStore{store: map[string]string{}})
+	data, err := s.Load()
+	if err != nil {
+		t.Fatalf("Load migration: %v", err)
+	}
+	if data.Connections[0].Password != "secret" {
+		t.Fatalf("Load password = %q, want secret", data.Connections[0].Password)
+	}
+	raw, err := os.ReadFile(filepath.Join(dir, storeFileName))
+	if err != nil {
+		t.Fatalf("read migrated file: %v", err)
+	}
+	if string(raw) == "" || string(raw) == "secret" || contains(string(raw), "secret") {
+		t.Fatalf("migrated connections file contains plaintext password: %s", raw)
+	}
+}
+
 // countingPasswordStore wraps fakePasswordStore and counts GetPassword calls.
 type countingPasswordStore struct {
 	fakePasswordStore

--- a/backend/store/connection_store_password_test.go
+++ b/backend/store/connection_store_password_test.go
@@ -1,0 +1,137 @@
+package store
+
+import (
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"github.com/ys-ll/uniterm/backend/session"
+)
+
+// TestConnectionStore_LoadFillsPasswordSynchronously verifies the F-110
+// regression fix: Load() must return connections with their keychain
+// passwords already populated. Previously the password was filled by an
+// async goroutine AFTER Load returned, so the frontend received a snapshot
+// with empty passwords and prompted the user for a password that already
+// existed in the keychain.
+func TestConnectionStore_LoadFillsPasswordSynchronously(t *testing.T) {
+	dir := t.TempDir()
+	s := &ConnectionStore{configDir: dir}
+
+	// Seed connections.json with a password-auth connection (password
+	// field empty — the keychain holds it, matching the migrated format).
+	seed := session.ConnectionStoreData{
+		Groups: []session.ConnectionGroup{},
+		Connections: []session.ConnectionConfig{
+			{ID: "c1", Name: "prod", Type: "ssh", AuthType: "password", Host: "8.41.56.121", User: "cnapsafe", Password: ""},
+			{ID: "c2", Name: "keyless", Type: "ssh", AuthType: "key", Host: "h2", User: "u2"},
+		},
+	}
+	if err := s.writeJSONLocked(seed); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// Wire a keychain that has a password for c1 only.
+	ps := fakePasswordStore{store: map[string]string{"c1": "cnapsafe-pw"}}
+	s.SetPasswordStore(ps)
+
+	data, err := s.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(data.Connections) != 2 {
+		t.Fatalf("expected 2 connections, got %d", len(data.Connections))
+	}
+
+	// c1: password must be present synchronously.
+	var c1, c2 session.ConnectionConfig
+	for _, c := range data.Connections {
+		switch c.ID {
+		case "c1":
+			c1 = c
+		case "c2":
+			c2 = c
+		}
+	}
+	if c1.Password != "cnapsafe-pw" {
+		t.Fatalf("c1 password not filled by Load: got %q, want %q (async-fill regression)", c1.Password, "cnapsafe-pw")
+	}
+	// c2: key auth — password untouched.
+	if c2.Password != "" {
+		t.Fatalf("c2 should have empty password, got %q", c2.Password)
+	}
+}
+
+// TestConnectionStore_LoadMissingPasswordStaysEmpty verifies that a
+// password-auth connection with NO keychain entry loads cleanly with an
+// empty password (the session will then prompt interactively) instead of
+// erroring out.
+func TestConnectionStore_LoadMissingPasswordStaysEmpty(t *testing.T) {
+	dir := t.TempDir()
+	s := &ConnectionStore{configDir: dir}
+
+	seed := session.ConnectionStoreData{
+		Groups:      []session.ConnectionGroup{},
+		Connections: []session.ConnectionConfig{{ID: "c1", Type: "ssh", AuthType: "password", Password: ""}},
+	}
+	if err := s.writeJSONLocked(seed); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	s.SetPasswordStore(fakePasswordStore{store: map[string]string{}})
+
+	data, err := s.Load()
+	if err != nil {
+		t.Fatalf("Load with no keychain entry should not error: %v", err)
+	}
+	if len(data.Connections) != 1 {
+		t.Fatalf("expected 1 connection, got %d", len(data.Connections))
+	}
+	if data.Connections[0].Password != "" {
+		t.Fatalf("expected empty password, got %q", data.Connections[0].Password)
+	}
+}
+
+// TestConnectionStore_LoadUsesCache verifies the pwdCache optimization:
+// the keychain is consulted only once per connection; subsequent Loads
+// serve from cache.
+func TestConnectionStore_LoadUsesCache(t *testing.T) {
+	dir := t.TempDir()
+	s := &ConnectionStore{configDir: dir}
+
+	seed := session.ConnectionStoreData{
+		Groups:      []session.ConnectionGroup{},
+		Connections: []session.ConnectionConfig{{ID: "c1", Type: "ssh", AuthType: "password", Password: ""}},
+	}
+	if err := s.writeJSONLocked(seed); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	var gets atomic.Int32
+	ps := countingPasswordStore{fakePasswordStore{store: map[string]string{"c1": "pw"}}, &gets}
+	s.SetPasswordStore(ps)
+
+	if _, err := s.Load(); err != nil {
+		t.Fatalf("first Load: %v", err)
+	}
+	if _, err := s.Load(); err != nil {
+		t.Fatalf("second Load: %v", err)
+	}
+	if got := gets.Load(); got != 1 {
+		t.Fatalf("keychain GetPassword called %d times, want 1 (cache miss on repeat loads)", got)
+	}
+}
+
+// countingPasswordStore wraps fakePasswordStore and counts GetPassword calls.
+type countingPasswordStore struct {
+	fakePasswordStore
+	gets *atomic.Int32
+}
+
+func (c countingPasswordStore) GetPassword(connID string) (string, error) {
+	c.gets.Add(1)
+	return c.fakePasswordStore.GetPassword(connID)
+}
+
+var _ = os.Stat // keep os import if unused on some platforms
+var _ = filepath.Join


### PR DESCRIPTION
## Summary

Fix three SSH credential and compatibility issues observed in normal use:

- saved keychain passwords could be missing from the first connection snapshot after startup;
- keyboard-interactive-only servers prompted again even when a password was saved;
- some old SSH servers advertise GCM but terminate the handshake with EOF after GCM is selected.

The changes preserve modern cipher preference and only apply the legacy CTR-first order as a one-time fallback on handshake EOF.

## Changes

- Load keychain passwords synchronously and cache them so the first connection attempt receives complete credentials.
- Keep the password cache consistent when credentials are updated or cleared.
- Ensure plaintext passwords migrated to the OS keychain are removed from the JSON written to disk.
- Resolve saved passwords defensively when creating or starting sessions, including jump hosts.
- Auto-answer keyboard-interactive only for a single hidden password challenge and only for password authentication.
- Keep AEAD/GCM first by default, then retry once on a fresh TCP connection with CTR first when the initial SSH handshake returns EOF.
- Add regression tests for password loading, cache updates, plaintext migration, challenge filtering, and cipher ordering.

## Validation

- `go test ./...`
- `go vet ./...`
- `go test -race ./backend/store ./backend/session`
- `npm run build`
- Local macOS Wails application build and manual SSH connection test

Related to #497

---

## 变更摘要

修复实际使用中遇到的三个 SSH 凭据与兼容性问题：

- 应用启动后的首次连接快照可能拿不到已经保存在系统钥匙串中的密码；
- 仅支持 keyboard-interactive 的服务器即使已保存密码仍会再次提示输入；
- 部分旧 SSH 服务器虽然声明支持 GCM，但在选择 GCM 后会以 EOF 中断握手。

本次修改仍然优先使用现代加密算法，仅在握手明确返回 EOF 时，以 CTR 优先顺序重新建立一次连接。

## 变更内容

- 同步读取并缓存钥匙串密码，确保首次连接即可获得完整凭据。
- 修改或清空密码时同步更新内存缓存。
- 将明文密码迁移到系统钥匙串后，确保写回 JSON 的副本不包含明文。
- 创建、启动会话以及使用跳板机时，增加钥匙串密码的防御性补全。
- 仅针对单个、不回显的密码 challenge 自动回答 keyboard-interactive，避免误填私钥口令或 OTP。
- 默认保持 AEAD/GCM 优先，仅在首次 SSH 握手返回 EOF 时，用全新 TCP 连接按 CTR 优先重试一次。
- 增加密码加载、缓存更新、明文迁移、challenge 判定及 cipher 顺序的回归测试。

## 验证

- `go test ./...`
- `go vet ./...`
- `go test -race ./backend/store ./backend/session`
- `npm run build`
- macOS Wails 应用本地构建及 SSH 连接手动测试

Related to #497
