### PR TITLE
feat(sftp): prompt overwrite/rename/cancel on local download conflict

### DIFF
--- a/frontend/src/components/SFTPTabContent.vue
+++ b/frontend/src/components/SFTPTabContent.vue
@@ -940,13 +940,24 @@ async function onSendToRemote(items: FileItem[]) {
   }
 }
 
-function onSendToLocal(items: FileItem[]) {
+async function onSendToLocal(items: FileItem[]) {
   const sid = panel.value?.sessionId
   if (!sid) return
+
+  const fileNames = items.filter(i => i.name !== '..').map(i => i.name)
+  const action = await checkLocalConflicts(fileNames)
+  if (action === 'cancel') return
+
+  const existingNames = localFiles.value.map(f => f.name)
   for (const item of items) {
     if (item.name === '..') continue
+    let resolvedName = item.name
+    if (action === 'rename' && existingNames.includes(item.name)) {
+      resolvedName = autoRename(item.name, existingNames)
+    }
+    existingNames.push(resolvedName)
     const remotePath = joinPath(cwd.value, item.name)
-    const localPath = joinPath(localCwd.value, item.name).replace(/\\/g, '/')
+    const localPath = joinPath(localCwd.value, resolvedName).replace(/\\/g, '/')
     SftpGet(sid, remotePath, localPath, item.isDir)
   }
 }
@@ -982,10 +993,30 @@ async function onDownloadTo(items: FileItem[]) {
   try {
     const dir = await OpenDirectoryDialog()
     if (!dir) return
+
+    const fileNames = items.filter(i => i.name !== '..').map(i => i.name)
+    // Conflict check against the selected directory (may differ from current localCwd).
+    let targetNames: string[] = []
+    try {
+      const result = await SftpListLocal(sid, dir)
+      targetNames = result.files.map(f => f.name)
+    } catch { /* if listing fails, proceed without conflict prompting */ }
+    const conflicts = fileNames.filter(n => targetNames.includes(n))
+    let action: 'overwrite' | 'rename' | 'cancel' = 'overwrite'
+    if (conflicts.length > 0) {
+      action = await showConflictDialog(conflicts)
+      if (action === 'cancel') return
+    }
+    const existingNames = [...targetNames]
     for (const item of items) {
       if (item.name === '..') continue
+      let resolvedName = item.name
+      if (action === 'rename' && existingNames.includes(item.name)) {
+        resolvedName = autoRename(item.name, existingNames)
+      }
+      existingNames.push(resolvedName)
       const remotePath = joinPath(cwd.value, item.name)
-      const localPath = (dir + '/' + item.name).replace(/\\/g, '/')
+      const localPath = (dir + '/' + resolvedName).replace(/\\/g, '/')
       SftpGet(sid, remotePath, localPath, item.isDir)
     }
   } catch (e) {
@@ -1069,6 +1100,13 @@ function showConflictDialog(conflicts: string[]): Promise<'overwrite' | 'rename'
 
 async function checkRemoteConflicts(fileNames: string[]): Promise<'overwrite' | 'rename' | 'cancel'> {
   const existingNames = remoteFiles.value.map(f => f.name)
+  const conflicts = fileNames.filter(n => existingNames.includes(n))
+  if (conflicts.length === 0) return 'overwrite'
+  return showConflictDialog(conflicts)
+}
+
+async function checkLocalConflicts(fileNames: string[]): Promise<'overwrite' | 'rename' | 'cancel'> {
+  const existingNames = localFiles.value.map(f => f.name)
   const conflicts = fileNames.filter(n => existingNames.includes(n))
   if (conflicts.length === 0) return 'overwrite'
   return showConflictDialog(conflicts)
@@ -1604,7 +1642,7 @@ function clearDragState() {
   dragSource.value = null
 }
 
-function onDropLocal(e: DragEvent) {
+async function onDropLocal(e: DragEvent) {
   e.preventDefault()
   dragDroppedInternally = true
   clearDragState()
@@ -1613,9 +1651,19 @@ function onDropLocal(e: DragEvent) {
   try {
     const item = JSON.parse(data)
     if (item.mode === 'remote') {
+      const sid = panel.value?.sessionId
+      if (!sid) return
+      const action = await checkLocalConflicts([item.name])
+      if (action === 'cancel') return
+
+      let resolvedName = item.name
+      if (action === 'rename') {
+        const existingNames = localFiles.value.map(f => f.name)
+        resolvedName = autoRename(item.name, existingNames)
+      }
       const remotePath = joinPath(cwd.value, item.name)
-      const localPath = joinPath(localCwd.value, item.name).replace(/\\/g, '/')
-      SftpGet(panel.value?.sessionId!, remotePath, localPath, item.isDir)
+      const localPath = joinPath(localCwd.value, resolvedName).replace(/\\/g, '/')
+      SftpGet(sid, remotePath, localPath, item.isDir)
     }
   } catch (e) { console.error('onDropLocal:', e) }
 }


### PR DESCRIPTION
## What changed

Added overwrite/rename/cancel conflict detection for the three SFTP **download** paths that previously overwrote local same-name files without any prompt:

1. Remote list → "send to local"
2. Dragging a remote file onto the local pane
3. "Download to…" (conflicts checked against the selected target directory, which may differ from the current local dir)

The remote → local upload paths already had this prompt (`checkRemoteConflicts`); this adds the mirror `checkLocalConflicts` so all transfer flows behave consistently.

refs #519

---

## 变更内容

为三个 SFTP **下载**路径补充了重名文件冲突检测（覆盖 / 重命名 / 取消），此前这些路径遇到本地同名文件会直接覆盖、没有任何提示：

1. 远程列表 →「发送到本地」
2. 把远程文件拖拽到本地面板
3. 「下载到…」（冲突会针对所选目标目录判断，该目录可能不同于当前本地目录）

本地 → 远程的上传路径此前已有该提示（`checkRemoteConflicts`）；本次新增对应的 `checkLocalConflicts`，使所有传输流程行为一致。

refs #519
