### PR TITLE
fix(redis): scan full page and treat plain text as substring search

### DIFF
--- a/backend/session/redis_session.go
+++ b/backend/session/redis_session.go
@@ -209,6 +209,11 @@ func (s *RedisSession) SwitchDB(idx int) error {
 
 // ScanKeys scans keys matching pattern with cursor-based pagination.
 // Returns key metadata (name, type, TTL) via pipeline batching.
+//
+// A single SCAN iteration inspects ~count slots but may return far fewer
+// (or zero) matching keys even when matches exist later in the keyspace.
+// Keep iterating until the page is reasonably full or the cursor wraps,
+// so a sparse MATCH does not render as a misleading empty page.
 func (s *RedisSession) ScanKeys(pattern string, cursor uint64, count int64) (*ScanResult, error) {
 	if count <= 0 {
 		count = 100
@@ -218,9 +223,18 @@ func (s *RedisSession) ScanKeys(pattern string, cursor uint64, count int64) (*Sc
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	keys, nextCursor, err := client.Scan(ctx, cursor, pattern, count).Result()
-	if err != nil {
-		return nil, fmt.Errorf("scan: %w", err)
+	var keys []string
+	nextCursor := cursor
+	for {
+		batch, c, err := client.Scan(ctx, nextCursor, pattern, count).Result()
+		if err != nil {
+			return nil, fmt.Errorf("scan: %w", err)
+		}
+		keys = append(keys, batch...)
+		nextCursor = c
+		if nextCursor == 0 || int64(len(keys)) >= count || ctx.Err() != nil {
+			break
+		}
 	}
 
 	result := &ScanResult{
@@ -241,7 +255,7 @@ func (s *RedisSession) ScanKeys(pattern string, cursor uint64, count int64) (*Sc
 		typeCmds[i] = pipe.Type(ctx, key)
 		ttlCmds[i] = pipe.TTL(ctx, key)
 	}
-	_, err = pipe.Exec(ctx)
+	_, err := pipe.Exec(ctx)
 	if err != nil && err != redis.Nil {
 		return nil, fmt.Errorf("scan pipeline: %w", err)
 	}

--- a/frontend/src/components/RedisTabContent.vue
+++ b/frontend/src/components/RedisTabContent.vue
@@ -386,10 +386,20 @@ function onNewKeyTypeChange() {
 }
 
 // --- Key scanning ---
+
+// Plain text (no glob metachars) is treated as a substring search: "pod"
+// scans as "*pod*". Patterns that already contain * ? [ are sent as-is.
+function effectivePattern(): string {
+  const p = scanPattern.value.trim()
+  if (!p || p === '*') return '*'
+  if (/[*?[]/.test(p)) return p
+  return `*${p}*`
+}
+
 async function doScan(cursor: number) {
   loading.value = true
   try {
-    const result: ScanResult = await RedisScanKeys(props.sessionId, scanPattern.value, cursor, pageSize.value)
+    const result: ScanResult = await RedisScanKeys(props.sessionId, effectivePattern(), cursor, pageSize.value)
     keys.value = (result.keys || []).sort((a, b) => a.name.localeCompare(b.name))
     nextCursor.value = result.cursor
     hasMore.value = result.cursor !== 0


### PR DESCRIPTION
## Summary / 概述

修复 Redis 面板搜索键搜不到的问题：键实际存在（`redis-cli HGETALL` 可查到），但 UI 搜索显示空列表。

## Root Cause / 根因

1. **单次 SCAN 当一页用**：`SCAN` 的 `COUNT` 是「本次迭代检查的槽位数提示」，不是「返回的匹配数」。当库中键多而匹配少时，单次迭代很可能返回 0 条匹配 + 非零 cursor，UI 直接显示「没有键」，用户以为搜不到。
2. **MATCH 是 glob 不是子串**：输入不带 `*` 的关键字（如 `super_pod`）glob 匹配不到任何键，且 UI 无提示。

## Changes / 改动

### backend `redis_session.go` — ScanKeys 循环迭代
- 反复 SCAN 直到「凑满约 count 个匹配」或「cursor 归零」，受已有 10s 超时约束
- 空结果页从此意味着「真的没有」，翻页语义不变（cursor 照常返回）

### frontend `RedisTabContent.vue` — 纯文本按子串搜索
- 输入不含 glob 元字符（`*` `?` `[`）时自动按 `*输入*` 扫描，输 `super_pod` 即可命中 `gv:cl:service:super_pod_sgm_config`
- 含通配符的输入原样透传，高级用法不受影响

## Validation / 验证
- `go build` 通过
- frontend `vite build` 通过；type-check 无新增错误（RedisTabContent 的 6 个类型报错在 main 上同样存在，属预存）

## Repro / 复现场景
db 15 中有大量键，搜索完整键名 `gv:cl:service:super_pod_sgm_config` 或子串 `super_pod` 均显示空列表；`redis-cli -n 15 HGETALL <key>` 能查到数据。修复后两种输入都能直接命中。
