### PR TITLE
fix(sync): reload stores after startup auto-sync pull

### DIFF
--- a/app.go
+++ b/app.go
@@ -285,6 +285,12 @@ func (a *App) initStores(dataDir string, upgrade bool) {
 						"remoteTime": result.Conflict.RemoteTime.Format(time.RFC3339),
 					})
 				}
+				// Reload in-memory stores after a startup pull so the UI shows
+				// the freshly synced config without requiring a restart.
+				if err == nil && result.Direction == sync.SyncPull {
+					a.reloadStoresAfterSync()
+				}
+				runtime.EventsEmit(a.ctx, "sync:completed")
 			}()
 		}
 	}


### PR DESCRIPTION
## Summary
Startup auto-sync (`app.go` initStores) ran `Sync()` but never refreshed the in-memory stores after a pull. A config synced on launch was written to disk but invisible in the UI until the app was restarted. A manual "Sync Now" also didn't help because, once the pull had reached disk, local == remote so it returned "已是最新" (SyncNone) and skipped the store reload.

Fix: mirror `triggerAutoSync` / `SyncNow` — after a startup `SyncPull`, call `reloadStoresAfterSync()` and emit `sync:completed`.

Fixes #554

---
## 概述
启动时的自动同步（`app.go` initStores）只调用 `Sync()`，拉取后没有刷新内存中的 store。同步到磁盘的新配置要等重启后重新加载内存才会在界面显示；而“立即同步”在磁盘已是最新时返回“已是最新”（SyncNone），同样不会刷新内存，因此该问题无法通过手动同步解决。

修复：对齐 `triggerAutoSync` / `SyncNow` —— 启动拉取（`SyncPull`）后调用 `reloadStoresAfterSync()` 并派发 `sync:completed`。

修复 #554