### PR TITLE
fix(ai): strip trailing prompt and reorder completion status in tool output

### DIFF
--- a/frontend/src/services/agent.ts
+++ b/frontend/src/services/agent.ts
@@ -1,5 +1,6 @@
 import { chat, AVAILABLE_TOOLS, ChatCancelledError, ChatTimeoutError } from './llm'
 import { executeCommand, startCommand, captureTerminal, collectOutput, sendTerminalKey } from './terminalAgent'
+import type { ExecuteResult } from './terminalAgent'
 import { useAIStore } from '../stores/aiStore'
 import { useSettingsStore } from '../stores/settingsStore'
 import { useTabStore } from '../stores/tabStore'
@@ -242,6 +243,20 @@ function capToolResult(text: string): string {
   const tail = text.slice(text.length - TOOL_RESULT_TAIL_BYTES)
   const omitted = text.length - TOOL_RESULT_HEAD_BYTES - TOOL_RESULT_TAIL_BYTES
   return `${head}\n\n─────── [已截断: 工具结果共 ${text.length} 字节, 已省略 ${omitted} 字节] ────────\n调整工具参数（如 head_lines / tail_lines）或分段调用以查看被截断部分。\n\n${tail}`
+}
+
+function formatExecuteResult(result: ExecuteResult): string {
+  if (!result.timedOut) {
+    return `${result.output}\n\n[COMMAND COMPLETED]`
+  }
+  // Put the timeout guidance right after the status line so the AI sees the
+  // verdict before reading the follow-up advice.
+  return `${result.output}\n\n[COMMAND TIMED OUT]\n\n`
+    + `⚠️ The command did not finish within the timeout and may still be running.\n`
+    + `Do not resend the same command.\n`
+    + `• If the output shows progress (percentages, scrolling filenames, etc.) → use collect_output to keep waiting\n`
+    + `• If the output shows a password/confirmation prompt → use send_terminal_key to respond\n`
+    + `• If the command is stuck and unresponsive → use interrupt_command to cancel`
 }
 
 function getShellName(path?: string): string {
@@ -693,11 +708,10 @@ export async function runAgent(userInput: string, skillName?: string, skillBody?
           cleanupStreamListeners()
           return
         }
-        const status = result.timedOut ? '[COMMAND TIMED OUT]' : '[COMMAND COMPLETED]'
         store.addMessage({
           id: `msg-${Date.now()}`,
           role: 'tool',
-          content: capToolResult(`${status}\n${result.output}`),
+          content: capToolResult(formatExecuteResult(result)),
           tool_call_id: tu.id
         })
       } catch (e: any) {
@@ -803,7 +817,7 @@ export async function runAgent(userInput: string, skillName?: string, skillBody?
         store.addMessage({
           id: `msg-${Date.now()}`,
           role: 'tool',
-          content: capToolResult(`${status}\n${result.output}`),
+          content: capToolResult(`${result.output}\n\n${status}`),
           tool_call_id: tu.id
         })
       } catch (e: any) {
@@ -1044,11 +1058,10 @@ export async function approveTool(_messageId: string) {
       })
     } else {
       const result = await executeCommand(cmd.command)
-      const status = result.timedOut ? '[COMMAND TIMED OUT]' : '[COMMAND COMPLETED]'
       store.addMessage({
         id: `msg-${Date.now()}`,
         role: 'tool',
-        content: capToolResult(`${status}\n${result.output}`),
+        content: capToolResult(formatExecuteResult(result)),
         tool_call_id: cmd.toolId
       })
     }

--- a/frontend/src/services/terminalAgent.test.ts
+++ b/frontend/src/services/terminalAgent.test.ts
@@ -112,8 +112,8 @@ describe('truncateOutput', () => {
     expect(result).toContain('line18')
     expect(result).toContain('line19')
     expect(result).toContain('line20')
-    expect(result).toContain('截断')
-    expect(result).toContain('已省略')
+    expect(result).toContain('TRUNCATED')
+    expect(result).toContain('omitted')
   })
 
   it('handles edge case: headLines=0', () => {
@@ -121,7 +121,7 @@ describe('truncateOutput', () => {
     const text = lines.join('\n')
     const result = truncateOutput(text, 0, 2)
 
-    expect(result).toContain('省略')
+    expect(result).toContain('omitted')
     expect(result).toContain('line9')
     expect(result).toContain('line10')
   })
@@ -133,7 +133,7 @@ describe('truncateOutput', () => {
 
     expect(result).toContain('line1')
     expect(result).toContain('line3')
-    expect(result).toContain('省略')
+    expect(result).toContain('omitted')
   })
 
   it('handles single line input', () => {
@@ -197,6 +197,9 @@ describe('watchOutput', () => {
     const result: WatchResult = await promise
     expect(result.timedOut).toBe(false)
     expect(result.output).toContain('hi')
+    // The reappeared prompt line is stripped: output ends at the last output
+    // line, not with a trailing prompt.
+    expect(result.output).not.toMatch(/\[root@node140 ~\]#\s*$/)
   })
 
   it('resolves via idle heuristic when prompt differs (e.g. dynamic prompt)', async () => {
@@ -410,7 +413,7 @@ describe('executeCommand', () => {
     const result: ExecuteResult = await cmdPromise
     expect(result.exitCode).toBe(-1)
     expect(result.timedOut).toBe(true)
-    expect(result.output).toContain('截断')
+    expect(result.output).toContain('TRUNCATED')
     expect(result.output).toContain('line1')
     expect(result.output).toContain('line2')
     expect(result.output).toContain('line4')
@@ -444,15 +447,18 @@ describe('executeCommand', () => {
     const result: ExecuteResult = await cmdPromise
     expect(result.exitCode).toBe(0)
     expect(result.timedOut).toBe(false)
-    expect(result.output).toContain('截断')
-    // headLines=3 keeps the echoed command line + line1 + line2;
-    // tailLines=3 keeps line9 + line10 + the returning prompt. line8
-    // falls inside the omitted middle.
+    expect(result.output).toContain('TRUNCATED')
+    // headLines=3 keeps the echoed command line + line1 + line2. The trailing
+    // prompt that reappeared on completion is stripped before truncation, so
+    // tailLines=3 now keeps line8 + line9 + line10 (line8 was previously
+    // omitted because the returning prompt occupied one tail slot).
     expect(result.output).toContain('line1')
     expect(result.output).toContain('line2')
-    expect(result.output).not.toContain('line8')
+    expect(result.output).toContain('line8')
     expect(result.output).toContain('line9')
     expect(result.output).toContain('line10')
+    // The reappeared prompt must not leak into the returned output.
+    expect(result.output).not.toMatch(/\n\[root@node140 ~\]#\s*$/)
 
     restore()
   })

--- a/frontend/src/services/terminalAgent.ts
+++ b/frontend/src/services/terminalAgent.ts
@@ -143,7 +143,17 @@ export function watchOutput(
         resolve({ output: '', timedOut: false, cancelled: true })
         return
       }
-      const normalized = toDisplayLines(stripAnsi(output)).join('\n').trim()
+      const lines = toDisplayLines(stripAnsi(output))
+      if (!timedOut) {
+        // The command finished when the shell prompt reappeared at the bottom.
+        // That prompt line belongs to the terminal, not the command output —
+        // completion is now reported explicitly by the caller's end-message
+        // (see executeCommand in agent.ts), so drop the prompt (and any
+        // trailing blanks) before returning the output to the AI.
+        while (lines.length > 0 && lines[lines.length - 1].trimEnd() === '') lines.pop()
+        if (lines.length > 0) lines.pop()
+      }
+      const normalized = lines.join('\n').trim()
       resolve({ output: normalized, timedOut })
     }
 
@@ -212,7 +222,7 @@ export function truncateOutput(
   const head = lines.slice(0, headLines).join('\n')
   const tail = lines.slice(total - tailLines).join('\n')
   const omitted = total - headLines - tailLines
-  return `${head}\n\n─────── [截断: 共 ${total} 行, 已省略 ${omitted} 行] ────────\n调整 head_lines / tail_lines 参数可查看更多内容。\n\n${tail}`
+  return `${head}\n\n─────── [TRUNCATED: ${total} lines total, ${omitted} lines omitted] ────────\nAdjust head_lines / tail_lines to see more content.\n\n${tail}`
 }
 
 function resolveActiveSession(panelTitle?: string): { sessionId: string; shellPath?: string; remoteOS?: string } {
@@ -347,14 +357,8 @@ export async function executeCommand(
 
   if (result.timedOut) {
     const truncated = truncateOutput(result.output, headLines, tailLines)
-    const timeoutSec = Math.round(timeoutMs / 1000)
     return {
-      output: truncated
-        + `\n\n⚠️ 命令在 ${timeoutSec}s 内未完成，可能仍在运行中。\n`
-        + `请勿重复发送相同命令。\n`
-        + `• 如果输出显示进度（百分比、文件名滚动等）→ 使用 collect_output 继续等待\n`
-        + `• 如果输出显示密码/确认提示 → 使用 send_terminal_key 响应\n`
-        + `• 如果命令卡住无响应 → 使用 interrupt_command 取消`,
+      output: truncated,
       exitCode: -1,
       timedOut: true,
     }


### PR DESCRIPTION
Closes #558

When the AI executes a command, the refreshed shell prompt (the line shown after the command completes) was being included in the tool output sent back to the model. That prompt was originally kept on purpose so the AI could detect completion, but completion is now reported explicitly, so the prompt line can be dropped.

### Changes
- **strip trailing prompt** — `watchOutput` no longer returns the reappeared shell prompt line; completion is signaled by the explicit status message instead
- **reorder status** — the completion verdict (`[COMMAND COMPLETED]` / `[COMMAND TIMED OUT]`) now appears right after the command output (end of the message); the timeout guidance block (`⚠️ ...`) is placed directly after the `[COMMAND TIMED OUT]` line so the AI reads the verdict before the advice
- **English messages** — unified the `terminalAgent` output messages (truncation marker, timeout guidance) to English

Affects `execute_command`, `collect_output`, and the approve-flow path.

---
Closes #558

AI 执行命令时，命令结束后再现的那一行 shell 提示符会被一并放进回传给模型的结果里。之前特意保留该提示符是为了让 AI 判断命令是否结束；现在已新增显式的结束信息，因此可以把这行提示符去掉。

### 主要改动
- **去掉末尾提示符** —— `watchOutput` 返回结果不再包含再次出现的提示符行；是否结束由显式的状态信息来传达
- **状态信息放到命令输出之后** —— 结束状态（`[COMMAND COMPLETED]` / `[COMMAND TIMED OUT]`）现在紧跟命令输出（位于消息末尾）；超时引导块（`⚠️ ...`）放在 `[COMMAND TIMED OUT]` 这一行的后面，让 AI 先看到结论再读建议
- **提示信息统一为英文** —— 将 `terminalAgent` 输出里的提示（截断标记、超时建议）改为英文

涉及 `execute_command`、`collect_output` 以及审批执行路径。