### PR TITLE
feat(connection): open-session status indicator & locate session

### DIFF
--- a/frontend/src/components/GroupTreeItem.vue
+++ b/frontend/src/components/GroupTreeItem.vue
@@ -41,6 +41,7 @@
       class="connection-item indented"
       :class="{
         active: selected.has(conn.id),
+        'has-session': openConns.has(conn.id),
         'drop-before': dropIndicator?.id === conn.id && dropIndicator?.position === 'before',
         'drop-after': dropIndicator?.id === conn.id && dropIndicator?.position === 'after',
       }"
@@ -91,6 +92,7 @@ const totalCount = computed(() => {
 // Injected from Sidebar
 const expanded = inject<Set<string>>('expandedGroups')!
 const selected = inject<Set<string>>('selectedIds')!
+const openConns = inject<Set<string>>('openPanelConnIds')!
 const dragOverId = inject<any>('dragOverGroupId')!
 const dropIndicator = inject<any>('dropIndicator')!
 const handlers = inject<any>('groupHandlers')!
@@ -252,6 +254,11 @@ function onMoreClick(e: MouseEvent, conn: ConnectionConfig) {
 }
 .connection-item.active .name {
   color: var(--accent);
+}
+
+/* Connection has an open session → highlight its icon with the AI-lock amber */
+.connection-item.has-session .conn-icon {
+  color: var(--warning);
 }
 
 .conn-more-btn {

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -124,6 +124,7 @@
             class="connection-item indented"
             :class="{
               active: selectedIds.has(conn.id),
+              'has-session': openPanelConnIds.has(conn.id),
               'drop-before': dropIndicator?.id === conn.id && dropIndicator?.position === 'before',
               'drop-after': dropIndicator?.id === conn.id && dropIndicator?.position === 'after',
             }"
@@ -156,6 +157,7 @@
           class="connection-item"
           :class="{
             active: selectedIds.has(conn.id),
+            'has-session': openPanelConnIds.has(conn.id),
             'drop-before': dropIndicator?.id === conn.id && dropIndicator?.position === 'before',
             'drop-after': dropIndicator?.id === conn.id && dropIndicator?.position === 'after',
           }"
@@ -348,6 +350,7 @@
       <div v-if="selectedConn && selectedConn.type === 'k8s'" class="menu-item" @click="doConnectK8s">{{ t('sidebar.connectK8s') }}</div>
       <div v-if="selectedConn && selectedConn.type === 'container'" class="menu-item" @click="doConnect">{{ t('sidebar.connectContainer') }}</div>
       <div v-if="selectedConn && selectedConn.type === 'ssh'" class="menu-item" @click="doConnectMonitor">{{ t('sidebar.connectMonitor') }}</div>
+      <div v-if="selectedConn && isConnOpen(selectedConn.id)" class="menu-item" @click="doLocateSession">{{ t('sidebar.locateSession') }}</div>
       <div class="menu-divider" />
       <div class="menu-item" :class="{ disabled: selectedIds.size > 1 }" @click="selectedIds.size <= 1 && doEdit()">{{ t('sidebar.edit') }}</div>
       <div class="menu-item" @click="doDuplicate">{{ t('sidebar.duplicate') }}</div>
@@ -497,6 +500,8 @@ import { ElMessageBox } from 'element-plus'
 import { msg } from '../services/message'
 import { useConnectionStore } from '../stores/connectionStore'
 import type { GroupTreeNode } from '../stores/connectionStore'
+import { usePanelStore } from '../stores/panelStore'
+import { useTabStore } from '../stores/tabStore'
 import { useSettingsStore } from '../stores/settingsStore'
 import { useI18n } from '../i18n'
 import ConnectionForm from './ConnectionForm.vue'
@@ -521,7 +526,19 @@ defineProps<{
 const emit = defineEmits(['connect', 'connectSftp', 'connectFtp', 'connectSmb', 'connectWebdav', 'connectS3', 'connectRdp', 'connectVnc', 'connectSpice', 'connectX11Desktop', 'connectDB', 'connectMonitor', 'connectSerial', 'connectK8s', 'toggle', 'new-local-terminal-with-shell'])
 const connectionStore = useConnectionStore()
 const settingsStore = useSettingsStore()
+const panelStore = usePanelStore()
+const tabStore = useTabStore()
 const { t } = useI18n()
+
+// Connection ids that currently have an open panel/session (panel.config.id).
+// Reactive over the panelStore map, so it updates as panels open/close.
+const openPanelConnIds = computed<Set<string>>(() => {
+  const s = new Set<string>()
+  for (const p of panelStore.panels.values()) {
+    if (p.config?.id) s.add(p.config.id)
+  }
+  return s
+})
 const showForm = ref(false)
 const showExportDialog = ref(false)
 const showImportDialog = ref(false)
@@ -1290,6 +1307,28 @@ function doConnectMonitor() {
   }
 }
 
+// Whether the given connection id currently has an open panel/session.
+function isConnOpen(id: string): boolean {
+  return openPanelConnIds.value.has(id)
+}
+
+// Switch to the existing tab/session hosting this connection instead of opening a new one.
+function doLocateSession() {
+  closeMenu()
+  const id = selectedConn.value?.id
+  if (!id) return
+  for (const p of panelStore.panels.values()) {
+    if (p.config?.id !== id) continue
+    const tab = tabStore.tabs.find(t => t.id === p.tabId)
+    if (!tab) continue
+    tabStore.setActiveTab(tab.id)
+    if (tab.type === 'workspace') {
+      tabStore.setActivePanel(tab.id, p.id)
+    }
+    break
+  }
+}
+
 function doConnectRDP() {
   const ids = getSelectedConnectionIds()
   const conns = ids.map(id => connectionStore.connections.find(c => c.id === id)).filter(Boolean) as ConnectionConfig[]
@@ -1863,6 +1902,7 @@ onUnmounted(() => {
 // Provide to GroupTreeItem (after all refs/functions are defined)
 provide('expandedGroups', expandedGroups)
 provide('selectedIds', selectedIds)
+provide('openPanelConnIds', openPanelConnIds)
 provide('dragOverGroupId', dragOverGroupId)
 provide('dropIndicator', dropIndicator)
 provide('groupHandlers', {
@@ -2130,6 +2170,11 @@ defineExpose({ focusSearch, openChangeGroupFor, openChangeGroupForGroup })
 
 .connection-item.active .name {
   color: var(--accent);
+}
+
+/* Connection has an open session → highlight its icon with the AI-lock amber */
+.connection-item.has-session .conn-icon {
+  color: var(--warning);
 }
 
 .conn-more-btn {

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -20,6 +20,7 @@
   "sidebar.connectS3": "S3 verbinden",
   "sidebar.edit": "Bearbeiten",
   "sidebar.duplicate": "Duplizieren",
+  "sidebar.locateSession": "Sitzung finden",
   "sidebar.delete": "Löschen",
   "sidebar.deleteConfirm": "{connCount} ausgewählte Verbindung(en) löschen?",
   "sidebar.newConnectionFromSearch": "Neue Verbindung...",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -20,6 +20,7 @@
   "sidebar.connectS3": "Connect S3",
   "sidebar.edit": "Edit",
   "sidebar.duplicate": "Duplicate",
+  "sidebar.locateSession": "Locate session",
   "sidebar.delete": "Delete",
   "sidebar.deleteConfirm": "Delete {count} selected connection(s)?",
   "sidebar.newConnectionFromSearch": "New Connection...",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -20,6 +20,7 @@
   "sidebar.connectS3": "Conectar S3",
   "sidebar.edit": "Editar",
   "sidebar.duplicate": "Duplicar",
+  "sidebar.locateSession": "Localizar sesión",
   "sidebar.delete": "Eliminar",
   "sidebar.deleteConfirm": "¿Eliminar {connCount} conexión(es) seleccionada(s)?",
   "sidebar.newConnectionFromSearch": "Nueva Conexión...",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -20,6 +20,7 @@
   "sidebar.connectS3": "Connecter en S3",
   "sidebar.edit": "Modifier",
   "sidebar.duplicate": "Dupliquer",
+  "sidebar.locateSession": "Localiser la session",
   "sidebar.delete": "Supprimer",
   "sidebar.deleteConfirm": "Supprimer {connCount} connexion(s) sélectionnée(s) ?",
   "sidebar.newConnectionFromSearch": "Nouvelle connexion...",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -20,6 +20,7 @@
   "sidebar.connectS3": "S3 で接続",
   "sidebar.edit": "編集",
   "sidebar.duplicate": "複製",
+  "sidebar.locateSession": "セッションを探す",
   "sidebar.delete": "削除",
   "sidebar.deleteConfirm": "選択した接続 {connCount} 件を削除しますか？",
   "sidebar.newConnectionFromSearch": "新規接続...",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -20,6 +20,7 @@
   "sidebar.connectS3": "S3 연결",
   "sidebar.edit": "편집",
   "sidebar.duplicate": "복제",
+  "sidebar.locateSession": "세션 위치 찾기",
   "sidebar.delete": "삭제",
   "sidebar.deleteConfirm": "선택한 연결 {connCount}개를 삭제할까요?",
   "sidebar.newConnectionFromSearch": "새 연결...",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -20,6 +20,7 @@
   "sidebar.connectS3": "Подключиться по S3",
   "sidebar.edit": "Редактировать",
   "sidebar.duplicate": "Дублировать",
+  "sidebar.locateSession": "Найти сеанс",
   "sidebar.delete": "Удалить",
   "sidebar.deleteConfirm": "Удалить {connCount} выбранных подключений?",
   "sidebar.newConnectionFromSearch": "Новое подключение...",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -20,6 +20,7 @@
   "sidebar.connectS3": "连接 S3",
   "sidebar.edit": "编辑",
   "sidebar.duplicate": "复制连接",
+  "sidebar.locateSession": "定位到会话",
   "sidebar.delete": "删除",
   "sidebar.deleteConfirm": "确定要删除选中的 {count} 个连接吗？",
   "sidebar.newConnectionFromSearch": "新建连接...",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -20,6 +20,7 @@
   "sidebar.connectS3": "連線 S3",
   "sidebar.edit": "編輯",
   "sidebar.duplicate": "複製連接",
+  "sidebar.locateSession": "定位到會話",
   "sidebar.delete": "刪除",
   "sidebar.deleteConfirm": "確定要刪除選中的 {connCount} 個連線嗎？",
   "sidebar.newConnectionFromSearch": "新增連線...",


### PR DESCRIPTION
## Summary
Show a status indicator in the sidebar connection list for connections that already have an open session, and let users jump straight to that existing session from the row's context menu.

- When a connection has an open session, its leading icon is highlighted amber (`var(--warning)`, matching the AI-lock hue) — applied consistently in both grouped and ungrouped views.
- A **Locate session** (`sidebar.locateSession`) menu item is added to the connection context menu, shown only when that connection is open. Clicking it switches to the existing tab/session (activating the panel inside workspace tabs) instead of opening a duplicate.

Fixes #326.

## Changes
- **Sidebar.vue**: `openPanelConnIds` computed (ids of all open panels) provided to GroupTreeItem + `has-session` class and amber icon; `isConnOpen()` / `doLocateSession()` handlers + context-menu item.
- **GroupTreeItem.vue**: inject `openPanelConnIds`, `has-session` class and amber icon.
- **i18n**: `sidebar.locateSession` added to all 9 locales.

---
## 概述
在左侧连接列表中为已打开会话的连接加上状态标识，并允许用户从该行的右键菜单直接跳转到已有会话。

- 当某个连接已有打开的会话时，其前置图标会高亮为琥珀色（`var(--warning)`，与 AI 锁定色一致），分组与未分组两种视图一致生效。
- 连接右键菜单新增 **定位到会话**（`sidebar.locateSession`），仅当该连接已打开时显示。点击后切换到已有标签/会话（在工作区标签内同时激活对应面板），而不是新开一个重复窗口。

修复 #326。

## 改动
- **Sidebar.vue**：新增 `openPanelConnIds` computed（所有打开面板的连接 id）并通过 provide 传递给 GroupTreeItem，添加 `has-session` class 与琥珀色图标；新增 `isConnOpen()` / `doLocateSession()` 处理器及右键菜单项。
- **GroupTreeItem.vue**：注入 `openPanelConnIds`，添加 `has-session` class 与琥珀色图标。
- **i18n**：为 9 个语言文件新增 `sidebar.locateSession` 文案。