### PR TITLE
fix(settings): actually relaunch app when toggling system title bar

### DIFF
--- a/app.go
+++ b/app.go
@@ -1971,6 +1971,20 @@ func (a *App) GetAppInfo() AppInfo {
 	}
 }
 
+// RelaunchApp spawns a fresh instance, then quits the current one so settings
+// that are fixed at startup (e.g. the window title bar) can take effect. The
+// new process is started first; a short delay lets it finish spawning before
+// this instance exits, keeping the overlap window minimal.
+func (a *App) RelaunchApp() {
+	if err := a.relaunchProcess(); err != nil {
+		log.Writef("relaunch failed: %v", err)
+	}
+	go func() {
+		time.Sleep(300 * time.Millisecond)
+		runtime.Quit(a.ctx)
+	}()
+}
+
 func (a *App) CheckForUpdate(source string) (*update.UpdateInfo, error) {
 	return update.Check(Version, source)
 }

--- a/frontend/src/components/SettingsTab.vue
+++ b/frontend/src/components/SettingsTab.vue
@@ -722,14 +722,13 @@
 import { ref, reactive, watch, computed, onMounted } from 'vue'
 import { Settings, Monitor, MessageCircleMore, Info, RefreshCw, Pencil, Trash2, Globe, Keyboard, Plus, BookOpen, Wrench, FolderOpen } from '@lucide/vue'
 import { msg } from '../services/message'
-import { FetchModels, ChatCompletion, GetPlatform, GetSystemFonts, GetDefaultSessionLogDir, OpenDirectoryDialog, OpenFileDialogFiltered, SetBackgroundImage, ClearBackgroundImage, GetBackgroundImage } from '../../wailsjs/go/main/App'
+import { FetchModels, ChatCompletion, GetPlatform, GetSystemFonts, GetDefaultSessionLogDir, OpenDirectoryDialog, OpenFileDialogFiltered, SetBackgroundImage, ClearBackgroundImage, GetBackgroundImage, RelaunchApp } from '../../wailsjs/go/main/App'
 import { useSettingsStore } from '../stores/settingsStore'
 import { useSyncStore } from '../stores/syncStore'
 import { useLocalStateStore } from '../stores/localStateStore'
 import { useUpdateCheck } from '../composables/useUpdateCheck'
 import { useI18n, locale } from '../i18n'
 import { BrowserOpenURL } from '../../wailsjs/runtime'
-import { Quit } from '../../wailsjs/runtime'
 import { ElMessageBox } from 'element-plus'
 import { FONT_OPTIONS, LANGUAGE_OPTIONS, DEFAULT_KEYBOARD, SHORTCUT_LABELS, USER_AGENT_PRESETS } from '../types/settings'
 import { formatFontFamily } from '../utils/formatFontFamily'
@@ -1167,7 +1166,7 @@ async function onToggleSystemTitleBar(v: boolean) {
   } catch {
     return
   }
-  Quit()
+  await RelaunchApp()
 }
 </script>
 

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -311,6 +311,8 @@ export function RedisZSetRemove(arg1:string,arg2:string,arg3:Array<string>):Prom
 
 export function RegisterSessionForPanel(arg1:string,arg2:string):Promise<void>;
 
+export function RelaunchApp():Promise<void>;
+
 export function RemoveTempFile(arg1:string):Promise<void>;
 
 export function SaveAIConfig(arg1:store.AIConfig):Promise<void>;

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -606,6 +606,10 @@ export function RegisterSessionForPanel(arg1, arg2) {
   return window['go']['main']['App']['RegisterSessionForPanel'](arg1, arg2);
 }
 
+export function RelaunchApp() {
+  return window['go']['main']['App']['RelaunchApp']();
+}
+
 export function RemoveTempFile(arg1) {
   return window['go']['main']['App']['RemoveTempFile'](arg1);
 }

--- a/relaunch.go
+++ b/relaunch.go
@@ -1,0 +1,21 @@
+//go:build !darwin
+
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+// relaunchProcess spawns a fresh, detached copy of the current executable.
+// On Windows/Linux the binary path from os.Executable() is directly runnable.
+func (a *App) relaunchProcess() error {
+	exe, err := os.Executable()
+	if err != nil {
+		return err
+	}
+	cmd := exec.Command(exe)
+	cmd.Dir = filepath.Dir(exe)
+	return cmd.Start()
+}

--- a/relaunch_darwin.go
+++ b/relaunch_darwin.go
@@ -1,0 +1,27 @@
+//go:build darwin
+
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// relaunchProcess spawns a fresh copy of the app. On macOS the executable lives
+// inside a .app bundle (.../Foo.app/Contents/MacOS/Foo); re-exec'ing that path
+// bypasses LaunchServices, so walk up to the bundle and use `open -n` instead.
+// Falls back to a raw re-exec when not running from a bundle (e.g. `wails dev`).
+func (a *App) relaunchProcess() error {
+	exe, err := os.Executable()
+	if err != nil {
+		return err
+	}
+	// .../Foo.app/Contents/MacOS/Foo -> .../Foo.app
+	bundle := filepath.Dir(filepath.Dir(filepath.Dir(exe)))
+	if strings.HasSuffix(bundle, ".app") {
+		return exec.Command("open", "-n", bundle).Start()
+	}
+	return exec.Command(exe).Start()
+}


### PR DESCRIPTION
## Summary / 概述

The "Use System Title Bar" toggle warns that a restart is required and offers a **Restart Now** button, but clicking it only quit the app — it never reopened. Fixed by adding a cross-platform self-relaunch.

「使用系统标题栏」开关会提示需重启并提供「立即重启」按钮,但点击后应用只关闭、不会重新打开。本次新增跨平台自重启逻辑修复该问题。

Closes #532

## Changes / 改动

- **`relaunch.go` (Windows/Linux)** — re-exec `os.Executable()` directly to spawn a fresh instance.
  直接 re-exec `os.Executable()` 拉起新实例。
- **`relaunch_darwin.go` (macOS)** — the binary lives inside a `.app` bundle, so resolve the enclosing bundle and use `open -n`; a raw re-exec bypasses LaunchServices and `open` without `-n` only focuses the still-running instance. Falls back to a raw re-exec when not bundled (`wails dev`).
  可执行文件位于 `.app` bundle 内,故解析出 bundle 用 `open -n` 拉起(直接 re-exec 会绕过 LaunchServices,`open` 不带 `-n` 只会聚焦旧实例);非 bundle 环境回退直接 re-exec。
- **`app.go`** — new bound method `RelaunchApp()`: spawn the new instance first, then `runtime.Quit()` after a short delay to minimize the two-instance overlap.
  新增绑定方法 `RelaunchApp()`:先 spawn 新实例,再延迟 `runtime.Quit()` 退出旧实例,缩小双实例重叠窗口。
- **`SettingsTab.vue`** — call `RelaunchApp()` instead of the bare `Quit()`.
  调用 `RelaunchApp()` 替代裸 `Quit()`。

## Validation / 验证

- `go build ./...` + `go vet ./...` clean; cross-compiled for darwin / windows / linux.
  Go 编译与 vet 通过;darwin/windows/linux 三平台交叉编译通过。
- `wails build` 打包 `.app` 成功,从 Finder 启动后切换标题栏开关 → 点「立即重启」,应用关闭后自动重新打开。