### PR TITLE
feat(ui): show configured keybindings in context menus and header tooltips

### DIFF
--- a/frontend/src/components/AppHeader.vue
+++ b/frontend/src/components/AppHeader.vue
@@ -8,7 +8,7 @@
     <div v-if="platform === 'darwin'" class="mac-traffic-light-spacer" />
 
     <!-- Connections button (icon only, leftmost) -->
-    <button class="header-btn" @click="emit('toggle-sidebar')" :title="t('header.connections')">
+    <button class="header-btn" @click="emit('toggle-sidebar')" :title="t('header.connections') + shortcutSuffix('toggleSidebar')">
       <el-icon><PanelLeft :size="14" /></el-icon>
     </button>
 
@@ -24,12 +24,12 @@
     </div>
 
     <!-- AI button -->
-    <button class="header-btn" @click="emit('toggle-ai')" :title="t('header.ai')">
+    <button class="header-btn" @click="emit('toggle-ai')" :title="t('header.ai') + shortcutSuffix('focusAI')">
       <el-icon><Bot :size="14" /></el-icon>
     </button>
 
     <!-- Settings button (icon only, rightmost) -->
-    <button class="header-btn" @click="emit('open-settings')" :title="t('header.settings')">
+    <button class="header-btn" @click="emit('open-settings')" :title="t('header.settings') + shortcutSuffix('openSettings')">
       <el-icon><Settings :size="14" /></el-icon>
     </button>
 
@@ -53,6 +53,7 @@ import { useTabStore } from '../stores/tabStore'
 import { usePanelStore } from '../stores/panelStore'
 import { useSessionStore } from '../stores/sessionStore'
 import { useSettingsStore } from '../stores/settingsStore'
+import { formatKeyBinding } from '../composables/useKeyboardShortcuts'
 import { useLocalStateStore } from '../stores/localStateStore'
 import WindowControls from './WindowControls.vue'
 import TabsList from './TabsList.vue'
@@ -78,6 +79,17 @@ const panelStore = usePanelStore()
 const sessionStore = useSessionStore()
 const settingsStore = useSettingsStore()
 const localStateStore = useLocalStateStore()
+
+const isMac = /Mac|iPhone|iPad/.test(navigator.userAgent)
+
+// " (Ctrl+Shift+K)" suffix for a shortcut action's tooltip, '' when unset.
+// Reactive via settingsStore, so tooltips update when the user rebinds keys.
+function shortcutSuffix(action: 'focusAI' | 'toggleSidebar' | 'openSettings'): string {
+  const b = settingsStore.settings.keyboard[action]
+  if (!b) return ''
+  const key = formatKeyBinding(b, isMac)
+  return key ? ` (${key})` : ''
+}
 
 const hasActiveConnections = computed(() =>
   tabStore.tabs.some(t => {

--- a/frontend/src/components/BaseTerminal.vue
+++ b/frontend/src/components/BaseTerminal.vue
@@ -45,18 +45,25 @@
       <!-- ① 剪贴板 -->
       <div class="menu-item" :class="{ disabled: !menu.hasSelection.value }" @click="menu.copySelection">
         {{ t('terminal.copy') }}
+        <span class="menu-shortcut">{{ menuShortcut('copy') }}</span>
       </div>
       <div class="menu-item" :class="{ disabled: !menu.hasSelection.value }" @click="menu.copyAndPaste">
         {{ t('terminal.copyAndPaste') }}
       </div>
-      <div class="menu-item" @click="menu.pasteFromClipboard">{{ t('terminal.paste') }}</div>
+      <div class="menu-item" @click="menu.pasteFromClipboard">
+        {{ t('terminal.paste') }}
+        <span class="menu-shortcut">{{ menuShortcut('paste') }}</span>
+      </div>
       <div class="menu-item" :class="{ disabled: !menu.hasSelection.value }" @click="menu.askAI">
         {{ t('terminal.askAI') }}
       </div>
 
       <!-- ② 会话文本操作 -->
       <div class="menu-divider" />
-      <div class="menu-item" @click="triggerSearch">{{ t('terminal.searchText') }}</div>
+      <div class="menu-item" @click="triggerSearch">
+        {{ t('terminal.searchText') }}
+        <span class="menu-shortcut">{{ menuShortcut('terminalSearch') }}</span>
+      </div>
       <div class="menu-item" @click="menu.closeMenu(); exportContent()">{{ t('terminal.export') }}</div>
       <div v-if="supportsOutputLog" class="menu-item" @click="toggleOutputLog">
         {{ isOutputLogOn ? t('session.stopLog') : t('session.startLog') }}
@@ -101,7 +108,8 @@ import { EventsOn, BrowserOpenURL, ClipboardGetText } from '../../wailsjs/runtim
 import { useSettingsStore } from '../stores/settingsStore'
 import { useLocalStateStore } from '../stores/localStateStore'
 import { highlight } from '../composables/useHighlight'
-import { onTerminalKey } from '../composables/useKeyboardShortcuts'
+import { onTerminalKey, formatKeyBinding } from '../composables/useKeyboardShortcuts'
+import type { ShortcutAction } from '../types/settings'
 import { useSessionStore } from '../stores/sessionStore'
 import { useTabStore } from '../stores/tabStore'
 import { usePanelStore } from '../stores/panelStore'
@@ -144,6 +152,15 @@ const props = defineProps<{
 const isMac = /Mac|iPhone|iPad/.test(navigator.userAgent)
 
 const settingsStore = useSettingsStore()
+
+// Human-readable keybinding for a shortcut action ('' when unset), used to show
+// the current shortcut hint in the terminal right-click context menu. Reactive
+// via settingsStore, so hints update automatically when the user rebinds keys.
+function menuShortcut(action: ShortcutAction): string {
+  const b = settingsStore.settings.keyboard[action]
+  if (!b) return ''
+  return formatKeyBinding(b, isMac)
+}
 const sessionStore = useSessionStore()
 const tabStore = useTabStore()
 const panelStore = usePanelStore()
@@ -1943,6 +1960,10 @@ defineExpose({
 }
 
 .menu-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
   padding: 7px 14px;
   font-size: 12px;
   font-family: var(--font-ui);
@@ -1951,6 +1972,14 @@ defineExpose({
   user-select: none;
   border-radius: var(--radius-sm);
   transition: all 0.1s ease;
+  white-space: nowrap;
+}
+
+.menu-shortcut {
+  color: var(--text-muted, var(--text-disabled));
+  font-size: 11px;
+  font-family: var(--font-mono);
+  opacity: 0.8;
 }
 
 .menu-item:hover:not(.disabled) {
@@ -1961,6 +1990,10 @@ defineExpose({
 .menu-item.disabled {
   color: var(--text-disabled);
   cursor: default;
+}
+
+.menu-item.disabled .menu-shortcut {
+  opacity: 0.4;
 }
 
 .menu-divider {

--- a/frontend/src/components/Panel.vue
+++ b/frontend/src/components/Panel.vue
@@ -56,12 +56,18 @@
           </button>
           <div v-show="moreMenuVisible" class="panel-more-menu" @click.stop>
             <!-- ① 面板操作 -->
-            <div class="menu-item" @click="emit('duplicate', panel.id); moreMenuVisible = false">{{ t('tab.duplicate') }}</div>
+            <div class="menu-item" @click="emit('duplicate', panel.id); moreMenuVisible = false">
+              {{ t('tab.duplicate') }}
+              <span class="menu-shortcut">{{ menuShortcut('duplicateSession') }}</span>
+            </div>
             <div class="menu-item" @click="renamePanel">{{ t('tab.rename') }}</div>
 
             <!-- ② 会话文本操作 -->
             <div class="menu-divider" />
-            <div class="menu-item" @click="triggerSearch(); moreMenuVisible = false">{{ t('terminal.searchText') }}</div>
+            <div class="menu-item" @click="triggerSearch(); moreMenuVisible = false">
+              {{ t('terminal.searchText') }}
+              <span class="menu-shortcut">{{ menuShortcut('terminalSearch') }}</span>
+            </div>
             <div class="menu-item" @click="triggerExport(); moreMenuVisible = false">{{ t('terminal.export') }}</div>
             <div class="menu-item" @click="toggleOutputLog(); moreMenuVisible = false">
               {{ isOutputLogOn ? t('session.stopLog') : t('session.startLog') }}
@@ -100,6 +106,8 @@ import { useTabStore } from '../stores/tabStore'
 import { usePanelStore } from '../stores/panelStore'
 import { useSessionStore } from '../stores/sessionStore'
 import { useSettingsStore } from '../stores/settingsStore'
+import { formatKeyBinding } from '../composables/useKeyboardShortcuts'
+import type { ShortcutAction } from '../types/settings'
 import {
   CreateSession,
   CloseSession,
@@ -150,6 +158,17 @@ const tabStore = useTabStore()
 const panelStore = usePanelStore()
 const sessionStore = useSessionStore()
 const settingsStore = useSettingsStore()
+
+const isMac = /Mac|iPhone|iPad/.test(navigator.userAgent)
+
+// Human-readable keybinding for a shortcut action ('' when unset), shown as a
+// hint in the panel "..." menu. Reactive via settingsStore, so the hint updates
+// automatically when the user rebinds keys.
+function menuShortcut(action: ShortcutAction): string {
+  const b = settingsStore.settings.keyboard[action]
+  if (!b) return ''
+  return formatKeyBinding(b, isMac)
+}
 
 const showCredentialDialog = inject<(title: string, subtitle: string, fields: ('user' | 'password')[], initialUser?: string, initialPassword?: string) => Promise<CredentialResult | null>>('showCredentialDialog', () => Promise.resolve(null))
 
@@ -657,6 +676,10 @@ watch(() => props.panel.outputLog, (val) => {
   padding: 4px;
 }
 .panel-more-menu .menu-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
   padding: 7px 14px;
   font-size: 12px;
   font-family: var(--font-ui);
@@ -669,6 +692,12 @@ watch(() => props.panel.outputLog, (val) => {
 .panel-more-menu .menu-item:hover {
   background: var(--bg-hover);
   color: var(--text-primary);
+}
+.panel-more-menu .menu-shortcut {
+  color: var(--text-muted, var(--text-disabled));
+  font-size: 11px;
+  font-family: var(--font-mono);
+  opacity: 0.8;
 }
 .panel-more-menu .menu-divider {
   height: 1px;

--- a/frontend/src/components/SettingsTab.vue
+++ b/frontend/src/components/SettingsTab.vue
@@ -899,7 +899,7 @@ import SkillsManager from './SkillsManager.vue'
 import CommandsManager from './CommandsManager.vue'
 import type { AIModelConfig, ShortcutAction, KeyBinding, KeyboardSettings } from '../types/settings'
 import { useTerminalThemeOptions } from '../composables/useTerminalThemeOptions'
-import { uninstallGlobalListener, installGlobalListener } from '../composables/useKeyboardShortcuts'
+import { uninstallGlobalListener, installGlobalListener, formatKeyBinding } from '../composables/useKeyboardShortcuts'
 import AddRepoDialog from './AddRepoDialog.vue'
 import EditRepoDialog from './EditRepoDialog.vue'
 import ChangePasswordDialog from './ChangePasswordDialog.vue'
@@ -1162,13 +1162,7 @@ const rebindingAction = ref<ShortcutAction | null>(null)
 function bindingDisplay(action: ShortcutAction): string {
   const b = settingsStore.settings.keyboard[action]
   if (!b) return ''
-  const parts: string[] = []
-  if (b.ctrl) parts.push('Ctrl')
-  if (b.meta) parts.push(isMac.value ? 'Cmd' : 'Meta')
-  if (b.shift) parts.push('Shift')
-  if (b.alt) parts.push('Alt')
-  parts.push(b.key)
-  return parts.join('+')
+  return formatKeyBinding(b, isMac.value)
 }
 
 function isDefaultBinding(action: ShortcutAction): boolean {

--- a/frontend/src/components/TabItem.vue
+++ b/frontend/src/components/TabItem.vue
@@ -58,10 +58,14 @@
         @click.stop
       >
         <!-- ① 标签类操作 -->
-        <div v-if="canDuplicate" class="menu-item" @click="duplicateTab">{{ t('tab.duplicate') }}</div>
+        <div v-if="canDuplicate" class="menu-item" @click="duplicateTab">
+          {{ t('tab.duplicate') }}
+          <span class="menu-shortcut">{{ menuShortcut('duplicateSession') }}</span>
+        </div>
         <div v-if="hasServerHost" class="menu-item" @click="copyHostAddress">{{ t('tab.copyHostAddress') }}</div>
         <div v-if="tab.type === 'terminal'" class="menu-item" @click="toggleAiLock">
           {{ isAILocked ? t('terminal.aiLocked') : t('terminal.lockAI') }}
+          <span class="menu-shortcut">{{ menuShortcut('lockAI') }}</span>
         </div>
         <div v-if="tab.type !== 'start' && tab.type !== 'settings'" class="menu-item" @click="startEdit">{{ t('tab.rename') }}</div>
         <div v-if="tab.type !== 'start' && tab.type !== 'settings'" class="menu-item" @click="toggleLock">
@@ -70,7 +74,10 @@
 
         <!-- ② 会话文本操作 -->
         <div v-if="showGroupTab && showGroupText" class="menu-divider" />
-        <div v-if="tab.type === 'terminal'" class="menu-item" @click="triggerSearch">{{ t('terminal.searchText') }}</div>
+        <div v-if="tab.type === 'terminal'" class="menu-item" @click="triggerSearch">
+          {{ t('terminal.searchText') }}
+          <span class="menu-shortcut">{{ menuShortcut('terminalSearch') }}</span>
+        </div>
         <div v-if="tab.type === 'terminal'" class="menu-item" @click="triggerExport">{{ t('terminal.export') }}</div>
         <div v-if="supportsOutputLog" class="menu-item" @click="toggleOutputLog">
           {{ isOutputLogOn ? t('session.stopLog') : t('session.startLog') }}
@@ -88,7 +95,10 @@
 
         <!-- ④ 关闭标签操作 -->
         <div v-if="showGroupTab || showGroupText || showGroupConn" class="menu-divider" />
-        <div class="menu-item" :class="{ 'menu-item-disabled': tab.locked }" @click="tab.locked ? null : closeTab()">{{ t('tab.close') }}</div>
+        <div class="menu-item" :class="{ 'menu-item-disabled': tab.locked }" @click="tab.locked ? null : closeTab()">
+          {{ t('tab.close') }}
+          <span class="menu-shortcut">{{ menuShortcut('closePanel') }}</span>
+        </div>
         <div class="menu-item" @click="closeOther">{{ t('tab.closeOther') }}</div>
         <div class="menu-item" @click="closeRight">{{ t('tab.closeRight') }}</div>
       </div>
@@ -102,6 +112,8 @@ import { useTabStore } from '../stores/tabStore'
 import { usePanelStore } from '../stores/panelStore'
 import { useSessionStore } from '../stores/sessionStore'
 import { useSettingsStore } from '../stores/settingsStore'
+import { formatKeyBinding } from '../composables/useKeyboardShortcuts'
+import type { ShortcutAction } from '../types/settings'
 import { useK8sStore } from '../stores/k8sStore'
 import { useContainerStore } from '../stores/containerStore'
 import { useI18n } from '../i18n'
@@ -145,6 +157,17 @@ const k8sStore = useK8sStore()
 const containerStore = useContainerStore()
 const settingsStore = useSettingsStore()
 const { t } = useI18n()
+
+const isMac = /Mac|iPhone|iPad/.test(navigator.userAgent)
+
+// Human-readable keybinding for a shortcut action ('' when unset), shown as a
+// hint in the tab right-click context menu. Reactive via settingsStore, so the
+// hint updates automatically when the user rebinds keys.
+function menuShortcut(action: ShortcutAction): string {
+  const b = settingsStore.settings.keyboard[action]
+  if (!b) return ''
+  return formatKeyBinding(b, isMac)
+}
 
 const hovered = ref(false)
 const contextMenuVisible = ref(false)
@@ -745,6 +768,10 @@ onUnmounted(() => {
   backdrop-filter: blur(8px);
 }
 .tab-context-menu .menu-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
   padding: 7px 14px;
   font-size: 12px;
   font-family: var(--font-ui);
@@ -753,14 +780,24 @@ onUnmounted(() => {
   user-select: none;
   border-radius: var(--radius-sm);
   transition: all 0.1s ease;
+  white-space: nowrap;
 }
 .tab-context-menu .menu-item:hover {
   background: var(--bg-hover);
   color: var(--text-primary);
 }
+.tab-context-menu .menu-shortcut {
+  color: var(--text-muted, var(--text-disabled));
+  font-size: 11px;
+  font-family: var(--font-mono);
+  opacity: 0.8;
+}
 .tab-context-menu .menu-item-disabled {
   opacity: 0.4;
   pointer-events: none;
+}
+.tab-context-menu .menu-item-disabled .menu-shortcut {
+  opacity: 0.4;
 }
 .tab-context-menu .menu-item-icon {
   margin-right: 6px;

--- a/frontend/src/components/TabsList.vue
+++ b/frontend/src/components/TabsList.vue
@@ -32,7 +32,7 @@
     <button
       v-if="!showMore"
       class="tab-add-btn"
-      :title="t('startTab.defaultName')"
+      :title="t('startTab.defaultName') + shortcutSuffix('newConnection')"
       @click="onAddStartTab"
     >
       <Plus :size="14" />
@@ -58,7 +58,7 @@
     </el-dropdown>
     <button
       class="tab-add-btn"
-      :title="t('startTab.defaultName')"
+      :title="t('startTab.defaultName') + shortcutSuffix('newConnection')"
       @click="onAddStartTab"
     >
       <Plus :size="14" />
@@ -72,11 +72,26 @@ import { MoreHorizontal, Plus } from '@lucide/vue'
 import { useTabStore } from '../stores/tabStore'
 import { usePanelStore } from '../stores/panelStore'
 import { useI18n } from '../i18n'
+import { useSettingsStore } from '../stores/settingsStore'
+import { formatKeyBinding } from '../composables/useKeyboardShortcuts'
 import TabItem from './TabItem.vue'
 
 const tabStore = useTabStore()
 const panelStore = usePanelStore()
+const settingsStore = useSettingsStore()
 const { t } = useI18n()
+
+const isMac = /Mac|iPhone|iPad/.test(navigator.userAgent)
+
+// " (Ctrl+Shift+N)" suffix for the new-tab tooltip, '' when unset. Reactive via
+// settingsStore, so the tooltip updates when the user rebinds the shortcut.
+function shortcutSuffix(action: 'newConnection'): string {
+  const b = settingsStore.settings.keyboard[action]
+  if (!b) return ''
+  const key = formatKeyBinding(b, isMac)
+  return key ? ` (${key})` : ''
+}
+
 const tabs = computed(() => tabStore.tabs)
 const activeTabId = computed(() => tabStore.activeTabId)
 

--- a/frontend/src/composables/useKeyboardShortcuts.ts
+++ b/frontend/src/composables/useKeyboardShortcuts.ts
@@ -2,6 +2,22 @@ import type { KeyboardSettings, KeyBinding, ShortcutAction } from '../types/sett
 
 type ActionHandlers = Record<ShortcutAction, () => void>
 
+/**
+ * Render a KeyBinding as a human-readable combo, e.g. Ctrl+Shift+C.
+ * Shared by the settings UI and the terminal context-menu shortcut hints so
+ * both show the same format (Cmd on macOS, Meta elsewhere).
+ */
+export function formatKeyBinding(b: KeyBinding, isMac: boolean): string {
+  if (!b) return ''
+  const parts: string[] = []
+  if (b.ctrl) parts.push('Ctrl')
+  if (b.meta) parts.push(isMac ? 'Cmd' : 'Meta')
+  if (b.shift) parts.push('Shift')
+  if (b.alt) parts.push('Alt')
+  parts.push(b.key)
+  return parts.join('+')
+}
+
 function bindingKey(b: KeyBinding): string {
   if (!b.key) return ''
   let k = ''


### PR DESCRIPTION
## Summary

Show each action's currently-bound shortcut (e.g. `Ctrl+Shift+C`) right next to its menu item / tooltip so users can discover the app's configurable keybindings. Hints are reactive: they read `settingsStore.settings.keyboard` and share a single `formatKeyBinding` helper, so they update immediately when the user rebinds a key in Settings.

## Changes

- **Terminal right-click menu** (`BaseTerminal.vue`): show shortcut for 复制/Copy, 粘贴/Paste, 文本搜索/Search text
- **Tab right-click menu** (`TabItem.vue`): show shortcut for Duplicate (`duplicateSession`), Lock/Unlock AI (`lockAI`), Search text (`terminalSearch`), Close (`closePanel`)
- **Panel "..." menu** (`Panel.vue`): show shortcut for Duplicate and Search text
- **Header tooltips** (`AppHeader.vue`): append shortcut to Connection sidebar (`toggleSidebar`), AI sidebar (`focusAI`), Settings (`openSettings`)
- **New-tab "+" tooltip** (`TabsList.vue`): append shortcut (`newConnection`)
- Extract shared `formatKeyBinding` into `useKeyboardShortcuts.ts`, reused by SettingsTab and all of the above
- Menu items become flex rows with a right-aligned muted shortcut hint (`.menu-shortcut`)

---

## 变更摘要

在每个菜单项 / 提示旁显示对应操作当前绑定的快捷键（如 `Ctrl+Shift+C`），方便用户发现应用的可配置快捷键。提示是响应式的：读取 `settingsStore.settings.keyboard` 并复用统一的 `formatKeyBinding` 辅助函数，用户在设置里改键后即时更新。

## 变更内容

- **终端右键菜单**（`BaseTerminal.vue`）：为 复制、粘贴、文本搜索 显示快捷键
- **标签右键菜单**（`TabItem.vue`）：为 复制会话（duplicateSession）、锁定/解锁AI（lockAI）、文本搜索（terminalSearch）、关闭（closePanel）显示快捷键
- **面板 "..." 菜单**（`Panel.vue`）：为 复制会话 和 文本搜索 显示快捷键
- **顶栏按钮 tooltip**（`AppHeader.vue`）：连接边栏（toggleSidebar）、AI 边栏（focusAI）、设置（openSettings）提示追加快捷键
- **新标签 "+" tooltip**（`TabsList.vue`）：提示追加快捷键（newConnection）
- 抽取共享 `formatKeyBinding` 到 `useKeyboardShortcuts.ts`，供 SettingsTab 与上述各处复用
- 菜单项改为 flex 布局，右侧显示右对齐的弱化快捷键（`.menu-shortcut`）
