### PR TITLE
feat(connection): locate-to-connection in tab & panel menus

### DIFF
--- a/frontend/src/components/GroupTreeItem.vue
+++ b/frontend/src/components/GroupTreeItem.vue
@@ -39,6 +39,7 @@
       v-for="conn in node.connections"
       :key="conn.id"
       class="connection-item indented"
+      :data-conn-id="conn.id"
       :class="{
         active: selected.has(conn.id),
         'drop-before': dropIndicator?.id === conn.id && dropIndicator?.position === 'before',

--- a/frontend/src/components/Panel.vue
+++ b/frontend/src/components/Panel.vue
@@ -61,6 +61,7 @@
               <span class="menu-shortcut">{{ menuShortcut('duplicateSession') }}</span>
             </div>
             <div class="menu-item" @click="renamePanel">{{ t('tab.rename') }}</div>
+            <div v-if="panel.config?.id" class="menu-item" @click="locateConnection">{{ t('tab.locate') }}</div>
 
             <!-- ② 会话文本操作 -->
             <div class="menu-divider" />
@@ -303,6 +304,13 @@ function startEdit() {
 function renamePanel() {
   moreMenuVisible.value = false
   startEdit()
+}
+
+function locateConnection() {
+  moreMenuVisible.value = false
+  if (props.panel.config?.id) {
+    window.dispatchEvent(new CustomEvent('app:locate-connection', { detail: { id: props.panel.config.id } }))
+  }
 }
 
 function confirmEdit() {

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -122,6 +122,7 @@
             v-for="conn in filteredGrouped.ungrouped"
             :key="conn.id"
             class="connection-item indented"
+            :data-conn-id="conn.id"
             :class="{
               active: selectedIds.has(conn.id),
               'drop-before': dropIndicator?.id === conn.id && dropIndicator?.position === 'before',
@@ -154,6 +155,7 @@
           v-for="conn in filteredGrouped.ungrouped"
           :key="conn.id"
           class="connection-item"
+          :data-conn-id="conn.id"
           :class="{
             active: selectedIds.has(conn.id),
             'drop-before': dropIndicator?.id === conn.id && dropIndicator?.position === 'before',
@@ -1135,6 +1137,50 @@ function onItemClick(e: MouseEvent, conn: ConnectionConfig) {
   }
 }
 
+// ── Locate a connection from the tab context menu ──
+async function locateConnectionById(id: string) {
+  const conn = connectionStore.connections.find(c => c.id === id)
+  if (!conn) return
+
+  // Surface the target: drop any search / type filter that could hide it.
+  searchQuery.value = ''
+  selectedTypeFilter.value = 'all'
+
+  // Expand the containing group (and its ancestors) so the row is rendered.
+  if (conn.groupId) {
+    let gid: string | undefined = conn.groupId
+    while (gid) {
+      expandedGroups.value.add(gid)
+      collapsedGroupIds.value.delete(gid)
+      const g = connectionStore.groups.find(g => g.id === gid)
+      gid = g?.parentId
+    }
+    expandedGroups.value = new Set(expandedGroups.value)
+  } else if (connectionStore.groups.length > 0) {
+    // Ungrouped target with real groups present → expand the virtual No-Group group.
+    expandedGroups.value.add('__ungrouped__')
+    collapsedGroupIds.value.delete('__ungrouped__')
+    expandedGroups.value = new Set(expandedGroups.value)
+  }
+
+  // Select the target. focusedId is set before the filter watcher flushes,
+  // so that watcher keeps our selection instead of resetting to the first row.
+  focusedId.value = conn.id
+  lastClickId.value = conn.id
+  selectedConn.value = conn
+  selectedIds.value = new Set([conn.id])
+
+  await nextTick()
+  await nextTick()
+  const row = sidebarEl.value?.querySelector<HTMLElement>(`.connection-item[data-conn-id="${conn.id}"]`)
+  row?.scrollIntoView({ block: 'nearest' })
+}
+
+function onLocateConnection(e: Event) {
+  const id = (e as CustomEvent)?.detail?.id
+  if (typeof id === 'string') locateConnectionById(id)
+}
+
 function onItemDblClick(conn: ConnectionConfig) {
   selectedIds.value = new Set()
   if (conn.type === 'database') {
@@ -1820,6 +1866,7 @@ onMounted(async () => {
     closeGroupMenu()
     closeEmptyAreaMenu()
   })
+  window.addEventListener('app:locate-connection', onLocateConnection)
   document.addEventListener('click', () => {
     closeMenu()
     closeGroupMenu()
@@ -1853,6 +1900,7 @@ onUnmounted(() => {
     closeGroupMenu()
     closeEmptyAreaMenu()
   })
+  window.removeEventListener('app:locate-connection', onLocateConnection)
   document.removeEventListener('click', () => {
     closeMenu()
     closeGroupMenu()

--- a/frontend/src/components/TabItem.vue
+++ b/frontend/src/components/TabItem.vue
@@ -68,6 +68,7 @@
           <span class="menu-shortcut">{{ menuShortcut('lockAI') }}</span>
         </div>
         <div v-if="tab.type !== 'start' && tab.type !== 'settings'" class="menu-item" @click="startEdit">{{ t('tab.rename') }}</div>
+        <div v-if="hasLocatableConnection" class="menu-item" @click="locateHost">{{ t('tab.locate') }}</div>
         <div v-if="tab.type !== 'start' && tab.type !== 'settings'" class="menu-item" @click="toggleLock">
           {{ tab.locked ? t('tab.unlock') : t('tab.lock') }}
         </div>
@@ -291,6 +292,13 @@ const showGroupTab = computed(() =>
 )
 const showGroupText = computed(() => props.tab.type === 'terminal')
 const showGroupConn = computed(() => props.tab.type === 'rdp' || isSsh.value)
+
+// True when the tab's panel is backed by a saved connection (has a config id),
+// so the "定位到连接" item can locate it in the sidebar's connection list.
+const hasLocatableConnection = computed(() => {
+  if (!('panelId' in props.tab)) return false
+  return !!panelStore.getPanel(props.tab.panelId)?.config?.id
+})
 
 // Connection host (IP or hostname) of the tab's panel. Empty for tab types
 // without a remote endpoint (local, k8s, container, start, settings…).
@@ -542,6 +550,14 @@ function openMonitor() {
   const panel = panelStore.getPanel((props.tab as TerminalTab).panelId)
   if (panel) {
     window.dispatchEvent(new CustomEvent('app:connect-monitor', { detail: panel }))
+  }
+  closeContextMenu()
+}
+
+function locateHost() {
+  const panel = panelStore.getPanel((props.tab as TerminalTab).panelId)
+  if (panel?.config?.id) {
+    window.dispatchEvent(new CustomEvent('app:locate-connection', { detail: { id: panel.config.id } }))
   }
   closeContextMenu()
 }

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -105,6 +105,7 @@
   "tab.copyHostAddress": "Hostadresse kopieren",
   "tab.hostCopied": "Hostadresse kopiert: {host}",
   "tab.rename": "Umbenennen",
+  "tab.locate": "Verbindung finden",
   "tab.closeRight": "Tabs rechts schließen",
   "tab.closeLeft": "Tabs links schließen",
   "tab.closeOther": "Andere Tabs schließen",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -105,6 +105,7 @@
   "tab.copyHostAddress": "Copy Host Address",
   "tab.hostCopied": "Host address copied: {host}",
   "tab.rename": "Rename",
+  "tab.locate": "Locate connection",
   "tab.closeRight": "Close Tabs to the Right",
   "tab.closeLeft": "Close Tabs to the Left",
   "tab.closeOther": "Close Other Tabs",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -105,6 +105,7 @@
   "tab.copyHostAddress": "Copiar dirección del host",
   "tab.hostCopied": "Dirección del host copiada: {host}",
   "tab.rename": "Renombrar",
+  "tab.locate": "Localizar conexión",
   "tab.closeRight": "Cerrar pestañas a la derecha",
   "tab.closeLeft": "Cerrar pestañas a la izquierda",
   "tab.closeOther": "Cerrar otras pestañas",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -105,6 +105,7 @@
   "tab.copyHostAddress": "Copier l'adresse de l'hôte",
   "tab.hostCopied": "Adresse de l'hôte copiée : {host}",
   "tab.rename": "Renommer",
+  "tab.locate": "Localiser la connexion",
   "tab.closeRight": "Fermer les onglets à droite",
   "tab.closeLeft": "Fermer les onglets à gauche",
   "tab.closeOther": "Fermer les autres onglets",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -105,6 +105,7 @@
   "tab.copyHostAddress": "ホストアドレスをコピー",
   "tab.hostCopied": "ホストアドレスをコピーしました：{host}",
   "tab.rename": "名前を変更",
+  "tab.locate": "接続先を探す",
   "tab.closeRight": "右側のタブを閉じる",
   "tab.closeLeft": "左側のタブを閉じる",
   "tab.closeOther": "他のタブを閉じる",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -105,6 +105,7 @@
   "tab.copyHostAddress": "호스트 주소 복사",
   "tab.hostCopied": "호스트 주소가 복사되었습니다: {host}",
   "tab.rename": "이름 변경",
+  "tab.locate": "연결 위치 찾기",
   "tab.closeRight": "오른쪽 탭 닫기",
   "tab.closeLeft": "왼쪽 탭 닫기",
   "tab.closeOther": "다른 탭 닫기",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -105,6 +105,7 @@
   "tab.copyHostAddress": "Скопировать адрес хоста",
   "tab.hostCopied": "Адрес хоста скопирован: {host}",
   "tab.rename": "Переименовать",
+  "tab.locate": "Найти подключение",
   "tab.closeRight": "Закрыть вкладки справа",
   "tab.closeLeft": "Закрыть вкладки слева",
   "tab.closeOther": "Закрыть другие вкладки",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -105,6 +105,7 @@
   "tab.copyHostAddress": "复制主机地址",
   "tab.hostCopied": "已复制主机地址：{host}",
   "tab.rename": "重命名",
+  "tab.locate": "定位到连接",
   "tab.closeRight": "关闭右侧标签",
   "tab.closeLeft": "关闭左侧标签",
   "tab.closeOther": "关闭其他标签",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -105,6 +105,7 @@
   "tab.copyHostAddress": "複製主機位址",
   "tab.hostCopied": "已複製主機位址：{host}",
   "tab.rename": "重新命名",
+  "tab.locate": "定位到連接",
   "tab.closeRight": "關閉右側分頁",
   "tab.closeLeft": "關閉左側分頁",
   "tab.closeOther": "關閉其他分頁",


### PR DESCRIPTION
## Summary
Add a **Locate connection** menu item to both the tab context menu (TabItem.vue) and the panel "..." menu (Panel.vue), placed directly below *Rename*. Clicking it dispatches an `app:locate-connection` event; the sidebar matches the connection by id, selects and highlights it, expands its containing group (walking the `parentId` chain, including the virtual *No Group* group), and scrolls it into view. Any active search or type filter is cleared so the target is always surfaceable.

Fixes #410.

## Changes
- **TabItem.vue** / **Panel.vue**: "Locate connection" (`tab.locate`) menu item below Rename, gated on the tab/panel having a saved connection config id.
- **Sidebar.vue**: `app:locate-connection` listener + `locateConnectionById()` (clear filters, expand group ancestors, select, scroll).
- **GroupTreeItem.vue / Sidebar.vue**: added `:data-conn-id` to connection rows for robust scroll targeting.
- **i18n**: `tab.locate` key added to all 9 locale files.

---
## 概述
在标签右键菜单和面板的「...」菜单中都新增 **定位到连接** 菜单项，放置在*重命名*下方。点击后派发 `app:locate-connection` 事件，侧边栏按连接 id 匹配并选中高亮，展开所在分组（沿 `parentId` 链，含虚拟「无分组」），并滚动到可见位置。若存在搜索或类型过滤，会先清除以便目标连接始终可见。

修复 #410。

## 改动
- **TabItem.vue / Panel.vue**：在「重命名」下方新增「定位到连接」菜单项，按标签/面板是否拥有已保存连接的 config id 控制显隐。
- **Sidebar.vue**：新增 `app:locate-connection` 监听及 `locateConnectionById()`（清过滤、展开分组祖先、选中、滚动）。
- **GroupTreeItem.vue / Sidebar.vue**：为连接行添加 `:data-conn-id`，便于稳定滚动定位。
- **i18n**：为 9 个语言文件新增 `tab.locate` 文案。