### PR TITLE
feat(terminal): follow-app theme default and rename menu items

### DIFF
--- a/frontend/src/components/BaseTerminal.vue
+++ b/frontend/src/components/BaseTerminal.vue
@@ -117,7 +117,7 @@ import {
   bumpOnDataGeneration,
 } from '../services/terminalManager'
 import { getXtermTheme } from '../composables/useTerminal'
-import { resolveXtermBackground, applyTerminalBgVar } from '../composables/useTerminalTheme'
+import { resolveXtermBackground, applyTerminalBgVar, resolveTerminalThemeName } from '../composables/useTerminalTheme'
 import { stripCursorBlink } from '../utils/cursor'
 import { applyBackspaceKey } from '../utils/backspaceKey'
 import {
@@ -1564,7 +1564,7 @@ function onSearchPrev() {
 function applyXtermTheme(themeName: string) {
   if (!terminal) return
   const theme = resolveXtermBackground(
-    getXtermTheme(themeName, settingsStore.settings.customTerminalThemes),
+    getXtermTheme(resolveTerminalThemeName(themeName, settingsStore.resolvedAppTheme), settingsStore.settings.customTerminalThemes),
     localStateStore.state.backgroundEnabled,
     localStateStore.state.backgroundImage
   )
@@ -1599,6 +1599,12 @@ watch(() => settingsStore.settings.terminal, (ts) => {
 // Watch for background image toggling to update terminal transparency
 watch(
   () => localStateStore.state.backgroundEnabled,
+  () => applyXtermTheme(settingsStore.settings.terminal.theme || 'dark')
+)
+
+// Re-apply when the app theme flips so FOLLOW_APP_THEME tracks it live.
+watch(
+  () => settingsStore.resolvedAppTheme,
   () => applyXtermTheme(settingsStore.settings.terminal.theme || 'dark')
 )
 

--- a/frontend/src/components/Panel.vue
+++ b/frontend/src/components/Panel.vue
@@ -57,6 +57,7 @@
           <div v-show="moreMenuVisible" class="panel-more-menu" @click.stop>
             <!-- ① 面板操作 -->
             <div class="menu-item" @click="emit('duplicate', panel.id); moreMenuVisible = false">{{ t('tab.duplicate') }}</div>
+            <div class="menu-item" @click="renamePanel">{{ t('tab.rename') }}</div>
 
             <!-- ② 会话文本操作 -->
             <div class="menu-divider" />
@@ -278,6 +279,11 @@ function startEdit() {
     editInputRef.value?.focus()
     editInputRef.value?.select()
   })
+}
+
+function renamePanel() {
+  moreMenuVisible.value = false
+  startEdit()
 }
 
 function confirmEdit() {

--- a/frontend/src/components/SettingsTab.vue
+++ b/frontend/src/components/SettingsTab.vue
@@ -240,6 +240,7 @@
             <div class="setting-control">
               <div class="theme-select-row">
                 <el-select v-model="settingsStore.settings.terminal.theme" @change="settingsStore.save()" popper-class="theme-select-popper">
+                  <el-option :label="t('settings.followAppTheme')" :value="FOLLOW_APP_THEME" />
                   <el-option-group
                     v-for="group in terminalThemeGroups"
                     :key="group.label"
@@ -892,7 +893,7 @@ import { useUpdateCheck } from '../composables/useUpdateCheck'
 import { useI18n, locale } from '../i18n'
 import { BrowserOpenURL } from '../../wailsjs/runtime'
 import { ElMessage, ElMessageBox } from 'element-plus'
-import { FONT_OPTIONS, LANGUAGE_OPTIONS, DEFAULT_KEYBOARD, SHORTCUT_LABELS, USER_AGENT_PRESETS } from '../types/settings'
+import { FONT_OPTIONS, LANGUAGE_OPTIONS, DEFAULT_KEYBOARD, SHORTCUT_LABELS, USER_AGENT_PRESETS, FOLLOW_APP_THEME } from '../types/settings'
 import { formatFontFamily } from '../utils/formatFontFamily'
 import SkillsManager from './SkillsManager.vue'
 import CommandsManager from './CommandsManager.vue'

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -237,6 +237,7 @@
           <div class="persist-label">{{ t('settings.colorScheme') }}</div>
           <div class="theme-select-row">
             <el-select v-model="settingsStore.settings.terminal.theme" @change="settingsStore.save()" popper-class="theme-select-popper">
+              <el-option :label="t('settings.followAppTheme')" :value="FOLLOW_APP_THEME" />
               <el-option-group v-for="group in terminalThemeGroups" :key="group.label" :label="group.label">
                 <el-option v-for="th in group.options" :key="th.value" :label="th.label" :value="th.value" />
               </el-option-group>
@@ -474,7 +475,7 @@ import CustomThemeEditor from './CustomThemeEditor.vue'
 import GroupTreeItem from './GroupTreeItem.vue'
 import type { ConnectionConfig, ConnectionGroup } from '../types/session'
 import { parseQuickConnect, formatConnSubtitle } from '../utils/quickConnect'
-import { FONT_OPTIONS, LANGUAGE_OPTIONS } from '../types/settings'
+import { FONT_OPTIONS, LANGUAGE_OPTIONS, FOLLOW_APP_THEME } from '../types/settings'
 import { formatFontFamily } from '../utils/formatFontFamily'
 import { useTerminalThemeOptions } from '../composables/useTerminalThemeOptions'
 import { GetSystemFonts } from '../../wailsjs/go/main/App'

--- a/frontend/src/components/TabItem.vue
+++ b/frontend/src/components/TabItem.vue
@@ -63,6 +63,7 @@
         <div v-if="tab.type === 'terminal'" class="menu-item" @click="toggleAiLock">
           {{ isAILocked ? t('terminal.aiLocked') : t('terminal.lockAI') }}
         </div>
+        <div v-if="tab.type !== 'start' && tab.type !== 'settings'" class="menu-item" @click="startEdit">{{ t('tab.rename') }}</div>
         <div v-if="tab.type !== 'start' && tab.type !== 'settings'" class="menu-item" @click="toggleLock">
           {{ tab.locked ? t('tab.unlock') : t('tab.lock') }}
         </div>

--- a/frontend/src/composables/useTerminal.ts
+++ b/frontend/src/composables/useTerminal.ts
@@ -12,7 +12,7 @@ import { useLocalStateStore } from '../stores/localStateStore'
 import { useSessionStore } from '../stores/sessionStore'
 import { highlight } from './useHighlight'
 import { stripCursorBlink } from '../utils/cursor'
-import { resolveXtermBackground, applyTerminalBgVar } from './useTerminalTheme'
+import { resolveXtermBackground, applyTerminalBgVar, resolveTerminalThemeName } from './useTerminalTheme'
 import type { CustomTerminalTheme } from '../types/settings'
 
 export interface UseTerminalOptions {
@@ -350,7 +350,7 @@ export function useTerminal(
   function getTerminalOptions() {
     const ts = settingsStore.settings.terminal
     const ls = useLocalStateStore()
-    const themeName = ts.theme || 'uniterm-dark'
+    const themeName = resolveTerminalThemeName(ts.theme, settingsStore.resolvedAppTheme)
     const theme = resolveXtermBackground(
       getXtermTheme(themeName, settingsStore.settings.customTerminalThemes),
       ls.state.backgroundEnabled,
@@ -694,7 +694,7 @@ export function useTerminal(
     if (!terminal) return
     const ls = useLocalStateStore()
     const theme = resolveXtermBackground(
-      getXtermTheme(themeName, settingsStore.settings.customTerminalThemes),
+      getXtermTheme(resolveTerminalThemeName(themeName, settingsStore.resolvedAppTheme), settingsStore.settings.customTerminalThemes),
       ls.state.backgroundEnabled,
       ls.state.backgroundImage
     )
@@ -720,6 +720,12 @@ export function useTerminal(
   const localStateStore = useLocalStateStore()
   watch(
     () => localStateStore.state.backgroundEnabled,
+    () => applyXtermTheme(settingsStore.settings.terminal.theme || 'dark')
+  )
+
+  // Re-apply when the app theme flips so FOLLOW_APP_THEME tracks it live.
+  watch(
+    () => settingsStore.resolvedAppTheme,
     () => applyXtermTheme(settingsStore.settings.terminal.theme || 'dark')
   )
 

--- a/frontend/src/composables/useTerminalTheme.ts
+++ b/frontend/src/composables/useTerminalTheme.ts
@@ -1,4 +1,20 @@
 import type { ITheme, Terminal } from '@xterm/xterm'
+import { FOLLOW_APP_THEME } from '../types/settings'
+
+/**
+ * Resolve the concrete built-in terminal theme name to render.
+ *
+ * When the user picks an explicit palette it is returned unchanged; only the
+ * special FOLLOW_APP_THEME value is derived from the app theme. `appTheme` here
+ * is expected to be already resolved to a concrete light/dark choice.
+ */
+export function resolveTerminalThemeName(
+  terminalTheme: string | undefined,
+  appTheme: 'dark' | 'light'
+): string {
+  if (terminalTheme !== FOLLOW_APP_THEME) return terminalTheme || 'uniterm-dark'
+  return appTheme === 'light' ? 'uniterm-light' : 'uniterm-dark'
+}
 
 /**
  * Resolve the real background color for an xterm theme.

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -336,6 +336,7 @@
   "settings.themeDesc": "Oberflächendesign auswählen",
   "settings.languageDesc": "Anzeigesprache wechseln",
   "settings.colorSchemeDesc": "Farbschema des Terminals",
+  "settings.followAppTheme": "App-Theme folgen",
   "settings.fontDesc": "Schriftart des Terminals",
   "settings.fontSizeDesc": "Schriftgröße des Terminals",
   "settings.defaultLocalShell": "Standard-Shell",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -336,6 +336,7 @@
   "settings.themeDesc": "Choose the interface theme",
   "settings.languageDesc": "Switch the display language",
   "settings.colorSchemeDesc": "Terminal color scheme",
+  "settings.followAppTheme": "Follow app theme",
   "settings.fontDesc": "Terminal font family",
   "settings.fontSizeDesc": "Terminal font size",
   "settings.defaultLocalShell": "Default Local Shell",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -336,6 +336,7 @@
   "settings.themeDesc": "Elija el tema de la interfaz",
   "settings.languageDesc": "Cambiar el idioma de la interfaz",
   "settings.colorSchemeDesc": "Esquema de colores de la terminal",
+  "settings.followAppTheme": "Seguir tema de la aplicación",
   "settings.fontDesc": "Familia tipográfica de la terminal",
   "settings.fontSizeDesc": "Tamaño de fuente de la terminal",
   "settings.defaultLocalShell": "Shell local predeterminado",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -336,6 +336,7 @@
   "settings.themeDesc": "Choisir le thème de l'interface",
   "settings.languageDesc": "Changer la langue d'affichage",
   "settings.colorSchemeDesc": "Palette de couleurs du terminal",
+  "settings.followAppTheme": "Suivre le thème de l'application",
   "settings.fontDesc": "Police du terminal",
   "settings.fontSizeDesc": "Taille de police du terminal",
   "settings.defaultLocalShell": "Shell local par défaut",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -336,6 +336,7 @@
   "settings.themeDesc": "インターフェースのテーマを選択",
   "settings.languageDesc": "表示言語を切り替え",
   "settings.colorSchemeDesc": "ターミナルのカラースキーム",
+  "settings.followAppTheme": "アプリのテーマに従う",
   "settings.fontDesc": "ターミナルのフォント",
   "settings.fontSizeDesc": "ターミナルのフォントサイズ",
   "settings.defaultLocalShell": "デフォルトのローカルシェル",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -336,6 +336,7 @@
   "settings.themeDesc": "인터페이스 테마를 선택하세요",
   "settings.languageDesc": "표시 언어를 전환하세요",
   "settings.colorSchemeDesc": "터미널 색상 구성",
+  "settings.followAppTheme": "앱 테마 따르기",
   "settings.fontDesc": "터미널 글꼴 패밀리",
   "settings.fontSizeDesc": "터미널 글꼴 크기",
   "settings.defaultLocalShell": "기본 로컬 셸",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -336,6 +336,7 @@
   "settings.themeDesc": "Выберите тему интерфейса",
   "settings.languageDesc": "Переключить язык интерфейса",
   "settings.colorSchemeDesc": "Цветовая схема терминала",
+  "settings.followAppTheme": "Следовать теме приложения",
   "settings.fontDesc": "Шрифт терминала",
   "settings.fontSizeDesc": "Размер шрифта терминала",
   "settings.defaultLocalShell": "Оболочка локального терминала по умолчанию",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -336,6 +336,7 @@
   "settings.themeDesc": "选择界面主题风格",
   "settings.languageDesc": "切换界面显示语言",
   "settings.colorSchemeDesc": "终端窗口的配色方案",
+  "settings.followAppTheme": "跟随应用主题",
   "settings.fontDesc": "终端显示的字体",
   "settings.fontSizeDesc": "终端字体大小",
   "settings.defaultLocalShell": "默认本地终端",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -336,6 +336,7 @@
   "settings.themeDesc": "選擇介面主題風格",
   "settings.languageDesc": "切換介面顯示語言",
   "settings.colorSchemeDesc": "終端機視窗的配色方案",
+  "settings.followAppTheme": "跟隨應用程式主題",
   "settings.fontDesc": "終端機顯示的字型",
   "settings.fontSizeDesc": "終端機字型大小",
   "settings.defaultLocalShell": "預設本機 Shell",

--- a/frontend/src/services/terminalManager.ts
+++ b/frontend/src/services/terminalManager.ts
@@ -3,7 +3,7 @@ import { FitAddon } from '@xterm/addon-fit'
 import { Unicode11Addon } from '@xterm/addon-unicode11'
 import { SearchAddon } from '@xterm/addon-search'
 import { getXtermTheme } from '../composables/useTerminal'
-import { resolveXtermBackground, applyTerminalBgVar } from '../composables/useTerminalTheme'
+import { resolveXtermBackground, applyTerminalBgVar, resolveTerminalThemeName } from '../composables/useTerminalTheme'
 import { useSettingsStore } from '../stores/settingsStore'
 import { useLocalStateStore } from '../stores/localStateStore'
 import type { CustomTerminalTheme } from '../types/settings'
@@ -77,7 +77,7 @@ export function acquireTerminal(
       || '\\ :;~`!@#$%^&*()=+|[]{}\'",<>?'
     const ls = useLocalStateStore()
     const theme = resolveXtermBackground(
-      getXtermTheme(options.themeName ?? 'dark', customThemes),
+      getXtermTheme(resolveTerminalThemeName(options.themeName, useSettingsStore().resolvedAppTheme), customThemes),
       ls.state.backgroundEnabled,
       ls.state.backgroundImage
     )

--- a/frontend/src/stores/settingsStore.ts
+++ b/frontend/src/stores/settingsStore.ts
@@ -21,6 +21,18 @@ export const useSettingsStore = defineStore('settings', () => {
   const terminal = computed(() => settings.value.terminal)
   const ai = computed(() => settings.value.ai)
 
+  // Tracks the OS color-scheme preference so `resolvedAppTheme` stays reactive
+  // to live system changes while the app theme is set to 'system'.
+  const systemPrefersDark = ref(window.matchMedia('(prefers-color-scheme: dark)').matches)
+  // The app theme collapsed to a concrete light/dark choice (never 'system').
+  // Used by the terminal to resolve FOLLOW_APP_THEME.
+  const resolvedAppTheme = computed<'dark' | 'light'>(() => {
+    if (settings.value.theme === 'light') return 'light'
+    if (settings.value.theme === 'system') return systemPrefersDark.value ? 'dark' : 'light'
+    // 'dark' and 'deep-blue' are both dark.
+    return 'dark'
+  })
+
   const activeModel = computed(() =>
     settings.value.ai.models.find(m => m.id === settings.value.ai.activeModelId) || settings.value.ai.models[0]
   )
@@ -189,7 +201,8 @@ export const useSettingsStore = defineStore('settings', () => {
   watch(() => settings.value.theme, applyTheme)
 
   // Listen for system color scheme changes
-  window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
+  window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
+    systemPrefersDark.value = e.matches
     if (settings.value.theme === 'system') {
       applyTheme()
     }
@@ -215,6 +228,7 @@ export const useSettingsStore = defineStore('settings', () => {
     loaded,
     availableShells,
     theme,
+    resolvedAppTheme,
     language,
     terminal,
     ai,

--- a/frontend/src/types/settings.ts
+++ b/frontend/src/types/settings.ts
@@ -7,6 +7,12 @@ export type Language = Locale | 'system'
 export type Theme = 'dark' | 'deep-blue' | 'light' | 'system'
 export type TerminalTheme = 'uniterm-dark' | 'uniterm-light' | 'solarized-dark' | 'solarized-light' | 'monokai' | 'dracula' | 'molokai' | 'tomorrow-night' | 'tomorrow-night-bright' | 'tomorrow' | 'one-dark' | 'one-light' | 'github-dark' | 'github-light' | 'gotham' | 'hybrid' | 'nord' | 'gruvbox-dark' | 'gruvbox-light' | 'catppuccin-mocha' | 'catppuccin-latte' | 'tokyo-night' | 'tokyo-day' | 'rose-pine' | 'rose-pine-dawn' | 'everforest-dark' | 'everforest-light'
 
+// Magic value for `AppSettings.terminal.theme`: the effective built-in theme
+// is derived from the current app theme (dark / deep-blue -> uniterm-dark,
+// light -> uniterm-light) instead of being fixed. Kept out of TERMINAL_THEMES
+// because it has no color palette of its own.
+export const FOLLOW_APP_THEME = 'follow-app'
+
 // xterm.js's ITheme shape: the 4 base colors plus the 16 ANSI colors, all as hex strings.
 export interface TerminalThemeColors {
   background: string
@@ -140,7 +146,7 @@ export const DEFAULT_KEYBOARD: KeyboardSettings = {
   navigateNext: { ctrl: false, shift: false, alt: true, key: 'arrowright' },
   lockAI: { ctrl: true, shift: true, alt: false, key: 'l' },
   duplicateSession: { ctrl: true, shift: true, alt: false, key: 'd' },
-  terminalSearch: { ctrl: true, shift: false, alt: false, key: 'f' },
+  terminalSearch: { ctrl: true, shift: true, alt: false, key: 'f' },
   openSettings: { ctrl: true, shift: false, alt: false, key: ',' },
   copy: { ctrl: true, shift: true, alt: false, key: 'c' },
   paste: { ctrl: true, shift: true, alt: false, key: 'v' },
@@ -171,7 +177,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   theme: 'dark',
   language: 'system',
   terminal: {
-    theme: 'uniterm-dark',
+    theme: FOLLOW_APP_THEME,
     fontFamily: '"JetBrains Mono Variable", Menlo, Consolas, "Courier New", monospace',
     fontSize: 14,
     selectionAction: 'none',


### PR DESCRIPTION
Add "Follow app theme" as the default terminal theme, add rename menu items, and switch the terminal search default shortcut.

- Add a special `follow-app` terminal theme that resolves from the app theme (dark / deep-blue → uniTerm Dark, light → uniTerm Light) and make it the default. It updates live on app-theme switches and is resolved on both terminal creation paths.
- Change the terminal search default keybinding from `Ctrl+F` to `Ctrl+Shift+F`.
- Add a Rename tab item above Lock tab in the tab right-click menu, consistent with Lock's applicable tab types.
- Add a Rename item below Duplicate in the panel "⋯" menu.

---
- 新增「跟随应用主题」终端主题并作为默认值：按应用主题解析（深色/深蓝 → uniTerm Dark，浅色 → uniTerm Light），切换应用主题时实时跟随，两条终端创建路径都正确解析。
- 终端搜索默认快捷键由 `Ctrl+F` 改为 `Ctrl+Shift+F`。
- 标签右键菜单在「锁定标签」上方新增「重命名标签」，生效标签类型与锁定一致。
- 面板「⋯」菜单在「复制会话」下方新增「重命名」。