### PR TITLE
feat(shortcuts): make Ctrl+Shift+C/V configurable terminal-scoped shortcuts

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -811,6 +811,14 @@ const actionHandlers: Record<ShortcutAction, () => void> = {
     const pid = tabStore.getActivePanelId()
     if (pid) window.dispatchEvent(new CustomEvent('terminal:open-search', { detail: { panelId: pid } }))
   },
+  copy: () => {
+    const pid = tabStore.getActivePanelId()
+    if (pid) window.dispatchEvent(new CustomEvent('terminal:copy', { detail: { panelId: pid } }))
+  },
+  paste: () => {
+    const pid = tabStore.getActivePanelId()
+    if (pid) window.dispatchEvent(new CustomEvent('terminal:paste', { detail: { panelId: pid } }))
+  },
   navigatePrev: () => navigatePanel(-1),
   navigateNext: () => navigatePanel(1),
   openSettings: () => openSettings(),

--- a/frontend/src/components/BaseTerminal.vue
+++ b/frontend/src/components/BaseTerminal.vue
@@ -178,6 +178,8 @@ let onTerminalAuxClick: ((e: MouseEvent) => void) | null = null
 let onOpenSearch: ((e: Event) => void) | null = null
 let onExport: ((e: Event) => void) | null = null
 let onSendRz: ((e: Event) => void) | null = null
+let onTerminalCopy: ((e: Event) => void) | null = null
+let onTerminalPaste: ((e: Event) => void) | null = null
 
 let resizeTimer: ReturnType<typeof setTimeout> | null = null
 let isResizing = false
@@ -676,13 +678,12 @@ function handleTerminalKey(e: KeyboardEvent): boolean {
   }
 
   // Paste via Wails clipboard (xterm's DOM paste is unreliable in WKWebView).
-  // Bind to the platform's paste shortcut only — Cmd+V on macOS, Ctrl+Shift+V
-  // elsewhere. Plain Ctrl+V is never intercepted, so it passes through to the
-  // terminal app (vim visual block, bash literal-next…) on every platform.
-  const pasteCombo = isMac
-    ? (e.metaKey && !e.ctrlKey && !e.shiftKey && !e.altKey)
-    : (e.ctrlKey && e.shiftKey && !e.metaKey && !e.altKey)
-  if (pasteCombo && (e.key === 'v' || e.key === 'V') && e.type === 'keydown') {
+  // macOS Cmd+V stays hardcoded — it is not one of the configurable shortcuts.
+  // On Windows/Linux, Ctrl+Shift+V is handled by the configurable shortcut
+  // system (see the terminal:paste event below). Plain Ctrl+V is never
+  // intercepted, so it passes through to the terminal app (vim visual block,
+  // bash literal-next…) on every platform.
+  if (isMac && e.metaKey && !e.ctrlKey && !e.shiftKey && !e.altKey && (e.key === 'v' || e.key === 'V') && e.type === 'keydown') {
     e.preventDefault()
     if (props.mode === 'ssh' || props.mode === 'local') {
       ClipboardGetText().then(text => {
@@ -702,15 +703,6 @@ function handleTerminalKey(e: KeyboardEvent): boolean {
       return false
     }
     return true
-  }
-
-  // Ctrl+Shift+C: copy terminal selection to clipboard
-  if ((e.ctrlKey || e.metaKey) && e.shiftKey && (e.key === 'c' || e.key === 'C') && e.type === 'keydown') {
-    const sel = terminal?.getSelection()
-    if (sel) {
-      navigator.clipboard.writeText(sel).catch(() => {})
-    }
-    return false
   }
 
   // macOS-style cursor word/line jumping via Option/Cmd + arrow keys
@@ -1286,6 +1278,31 @@ onMounted(() => {
   }
   window.addEventListener('terminal:send-rz', onSendRz)
 
+  // Configurable copy/paste shortcuts (Ctrl+Shift+C/V on Windows/Linux).
+  // The App-level shortcut handler dispatches these events to the active panel.
+  onTerminalCopy = (e: Event) => {
+    if (!isActive.value) return
+    const detail = (e as CustomEvent).detail
+    if (detail?.panelId && detail.panelId !== props.panelId) return
+    const sel = terminal?.getSelection()
+    if (sel) {
+      navigator.clipboard.writeText(sel).catch(() => {})
+    }
+  }
+  window.addEventListener('terminal:copy', onTerminalCopy)
+
+  onTerminalPaste = (e: Event) => {
+    if (!isActive.value) return
+    const detail = (e as CustomEvent).detail
+    if (detail?.panelId && detail.panelId !== props.panelId) return
+    if (props.mode === 'ssh' || props.mode === 'local') {
+      ClipboardGetText().then(text => {
+        if (text) pasteToSession(text)
+      }).catch(() => {})
+    }
+  }
+  window.addEventListener('terminal:paste', onTerminalPaste)
+
   bindListeners()
 
   resizeObserver = new ResizeObserver(() => {
@@ -1590,6 +1607,8 @@ onUnmounted(() => {
   if (onOpenSearch) window.removeEventListener('terminal:open-search', onOpenSearch)
   if (onExport) window.removeEventListener('terminal:export', onExport)
   if (onSendRz) window.removeEventListener('terminal:send-rz', onSendRz)
+  if (onTerminalCopy) window.removeEventListener('terminal:copy', onTerminalCopy)
+  if (onTerminalPaste) window.removeEventListener('terminal:paste', onTerminalPaste)
   suggestions.close()
   if (!zmodemStore.getActiveTransfer(props.sessionId || '')) {
     disposeZmodemService(props.sessionId || '')

--- a/frontend/src/components/SPICETabContent.vue
+++ b/frontend/src/components/SPICETabContent.vue
@@ -25,6 +25,7 @@
       ref="spiceContainer"
       class="spice-area"
       tabindex="0"
+      @paste="onPaste"
     />
 
     <!-- Status bar -->
@@ -51,7 +52,7 @@ import { useI18n } from '../i18n'
 import { usePanelStore } from '../stores/panelStore'
 import type { ConnectionConfig } from '../types/session'
 import { CreateSession, CloseSession } from '../../wailsjs/go/main/App'
-import { EventsOn, ClipboardSetText, ClipboardGetText } from '../../wailsjs/runtime'
+import { EventsOn, ClipboardSetText } from '../../wailsjs/runtime'
 
 const { t } = useI18n()
 const panelStore = usePanelStore()
@@ -134,17 +135,14 @@ async function initSpice(proxyAddr: string, password: string) {
   isIniting = false
 }
 
-function handleKeyDown(e: KeyboardEvent) {
+// Paste into the SPICE remote via the native paste event (Ctrl+V / context menu).
+// SPICE handles clipboard through the agent channel.
+function onPaste(e: ClipboardEvent) {
+  e.preventDefault()
   if (!sc || status.value !== 'connected') return
-  // Ctrl+Shift+V: paste from local clipboard to SPICE
-  if (e.ctrlKey && e.shiftKey && (e.key === 'v' || e.key === 'V')) {
-    e.preventDefault()
-    ClipboardGetText().then(text => {
-      if (text && sc) {
-        // SPICE handles clipboard through agent channel
-        try { sc.sendClipboard(text) } catch (_) {}
-      }
-    }).catch(() => {})
+  const text = e.clipboardData?.getData('text')
+  if (text && sc) {
+    try { sc.sendClipboard(text) } catch (_) {}
   }
 }
 
@@ -196,7 +194,6 @@ onMounted(() => {
     sc = cached.sc
     panelStore.removeSPICECache(props.panelId)
     status.value = 'connected'
-    document.addEventListener('keydown', handleKeyDown)
     return
   }
 
@@ -210,8 +207,6 @@ onMounted(() => {
   } else {
     connect()
   }
-
-  document.addEventListener('keydown', handleKeyDown)
 
   unsubStatus = EventsOn('session:status', (data: any) => {
     if (data.id !== currentSessionId.value) return
@@ -250,7 +245,6 @@ onMounted(() => {
 })
 
 onBeforeUnmount(() => {
-  document.removeEventListener('keydown', handleKeyDown)
   unsubStatus?.()
 
   if (spiceContainer.value) {

--- a/frontend/src/components/VNCTabContent.vue
+++ b/frontend/src/components/VNCTabContent.vue
@@ -72,7 +72,7 @@ import { useI18n } from '../i18n'
 import { usePanelStore } from '../stores/panelStore'
 import type { ConnectionConfig } from '../types/session'
 import { CreateSession, CloseSession } from '../../wailsjs/go/main/App'
-import { EventsOn, ClipboardSetText, ClipboardGetText } from '../../wailsjs/runtime'
+import { EventsOn, ClipboardSetText } from '../../wailsjs/runtime'
 
 const { t } = useI18n()
 const panelStore = usePanelStore()
@@ -269,18 +269,6 @@ function onPaste(e: ClipboardEvent) {
   }
 }
 
-function handleKeyDown(e: KeyboardEvent) {
-  if (!rfb || status.value !== 'connected') return
-  if (e.ctrlKey && e.shiftKey && (e.key === 'v' || e.key === 'V')) {
-    e.preventDefault()
-    ClipboardGetText().then(text => {
-      if (text && rfb) {
-        rfb.clipboardPasteFrom(text)
-      }
-    }).catch(() => {})
-  }
-}
-
 onMounted(() => {
   if (props.sessionId) {
     currentSessionId.value = props.sessionId
@@ -294,7 +282,6 @@ onMounted(() => {
     panelStore.removeVNCCache(props.panelId)
     status.value = 'connected'
     applyRFBOptions()
-    document.addEventListener('keydown', handleKeyDown)
     watchThemeBackground()
     return
   }
@@ -308,8 +295,6 @@ onMounted(() => {
   } else {
     connect()
   }
-
-  document.addEventListener('keydown', handleKeyDown)
 
   watchThemeBackground()
 
@@ -347,7 +332,6 @@ onMounted(() => {
 })
 
 onBeforeUnmount(() => {
-  document.removeEventListener('keydown', handleKeyDown)
   themeObserver?.disconnect()
   themeObserver = null
   unsubStatus?.()

--- a/frontend/src/composables/useKeyboardShortcuts.ts
+++ b/frontend/src/composables/useKeyboardShortcuts.ts
@@ -25,20 +25,29 @@ function normalize(e: KeyboardEvent): string {
 
 // Module-level state: key combo → action handler
 const shortcutMap = new Map<string, () => void>()
+// Terminal-scoped shortcuts: only fire while a terminal session is focused
+// (handled by onTerminalKey), never from the global capture listener, so they
+// don't hijack copy/paste while the user is typing in another input.
+const terminalShortcutMap = new Map<string, () => void>()
 // Reverse lookup: action → key combo (for display / dedup)
 const actionKeyMap = new Map<ShortcutAction, string>()
 
+// Actions that should only take effect while a terminal session is focused.
+const TERMINAL_SCOPED_ACTIONS: ShortcutAction[] = ['copy', 'paste']
+
 export function loadKeybindings(bindings: KeyboardSettings, handlers: ActionHandlers) {
   shortcutMap.clear()
+  terminalShortcutMap.clear()
   actionKeyMap.clear()
   for (const [action, b] of Object.entries(bindings) as [ShortcutAction, KeyBinding][]) {
     const key = bindingKey(b)
     if (!key) continue
     const handler = handlers[action]
     if (handler) {
-      shortcutMap.set(key, handler)
+      const target = TERMINAL_SCOPED_ACTIONS.includes(action) ? terminalShortcutMap : shortcutMap
+      target.set(key, handler)
       if (!b.meta && b.ctrl) {
-        shortcutMap.set(key.replace(/^ctrl\+/, 'meta+'), handler)
+        target.set(key.replace(/^ctrl\+/, 'meta+'), handler)
       }
       actionKeyMap.set(action, key)
     }
@@ -49,8 +58,8 @@ export function getActionKey(action: ShortcutAction): string {
   return actionKeyMap.get(action) || ''
 }
 
-function fire(e: KeyboardEvent, normalized: string): boolean {
-  const handler = shortcutMap.get(normalized)
+function fire(e: KeyboardEvent, normalized: string, map: Map<string, () => void>): boolean {
+  const handler = map.get(normalized)
   if (!handler) return false
   e.preventDefault()
   e.stopPropagation()
@@ -59,15 +68,13 @@ function fire(e: KeyboardEvent, normalized: string): boolean {
 }
 
 export function onGlobalKeydown(e: KeyboardEvent) {
-  fire(e, normalize(e))
+  fire(e, normalize(e), shortcutMap)
 }
 
 export function onTerminalKey(e: KeyboardEvent): boolean {
   const normalized = normalize(e)
-  if (shortcutMap.has(normalized)) {
-    fire(e, normalized)
-    return false
-  }
+  if (fire(e, normalized, shortcutMap)) return false
+  if (fire(e, normalized, terminalShortcutMap)) return false
   return true
 }
 

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -941,6 +941,8 @@
   "shortcut.duplicateSession": "Duplizieren",
   "shortcut.terminalSearch": "Terminal durchsuchen",
   "shortcut.openSettings": "Einstellungen öffnen",
+  "shortcut.copy": "Im Terminal kopieren",
+  "shortcut.paste": "Im Terminal einfügen",
   "shortcut.title": "Tastenkombinationen",
   "shortcut.colFunction": "Funktion",
   "shortcut.colBinding": "Tastenkombination",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -941,6 +941,8 @@
   "shortcut.duplicateSession": "Duplicate",
   "shortcut.terminalSearch": "Terminal Search",
   "shortcut.openSettings": "Open Settings",
+  "shortcut.copy": "Terminal Copy",
+  "shortcut.paste": "Terminal Paste",
   "shortcut.title": "Shortcuts",
   "shortcut.colFunction": "Function",
   "shortcut.colBinding": "Binding",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -941,6 +941,8 @@
   "shortcut.duplicateSession": "Duplicar",
   "shortcut.terminalSearch": "Buscar en terminal",
   "shortcut.openSettings": "Abrir configuración",
+  "shortcut.copy": "Copiar en terminal",
+  "shortcut.paste": "Pegar en terminal",
   "shortcut.title": "Atajos",
   "shortcut.colFunction": "Función",
   "shortcut.colBinding": "Atajo",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -941,6 +941,8 @@
   "shortcut.duplicateSession": "Dupliquer",
   "shortcut.terminalSearch": "Rechercher dans le terminal",
   "shortcut.openSettings": "Ouvrir les paramètres",
+  "shortcut.copy": "Copier dans le terminal",
+  "shortcut.paste": "Coller dans le terminal",
   "shortcut.title": "Raccourcis",
   "shortcut.colFunction": "Fonction",
   "shortcut.colBinding": "Raccourci",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -941,6 +941,8 @@
   "shortcut.duplicateSession": "複製",
   "shortcut.terminalSearch": "端末検索",
   "shortcut.openSettings": "設定を開く",
+  "shortcut.copy": "ターミナル内コピー",
+  "shortcut.paste": "ターミナル内貼り付け",
   "shortcut.title": "ショートカット",
   "shortcut.colFunction": "機能",
   "shortcut.colBinding": "キー",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -941,6 +941,8 @@
   "shortcut.duplicateSession": "복제",
   "shortcut.terminalSearch": "터미널 검색",
   "shortcut.openSettings": "설정 열기",
+  "shortcut.copy": "터미널 내 복사",
+  "shortcut.paste": "터미널 내 붙여넣기",
   "shortcut.title": "단축키",
   "shortcut.colFunction": "기능",
   "shortcut.colBinding": "단축키",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -941,6 +941,8 @@
   "shortcut.duplicateSession": "Дублировать",
   "shortcut.terminalSearch": "Поиск в терминале",
   "shortcut.openSettings": "Открыть настройки",
+  "shortcut.copy": "Копировать в терминале",
+  "shortcut.paste": "Вставить в терминале",
   "shortcut.title": "Горячие клавиши",
   "shortcut.colFunction": "Функция",
   "shortcut.colBinding": "Сочетание",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -941,6 +941,8 @@
   "shortcut.duplicateSession": "复制连接",
   "shortcut.terminalSearch": "终端搜索",
   "shortcut.openSettings": "打开设置",
+  "shortcut.copy": "终端内复制",
+  "shortcut.paste": "终端内粘贴",
   "shortcut.title": "快捷键",
   "shortcut.colFunction": "功能",
   "shortcut.colBinding": "快捷键",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -941,6 +941,8 @@
   "shortcut.duplicateSession": "複製連接",
   "shortcut.terminalSearch": "終端搜尋",
   "shortcut.openSettings": "開啟設定",
+  "shortcut.copy": "終端內複製",
+  "shortcut.paste": "終端內貼上",
   "shortcut.title": "快捷鍵",
   "shortcut.colFunction": "功能",
   "shortcut.colBinding": "快捷鍵",

--- a/frontend/src/types/settings.ts
+++ b/frontend/src/types/settings.ts
@@ -97,6 +97,8 @@ export type ShortcutAction =
   | 'duplicateSession'
   | 'terminalSearch'
   | 'openSettings'
+  | 'copy'
+  | 'paste'
 
 export interface KeyBinding {
   ctrl: boolean
@@ -122,6 +124,8 @@ export const SHORTCUT_LABELS: Record<ShortcutAction, string> = {
   duplicateSession: 'shortcut.duplicateSession',
   terminalSearch: 'shortcut.terminalSearch',
   openSettings: 'shortcut.openSettings',
+  copy: 'shortcut.copy',
+  paste: 'shortcut.paste',
 }
 
 export const DEFAULT_KEYBOARD: KeyboardSettings = {
@@ -138,6 +142,8 @@ export const DEFAULT_KEYBOARD: KeyboardSettings = {
   duplicateSession: { ctrl: true, shift: true, alt: false, key: 'd' },
   terminalSearch: { ctrl: true, shift: false, alt: false, key: 'f' },
   openSettings: { ctrl: true, shift: false, alt: false, key: ',' },
+  copy: { ctrl: true, shift: true, alt: false, key: 'c' },
+  paste: { ctrl: true, shift: true, alt: false, key: 'v' },
 }
 
 export interface SFTPBookmarks {


### PR DESCRIPTION
## Summary

Extract the hardcoded `Ctrl+Shift+C` / `Ctrl+Shift+V` copy-paste into the app's configurable keyboard shortcut system, scoped so they only fire while a terminal session is focused. `macOS Cmd+C/V` remains hardcoded and terminal-only.

### Changes
- **Shortcut config**: add `copy` / `paste` actions with defaults `Ctrl+Shift+C` / `Ctrl+Shift+V`; rebindable from the Shortcuts settings table.
- **Terminal-scoped dispatch**: `copy` / `paste` are routed to a terminal-only shortcut map, so the global capture listener never fires them — they only trigger via the focused terminal's key handler.
- **BaseTerminal**: dispatch `terminal:copy` / `terminal:paste` events to the active panel; macOS `Cmd+V` paste and `Cmd+C` copy stay hardcoded.
- **SPICE / VNC**: paste now uses the native `@paste` event instead of a document-level `Ctrl+Shift+V` keydown, removing the last app-wide handler for these combos.
- **i18n**: add `shortcut.copy` / `shortcut.paste` labels across all 9 locales.

### Behavior
| Context | Ctrl+Shift+C / V |
|---|---|
| SSH / Local terminal focused | copy / paste |
| AI sidebar, settings, other inputs | no-op |
| SPICE / VNC | paste via native Ctrl+V |

---

## 摘要

将硬编码的 `Ctrl+Shift+C` / `Ctrl+Shift+V` 复制粘贴抽取到应用的快捷键配置系统，并限定为仅终端聚焦时生效。macOS 的 `Cmd+C/V` 保持硬编码、仅在终端内生效。

### 改动
- **快捷键配置**：新增 `copy` / `paste` 动作，默认 `Ctrl+Shift+C` / `Ctrl+Shift+V`，可在快捷键设置表中重新绑定。
- **终端作用域分发**：`copy` / `paste` 路由到终端专用快捷键表，全局捕获监听不触发它们——只有聚焦终端的按键处理器会触发。
- **BaseTerminal**：向活动面板派发 `terminal:copy` / `terminal:paste` 事件；macOS `Cmd+V` 粘贴与 `Cmd+C` 拷贝保持硬编码。
- **SPICE / VNC**：粘贴改为原生 `@paste` 事件，不再使用 document 级 `Ctrl+Shift+V` 键盘监听，移除了这些组合键最后一个全应用处理器。
- **i18n**：全部 9 个语言文件新增 `shortcut.copy` / `shortcut.paste` 文案。

### 行为
| 场景 | Ctrl+Shift+C / V |
|---|---|
| SSH / 本地终端聚焦 | 复制 / 粘贴 |
| AI 侧栏、设置等其它输入 | 不触发 |
| SPICE / VNC | 通过原生 Ctrl+V 粘贴 |
