### PR TITLE
fix(db): scope DumpTable information_schema queries to the target schema

### DIFF
--- a/backend/database/provider_mysql.go
+++ b/backend/database/provider_mysql.go
@@ -581,7 +581,7 @@ func (p *mysqlProvider) DumpTable(db *sql.DB, dbName, tableName string, opts Dum
 	quotedTable := p.Quote(tableName)
 
 	if opts.Structure {
-		createStmt, kind, derr := showCreateStatement(conn, tableName, quotedTable)
+		createStmt, kind, derr := showCreateStatement(conn, dbName, tableName, quotedTable)
 		if derr != nil {
 			return "", derr
 		}
@@ -593,7 +593,7 @@ func (p *mysqlProvider) DumpTable(db *sql.DB, dbName, tableName string, opts Dum
 	}
 
 	if opts.Data {
-		cols, colTypes, derr := tableColumns(conn, tableName, quotedTable)
+		cols, colTypes, derr := tableColumns(conn, dbName, tableName, quotedTable)
 		if derr != nil {
 			return "", derr
 		}
@@ -643,11 +643,12 @@ func (p *mysqlProvider) DumpTable(db *sql.DB, dbName, tableName string, opts Dum
 }
 
 // tableKind returns "TABLE" or "VIEW" for the given name by querying
-// information_schema; defaults to TABLE on error.
-func tableKind(conn *sql.Conn, tableName string) string {
+// information_schema; defaults to TABLE on error. Scoped to the schema so a
+// name shared across databases resolves to the right object.
+func tableKind(conn *sql.Conn, dbName, tableName string) string {
 	var t string
 	err := conn.QueryRowContext(context.Background(),
-		"SELECT TABLE_TYPE FROM information_schema.tables WHERE TABLE_NAME = ? LIMIT 1", tableName).Scan(&t)
+		"SELECT TABLE_TYPE FROM information_schema.tables WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ? LIMIT 1", dbName, tableName).Scan(&t)
 	if err == nil && strings.HasPrefix(t, "VIEW") {
 		return "VIEW"
 	}
@@ -656,8 +657,8 @@ func tableKind(conn *sql.Conn, tableName string) string {
 
 // showCreateStatement returns the CREATE TABLE/VIEW statement (without trailing ;)
 // and the object kind ("TABLE" or "VIEW").
-func showCreateStatement(conn *sql.Conn, tableName, quotedTable string) (string, string, error) {
-	kind := tableKind(conn, tableName)
+func showCreateStatement(conn *sql.Conn, dbName, tableName, quotedTable string) (string, string, error) {
+	kind := tableKind(conn, dbName, tableName)
 	row := conn.QueryRowContext(context.Background(), "SHOW CREATE "+kind+" "+quotedTable)
 	if kind == "VIEW" {
 		var name, createSQL, charset, collation string
@@ -674,9 +675,12 @@ func showCreateStatement(conn *sql.Conn, tableName, quotedTable string) (string,
 }
 
 // tableColumns returns column names and their uppercased type tokens.
-func tableColumns(conn *sql.Conn, tableName, quotedTable string) ([]string, []string, error) {
+// TABLE_SCHEMA is filtered because information_schema is global — without it,
+// a name shared across schemas mixes in foreign columns and the SELECT below
+// fails with "Unknown column".
+func tableColumns(conn *sql.Conn, dbName, tableName, quotedTable string) ([]string, []string, error) {
 	rows, err := conn.QueryContext(context.Background(),
-		"SELECT COLUMN_NAME, DATA_TYPE FROM information_schema.columns WHERE TABLE_NAME = ? ORDER BY ORDINAL_POSITION", tableName)
+		"SELECT COLUMN_NAME, DATA_TYPE FROM information_schema.columns WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ? ORDER BY ORDINAL_POSITION", dbName, tableName)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
## Summary / 概述

修复导出表为 .sql 时报错：

```
Error 1054 (42S22): Unknown column 'vlan_tag' in 'field list'
```

## Root Cause / 根因

`DumpTable`（#543 引入）查询 `information_schema.columns` 和 `information_schema.tables` 时只按 `TABLE_NAME` 过滤。information_schema 是**全局**的，`USE <db>` 不会过滤它——当一个表名在多个 schema 里都存在时，查回来的列名混入了**别的库**的列（如 `vlan_tag`）。随后 `SELECT col1, col2 ... FROM <表>` 命中了表里不存在的列，触发 `Unknown column`。

## Changes / 改动

`provider_mysql.go`：
- `tableColumns`：WHERE 加 `TABLE_SCHEMA = ?`
- `tableKind`：WHERE 加 `TABLE_SCHEMA = ?`
- 两者签名增加 `dbName` 参数，调用点同步更新

`SHOW CREATE TABLE/VIEW` 本身受 `USE` 影响选对对象，但 `tableKind` 决定走 `SHOW CREATE TABLE` 还是 `VIEW`，不限定 schema 可能误判 kind，一并修正。

## Validation / 验证
- `go build` 通过

## Repro / 复现
多个 schema 存在同名表时，对其中一张执行「导出（结构+数据）」即报上述错误。修复后导出正常，列只来自目标 schema。
