### PR TITLE
fix(highlight): drop lookbehind regex that black-screens WKWebView on macOS <=12.3

### DIFF
--- a/frontend/src/composables/useHighlight.ts
+++ b/frontend/src/composables/useHighlight.ts
@@ -52,7 +52,11 @@ const C = {
 const PATTERNS: { sgr: string; regexes: RegExp[] }[] = [
   { sgr: C.url,     regexes: [/https?:\/\/[^\s\x1b]+/gi] },
   { sgr: C.ip,      regexes: [/\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}(:\d+)?\b/g] },
-  { sgr: C.path,    regexes: [/(?<=^|\s)(?:\/|~\/)[\w.\/-]+(?=[\s:;"')\]}]|$)/g] },
+  // NOTE: path/`~/` must not use a lookbehind ((?<=…)) — it is a parse-time
+  // feature unsupported by the JavaScriptCore in macOS ≤12.3 (Safari 15.4
+  // WebView), where the whole module fails to parse and the terminal shows
+  // a black screen. Anchor the start with a consuming (^|\s) group instead.
+  { sgr: C.path,    regexes: [/(?:^|\s)(?:\/|~\/)[\w.\/-]+(?=[\s:;"')\]}]|$)/g] },
   { sgr: C.datetime, regexes: [
     /\b\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}(?::\d{2})?(?:[.,]\d+)?Z?\b/g,
     /\b(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun)\s+(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s+\d{1,2}\s+\d{2}:\d{2}:\d{2}\s+\d{4}\b/g,


### PR DESCRIPTION
Closes #557

## Summary

Fix a black screen on macOS Monterey 12.3 (and earlier) by removing a regex
lookbehind that is a parse-time syntax error in that environment's WebView.

The path-highlight regex in `useHighlight.ts` used a lookbehind `(?<=^|\s)`.
Backtracking lookbehind is only supported by JavaScriptCore starting with
Safari 16.4; the WKWebView bundled in macOS 12.3 is based on Safari/JSContext
15.4. Critically this is a *parse* error, not a runtime one — the entire JS
module fails to compile, Vue never mounts, and the window renders as a black
screen. This happened for every user regardless of whether the path-highlight
logic actually ran.

Fix: anchor the match with a consuming `(?:^|\s)` group instead of lookbehind.
The leading whitespace is invisible, so the rendered output is unchanged, and
consuming the anchor keeps adjacent path matches from overlapping. A comment
documents why lookbehind is avoided so the regression cannot return.

## Verification

- Full `src/` scan confirms no other lookbehind literals remain.
- Clean rebuild (`rm -rf dist node_modules/.vite && npm run build`) succeeds.
- The compiled bundle contains the consuming-group form and no lookbehind from
  this module (the lone remaining `?<=` is inside element-plus, an
  unreachable branch guarded by `includeBoundaries`, which nothing sets true).

---
## 概述

修复 macOS Monterey 12.3（及更早版本）上的黑屏问题：移除一处在该环境 WebView 下属于
**解析期报错**的正则后行断言。

`useHighlight.ts` 的路径高亮正则在起点用了后行断言 `(?<=^|\s)`。后行断言（lookbehind）是
JavaScriptCore 从 Safari 16.4 才支持的特性，而 macOS 12.3 内置的 WKWebView 基于
Safari/JSContext 15.4。关键在于这是**解析期错误而非运行期错误**：整个 JS 模块编译失败、
Vue 挂载不上，窗口只剩深色背景（黑屏）。无论用户是否触发该高亮逻辑都会崩溃。

修复：改用消耗型分组 `(?:^|\s)` 作为起点锚定代替后行断言。前导空白不可见，渲染结果不变，
且消费掉锚点后相邻路径匹配天然不重叠。附注释说明为何避免后行断言，防止回归。

## 验证

- 全量扫描 `src/` 确认无其他后行断言残留。
- 清理缓存后重新构建（`rm -rf dist node_modules/.vite && npm run build`）成功。
- 产物中本模块为消耗型分组形式、无后行断言（唯一残留的 `?<=` 在 element-plus 内，属
  `includeBoundaries` 守卫下不可达的分支，无任何调用点会将其置真）。
