### PR TITLE
fix: sync from resolved data dir and reload skills/commands on first run

### DIFF
--- a/app.go
+++ b/app.go
@@ -261,8 +261,10 @@ func (a *App) initStores(dataDir string, upgrade bool) {
 	// connection + settings stores).
 	a.initCredentials(dataDir, upgrade)
 
-	// Sync service (uses its own system dir; independent of dataDir).
-	syncSvc, err := sync.NewSyncService()
+	// Sync service: sync metadata (sync-config.json + local repo clone) lives
+	// in the system user-config dir; the config files it encrypts/decrypts are
+	// read from dataDir.
+	syncSvc, err := sync.NewSyncService(dataDir)
 	if err != nil {
 		log.Writef("Failed to create sync service: %v", err)
 		a.sendStartupErr(fmt.Errorf("sync service: %w", err))

--- a/backend/sync/sync_service.go
+++ b/backend/sync/sync_service.go
@@ -15,7 +15,14 @@ import (
 var ErrWrongSyncPassword = errors.New("WRONG_SYNC_PASSWORD")
 
 type SyncService struct {
-	configDir   string
+	// configDir holds sync *metadata* — sync-config.json and the local
+	// sync-repo clone. It is fixed to the OS user-config dir and is
+	// independent of the migratable data directory.
+	configDir string
+	// dataDir is the resolved config data directory whose config files
+	// (connections.json, settings.json, …) are encrypted to / decrypted
+	// from the sync repo.
+	dataDir     string
 	repoPath    string
 	keychain    *Keychain
 	configStore *SyncConfigStore
@@ -40,21 +47,22 @@ type ConflictInfo struct {
 	RemoteTime time.Time `json:"remoteTime"`
 }
 
-func NewSyncService() (*SyncService, error) {
-	configDir, err := os.UserConfigDir()
+func NewSyncService(dataDir string) (*SyncService, error) {
+	cfgDir, err := os.UserConfigDir()
 	if err != nil {
 		return nil, err
 	}
-	appDir := filepath.Join(configDir, "uniTerm")
-	if err := os.MkdirAll(appDir, 0755); err != nil {
+	metaDir := filepath.Join(cfgDir, "uniTerm")
+	if err := os.MkdirAll(metaDir, 0755); err != nil {
 		return nil, err
 	}
 
 	s := &SyncService{
-		configDir:   appDir,
-		repoPath:    filepath.Join(appDir, "sync-repo"),
+		configDir:   metaDir,
+		dataDir:     dataDir,
+		repoPath:    filepath.Join(metaDir, "sync-repo"),
 		keychain:    NewKeychain(),
-		configStore: NewSyncConfigStore(appDir),
+		configStore: NewSyncConfigStore(metaDir),
 		ready:       make(chan struct{}),
 	}
 	s.readyOnce.Do(func() { close(s.ready) })
@@ -71,7 +79,7 @@ func NewSyncService() (*SyncService, error) {
 // Callers should `Ready()` (with a short timeout) before invoking
 // service methods; otherwise methods may fail with
 // ErrSyncNotInitialized until init completes.
-func NewSyncServiceAsync() (*SyncService, context.Context) {
+func NewSyncServiceAsync(dataDir string) (*SyncService, context.Context) {
 	s := &SyncService{ready: make(chan struct{})}
 	initDone, cancel := context.WithCancel(context.Background())
 	go func() {
@@ -80,14 +88,15 @@ func NewSyncServiceAsync() (*SyncService, context.Context) {
 		if err != nil {
 			return
 		}
-		appDir := filepath.Join(cfg, "uniTerm")
-		if err := os.MkdirAll(appDir, 0755); err != nil {
+		metaDir := filepath.Join(cfg, "uniTerm")
+		if err := os.MkdirAll(metaDir, 0755); err != nil {
 			return
 		}
-		s.configDir = appDir
-		s.repoPath = filepath.Join(appDir, "sync-repo")
+		s.configDir = metaDir
+		s.dataDir = dataDir
+		s.repoPath = filepath.Join(metaDir, "sync-repo")
 		s.keychain = NewKeychain()
-		s.configStore = NewSyncConfigStore(appDir)
+		s.configStore = NewSyncConfigStore(metaDir)
 		cancel()
 	}()
 	return s, initDone
@@ -160,7 +169,7 @@ func (s *SyncService) Sync() (*SyncResult, error) {
 		return nil, cmpErr
 	}
 	if !same {
-		if err := EncryptConfigFiles(s.configDir, s.repoPath, encKey, s.keychain); err != nil {
+		if err := EncryptConfigFiles(s.dataDir, s.repoPath, encKey, s.keychain); err != nil {
 			s.updateLastSyncResult("failed", fmt.Sprintf("encrypt files: %v", err))
 			return nil, fmt.Errorf("encrypt files: %w", err)
 		}
@@ -211,7 +220,7 @@ func (s *SyncService) Sync() (*SyncResult, error) {
 			s.updateLastSyncResult("failed", fmt.Sprintf("pull: %v", err))
 			return nil, fmt.Errorf("pull: %w", err)
 		}
-		if err := DecryptConfigFiles(s.repoPath, s.configDir, encKey, s.keychain); err != nil {
+		if err := DecryptConfigFiles(s.repoPath, s.dataDir, encKey, s.keychain); err != nil {
 			s.updateLastSyncResult("failed", fmt.Sprintf("decrypt files: %v", err))
 			return nil, fmt.Errorf("decrypt files: %w", err)
 		}
@@ -262,7 +271,7 @@ func (s *SyncService) ResolveConflict(useLocal bool) (*SyncResult, error) {
 	}
 
 	if useLocal {
-		if err := EncryptConfigFiles(s.configDir, s.repoPath, encKey, s.keychain); err != nil {
+		if err := EncryptConfigFiles(s.dataDir, s.repoPath, encKey, s.keychain); err != nil {
 			return nil, fmt.Errorf("encrypt files: %w", err)
 		}
 		if _, err := repo.StageAndCommit(commitMsg("uniTerm config sync (resolve conflict)")); err != nil {
@@ -279,7 +288,7 @@ func (s *SyncService) ResolveConflict(useLocal bool) (*SyncResult, error) {
 		return nil, fmt.Errorf("reset to remote: %w", err)
 	}
 
-	if err := DecryptConfigFiles(s.repoPath, s.configDir, encKey, s.keychain); err != nil {
+	if err := DecryptConfigFiles(s.repoPath, s.dataDir, encKey, s.keychain); err != nil {
 		return nil, fmt.Errorf("decrypt files: %w", err)
 	}
 
@@ -364,12 +373,12 @@ func (s *SyncService) ConfigureRepo(repoURL, username, token, masterPassword str
 			return nil, fmt.Errorf("decrypt remote for comparison: %w", err)
 		}
 
-		localEmpty := isConfigDirEmpty(s.configDir)
+		localEmpty := isConfigDirEmpty(s.dataDir)
 		remoteEmpty := isConfigDirEmpty(tmpDir)
 
 		if localEmpty {
 			// Local has no config — pull remote to local
-			if err := DecryptConfigFiles(s.repoPath, s.configDir, encKey, s.keychain); err != nil {
+			if err := DecryptConfigFiles(s.repoPath, s.dataDir, encKey, s.keychain); err != nil {
 				return nil, fmt.Errorf("decrypt files: %w", err)
 			}
 			cfg := SyncConfig{
@@ -386,7 +395,7 @@ func (s *SyncService) ConfigureRepo(repoURL, username, token, masterPassword str
 		}
 		if !remoteEmpty {
 			// Both have data — compare
-			same, err := compareConfigDirs(s.configDir, tmpDir, s.keychain)
+			same, err := compareConfigDirs(s.dataDir, tmpDir, s.keychain)
 			if err != nil {
 				return nil, fmt.Errorf("compare configs: %w", err)
 			}
@@ -400,7 +409,7 @@ func (s *SyncService) ConfigureRepo(repoURL, username, token, masterPassword str
 					_ = s.keychain.SetGitToken(token)
 				}
 				_ = s.configStore.Save(cfg)
-				localTime := getConfigModTime(s.configDir)
+				localTime := getConfigModTime(s.dataDir)
 				remoteTime := getConfigModTime(tmpDir)
 				s.updateLastSyncResult("conflict", "")
 				return &SyncResult{
@@ -422,7 +431,7 @@ func (s *SyncService) ConfigureRepo(repoURL, username, token, masterPassword str
 				_ = s.keychain.SetGitToken(token)
 			}
 			_ = s.configStore.Save(cfg)
-			if err := DecryptConfigFiles(s.repoPath, s.configDir, encKey, s.keychain); err != nil {
+			if err := DecryptConfigFiles(s.repoPath, s.dataDir, encKey, s.keychain); err != nil {
 				return nil, fmt.Errorf("decrypt files: %w", err)
 			}
 			s.updateLastSyncResult("success", "")
@@ -446,7 +455,7 @@ func (s *SyncService) ConfigureRepo(repoURL, username, token, masterPassword str
 	}
 
 	// Encrypt and push local config
-	if err := EncryptConfigFiles(s.configDir, s.repoPath, encKey, s.keychain); err != nil {
+	if err := EncryptConfigFiles(s.dataDir, s.repoPath, encKey, s.keychain); err != nil {
 		return nil, fmt.Errorf("encrypt files: %w", err)
 	}
 
@@ -480,7 +489,7 @@ func (s *SyncService) ConfigureRepo(repoURL, username, token, masterPassword str
 	}
 
 	// Decrypt remote files to local
-	if err := DecryptConfigFiles(s.repoPath, s.configDir, encKey, s.keychain); err != nil {
+	if err := DecryptConfigFiles(s.repoPath, s.dataDir, encKey, s.keychain); err != nil {
 		return nil, fmt.Errorf("decrypt files: %w", err)
 	}
 
@@ -832,7 +841,7 @@ func (s *SyncService) compareLocalWithRepo(encKey []byte) (bool, error) {
 	if err := DecryptConfigFiles(s.repoPath, tmpDir, encKey, nil); err != nil {
 		return false, fmt.Errorf("decrypt remote: %w", err)
 	}
-	return compareConfigDirs(s.configDir, tmpDir, s.keychain)
+	return compareConfigDirs(s.dataDir, tmpDir, s.keychain)
 }
 
 // repoHasFiles returns true if the repo directory contains encrypted config files.

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -193,6 +193,8 @@ import { useSessionStore } from './stores/sessionStore'
 import { useAIStore } from './stores/aiStore'
 import { useSettingsStore } from './stores/settingsStore'
 import { useQuickCommandStore } from './stores/quickCommandStore'
+import { useSkillStore } from './stores/skillStore'
+import { useCommandStore } from './stores/commandStore'
 import { useTunnelStore } from './stores/tunnelStore'
 import { useLocalStateStore } from './stores/localStateStore'
 import { useContainerStore } from './stores/containerStore'
@@ -306,6 +308,8 @@ function onDataDirDone(restart: boolean) {
   connectionStore.load()
   settingsStore.reload()
   useQuickCommandStore().load()
+  useSkillStore().reload()
+  useCommandStore().reload()
   tunnelStore.load()
   resolveCredentialDialog()
 }


### PR DESCRIPTION
## Summary

Two regressions from the configurable data directory feature are fixed:

### 1. Cloud sync encrypted the wrong directory

`SyncService` hardcoded `os.UserConfigDir()/uniTerm` as its config source, independent of the resolved (possibly custom) data directory. After migrating config to a custom directory, sync read the now-empty default directory and pushed empty `{}` config to the remote, wiping the cloud copy.

`NewSyncService`/`NewSyncServiceAsync` now take the resolved `dataDir` and encrypt/decrypt from it, while sync metadata (`sync-config.json` + the local `sync-repo` clone) stays in the system user-config dir.

### 2. Empty skill/command lists after selecting a data dir on first run

On first run the AI sidebar's `onMounted` calls `skillStore.load()`/`commandStore.load()` before the backend stores exist, caching empty results (`loaded = true`). After selecting the data dir, `onDataDirDone` reloaded connections/settings/quick-commands/tunnels but not skills/commands, so those lists stayed empty until restart.

Added `useSkillStore().reload()` and `useCommandStore().reload()` to `onDataDirDone`.

---

## 摘要

修复了「可配置数据目录」功能引入的两个回归：

### 1. 云同步加密了错误的目录

`SyncService` 硬编码了 `os.UserConfigDir()/uniTerm` 作为配置来源，独立于解析后的（可能是自定义的）数据目录。把配置迁移到自定义目录后，同步读取了已清空的默认目录，把空 `{}` 配置推送到了云端，覆盖掉了云端已有的配置。

`NewSyncService`/`NewSyncServiceAsync` 现在接收解析后的 `dataDir` 并从它加密/解密；同步元数据（`sync-config.json` + 本地 `sync-repo` 克隆）仍保留在系统 user-config 目录。

### 2. 首次启动选择目录后 skill/command 列表为空

首次启动时 AI 侧边栏的 `onMounted` 在后端 store 建立之前就调用了 `skillStore.load()`/`commandStore.load()`，缓存了空结果（`loaded = true`）。选择数据目录后，`onDataDirDone` 只 reload 了 connections/settings/quick-commands/tunnels，漏了 skills/commands，导致这些列表在重启前一直为空。

在 `onDataDirDone` 中补充了 `useSkillStore().reload()` 和 `useCommandStore().reload()`。
