### PR TITLE
fix(sync): normalize encrypted fields at sync boundary and gate on credential unlock

### DIFF
--- a/app.go
+++ b/app.go
@@ -270,6 +270,9 @@ func (a *App) initStores(dataDir string, upgrade bool) {
 		a.sendStartupErr(fmt.Errorf("sync service: %w", err))
 	} else {
 		a.syncService = syncSvc
+		// Normalize enc:v1: fields at the sync boundary using the credential
+		// store (set by initCredentials above).
+		syncSvc.SetPasswordStore(a.credentialStore)
 		// Auto-sync on startup if enabled
 		if syncSvc.IsAutoSyncEnabled() {
 			go func() {

--- a/backend/credentials/store.go
+++ b/backend/credentials/store.go
@@ -161,6 +161,15 @@ func (s *Store) Key() []byte {
 	return s.key
 }
 
+// Unlocked reports whether the store holds a usable key. It is false while
+// master-password mode is not yet unlocked, keychain mode has lost its key, or
+// the store has never been set up.
+func (s *Store) Unlocked() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.key != nil
+}
+
 func (s *Store) SetKey(key []byte) {
 	s.mu.Lock()
 	s.key = key

--- a/backend/sync/crypto.go
+++ b/backend/sync/crypto.go
@@ -21,10 +21,26 @@ const encFieldPrefix = "enc:v1:"
 // from keychain or stripping it.
 func isEncryptedField(s string) bool { return strings.HasPrefix(s, encFieldPrefix) }
 
+// PasswordStore encrypts/decrypts individual in-place secret field values
+// (enc:v1:). It is the credential store. Sync uses it to normalize fields to
+// plaintext before upload (so the whole file is protected solely by the sync
+// key) and back to enc:v1: after download (so local storage stays encrypted
+// under the local credential mode's key).
+type PasswordStore interface {
+	Encrypt(plaintext string) (string, error)
+	Decrypt(encoded string) (string, error)
+	// Unlocked reports whether the credential store currently holds a usable
+	// key. When false (master-password not yet entered, keychain lost, or never
+	// set up), sync must refuse to run rather than leak or mis-carry secrets.
+	Unlocked() bool
+}
+
 // EncryptConfigFiles encrypts entire config files from srcDir into destDir.
-// kc is used to backfill passwords from keychain before encryption.
-// Pass nil for kc to skip backfill.
-func EncryptConfigFiles(srcDir, destDir string, key []byte, kc *Keychain) error {
+// kc is used to backfill legacy empty passwords from keychain before
+// encryption. ps is used to normalize enc:v1: fields to plaintext so only the
+// sync key protects the file at rest in the repo. Pass nil for either to skip
+// that step.
+func EncryptConfigFiles(srcDir, destDir string, key []byte, kc *Keychain, ps PasswordStore) error {
 	if err := os.MkdirAll(destDir, 0755); err != nil {
 		return err
 	}
@@ -32,7 +48,7 @@ func EncryptConfigFiles(srcDir, destDir string, key []byte, kc *Keychain) error 
 	if err := encryptConnectionsFile(
 		filepath.Join(srcDir, "connections.json"),
 		filepath.Join(destDir, "connections.json"),
-		key, kc,
+		key, kc, ps,
 	); err != nil {
 		return fmt.Errorf("encrypt connections: %w", err)
 	}
@@ -40,7 +56,7 @@ func EncryptConfigFiles(srcDir, destDir string, key []byte, kc *Keychain) error 
 	if err := encryptSettingsFile(
 		filepath.Join(srcDir, "settings.json"),
 		filepath.Join(destDir, "settings.json"),
-		key, kc,
+		key, kc, ps,
 	); err != nil {
 		return fmt.Errorf("encrypt settings: %w", err)
 	}
@@ -53,18 +69,18 @@ func EncryptConfigFiles(srcDir, destDir string, key []byte, kc *Keychain) error 
 		return fmt.Errorf("encrypt quick commands: %w", err)
 	}
 
-	if err := encryptGenericFile(
+	if err := encryptIdentitiesFile(
 		filepath.Join(srcDir, "identities.json"),
 		filepath.Join(destDir, "identities.json"),
-		key,
+		key, ps,
 	); err != nil {
 		return fmt.Errorf("encrypt identities: %w", err)
 	}
 
-	if err := encryptGenericFile(
+	if err := encryptProxiesFile(
 		filepath.Join(srcDir, "proxies.json"),
 		filepath.Join(destDir, "proxies.json"),
-		key,
+		key, ps,
 	); err != nil {
 		return fmt.Errorf("encrypt proxies: %w", err)
 	}
@@ -72,13 +88,13 @@ func EncryptConfigFiles(srcDir, destDir string, key []byte, kc *Keychain) error 
 	return nil
 }
 
-func encryptConnectionsFile(src, dest string, key []byte, kc *Keychain) error {
+func encryptConnectionsFile(src, dest string, key []byte, kc *Keychain, ps PasswordStore) error {
 	data, err := readJSONFile(src)
 	if err != nil {
 		return err
 	}
 
-	if kc != nil {
+	if kc != nil || ps != nil {
 		var wrapper struct {
 			Groups      []map[string]interface{} `json:"groups"`
 			Connections []map[string]interface{} `json:"connections"`
@@ -92,10 +108,16 @@ func encryptConnectionsFile(src, dest string, key []byte, kc *Keychain) error {
 			}
 			pw, _ := cm["password"].(string)
 			if pw == "" {
-				if id, ok := cm["id"].(string); ok {
+				// Legacy: password stored in keychain, not in JSON.
+				if id, ok := cm["id"].(string); ok && kc != nil {
 					if kcPw, err := kc.GetPassword(id); err == nil && kcPw != "" {
 						cm["password"] = kcPw
 					}
+				}
+			} else if isEncryptedField(pw) && ps != nil {
+				// Normalize in-place encrypted field to plaintext for upload.
+				if pt, err := ps.Decrypt(pw); err == nil {
+					cm["password"] = pt
 				}
 			}
 		}
@@ -109,13 +131,13 @@ func encryptConnectionsFile(src, dest string, key []byte, kc *Keychain) error {
 	return os.WriteFile(dest, []byte(encoded), 0600)
 }
 
-func encryptSettingsFile(src, dest string, key []byte, kc *Keychain) error {
+func encryptSettingsFile(src, dest string, key []byte, kc *Keychain, ps PasswordStore) error {
 	data, err := readJSONFile(src)
 	if err != nil {
 		return err
 	}
 
-	if kc != nil {
+	if kc != nil || ps != nil {
 		var obj map[string]interface{}
 		if err := json.Unmarshal(data, &obj); err == nil {
 			if ai, ok := obj["ai"].(map[string]interface{}); ok {
@@ -124,10 +146,15 @@ func encryptSettingsFile(src, dest string, key []byte, kc *Keychain) error {
 						if mm, ok := m.(map[string]interface{}); ok {
 							ak, _ := mm["apiKey"].(string)
 							if ak == "" {
-								if id, ok := mm["id"].(string); ok {
+								// Legacy: apiKey stored in keychain, not in JSON.
+								if id, ok := mm["id"].(string); ok && kc != nil {
 									if kcAk, err := kc.GetModelAPIKey(id); err == nil && kcAk != "" {
 										mm["apiKey"] = kcAk
 									}
+								}
+							} else if isEncryptedField(ak) && ps != nil {
+								if pt, err := ps.Decrypt(ak); err == nil {
+									mm["apiKey"] = pt
 								}
 							}
 						}
@@ -145,10 +172,75 @@ func encryptSettingsFile(src, dest string, key []byte, kc *Keychain) error {
 	return os.WriteFile(dest, []byte(encoded), 0600)
 }
 
+// encryptIdentitiesFile encrypts identities.json, normalizing any enc:v1:
+// Password field to plaintext for upload.
+func encryptIdentitiesFile(src, dest string, key []byte, ps PasswordStore) error {
+	data, err := readJSONFile(src)
+	if err != nil {
+		return err
+	}
+
+	if ps != nil {
+		var wrapper struct {
+			Identities []map[string]interface{} `json:"identities"`
+		}
+		if err := json.Unmarshal(data, &wrapper); err != nil {
+			return fmt.Errorf("parse identities: %w", err)
+		}
+		for _, im := range wrapper.Identities {
+			if pw, ok := im["password"].(string); ok && isEncryptedField(pw) {
+				if pt, err := ps.Decrypt(pw); err == nil {
+					im["password"] = pt
+				}
+			}
+		}
+		data, _ = json.MarshalIndent(wrapper, "", "  ")
+	}
+
+	encoded, err := encryptBytes(data, key)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(dest, []byte(encoded), 0600)
+}
+
+// encryptProxiesFile encrypts proxies.json, normalizing any enc:v1: pass field
+// to plaintext for upload.
+func encryptProxiesFile(src, dest string, key []byte, ps PasswordStore) error {
+	data, err := readJSONFile(src)
+	if err != nil {
+		return err
+	}
+
+	if ps != nil {
+		var wrapper struct {
+			Proxies []map[string]interface{} `json:"proxies"`
+		}
+		if err := json.Unmarshal(data, &wrapper); err != nil {
+			return fmt.Errorf("parse proxies: %w", err)
+		}
+		for _, pm := range wrapper.Proxies {
+			if pass, ok := pm["pass"].(string); ok && isEncryptedField(pass) {
+				if pt, err := ps.Decrypt(pass); err == nil {
+					pm["pass"] = pt
+				}
+			}
+		}
+		data, _ = json.MarshalIndent(wrapper, "", "  ")
+	}
+
+	encoded, err := encryptBytes(data, key)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(dest, []byte(encoded), 0600)
+}
+
 // DecryptConfigFiles decrypts config files from srcDir into destDir.
-// kc is used to write decrypted passwords to keychain and clear them from JSON.
-// Pass nil for kc to skip keychain (passwords stay in JSON).
-func DecryptConfigFiles(srcDir, destDir string, key []byte, kc *Keychain) error {
+// ps is used to re-encrypt plaintext secret fields back to enc:v1: under the
+// local credential key after download. Pass nil for ps to keep fields as
+// plaintext (e.g. temporary dirs used only for comparison).
+func DecryptConfigFiles(srcDir, destDir string, key []byte, ps PasswordStore) error {
 	if err := os.MkdirAll(destDir, 0755); err != nil {
 		return err
 	}
@@ -156,7 +248,7 @@ func DecryptConfigFiles(srcDir, destDir string, key []byte, kc *Keychain) error 
 	if err := decryptConnectionsFile(
 		filepath.Join(srcDir, "connections.json"),
 		filepath.Join(destDir, "connections.json"),
-		key, kc,
+		key, ps,
 	); err != nil {
 		return fmt.Errorf("decrypt connections: %w", err)
 	}
@@ -164,7 +256,7 @@ func DecryptConfigFiles(srcDir, destDir string, key []byte, kc *Keychain) error 
 	if err := decryptSettingsFile(
 		filepath.Join(srcDir, "settings.json"),
 		filepath.Join(destDir, "settings.json"),
-		key, kc,
+		key, ps,
 	); err != nil {
 		return fmt.Errorf("decrypt settings: %w", err)
 	}
@@ -177,18 +269,18 @@ func DecryptConfigFiles(srcDir, destDir string, key []byte, kc *Keychain) error 
 		return fmt.Errorf("decrypt quick commands: %w", err)
 	}
 
-	if err := decryptGenericFile(
+	if err := decryptIdentitiesFile(
 		filepath.Join(srcDir, "identities.json"),
 		filepath.Join(destDir, "identities.json"),
-		key,
+		key, ps,
 	); err != nil {
 		return fmt.Errorf("decrypt identities: %w", err)
 	}
 
-	if err := decryptGenericFile(
+	if err := decryptProxiesFile(
 		filepath.Join(srcDir, "proxies.json"),
 		filepath.Join(destDir, "proxies.json"),
-		key,
+		key, ps,
 	); err != nil {
 		return fmt.Errorf("decrypt proxies: %w", err)
 	}
@@ -196,7 +288,7 @@ func DecryptConfigFiles(srcDir, destDir string, key []byte, kc *Keychain) error 
 	return nil
 }
 
-func decryptConnectionsFile(src, dest string, key []byte, kc *Keychain) error {
+func decryptConnectionsFile(src, dest string, key []byte, ps PasswordStore) error {
 	data, err := os.ReadFile(src)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -210,7 +302,7 @@ func decryptConnectionsFile(src, dest string, key []byte, kc *Keychain) error {
 		return fmt.Errorf("decrypt connections: %w", err)
 	}
 
-	if kc != nil {
+	if ps != nil {
 		var wrapper struct {
 			Groups      []map[string]interface{} `json:"groups"`
 			Connections []map[string]interface{} `json:"connections"`
@@ -220,10 +312,10 @@ func decryptConnectionsFile(src, dest string, key []byte, kc *Keychain) error {
 		}
 		for _, cm := range wrapper.Connections {
 			if pw, ok := cm["password"].(string); ok && pw != "" && !isEncryptedField(pw) {
-				if id, ok := cm["id"].(string); ok {
-					_ = kc.SetPassword(id, pw)
+				// Re-encrypt plaintext under the local credential key.
+				if enc, err := ps.Encrypt(pw); err == nil {
+					cm["password"] = enc
 				}
-				cm["password"] = ""
 			}
 		}
 		plaintext, _ = json.MarshalIndent(wrapper, "", "  ")
@@ -232,7 +324,7 @@ func decryptConnectionsFile(src, dest string, key []byte, kc *Keychain) error {
 	return os.WriteFile(dest, plaintext, 0600)
 }
 
-func decryptSettingsFile(src, dest string, key []byte, kc *Keychain) error {
+func decryptSettingsFile(src, dest string, key []byte, ps PasswordStore) error {
 	data, err := os.ReadFile(src)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -246,8 +338,7 @@ func decryptSettingsFile(src, dest string, key []byte, kc *Keychain) error {
 		return fmt.Errorf("decrypt settings: %w", err)
 	}
 
-	// Extract per-model apiKeys to keychain, clear from JSON
-	if kc != nil {
+	if ps != nil {
 		var obj map[string]interface{}
 		if err := json.Unmarshal(plaintext, &obj); err == nil {
 			if ai, ok := obj["ai"].(map[string]interface{}); ok {
@@ -255,10 +346,10 @@ func decryptSettingsFile(src, dest string, key []byte, kc *Keychain) error {
 					for _, m := range models {
 						if mm, ok := m.(map[string]interface{}); ok {
 							if ak, ok := mm["apiKey"].(string); ok && ak != "" && !isEncryptedField(ak) {
-								if id, ok := mm["id"].(string); ok {
-									_ = kc.SetModelAPIKey(id, ak)
+								// Re-encrypt plaintext under the local credential key.
+								if enc, err := ps.Encrypt(ak); err == nil {
+									mm["apiKey"] = enc
 								}
-								mm["apiKey"] = ""
 							}
 						}
 					}
@@ -266,6 +357,78 @@ func decryptSettingsFile(src, dest string, key []byte, kc *Keychain) error {
 			}
 			plaintext, _ = json.MarshalIndent(obj, "", "  ")
 		}
+	}
+
+	return os.WriteFile(dest, plaintext, 0600)
+}
+
+// decryptIdentitiesFile decrypts identities.json, re-encrypting any plaintext
+// Password field back to enc:v1: under the local credential key.
+func decryptIdentitiesFile(src, dest string, key []byte, ps PasswordStore) error {
+	data, err := os.ReadFile(src)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return os.WriteFile(dest, []byte("{}"), 0600)
+		}
+		return err
+	}
+
+	plaintext, err := decryptBytes(string(data), key)
+	if err != nil {
+		return fmt.Errorf("decrypt identities: %w", err)
+	}
+
+	if ps != nil {
+		var wrapper struct {
+			Identities []map[string]interface{} `json:"identities"`
+		}
+		if err := json.Unmarshal(plaintext, &wrapper); err != nil {
+			return fmt.Errorf("parse identities: %w", err)
+		}
+		for _, im := range wrapper.Identities {
+			if pw, ok := im["password"].(string); ok && pw != "" && !isEncryptedField(pw) {
+				if enc, err := ps.Encrypt(pw); err == nil {
+					im["password"] = enc
+				}
+			}
+		}
+		plaintext, _ = json.MarshalIndent(wrapper, "", "  ")
+	}
+
+	return os.WriteFile(dest, plaintext, 0600)
+}
+
+// decryptProxiesFile decrypts proxies.json, re-encrypting any plaintext pass
+// field back to enc:v1: under the local credential key.
+func decryptProxiesFile(src, dest string, key []byte, ps PasswordStore) error {
+	data, err := os.ReadFile(src)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return os.WriteFile(dest, []byte("{}"), 0600)
+		}
+		return err
+	}
+
+	plaintext, err := decryptBytes(string(data), key)
+	if err != nil {
+		return fmt.Errorf("decrypt proxies: %w", err)
+	}
+
+	if ps != nil {
+		var wrapper struct {
+			Proxies []map[string]interface{} `json:"proxies"`
+		}
+		if err := json.Unmarshal(plaintext, &wrapper); err != nil {
+			return fmt.Errorf("parse proxies: %w", err)
+		}
+		for _, pm := range wrapper.Proxies {
+			if pass, ok := pm["pass"].(string); ok && pass != "" && !isEncryptedField(pass) {
+				if enc, err := ps.Encrypt(pass); err == nil {
+					pm["pass"] = enc
+				}
+			}
+		}
+		plaintext, _ = json.MarshalIndent(wrapper, "", "  ")
 	}
 
 	return os.WriteFile(dest, plaintext, 0600)
@@ -298,6 +461,61 @@ func decryptGenericFile(src, dest string, key []byte) error {
 		return fmt.Errorf("decrypt: %w", err)
 	}
 	return os.WriteFile(dest, plaintext, 0600)
+}
+
+// decryptFieldsInPlace decrypts any enc:v1: secret fields in a decoded config
+// object so both sides of a sync comparison are plaintext. Best-effort: on a
+// decrypt error (locked/wrong key) the field is left untouched.
+func decryptFieldsInPlace(obj map[string]interface{}, ps PasswordStore) {
+	if ps == nil {
+		return
+	}
+	if conns, ok := obj["connections"].([]interface{}); ok {
+		for _, c := range conns {
+			if cm, ok := c.(map[string]interface{}); ok {
+				if pw, ok := cm["password"].(string); ok && isEncryptedField(pw) {
+					if pt, err := ps.Decrypt(pw); err == nil {
+						cm["password"] = pt
+					}
+				}
+			}
+		}
+	}
+	if ai, ok := obj["ai"].(map[string]interface{}); ok {
+		if models, ok := ai["models"].([]interface{}); ok {
+			for _, m := range models {
+				if mm, ok := m.(map[string]interface{}); ok {
+					if ak, ok := mm["apiKey"].(string); ok && isEncryptedField(ak) {
+						if pt, err := ps.Decrypt(ak); err == nil {
+							mm["apiKey"] = pt
+						}
+					}
+				}
+			}
+		}
+	}
+	if ids, ok := obj["identities"].([]interface{}); ok {
+		for _, id := range ids {
+			if im, ok := id.(map[string]interface{}); ok {
+				if pw, ok := im["password"].(string); ok && isEncryptedField(pw) {
+					if pt, err := ps.Decrypt(pw); err == nil {
+						im["password"] = pt
+					}
+				}
+			}
+		}
+	}
+	if proxies, ok := obj["proxies"].([]interface{}); ok {
+		for _, p := range proxies {
+			if pm, ok := p.(map[string]interface{}); ok {
+				if pass, ok := pm["pass"].(string); ok && isEncryptedField(pass) {
+					if pt, err := ps.Decrypt(pass); err == nil {
+						pm["pass"] = pt
+					}
+				}
+			}
+		}
+	}
 }
 
 // encryptBytes encrypts plaintext under key, binding the ciphertext to a

--- a/backend/sync/crypto_normalization_test.go
+++ b/backend/sync/crypto_normalization_test.go
@@ -1,0 +1,147 @@
+package sync
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// fakePS is a PasswordStore that encodes "enc:v1:fake-"+pt. Its output is
+// recognized by isEncryptedField, so round-trips through the sync boundary
+// exercise the real normalization path.
+type fakePS struct{}
+
+func (fakePS) Encrypt(plaintext string) (string, error) {
+	return "enc:v1:fake-" + plaintext, nil
+}
+func (fakePS) Decrypt(encoded string) (string, error) {
+	return strings.TrimPrefix(encoded, "enc:v1:fake-"), nil
+}
+func (fakePS) Unlocked() bool { return true }
+
+// lockedPS is a PasswordStore that reports itself locked; used to assert that
+// sync refuses to run when the credential store holds no usable key.
+type lockedPS struct{}
+
+func (lockedPS) Encrypt(plaintext string) (string, error) { return "", nil }
+func (lockedPS) Decrypt(encoded string) (string, error)   { return "", nil }
+func (lockedPS) Unlocked() bool                           { return false }
+
+// TestSyncBoundaryNormalizesEncryptedFields is the regression test for the
+// enc:v1: opacity bug: in-place encrypted secret fields must be normalized to
+// plaintext on push and back to enc:v1: on pull, so the whole file is
+// protected solely by the sync key at rest in the repo.
+func TestSyncBoundaryNormalizesEncryptedFields(t *testing.T) {
+	key := make([]byte, 32)
+	srcDir := t.TempDir()
+	repoDir := t.TempDir()
+	dstDir := t.TempDir()
+
+	write := func(dir, name, content string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0600); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+
+	write(srcDir, "connections.json", `{"connections":[{"id":"c1","authType":"password","password":"enc:v1:fake-secret"}]}`)
+	write(srcDir, "identities.json", `{"identities":[{"id":"i1","password":"enc:v1:fake-idpass"}]}`)
+	write(srcDir, "proxies.json", `{"proxies":[{"id":"p1","pass":"enc:v1:fake-proxypass"}]}`)
+	write(srcDir, "settings.json", `{"ai":{"models":[{"id":"m1","apiKey":"enc:v1:fake-apikey"}]}}`)
+
+	if err := EncryptConfigFiles(srcDir, repoDir, key, nil, fakePS{}); err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+
+	// The repo copy must be plaintext (protected only by the sync key).
+	repoData, err := os.ReadFile(filepath.Join(repoDir, "connections.json"))
+	if err != nil {
+		t.Fatalf("read repo connections: %v", err)
+	}
+	repoPlain, err := decryptBytes(string(repoData), key)
+	if err != nil {
+		t.Fatalf("decrypt repo connections: %v", err)
+	}
+	var repoConn struct {
+		Connections []map[string]interface{} `json:"connections"`
+	}
+	if err := json.Unmarshal(repoPlain, &repoConn); err != nil {
+		t.Fatalf("parse repo connections: %v", err)
+	}
+	if got := repoConn.Connections[0]["password"]; got != "secret" {
+		t.Fatalf("repo password = %q, want plaintext %q", got, "secret")
+	}
+
+	// Pull must re-encrypt back to enc:v1: under the local credential key.
+	if err := DecryptConfigFiles(repoDir, dstDir, key, fakePS{}); err != nil {
+		t.Fatalf("decrypt: %v", err)
+	}
+	dstData, err := os.ReadFile(filepath.Join(dstDir, "connections.json"))
+	if err != nil {
+		t.Fatalf("read dst connections: %v", err)
+	}
+	var dstConn struct {
+		Connections []map[string]interface{} `json:"connections"`
+	}
+	if err := json.Unmarshal(dstData, &dstConn); err != nil {
+		t.Fatalf("parse dst connections: %v", err)
+	}
+	if got := dstConn.Connections[0]["password"]; got != "enc:v1:fake-secret" {
+		t.Fatalf("dst password = %q, want %q", got, "enc:v1:fake-secret")
+	}
+}
+
+// TestCompareConfigFilesNormalizesEncryptedFields verifies that the comparison
+// path decrypts local enc:v1: fields so a push whose only change is the local
+// encryption mode does not report a spurious difference (which would loop).
+func TestCompareConfigFilesNormalizesEncryptedFields(t *testing.T) {
+	dir := t.TempDir()
+	local := filepath.Join(dir, "local")
+	remote := filepath.Join(dir, "remote")
+	if err := os.MkdirAll(local, 0755); err != nil {
+		t.Fatalf("mkdir local: %v", err)
+	}
+	if err := os.MkdirAll(remote, 0755); err != nil {
+		t.Fatalf("mkdir remote: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(local, "connections.json"),
+		[]byte(`{"connections":[{"id":"c1","authType":"password","password":"enc:v1:fake-secret"}]}`), 0600); err != nil {
+		t.Fatalf("write local: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(remote, "connections.json"),
+		[]byte(`{"connections":[{"id":"c1","authType":"password","password":"secret"}]}`), 0600); err != nil {
+		t.Fatalf("write remote: %v", err)
+	}
+
+	same, err := compareConfigFiles(filepath.Join(local, "connections.json"), filepath.Join(remote, "connections.json"), nil, fakePS{})
+	if err != nil {
+		t.Fatalf("compare: %v", err)
+	}
+	if !same {
+		t.Fatalf("compareConfigFiles reported a difference when local enc:v1: decrypts to the same plaintext")
+	}
+}
+
+// TestRequireUnlocked verifies sync refuses to run when the credential store is
+// locked, but still allows a nil (unwired) or unlocked store.
+func TestRequireUnlocked(t *testing.T) {
+	s := &SyncService{}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if err := s.requireUnlocked(); err != nil {
+		t.Fatalf("nil store should be allowed, got %v", err)
+	}
+
+	s.passwordStore = fakePS{}
+	if err := s.requireUnlocked(); err != nil {
+		t.Fatalf("unlocked store should be allowed, got %v", err)
+	}
+
+	s.passwordStore = lockedPS{}
+	if err := s.requireUnlocked(); err == nil {
+		t.Fatal("locked store should be refused")
+	}
+}

--- a/backend/sync/security_test.go
+++ b/backend/sync/security_test.go
@@ -82,7 +82,7 @@ func TestCompareLocalWithRepo_WrongKeyReturnsError(t *testing.T) {
 		[]byte(`{"connections":[]}`), 0600); err != nil {
 		t.Fatalf("write src connections: %v", err)
 	}
-	if err := EncryptConfigFiles(srcDir, repoPath, realKey, nil); err != nil {
+	if err := EncryptConfigFiles(srcDir, repoPath, realKey, nil, nil); err != nil {
 		t.Fatalf("encrypt with realKey: %v", err)
 	}
 
@@ -104,7 +104,7 @@ func TestSync_WrongPasswordSetsPasswordMismatchStatus(t *testing.T) {
 		[]byte(`{"connections":[]}`), 0600); err != nil {
 		t.Fatalf("write src: %v", err)
 	}
-	if err := EncryptConfigFiles(srcDir, repoPath, realKey, nil); err != nil {
+	if err := EncryptConfigFiles(srcDir, repoPath, realKey, nil, nil); err != nil {
 		t.Fatalf("encrypt: %v", err)
 	}
 
@@ -153,7 +153,7 @@ func TestChangePassword_RewritesSaltAndReencryptsFiles(t *testing.T) {
 			t.Fatalf("write seed %s: %v", name, err)
 		}
 	}
-	if err := EncryptConfigFiles(srcDir, repoPath, oldKey, nil); err != nil {
+	if err := EncryptConfigFiles(srcDir, repoPath, oldKey, nil, nil); err != nil {
 		t.Fatalf("encrypt with oldKey: %v", err)
 	}
 	if err := WriteSaltFile(repoPath, oldSalt); err != nil {

--- a/backend/sync/sync_service.go
+++ b/backend/sync/sync_service.go
@@ -26,7 +26,12 @@ type SyncService struct {
 	repoPath    string
 	keychain    *Keychain
 	configStore *SyncConfigStore
-	mu          sync.Mutex
+	// passwordStore normalizes in-place encrypted fields (enc:v1:) to plaintext
+	// on upload and back to enc:v1: on download. It is the credential store,
+	// wired in after startup. nil until set; sync degrades to carrying fields
+	// through opaque (best-effort) when it is absent.
+	passwordStore PasswordStore
+	mu            sync.Mutex
 
 	// ready is closed by NewSyncService() once the disk-touching
 	// init (UserConfigDir → MkdirAll → NewKeychain → NewSyncConfigStore)
@@ -108,6 +113,28 @@ func (s *SyncService) Ready() <-chan struct{} {
 	return s.ready
 }
 
+// SetPasswordStore wires the credential store so sync can normalize enc:v1:
+// fields to plaintext on upload and back on download.
+func (s *SyncService) SetPasswordStore(ps PasswordStore) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.passwordStore = ps
+}
+
+// requireUnlocked refuses sync when the credential store is wired but locked.
+// A nil store means no credential store was wired (test-only path) and is not
+// an error; production always wires it via SetPasswordStore. Callers must hold
+// s.mu.
+func (s *SyncService) requireUnlocked() error {
+	if s.passwordStore == nil {
+		return nil
+	}
+	if !s.passwordStore.Unlocked() {
+		return errors.New("本地凭证库未解锁，无法同步")
+	}
+	return nil
+}
+
 // GetConfig returns the current sync configuration.
 func (s *SyncService) GetConfig() (SyncConfig, error) {
 	return s.configStore.Load()
@@ -132,6 +159,10 @@ func (s *SyncService) getToken() string {
 func (s *SyncService) Sync() (*SyncResult, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
+	if err := s.requireUnlocked(); err != nil {
+		return nil, err
+	}
 
 	config, err := s.configStore.Load()
 	if err != nil {
@@ -169,7 +200,7 @@ func (s *SyncService) Sync() (*SyncResult, error) {
 		return nil, cmpErr
 	}
 	if !same {
-		if err := EncryptConfigFiles(s.dataDir, s.repoPath, encKey, s.keychain); err != nil {
+		if err := EncryptConfigFiles(s.dataDir, s.repoPath, encKey, s.keychain, s.passwordStore); err != nil {
 			s.updateLastSyncResult("failed", fmt.Sprintf("encrypt files: %v", err))
 			return nil, fmt.Errorf("encrypt files: %w", err)
 		}
@@ -220,7 +251,7 @@ func (s *SyncService) Sync() (*SyncResult, error) {
 			s.updateLastSyncResult("failed", fmt.Sprintf("pull: %v", err))
 			return nil, fmt.Errorf("pull: %w", err)
 		}
-		if err := DecryptConfigFiles(s.repoPath, s.dataDir, encKey, s.keychain); err != nil {
+		if err := DecryptConfigFiles(s.repoPath, s.dataDir, encKey, s.passwordStore); err != nil {
 			s.updateLastSyncResult("failed", fmt.Sprintf("decrypt files: %v", err))
 			return nil, fmt.Errorf("decrypt files: %w", err)
 		}
@@ -253,6 +284,10 @@ func (s *SyncService) ResolveConflict(useLocal bool) (*SyncResult, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	if err := s.requireUnlocked(); err != nil {
+		return nil, err
+	}
+
 	config, err := s.configStore.Load()
 	if err != nil {
 		return nil, fmt.Errorf("load config: %w", err)
@@ -271,7 +306,7 @@ func (s *SyncService) ResolveConflict(useLocal bool) (*SyncResult, error) {
 	}
 
 	if useLocal {
-		if err := EncryptConfigFiles(s.dataDir, s.repoPath, encKey, s.keychain); err != nil {
+		if err := EncryptConfigFiles(s.dataDir, s.repoPath, encKey, s.keychain, s.passwordStore); err != nil {
 			return nil, fmt.Errorf("encrypt files: %w", err)
 		}
 		if _, err := repo.StageAndCommit(commitMsg("uniTerm config sync (resolve conflict)")); err != nil {
@@ -288,7 +323,7 @@ func (s *SyncService) ResolveConflict(useLocal bool) (*SyncResult, error) {
 		return nil, fmt.Errorf("reset to remote: %w", err)
 	}
 
-	if err := DecryptConfigFiles(s.repoPath, s.dataDir, encKey, s.keychain); err != nil {
+	if err := DecryptConfigFiles(s.repoPath, s.dataDir, encKey, s.passwordStore); err != nil {
 		return nil, fmt.Errorf("decrypt files: %w", err)
 	}
 
@@ -339,6 +374,10 @@ func (s *SyncService) ConfigureRepo(repoURL, username, token, masterPassword str
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	if err := s.requireUnlocked(); err != nil {
+		return nil, err
+	}
+
 	repo, err := CloneOrOpen(s.repoPath, repoURL, "main", username, token)
 	if err != nil {
 		return nil, fmt.Errorf("clone/open repo: %w", err)
@@ -378,7 +417,7 @@ func (s *SyncService) ConfigureRepo(repoURL, username, token, masterPassword str
 
 		if localEmpty {
 			// Local has no config — pull remote to local
-			if err := DecryptConfigFiles(s.repoPath, s.dataDir, encKey, s.keychain); err != nil {
+			if err := DecryptConfigFiles(s.repoPath, s.dataDir, encKey, s.passwordStore); err != nil {
 				return nil, fmt.Errorf("decrypt files: %w", err)
 			}
 			cfg := SyncConfig{
@@ -395,7 +434,7 @@ func (s *SyncService) ConfigureRepo(repoURL, username, token, masterPassword str
 		}
 		if !remoteEmpty {
 			// Both have data — compare
-			same, err := compareConfigDirs(s.dataDir, tmpDir, s.keychain)
+			same, err := compareConfigDirs(s.dataDir, tmpDir, s.keychain, s.passwordStore)
 			if err != nil {
 				return nil, fmt.Errorf("compare configs: %w", err)
 			}
@@ -431,7 +470,7 @@ func (s *SyncService) ConfigureRepo(repoURL, username, token, masterPassword str
 				_ = s.keychain.SetGitToken(token)
 			}
 			_ = s.configStore.Save(cfg)
-			if err := DecryptConfigFiles(s.repoPath, s.dataDir, encKey, s.keychain); err != nil {
+			if err := DecryptConfigFiles(s.repoPath, s.dataDir, encKey, s.passwordStore); err != nil {
 				return nil, fmt.Errorf("decrypt files: %w", err)
 			}
 			s.updateLastSyncResult("success", "")
@@ -455,7 +494,7 @@ func (s *SyncService) ConfigureRepo(repoURL, username, token, masterPassword str
 	}
 
 	// Encrypt and push local config
-	if err := EncryptConfigFiles(s.dataDir, s.repoPath, encKey, s.keychain); err != nil {
+	if err := EncryptConfigFiles(s.dataDir, s.repoPath, encKey, s.keychain, s.passwordStore); err != nil {
 		return nil, fmt.Errorf("encrypt files: %w", err)
 	}
 
@@ -489,7 +528,7 @@ func (s *SyncService) ConfigureRepo(repoURL, username, token, masterPassword str
 	}
 
 	// Decrypt remote files to local
-	if err := DecryptConfigFiles(s.repoPath, s.dataDir, encKey, s.keychain); err != nil {
+	if err := DecryptConfigFiles(s.repoPath, s.dataDir, encKey, s.passwordStore); err != nil {
 		return nil, fmt.Errorf("decrypt files: %w", err)
 	}
 
@@ -544,10 +583,12 @@ func isConfigDirEmpty(dir string) bool {
 
 // compareConfigDirs compares two decrypted config directories.
 // localDir is the local config directory; remoteDir is the decrypted remote copy.
-// Passwords are backfilled from keychain on the local side before comparison.
-func compareConfigDirs(localDir, remoteDir string, kc *Keychain) (bool, error) {
+// Legacy empty passwords are backfilled from keychain and enc:v1: fields are
+// normalized to plaintext on the local side before comparison so both sides
+// are comparable.
+func compareConfigDirs(localDir, remoteDir string, kc *Keychain, ps PasswordStore) (bool, error) {
 	for _, name := range []string{"connections.json", "settings.json", "quickCommands.json", "identities.json", "proxies.json"} {
-		same, err := compareConfigFiles(filepath.Join(localDir, name), filepath.Join(remoteDir, name), kc)
+		same, err := compareConfigFiles(filepath.Join(localDir, name), filepath.Join(remoteDir, name), kc, ps)
 		if err != nil {
 			return false, err
 		}
@@ -558,11 +599,12 @@ func compareConfigDirs(localDir, remoteDir string, kc *Keychain) (bool, error) {
 	return true, nil
 }
 
-// compareConfigFiles compares two config files after backfilling local passwords from keychain.
-// JSON is re-marshaled via json.MarshalIndent so Go's encoding/json sorts map
-// keys deterministically before byte comparison — prevents spurious diffs from
-// non-deterministic key ordering in the underlying JSON.
-func compareConfigFiles(localPath, remotePath string, kc *Keychain) (bool, error) {
+// compareConfigFiles compares two config files after normalizing the local side
+// (backfill legacy keychain passwords, decrypt enc:v1: fields) so both sides
+// are plaintext. JSON is re-marshaled via json.MarshalIndent so Go's
+// encoding/json sorts map keys deterministically before byte comparison —
+// prevents spurious diffs from non-deterministic key ordering.
+func compareConfigFiles(localPath, remotePath string, kc *Keychain, ps PasswordStore) (bool, error) {
 	localData, err := os.ReadFile(localPath)
 	if err != nil {
 		localData = []byte("{}")
@@ -580,8 +622,10 @@ func compareConfigFiles(localPath, remotePath string, kc *Keychain) (bool, error
 		return false, fmt.Errorf("parse remote %s: %w", remotePath, err)
 	}
 
-	// Backfill passwords from keychain on the local side so both sides are comparable
+	// Backfill legacy empty passwords from keychain, then decrypt any enc:v1:
+	// fields to plaintext, so the local side is comparable to the remote copy.
 	backfillFromKeychain(localObj, kc)
+	decryptFieldsInPlace(localObj, ps)
 
 	localNorm, err := json.MarshalIndent(localObj, "", "  ")
 	if err != nil {
@@ -841,7 +885,7 @@ func (s *SyncService) compareLocalWithRepo(encKey []byte) (bool, error) {
 	if err := DecryptConfigFiles(s.repoPath, tmpDir, encKey, nil); err != nil {
 		return false, fmt.Errorf("decrypt remote: %w", err)
 	}
-	return compareConfigDirs(s.dataDir, tmpDir, s.keychain)
+	return compareConfigDirs(s.dataDir, tmpDir, s.keychain, s.passwordStore)
 }
 
 // repoHasFiles returns true if the repo directory contains encrypted config files.


### PR DESCRIPTION
## Summary

Fixes a regression where sync carried in-place encrypted secret fields (`enc:v1:`) through as opaque bytes. When config was synced to a machine using a different credential mode, the `enc:v1:` values could not be decrypted locally, so every store failed to load and the app showed empty data.

Changes:
- Normalize secret fields (connections `password`, settings `ai.models[].apiKey`, identities `password`, proxies `pass`) to plaintext on push, and back to `enc:v1:` on pull, using the credential store injected as a `PasswordStore`.
- Move identities/proxies out of generic whole-file handling into field-level normalization.
- Decrypt local `enc:v1:` fields before the sync comparison so a change in encryption mode alone does not trigger a spurious diff (which would loop).
- Refuse sync when the credential store is locked (holds no usable key), instead of silently carrying secrets through opaque.

Tests:
- Added regression tests for push/pull round-trip normalization and comparison normalization.

---

## 摘要

修复了一个回归：同步把原地加密的敏感字段（`enc:v1:`）当作不透明字节直接上传。当配置同步到使用不同凭证模式的机器上时，`enc:v1:` 值无法在本地解密，所有 store 加载失败，应用显示为空。

改动：
- 推送时把敏感字段（连接 `password`、设置 `ai.models[].apiKey`、身份 `password`、代理 `pass`）归一化为明文，拉取时再加密回 `enc:v1:`，通过注入的 `PasswordStore` 完成。
- 把身份/代理从通用整包处理改为字段级归一化。
- 同步比较前先解密本地 `enc:v1:` 字段，避免仅因加密模式不同就产生虚假差异（会导致无限循环）。
- 凭证库锁定时拒绝同步，而不是静默携带敏感字段。

测试：
- 新增推拉往返归一化与比较归一化的回归测试。