### PR TITLE
feat: detect Windows OpenSSH and adapt AI shell guidance and command execution

### DIFF
--- a/app.go
+++ b/app.go
@@ -1679,6 +1679,14 @@ func (a *App) CreateSession(sessionType string, config session.ConnectionConfig)
 			if spice, ok := s.(*session.SPICESession); ok {
 				payload["proxyAddr"] = spice.ProxyAddr()
 			}
+			// Attach remoteOS for SSH sessions so the AI agent can distinguish
+			// Windows OpenSSH (cmd/PowerShell) from Unix-like shells. Empty for
+			// non-Windows or undetermined servers.
+			if sshSess, ok := s.(*session.SSHSession); ok {
+				if remoteOS := sshSess.RemoteOS(); remoteOS != "" {
+					payload["remoteOS"] = remoteOS
+				}
+			}
 		}
 
 		runtime.EventsEmit(a.ctx, "session:status", payload)

--- a/backend/session/ssh_session.go
+++ b/backend/session/ssh_session.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"os"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -30,6 +31,16 @@ const (
 	// connection. Dead-connection detection is NOT done here — see readLoop
 	// (EOF) and the OS-level TCP keepalive set in Connect.
 	sshKeepAliveInterval = 90 * time.Second
+
+	// Windows OpenSSH announces itself with a "for_Windows" marker in its
+	// SSH identification string (e.g. "SSH-2.0-OpenSSH_for_Windows_9.5"),
+	// unlike Linux/BSD OpenSSH ("SSH-2.0-OpenSSH_9.9p1"). We match on the
+	// marker to detect the remote OS at handshake time with zero extra
+	// round-trips.
+	windowsOpenSSHMarker = "for_Windows"
+
+	// RemoteOS value reported to the frontend when the marker matches.
+	remoteOSWindowsOpenSSH = "windows-openssh"
 )
 
 type SSHSession struct {
@@ -55,6 +66,11 @@ type SSHSession struct {
 	// Disconnect diagnostics (see readLoop / disconnect logs).
 	lastRecv atomic.Value // []byte: tail of most recent server output (diagnostics)
 	lastSent atomic.Value // []byte: most recent input sent to server (diagnostics)
+
+	// remoteOS records the detected remote operating system ("windows-openssh"
+	// for Microsoft's OpenSSH for Windows, "" otherwise). Set once during
+	// Connect from the server identification string.
+	remoteOS string
 }
 
 func NewSSHSession(id string) *SSHSession {
@@ -66,6 +82,13 @@ func NewSSHSession(id string) *SSHSession {
 		},
 		quit: make(chan struct{}),
 	}
+}
+
+// RemoteOS returns the detected remote operating system. For Microsoft's
+// OpenSSH for Windows this is "windows-openssh"; otherwise it is empty
+// (undetermined). Read-only and set once during Connect.
+func (s *SSHSession) RemoteOS() string {
+	return s.remoteOS
 }
 
 func shouldPromptForSSHPassword(config ConnectionConfig) bool {
@@ -205,6 +228,14 @@ func (s *SSHSession) Connect(config ConnectionConfig) error {
 	if err != nil {
 		s.setStatus(StatusError)
 		return err
+	}
+
+	// Detect Windows OpenSSH from the server identification string exchanged
+	// during the handshake. This is available before any auth/shell and needs
+	// no extra round-trip; the marker "for_Windows" only appears in Microsoft's
+	// OpenSSH fork.
+	if strings.Contains(string(client.ServerVersion()), windowsOpenSSHMarker) {
+		s.remoteOS = remoteOSWindowsOpenSSH
 	}
 
 	session, err := client.NewSession()

--- a/frontend/src/services/agent.ts
+++ b/frontend/src/services/agent.ts
@@ -4,6 +4,7 @@ import { useAIStore } from '../stores/aiStore'
 import { useSettingsStore } from '../stores/settingsStore'
 import { useTabStore } from '../stores/tabStore'
 import { usePanelStore } from '../stores/panelStore'
+import { useSessionStore } from '../stores/sessionStore'
 import { useSkillStore } from '../stores/skillStore'
 import { GetSkillFile, ListSkillFiles } from '../../wailsjs/go/main/App'
 import { EventsOn } from '../../wailsjs/runtime'
@@ -260,7 +261,10 @@ function getShellName(path?: string): string {
  * Shell-specific suffix: appended to system rules dynamically (NOT cached).
  * Lightweight enough that it doesn't significantly impact cache efficiency.
  */
-function getShellGuidance(shellPath?: string, isWindowsShell?: boolean): string {
+function getShellGuidance(shellPath?: string, isWindowsShell?: boolean, isWindowsOpenSSH?: boolean): string {
+  if (isWindowsOpenSSH) {
+    return '\n\nThe active terminal is a Windows OpenSSH remote. Its shell could be CMD or PowerShell — determine which first (e.g. run `echo %COMSPEC%` / `ver` for CMD, or `$PSVersionTable` for PowerShell), then use the matching syntax: CMD (dir, type, cd, wmic) or PowerShell (Get-ChildItem, Get-Content, Set-Location).'
+  }
   if (isWindowsShell) {
     const isCmd = shellPath?.toLowerCase().includes('cmd')
     return isCmd
@@ -268,6 +272,16 @@ function getShellGuidance(shellPath?: string, isWindowsShell?: boolean): string 
       : '\n\nThe active terminal is Windows PowerShell. Use cmdlets like Get-ChildItem, Set-Location, Get-Content, etc.'
   }
   return '\n\nThe active terminal is a Unix-like shell. Use standard Unix syntax (ls, cat, grep, find, etc.).'
+}
+
+/**
+ * Whether the given panel is a Windows OpenSSH remote, as detected by the
+ * backend from the SSH server identification string and reported via the
+ * session:status event. Only meaningful once the connection is established.
+ */
+function isWindowsOpenSSHPanel(p: { sessionId: string | null } | undefined): boolean {
+  if (!p?.sessionId) return false
+  return useSessionStore().getRemoteOS(p.sessionId) === 'windows-openssh'
 }
 
 /**
@@ -308,7 +322,7 @@ function buildDynamicContext(): string {
     const shellPath = p.config?.shellPath
     const shellName = shellPath
       ? getShellName(shellPath)
-      : (p.type === 'ssh' ? 'SSH (Unix-like)' : 'Unknown')
+      : (p.type === 'ssh' ? (isWindowsOpenSSHPanel(p) ? 'SSH (Windows OpenSSH)' : 'SSH (Unix-like)') : 'Unknown')
 
     const displayName = titleCounts.get(p.title)! > 1
       ? `${p.title} (id: ${p.id})`
@@ -353,7 +367,8 @@ function buildSystemPrompt(): string {
     shellPath.toLowerCase().includes('pwsh') ||
     shellPath.toLowerCase().includes('cmd')
   )
-  return store.systemPrompt + getShellGuidance(shellPath, isWindowsShell) + buildSkillIndex()
+  const isWindowsOpenSSH = isWindowsOpenSSHPanel(activePanel)
+  return store.systemPrompt + getShellGuidance(shellPath, isWindowsShell, isWindowsOpenSSH) + buildSkillIndex()
 }
 
 /**

--- a/frontend/src/services/terminalAgent.test.ts
+++ b/frontend/src/services/terminalAgent.test.ts
@@ -62,6 +62,13 @@ vi.mock('../stores/tabStore', () => ({
 vi.mock('../stores/panelStore', () => ({
   usePanelStore: vi.fn(() => mockPanelStore),
 }))
+const mockGetRemoteOS = vi.fn().mockReturnValue(undefined)
+const mockSessionStore = {
+  getRemoteOS: mockGetRemoteOS,
+}
+vi.mock('../stores/sessionStore', () => ({
+  useSessionStore: vi.fn(() => mockSessionStore),
+}))
 
 // ---- import after mocks ----
 import { watchOutput, executeCommand, truncateOutput } from './terminalAgent'
@@ -315,6 +322,7 @@ describe('executeCommand', () => {
     vi.mocked(mockGetPanel).mockReturnValue(mockPanel)
     vi.mocked(mockGetAILockedPanel).mockReturnValue(null)
     vi.mocked(mockGetAILockedPanels).mockReturnValue([])
+    vi.mocked(mockGetRemoteOS).mockReturnValue(undefined)
     mockActiveTab.type = 'terminal'
     mockActiveTab.panelId = 'panel-1'
   })
@@ -355,6 +363,29 @@ describe('executeCommand', () => {
     expect(result.exitCode).toBe(0)
     expect(result.timedOut).toBe(false)
     expect(typeof result.output).toBe('string')
+
+    restore()
+  }, 10000)
+
+  it('sends CR newline (not LF) and no leading space for Windows OpenSSH', async () => {
+    vi.mocked(mockGetRemoteOS).mockReturnValue('windows-openssh')
+    const restore = withMockedTime()
+
+    let capturedCallback: ((payload: { id: string; data: string }) => void) | null = null
+    vi.mocked(EventsOn).mockImplementation((_eventName, callback) => {
+      capturedCallback = callback
+      return () => {}
+    })
+
+    const cmdPromise = executeCommand('dir')
+
+    expect(mockSessionWrite).toHaveBeenCalledOnce()
+    const writtenArg = mockSessionWrite.mock.calls[0][1] as string
+    expect(writtenArg).toBe('dir\r') // CR terminator, no leading space
+
+    await Promise.resolve()
+    capturedCallback!(fakeData('test-session-id', `${PROMPT} dir\r\n${PROMPT} `))
+    await cmdPromise
 
     restore()
   }, 10000)

--- a/frontend/src/services/terminalAgent.ts
+++ b/frontend/src/services/terminalAgent.ts
@@ -3,6 +3,7 @@ import { SessionWrite } from '../../wailsjs/go/main/App'
 import { getManagedTerminal } from '../services/terminalManager'
 import { useTabStore } from '../stores/tabStore'
 import { usePanelStore } from '../stores/panelStore'
+import { useSessionStore } from '../stores/sessionStore'
 import { watch } from 'vue'
 
 // F-317: maintain a title→panelId index for O(1) lookups in
@@ -214,7 +215,7 @@ export function truncateOutput(
   return `${head}\n\n─────── [截断: 共 ${total} 行, 已省略 ${omitted} 行] ────────\n调整 head_lines / tail_lines 参数可查看更多内容。\n\n${tail}`
 }
 
-function resolveActiveSession(panelTitle?: string): { sessionId: string; shellPath?: string } {
+function resolveActiveSession(panelTitle?: string): { sessionId: string; shellPath?: string; remoteOS?: string } {
   const tabStore = useTabStore()
   const panelStore = usePanelStore()
 
@@ -275,10 +276,21 @@ function resolveActiveSession(panelTitle?: string): { sessionId: string; shellPa
     }
   }
 
-  return { sessionId: panel.sessionId, shellPath: panel.config?.shellPath }
+  const sessionId = panel.sessionId
+  return {
+    sessionId,
+    shellPath: panel.config?.shellPath,
+    remoteOS: useSessionStore().getRemoteOS(sessionId),
+  }
 }
 
-function getShellNewline(shellPath?: string): string {
+function getShellNewline(shellPath?: string, remoteOS?: string): string {
+  // Windows OpenSSH (cmd/PowerShell via ConPTY): the line terminator must be
+  // CR — a lone LF is not accepted as Enter, so the command is echoed but never
+  // executed. CR is what the Enter key actually emits in the terminal.
+  if (remoteOS === 'windows-openssh') {
+    return '\r'
+  }
   const lowerShell = (shellPath || '').toLowerCase()
   if (lowerShell.includes('powershell') || lowerShell.includes('pwsh')) {
     return '\r'
@@ -315,10 +327,10 @@ export async function executeCommand(
   shouldCancel?: () => boolean,
   panelTitle?: string
 ): Promise<ExecuteResult> {
-  const { sessionId, shellPath } = resolveActiveSession(panelTitle)
+  const { sessionId, shellPath, remoteOS } = resolveActiveSession(panelTitle)
   const promptLine = capturePromptLine(sessionId)
-  const fullCommand = buildCommand(command, shellPath)
-  const newline = getShellNewline(shellPath)
+  const fullCommand = buildCommand(command, shellPath, remoteOS)
+  const newline = getShellNewline(shellPath, remoteOS)
 
   await SessionWrite(sessionId, fullCommand + newline)
 
@@ -361,8 +373,8 @@ export interface StartResult {
 }
 
 export async function startCommand(command: string, panelTitle?: string): Promise<StartResult> {
-  const { sessionId, shellPath } = resolveActiveSession(panelTitle)
-  const newline = getShellNewline(shellPath)
+  const { sessionId, shellPath, remoteOS } = resolveActiveSession(panelTitle)
+  const newline = getShellNewline(shellPath, remoteOS)
 
   await SessionWrite(sessionId, command + newline)
 
@@ -472,7 +484,7 @@ export async function sendTerminalKey(
   sendEnter: boolean = true,
   panelTitle?: string
 ): Promise<SendKeyResult> {
-  const { sessionId, shellPath } = resolveActiveSession(panelTitle)
+  const { sessionId, shellPath, remoteOS } = resolveActiveSession(panelTitle)
 
   let data: string
   if (control) {
@@ -481,7 +493,7 @@ export async function sendTerminalKey(
     } else if (control === 'ctrl_d') {
       data = '\x04'
     } else if (control === 'enter') {
-      data = '\n'
+      data = remoteOS === 'windows-openssh' ? '\r' : '\n'
     } else {
       data = ''
     }
@@ -493,7 +505,7 @@ export async function sendTerminalKey(
 
   // Append shell-appropriate newline when send_enter is true and input was provided
   if (sendEnter && !control && input !== undefined && input !== '') {
-    data += getShellNewline(shellPath)
+    data += getShellNewline(shellPath, remoteOS)
   }
 
   await SessionWrite(sessionId, data)
@@ -522,9 +534,9 @@ export async function sendTerminalKey(
 // (see watchOutput). This keeps the terminal clean and, for POSIX shells,
 // avoids corrupting multi-line input such as here-documents. A single leading
 // space keeps the command out of shell history (HISTCONTROL=ignorespace).
-function buildCommand(command: string, shellPath?: string): string {
+function buildCommand(command: string, shellPath?: string, remoteOS?: string): string {
   const lower = (shellPath || '').toLowerCase()
-  if (lower.includes('powershell') || lower.includes('pwsh') || lower.includes('cmd')) {
+  if (remoteOS === 'windows-openssh' || lower.includes('powershell') || lower.includes('pwsh') || lower.includes('cmd')) {
     return command
   }
   // bash / sh / zsh / fish

--- a/frontend/src/stores/sessionStore.ts
+++ b/frontend/src/stores/sessionStore.ts
@@ -6,6 +6,9 @@ import type { SessionStatus } from '../types/session'
 interface SessionData {
   id: string
   status: SessionStatus
+  // Detected remote OS (e.g. "windows-openssh") reported by the backend on
+  // connect. Empty when unknown or not applicable.
+  remoteOS?: string
   data: string[]
   // Monotonically increasing count of chunks ever appended to this session.
   // Unlike data.length, it is NOT reset when `data` is trimmed from the front,
@@ -71,13 +74,16 @@ let unsubSessionStatus: (() => void) | null = null
 let unsubSessionData: (() => void) | null = null
 
 // Register event listeners once at module level
-unsubSessionStatus = EventsOn('session:status', (payload: { id: string; status: SessionStatus }) => {
+unsubSessionStatus = EventsOn('session:status', (payload: { id: string; status: SessionStatus; remoteOS?: string }) => {
   let s = sessionState.sessions.get(payload.id)
   if (!s) {
     s = { id: payload.id, status: 'connecting', data: [], seq: 0, bytes: 0 }
     sessionState.sessions.set(payload.id, s)
   }
   s.status = payload.status
+  if (payload.remoteOS !== undefined) {
+    s.remoteOS = payload.remoteOS
+  }
 })
 
 unsubSessionData = EventsOn('session:data', (payload: { id: string; data: string }) => {
@@ -119,6 +125,11 @@ export const useSessionStore = defineStore('session', () => {
   function getStatus(id: string): SessionStatus {
     const s = sessionState.sessions.get(id)
     return s ? s.status : 'disconnected'
+  }
+
+  function getRemoteOS(id: string): string | undefined {
+    const s = sessionState.sessions.get(id)
+    return s ? s.remoteOS : undefined
   }
 
   function appendData(id: string, chunk: string) {
@@ -195,6 +206,7 @@ export const useSessionStore = defineStore('session', () => {
     initSession,
     updateStatus,
     getStatus,
+    getRemoteOS,
     appendData,
     getData,
     getChunkCount,


### PR DESCRIPTION
## Summary

Fix the AI agent misidentifying SSH connections to Windows OpenSSH as Unix-like. It generated Linux commands (`ls`/`cat`/`grep`) and sent LF as the command terminator — both of which fail on Windows cmd/PowerShell.

## Root cause

Shell type was inferred solely from `config.shellPath`, which is always empty for SSH connections, so every SSH session was treated as Unix-like.

## Changes

- **Backend** — capture the SSH server identification string on connect and detect Microsoft's OpenSSH for Windows via its `for_Windows` marker (e.g. `SSH-2.0-OpenSSH_for_Windows_9.5`), exposing it as `remoteOS` in the `session:status` event.
- **Frontend (agent)** — when the target panel is Windows OpenSSH, instruct the AI to probe for cmd vs PowerShell instead of assuming Unix syntax.
- **Frontend (execution)** — send `\r` (CR) instead of `\n` (LF) as the command terminator for Windows OpenSSH, since ConPTY does not execute on a lone LF.

## Issues

- Closes #462 — AI could not execute commands on Windows OpenSSH.
- Closes #520 — the AI no longer misidentifies Windows environments; automatic detection resolves the root cause.

---

## 概述

修复 AI 将 Windows OpenSSH 的 SSH 连接误判为 Unix 环境的问题。此前 AI 会生成 Linux 命令（`ls`/`cat`/`grep`），并以 LF 作为命令结束符，在 Windows cmd/PowerShell 上均无法正常执行。

## 根因

shell 类型此前仅由 `config.shellPath` 推断，而 SSH 连接的该字段恒为空，导致所有 SSH 会话都被当作 Unix 处理。

## 改动

- **后端** — 连接时读取 SSH 服务器版本串，通过 `for_Windows` 标记识别微软 OpenSSH for Windows，并将其作为 `remoteOS` 随 `session:status` 事件上报。
- **前端（agent）** — 目标面板为 Windows OpenSSH 时，引导 AI 先探测 cmd 还是 PowerShell，而非默认 Unix 语法。
- **前端（执行）** — Windows OpenSSH 的命令结束符由 `\n`（LF）改为 `\r`（CR），因为 ConPTY 不会对单独的 LF 触发执行。

## 关联 issue

- Closes #462 — 连接 Windows OpenSSH 时 AI 无法执行命令。
- Closes #520 — AI 不再误判 Windows 环境，自动检测已解决根因。
