### PR TITLE
fix: reload keychain/proxy after sync and migrate backgrounds

### DIFF
--- a/app.go
+++ b/app.go
@@ -943,13 +943,19 @@ func (a *App) LoadLocalState() (store.LocalState, error) {
 }
 
 // bgDir returns the directory holding the (local-only, never-synced)
-// background image. It is created on demand.
+// background image. It is rooted under the active data directory so the
+// image moves with the config when the data dir is migrated. It is
+// created on demand.
 func (a *App) bgDir() (string, error) {
-	configDir, err := os.UserConfigDir()
-	if err != nil {
-		return "", err
+	base := a.dataDir
+	if base == "" {
+		var err error
+		base, err = store.DefaultDataDir()
+		if err != nil {
+			return "", err
+		}
 	}
-	dir := filepath.Join(configDir, "uniTerm", "backgrounds")
+	dir := filepath.Join(base, "backgrounds")
 	if err := os.MkdirAll(dir, 0700); err != nil {
 		return "", err
 	}
@@ -1051,6 +1057,16 @@ func (a *App) reloadStoresAfterSync() {
 			runtime.EventsEmit(a.ctx, "store:quickCommands:changed", data)
 		}
 	}
+	if a.identityStore != nil {
+		if data, err := a.identityStore.Load(); err == nil {
+			runtime.EventsEmit(a.ctx, "store:identities:changed", data)
+		}
+	}
+	if a.proxyStore != nil {
+		if data, err := a.proxyStore.Load(); err == nil {
+			runtime.EventsEmit(a.ctx, "store:proxies:changed", data)
+		}
+	}
 }
 
 func (a *App) triggerAutoSync() {
@@ -1148,12 +1164,7 @@ func (a *App) SyncResolveConflict(useLocal bool) (*sync.SyncResult, error) {
 		return nil, err
 	}
 	if result.Direction == sync.SyncPull {
-		if data, err := a.connectionStore.Load(); err == nil {
-			runtime.EventsEmit(a.ctx, "store:connections:changed", data)
-		}
-		if settings, err := a.settingsStore.Load(); err == nil {
-			runtime.EventsEmit(a.ctx, "store:settings:changed", settings)
-		}
+		a.reloadStoresAfterSync()
 	}
 	return result, nil
 }

--- a/frontend/src/stores/identityStore.ts
+++ b/frontend/src/stores/identityStore.ts
@@ -1,7 +1,11 @@
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
 import { LoadIdentities, SaveIdentities } from '../../wailsjs/go/main/App'
+import { EventsOn } from '../../wailsjs/runtime'
 import type { Identity, IdentityStoreData } from '../types/identity'
+
+// Module-level un-subscriber for the cross-window store:identities:changed listener.
+let unsubIdentitiesChanged: (() => void) | null = null
 
 export const useIdentityStore = defineStore('identity', () => {
   const identities = ref<Identity[]>([])
@@ -23,6 +27,18 @@ export const useIdentityStore = defineStore('identity', () => {
     await SaveIdentities({ identities: identities.value } as any)
   }
 
+  // Reload from disk when the backend pushes updated identity data (e.g. after
+  // a cloud sync pull), so the keychain isn't stale until restart.
+  unsubIdentitiesChanged?.()
+  unsubIdentitiesChanged = EventsOn('store:identities:changed', (data: IdentityStoreData) => {
+    if (data?.identities) identities.value = data.identities
+  })
+
+  function dispose() {
+    unsubIdentitiesChanged?.()
+    unsubIdentitiesChanged = null
+  }
+
   async function add(id: Identity) {
     identities.value.push(id)
     await save()
@@ -39,5 +55,5 @@ export const useIdentityStore = defineStore('identity', () => {
     await save()
   }
 
-  return { identities, loading, load, save, add, update, remove }
+  return { identities, loading, load, save, add, update, remove, dispose }
 })

--- a/frontend/src/stores/proxyStore.ts
+++ b/frontend/src/stores/proxyStore.ts
@@ -1,7 +1,11 @@
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
 import { LoadProxies, SaveProxies } from '../../wailsjs/go/main/App'
+import { EventsOn } from '../../wailsjs/runtime'
 import type { Proxy, ProxyStoreData } from '../types/proxy'
+
+// Module-level un-subscriber for the cross-window store:proxies:changed listener.
+let unsubProxiesChanged: (() => void) | null = null
 
 export const useProxyStore = defineStore('proxy', () => {
   const proxies = ref<Proxy[]>([])
@@ -23,6 +27,18 @@ export const useProxyStore = defineStore('proxy', () => {
     await SaveProxies({ proxies: proxies.value } as any)
   }
 
+  // Reload from disk when the backend pushes updated proxy data (e.g. after a
+  // cloud sync pull), so the list isn't stale until restart.
+  unsubProxiesChanged?.()
+  unsubProxiesChanged = EventsOn('store:proxies:changed', (data: ProxyStoreData) => {
+    if (data?.proxies) proxies.value = data.proxies
+  })
+
+  function dispose() {
+    unsubProxiesChanged?.()
+    unsubProxiesChanged = null
+  }
+
   async function add(p: Proxy) {
     proxies.value.push(p)
     await save()
@@ -39,5 +55,5 @@ export const useProxyStore = defineStore('proxy', () => {
     await save()
   }
 
-  return { proxies, loading, load, save, add, update, remove }
+  return { proxies, loading, load, save, add, update, remove, dispose }
 })


### PR DESCRIPTION
## Summary

Two bug fixes for data that didn't show up until a restart.

1. **Cloud sync pull left the keychain and proxy list empty.** `reloadStoresAfterSync` only reloaded connections, settings and quick commands, so after a sync pull in a fresh environment, `identities.json` (keychain) and `proxies.json` (proxy list) were written to disk but the in-memory stores stayed empty until restart. It now also reloads `identityStore` and `proxyStore`, and `SyncResolveConflict`'s pull branch delegates to the same reload path.
2. **Background image was not migrated with the config directory.** `bgDir()` resolved to a hardcoded `UserConfigDir/uniTerm/backgrounds`, unrelated to the active data directory, so changing data dir dropped the image. It now lives under the data directory (`<dataDir>/backgrounds`) and moves with it on migration.

---

## 概述

两个需要重启才能生效、或迁移后丢失的数据修复。

1. **云同步拉取后钥匙库和代理列表为空。** `reloadStoresAfterSync` 原来只重载连接、设置和快捷命令；同步 pull 后 `identities.json`（钥匙库）和 `proxies.json`（代理列表）已写入磁盘，但前端内存仍为空，直到重启。现在补上 `identityStore` 和 `proxyStore` 的重载，`SyncResolveConflict` 的拉取分支也统一走同一重载路径。
2. **背景图不随配置目录迁移。** `bgDir()` 原来写死用 `UserConfigDir/uniTerm/backgrounds`，与当前数据目录无关，更换数据目录后背景丢失。现在背景图存放在数据目录下（`<dataDir>/backgrounds`），随数据目录一起迁移。
