### PR TITLE
fix(connection): improve connection/group form UX and fix stale data bugs

### DIFF
--- a/frontend/src/components/ConnectionForm.vue
+++ b/frontend/src/components/ConnectionForm.vue
@@ -1,5 +1,5 @@
 <template>
-  <el-dialog append-to-body v-model="visible" :title="isEdit ? t('conn.editTitle') : t('conn.newTitle')" width="680px" class="conn-dialog">
+  <el-dialog append-to-body v-model="visible" :title="isEdit ? t('conn.editTitle') : t('conn.newTitle')" width="680px" class="conn-dialog" @opened="onDialogOpened">
     <div class="conn-layout">
       <!-- Left sidebar: category icons -->
       <div class="conn-categories">
@@ -51,9 +51,6 @@
                 </el-button>
               </div>
             </el-form-item>
-            <el-form-item :label="t('conn.remark')">
-              <el-input v-model="form.remark" />
-            </el-form-item>
             <el-form-item v-if="form.type === 'database' && form.dbType === 'redis'" :label="t('conn.redisMode')">
               <el-radio-group v-model="form.redisMode">
                 <el-radio-button label="standalone">{{ t('conn.redisModeStandalone') }}</el-radio-button>
@@ -70,7 +67,7 @@
             </template>
             <el-form-item :label="form.type === 's3' ? 'Endpoint' : form.type === 'webdav' ? 'URL' : t('conn.host')" required v-if="form.type !== 'local' && form.type !== 'serial' && form.type !== 'k8s' && form.type !== 'container' && !isRedisSentinel">
               <div class="host-port-row">
-                <el-input v-model="form.host" class="host-input" :placeholder="form.type === 's3' ? 'e.g. https://s3.amazonaws.com' : form.type === 'webdav' ? 'https://dav.example.com/dav/' : t('conn.hostPlaceholder')" />
+                <el-input ref="hostInputRef" v-model="form.host" class="host-input" :placeholder="form.type === 's3' ? 'e.g. https://s3.amazonaws.com' : form.type === 'webdav' ? 'https://dav.example.com/dav/' : t('conn.hostPlaceholder')" />
                 <template v-if="form.type !== 's3' && form.type !== 'webdav'">
                   <span class="host-port-sep">:</span>
                   <el-input-number v-model="form.port" :min="0" :max="65535" class="port-input" />
@@ -296,6 +293,9 @@
                 <div class="field-hint">{{ t('conn.x11DesktopCustomCmdHint') }}</div>
               </el-form-item>
             </template>
+            <el-form-item :label="t('conn.remark')">
+              <el-input v-model="form.remark" type="textarea" :rows="3" :placeholder="t('conn.remarkPlaceholder')" />
+            </el-form-item>
             <div v-if="showAdvancedToggle" class="advanced-toggle" @click="showAdvanced = !showAdvanced">
               <el-icon class="advanced-arrow" :class="{ expanded: showAdvanced }"><ChevronRight :size="14" /></el-icon>
               <span>{{ t('conn.advanced') }}</span>
@@ -529,7 +529,7 @@ import { useSettingsStore } from '../stores/settingsStore'
 import { useI18n } from '../i18n'
 import type { ConnectionConfig, PostLoginExpectStep } from '../types/session'
 import { OpenFileDialog, GetPlatform, ListSerialPorts } from '../../wailsjs/go/main/App'
-import { ElMessage } from 'element-plus'
+import { ElMessage, ElInput } from 'element-plus'
 import { Plus, Trash2, ChevronDown, ChevronRight, FolderOpen, RefreshCw, Terminal, Monitor, Database, DatabaseZap, Layers, SquareTerminal, Zap, Laptop, Cable, FolderUp, HardDrive, Cloud, Globe, MonitorCloud, MonitorSmartphone, Boxes, ShipWheel, AppWindow } from '@lucide/vue'
 import { listContexts } from '../services/k8sClient'
 import type { K8sContextInfo } from '../types/k8s'
@@ -712,6 +712,8 @@ const visible = computed({
   set: (v) => emit('update:modelValue', v)
 })
 
+const hostInputRef = ref<InstanceType<typeof ElInput> | null>(null)
+
 watch(visible, (val) => {
   if (val) {
     passwordInputKey.value++
@@ -724,6 +726,14 @@ watch(visible, (val) => {
     }
   }
 })
+
+function onDialogOpened() {
+  // New connections: focus the host field by default. The dialog's @opened
+  // event fires after the open transition, so the host input is mounted.
+  if (!isEdit.value) {
+    nextTick(() => hostInputRef.value?.focus())
+  }
+}
 
 const isEdit = computed(() => !!props.editConfig?.id)
 
@@ -885,12 +895,10 @@ const hydrating = ref(false)
 
 watch(() => props.editConfig, (config) => {
   if (config) {
-    // If editing an existing connection (has id), merge its full config.
-    // Otherwise (sparse config from quick-new), reset first to avoid stale
-    // data from a previously edited connection leaking in.
-    if (!config.id) {
-      resetForm()
-    }
+    // Always reset first so fields absent from the config (e.g. an empty
+    // password) don't leak values from a previously edited connection. Then
+    // merge the config over the clean defaults.
+    resetForm()
     hydrating.value = true
     Object.assign(form, { ...config, postLoginExpectSteps: cloneExpectSteps(config.postLoginExpectSteps || []) })
     // Existing connections without the field default to NLA off (old behavior).
@@ -946,6 +954,7 @@ watch(() => form.type, (newType) => {
   if (newType === 'ssh') form.port = 22
   else if (newType === 'telnet') form.port = 23
   else if (newType === 'mosh') form.port = 22
+  else if (newType === 'x11-desktop') form.port = 22
   else if (newType === 'rdp') form.port = 3389
   else if (newType === 'vnc') form.port = 5900
   else if (newType === 'spice') form.port = 5900

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -314,7 +314,7 @@
       <div class="menu-item" @click="doDuplicate">{{ t('sidebar.duplicate') }}</div>
       <div class="menu-divider" />
       <div class="menu-item" @click="doChangeGroup">{{ t('conn.moveTo') }}</div>
-      <div class="menu-item" @click="doNewGroup">{{ t('conn.newGroupTitle') }}</div>
+      <div class="menu-item" @click="doNewGroup(selectedGroupParentId())">{{ t('conn.newGroupTitle') }}</div>
       <div class="menu-divider" />
       <div class="menu-item danger" @click="doDelete">{{ t('sidebar.delete') }}</div>
     </div>
@@ -327,7 +327,7 @@
       :style="groupMenuStyle"
       @click.stop
     >
-      <div class="menu-item" @click="doNewGroup">{{ t('conn.newGroupTitle') }}</div>
+      <div class="menu-item" @click="doNewGroup(selectedGroupParentId())">{{ t('conn.newGroupTitle') }}</div>
       <div class="menu-item" @click="doNewConnInGroup">{{ t('sidebar.newConnection') }}</div>
       <template v-if="selectedGroup && selectedGroup.id !== '__ungrouped__'">
         <div class="menu-divider" />
@@ -346,7 +346,7 @@
       :style="emptyAreaMenuStyle"
       @click.stop
     >
-      <div class="menu-item" @click="doNewGroup">{{ t('conn.newGroupTitle') }}</div>
+      <div class="menu-item" @click="doNewGroup()">{{ t('conn.newGroupTitle') }}</div>
     </div>
 
     <!-- Delete group dialog -->
@@ -1395,14 +1395,20 @@ function doNewConnInGroup() {
   showForm.value = true
 }
 
-function doNewGroup() {
+function doNewGroup(parentGroupId?: string) {
   closeMenu()
   closeGroupMenu()
   closeEmptyAreaMenu()
   newGroupName.value = ''
-  // Default parent to selected group if triggered from group context menu
-  newGroupParentId.value = (selectedGroup.value && selectedGroup.value.id !== '__ungrouped__') ? selectedGroup.value.id : undefined
+  // Clear the parent first, then render the explicitly-passed group. Callers
+  // decide what to pass; empty-area creation passes nothing, so it defaults
+  // to "None" instead of carrying over a previously-selected group.
+  newGroupParentId.value = parentGroupId
   showNewGroupDialog.value = true
+}
+
+function selectedGroupParentId(): string | undefined {
+  return (selectedGroup.value && selectedGroup.value.id !== '__ungrouped__') ? selectedGroup.value.id : undefined
 }
 
 async function confirmNewGroup() {

--- a/frontend/src/components/StartTabContent.vue
+++ b/frontend/src/components/StartTabContent.vue
@@ -591,6 +591,13 @@ async function loadRecent() {
 }
 loadRecent()
 
+// Refresh the recent list when connections are added/removed, so a newly
+// created connection shows up in "Recent" without requiring a reload.
+watch(
+  () => connectionStore.connections.map(c => c.id),
+  () => loadRecent()
+)
+
 const recentConfigs = computed(() => {
   const query = searchQuery.value.trim().toLowerCase()
   return recentConnectionIds.value


### PR DESCRIPTION
Improve the new connection / group UI and fix stale-data bugs in the connection form.

Changes:
- Move the remark field to the last basic config item and make it multi-line.
- Auto-focus the host field when creating a new connection.
- Default the X11 Desktop port to 22.
- Reset the form before editing so absent fields (e.g. an empty password) no longer leak values from a previously edited connection.
- Auto-refresh the Recent list when connections are added or removed.
- Default the parent group to None when creating a group from empty space.

Fixes: #516, #517, #536

---
优化新建连接/新建分组的界面，并修复连接表单的旧数据残留 bug。

改动：
- 将备注字段调整为基础配置最后一项，并改为多行输入。
- 新建连接时默认聚焦主机字段。
- X11 Desktop 默认端口设为 22。
- 编辑前先重置表单，避免缺失字段（如未填密码）残留上一次编辑的值。
- 连接增删后自动刷新"最近"列表。
- 空白处新建分组时，默认父分组固定为"无"。

Fixes: #516, #517, #536