### PR TITLE
fix(input-number): paste overwrites number fields instead of prepending

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -627,8 +627,18 @@ function getInputSelection(el: HTMLElement): string {
 }
 
 function setInputSelection(el: HTMLInputElement | HTMLTextAreaElement, text: string) {
-  const start = el.selectionStart ?? 0
-  const end = el.selectionEnd ?? 0
+  // <input type="number"> (e.g. the port field) doesn't expose a text selection, so
+  // selectionStart/End are null. Falling the offsets back to 0 would prepend the pasted
+  // text instead of replacing it. Treat the unreadable selection as select-all so paste
+  // overwrites the whole value (issue #555).
+  const start = el.selectionStart
+  const end = el.selectionEnd
+  if (start === null || end === null) {
+    el.value = text
+    el.setSelectionRange(text.length, text.length)
+    el.focus()
+    return
+  }
   el.value = el.value.substring(0, start) + text + el.value.substring(end)
   const pos = start + text.length
   el.setSelectionRange(pos, pos)
@@ -660,51 +670,6 @@ function onWheel(e: WheelEvent) {
       ts.fontSize = next
       settingsStore.save()
     }
-  }
-}
-
-// WKWebView doesn't forward Cmd/Ctrl+A/C/V on input/textarea/contenteditable.
-function onEditShortcut(e: KeyboardEvent) {
-  if (e.defaultPrevented) return
-  const target = e.target as HTMLElement
-  const tag = target.tagName
-  const isEditable = tag === 'INPUT' || tag === 'TEXTAREA' || target.isContentEditable
-  if (!isEditable) return
-  const mod = e.metaKey || e.ctrlKey
-  if (!mod || e.shiftKey || e.altKey) return
-
-  if (e.key === 'a' || e.key === 'A') {
-    e.preventDefault()
-    if (target.isContentEditable) {
-      const el = target
-      const range = document.createRange()
-      range.selectNodeContents(el)
-      const sel = window.getSelection()
-      sel?.removeAllRanges()
-      sel?.addRange(range)
-    } else {
-      (target as HTMLInputElement | HTMLTextAreaElement).select()
-    }
-    return
-  }
-
-  if (e.key === 'c' || e.key === 'C') {
-    e.preventDefault()
-    const sel = getInputSelection(target)
-    navigator.clipboard.writeText(sel).catch(() => {})
-    return
-  }
-
-  if (e.key === 'v' || e.key === 'V') {
-    e.preventDefault()
-    ClipboardGetText().then(text => {
-      if (target.isContentEditable) {
-        insertTextAtContentEditable(target, text)
-      } else {
-        setInputSelection(target as HTMLInputElement | HTMLTextAreaElement, text)
-      }
-      target.dispatchEvent(new Event('input', { bubbles: true }))
-    }).catch(() => {})
   }
 }
 
@@ -753,8 +718,6 @@ onMounted(async () => {
   // Capture phase: xterm v6's viewport stopPropagation()s wheel events it
   // scrolls, but bails on defaultPrevented — so we must preempt it.
   document.addEventListener('wheel', onWheel, { passive: false, capture: true })
-  // WKWebView doesn't forward Cmd+A/C/V on input/textarea/contenteditable — handle globally.
-  document.addEventListener('keydown', onEditShortcut)
   // macOS system shortcuts (Cmd+Q / Cmd+W) — only armed on darwin.
   try { isMac = (await GetPlatform()) === 'darwin' } catch { isMac = false }
   if (isMac) document.addEventListener('keydown', onMacSystemShortcut, true)


### PR DESCRIPTION
# Summary

Fixes #555. Pasting into the connection **port field** (`el-input-number`, an `<input type="number">`) did not replace the selected default value — it prepended the clipboard text (e.g. select-all on `22` then paste `30021` produced `30021`22).

## Root cause

1. A global `onEditShortcut` handler (added for macOS WKWebView in #301, which doesn't forward Cmd+A/C/V natively) was registered on **all platforms**. On Windows/Linux it hijacked Ctrl+V and replaced native selection-aware paste with a custom insertion.
2. That custom `setInputSelection` read `el.selectionStart/End` and fell back to `0` on `null`. `<input type="number">` does not expose the text selection — the API returns `null` (verified: Edge/WebView2 returns null and `setSelectionRange` throws `InvalidStateError`) — so the pasted text was inserted at position 0 instead of replacing the selection.

## Changes (`frontend/src/App.vue`)

- **Delete `onEditShortcut`** — dead code since the macOS native Edit menu was restored (main.go); native Cmd+A/C/V are routed by the menu on macOS, and Windows/Linux are left to native selection-replacing paste.
- **Harden `setInputSelection`** — when the selection is unreadable (`null`, number inputs), treat paste as replace-the-whole-value so the field is overwritten.

Keyboard paste now works on all platforms; right-click paste on number fields works too. Normal text fields are unaffected (still replace the selection).

---

# 概述

修复 #555。新建连接时,往 **端口号输入框**(`el-input-number`,内部是 `<input type="number">`)粘贴无法覆盖选中的默认值——剪贴板内容被插到了前面(例如 `22` 全选后粘贴 `30021`,得到 `30021`22)。

## 根因

1. 一个全局 `onEditShortcut` 处理器(为 macOS WKWebView 引入,见 #301,该 WebView 不原生转发 Cmd+A/C/V)在所有平台都注册了。Windows/Linux 上它劫持了 Ctrl+V,用自定义插入取代了原生的选区感知粘贴。
2. 其调用链里的 `setInputSelection` 读取 `el.selectionStart/End`,在读到 `null` 时回退到 `0`。`<input type="number">` 不暴露文本选区——该 API 返回 `null`(已实测:Edge/WebView2 返回 null,`setRangeSelection` 抛 `InvalidStateError`)——于是粘贴文本被插入到位置 0 而非替换选区。

## 改动(`frontend/src/App.vue`)

- **删除 `onEditShortcut`** ——macOS 原生 Edit 菜单恢复(main.go)后即为死代码;macOS 由菜单原生路由 Cmd+A/C/V,Windows/Linux 交给浏览器原生选区替换。
- **加固 `setInputSelection`** ——选区不可读(`null`,number 输入框)时,把粘贴视为整体替换,使字段被覆盖。

键盘粘贴在全平台生效;number 输入框的右键粘贴同样生效。普通文本框不受影响(仍按选区替换)。