### PR TITLE
fix(terminal): stop Ctrl scroll-to-bottom and re-enable Shift+Delete (#538)

### DIFF
--- a/frontend/src/components/BaseTerminal.vue
+++ b/frontend/src/components/BaseTerminal.vue
@@ -675,6 +675,26 @@ function handleTerminalKey(e: KeyboardEvent): boolean {
     return false
   }
 
+  // A bare modifier key (Shift/Ctrl/Alt/Meta held alone) produces no input, yet
+  // xterm's _keyDown still runs and, with scrollOnUserInput=true, fires
+  // scrollToBottom() — yanking the viewport back to the bottom when the user
+  // has scrolled up to read history (issue #538). Short-circuit bare modifiers
+  // before they reach xterm's scroll logic; they shouldn't be PTY input anyway.
+  if (e.type === 'keydown' && (e.key === 'Control' || e.key === 'Shift' || e.key === 'Alt' || e.key === 'Meta')) {
+    return false
+  }
+
+  // macOS 26 WKWebView: xterm's modifier handling for Shift+Delete is
+  // unreliable and may emit no sequence, so the key silently fails to delete
+  // (issue #538). Inject the standard CSI delete sequence ESC[3~ directly for
+  // all plain Delete presses. Ctrl/Meta/Cmd combos are left to xterm so future
+  // Delete-chord shortcuts can still hook in.
+  if (e.type === 'keydown' && e.key === 'Delete' && !e.ctrlKey && !e.metaKey && !e.altKey) {
+    e.preventDefault()
+    terminal?.input('\x1b[3~')
+    return false
+  }
+
   // Paste via Wails clipboard (xterm's DOM paste is unreliable in WKWebView).
   // Bind to the platform's paste shortcut only — Cmd+V on macOS, Ctrl+Shift+V
   // elsewhere. Plain Ctrl+V is never intercepted, so it passes through to the


### PR DESCRIPTION
Closes #538

## Summary

Fixes two terminal input regressions reported on macOS 26 (uniTerm 1.7.0):

- **按住 Ctrl 后终端被强行拉回底部 / pressing Ctrl yanks the terminal back to the bottom.** When scrolled up to read history, pressing any Ctrl/Shift key snapped the viewport back to the cursor line.
- **Shift+Delete 无法删除字符 / Shift+Delete stops deleting.** Plain Delete worked, but Shift+Delete produced no effect.

## Root Cause

Both are xterm.js default behaviors, surfaced through `attachCustomKeyEventHandler` in `BaseTerminal.vue`:

- xterm's `_keyDown` runs with `scrollOnUserInput = true` (default), and **any** keydown — including a bare modifier key (Ctrl/Shift/Alt/Meta) that sends no PTY input — fires `scrollToBottom()`, resetting the viewport.
- `handleTerminalKey` returned `true` for Delete unconditionally, delegating to xterm. On macOS 26 WKWebView, xterm's modifier handling for Shift+Delete is unreliable and may emit no escape sequence, so the key silently does nothing.

## Changes

Only `frontend/src/components/BaseTerminal.vue`, in `handleTerminalKey` (after the CapsLock workaround, before the paste branch):

1. **Bare modifier short-circuit** — `Control`/`Shift`/`Alt`/`Meta` held alone returns `false`, so it never reaches xterm's scroll logic. These keys produce no input and have no reason to scroll.
2. **Plain Delete → `ESC[3~`** — for a Delete press without Ctrl/Meta/Cmd, inject the standard CSI delete sequence directly instead of letting xterm assemble the (unreliable) Shift-modified variant. Ctrl/Meta/Cmd combos are left to xterm so future Delete-chord shortcuts can still hook in.

No DB/provider/backend changes.

## Validation

- ✅ `npm run build` passes.
- ⏳ `wails dev` manual verification pending — planned checks:
  - scrolled up to history → pressing Ctrl / Shift alone stays on the history line (no jump to bottom)
  - typing at the prompt → Delete deletes; Shift+Delete also deletes (previously did nothing)
  - regression: CapsLock first-letter (#483), Cmd+V paste, Cmd+C copy, Ctrl+Shift+C, Option/Cmd + arrow word-jump unaffected