### PR TITLE
feat(db): export table as .sql for postgres/oracle/sqlserver/rqlite

### DIFF
--- a/backend/database/executor.go
+++ b/backend/database/executor.go
@@ -178,6 +178,24 @@ func truncate(s string, n int) string {
 	return s[:n] + "…"
 }
 
+// quotedString wraps a string in single quotes with embedded quotes doubled.
+// Shared by the per-dialect dump value escapers (all dialects agree on this
+// rule).
+func quotedString(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
+}
+
+// hexLower returns the lowercase hex encoding of b.
+func hexLower(b []byte) string {
+	const hex = "0123456789abcdef"
+	out := make([]byte, len(b)*2)
+	for i, c := range b {
+		out[i*2] = hex[c>>4]
+		out[i*2+1] = hex[c&0x0f]
+	}
+	return string(out)
+}
+
 // quoteStringValue escapes and quotes a value for an INSERT statement. NULL is
 // emitted as the bare keyword. Binary payloads become _binary 0x… .
 func quoteSQLValue(v any) string {

--- a/backend/database/provider_oracle.go
+++ b/backend/database/provider_oracle.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"time"
 
 	_ "github.com/sijms/go-ora/v2"
 )
@@ -507,5 +508,147 @@ var oracleIntTypes = []string{
 }
 
 func (p *oracleProvider) DumpTable(db *sql.DB, dbName, tableName string, opts DumpOptions) (string, error) {
-	return "", &errDumpUnsupported{"oracle"}
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return "", err
+	}
+	defer conn.Close()
+
+	if err := p.PrepareExec(conn, dbName); err != nil {
+		return "", err
+	}
+	// DBMS_METADATA.GET_DDL returns a CLOB; raise LONG so the full text is
+	// returned in the SELECT rather than truncated.
+	_, _ = conn.ExecContext(ctx, "ALTER SESSION SET LONG = 100000000")
+
+	owner, err := p.resolveSchema(db, dbName)
+	if err != nil {
+		return "", err
+	}
+
+	var b strings.Builder
+	quotedTable := p.Quote(tableName)
+
+	if opts.Structure {
+		kind := oracleTableKind(conn, owner, tableName)
+		var createSQL string
+		err := conn.QueryRowContext(ctx,
+			"SELECT DBMS_METADATA.GET_DDL(?, ?, ?) FROM DUAL",
+			strings.ToUpper(kind), strings.ToUpper(tableName), strings.ToUpper(owner)).Scan(&createSQL)
+		if err != nil {
+			return "", err
+		}
+		b.WriteString("--\n-- Structure for ")
+		b.WriteString(tableName)
+		b.WriteString("\n--\nDROP " + kind + " IF EXISTS " + quotedTable + ";\n")
+		b.WriteString(createSQL)
+		b.WriteString(";\n\n")
+	}
+
+	if opts.Data {
+		cols, colTypes, derr := oracleTableColumns(conn, owner, tableName)
+		if derr != nil {
+			return "", derr
+		}
+		if len(cols) > 0 {
+			b.WriteString("--\n-- Data for ")
+			b.WriteString(tableName)
+			b.WriteString("\n--\n")
+			colList := make([]string, len(cols))
+			for i, c := range cols {
+				colList[i] = p.Quote(c)
+			}
+			prefix := "INSERT INTO " + quotedTable + " (" + strings.Join(colList, ", ") + ") VALUES "
+
+			rows, err := conn.QueryContext(ctx, "SELECT "+strings.Join(colList, ", ")+" FROM "+quotedTable)
+			if err != nil {
+				return "", err
+			}
+			defer rows.Close()
+
+			for rows.Next() {
+				vals := make([]any, len(cols))
+				ptrs := make([]any, len(cols))
+				for i := range vals {
+					ptrs[i] = &vals[i]
+				}
+				if err := rows.Scan(ptrs...); err != nil {
+					return "", err
+				}
+				b.WriteString(prefix)
+				b.WriteByte('(')
+				for i, v := range vals {
+					if i > 0 {
+						b.WriteString(", ")
+					}
+					b.WriteString(dumpOracleValue(v, colTypes[i]))
+				}
+				b.WriteString(");\n")
+			}
+			if err := rows.Err(); err != nil {
+				return "", err
+			}
+			b.WriteByte('\n')
+		}
+	}
+
+	return b.String(), nil
+}
+
+// oracleTableKind returns "TABLE" or "VIEW" by querying all_objects.
+func oracleTableKind(conn *sql.Conn, owner, tableName string) string {
+	var t string
+	err := conn.QueryRowContext(context.Background(),
+		"SELECT object_type FROM all_objects WHERE owner = ? AND object_name = ? AND object_type IN ('TABLE','VIEW')",
+		strings.ToUpper(owner), strings.ToUpper(tableName)).Scan(&t)
+	if err == nil && t == "VIEW" {
+		return "VIEW"
+	}
+	return "TABLE"
+}
+
+// oracleTableColumns returns column names and types for a table.
+func oracleTableColumns(conn *sql.Conn, owner, tableName string) ([]string, []string, error) {
+	rows, err := conn.QueryContext(context.Background(),
+		`SELECT column_name, data_type || DECODE(data_length, 0, '', '(' || data_length || ')')
+		 FROM all_tab_columns WHERE owner = ? AND table_name = ? ORDER BY column_id`,
+		strings.ToUpper(owner), strings.ToUpper(tableName))
+	if err != nil {
+		return nil, nil, err
+	}
+	defer rows.Close()
+	var names, types []string
+	for rows.Next() {
+		var name, ty string
+		if err := rows.Scan(&name, &ty); err != nil {
+			return nil, nil, err
+		}
+		names = append(names, name)
+		types = append(types, ty)
+	}
+	return names, types, rows.Err()
+}
+
+// dumpOracleValue renders a scanned cell as an Oracle literal. BLOBs become
+// HEXTORAW('..'); timestamps use TIMESTAMP '..' for reliability against NLS.
+func dumpOracleValue(v any, typeToken string) string {
+	if v == nil {
+		return "NULL"
+	}
+	switch val := v.(type) {
+	case []byte:
+		return "HEXTORAW('" + hexLower(val) + "')"
+	case string:
+		return quotedString(val)
+	case bool:
+		if val {
+			return "1"
+		}
+		return "0"
+	case time.Time:
+		return "TIMESTAMP '" + val.Format("2006-01-02 15:04:05.999999") + "'"
+	default:
+		return scanToString(v)
+	}
 }

--- a/backend/database/provider_postgres.go
+++ b/backend/database/provider_postgres.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"strings"
 	"sync"
+	"time"
 
 	_ "github.com/lib/pq"
 	"golang.org/x/sync/errgroup"
@@ -477,5 +478,231 @@ var postgresIntTypes = []string{
 }
 
 func (p *postgresProvider) DumpTable(db *sql.DB, dbName, tableName string, opts DumpOptions) (string, error) {
-	return "", &errDumpUnsupported{"postgres"}
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return "", err
+	}
+	defer conn.Close()
+
+	schema := "public"
+	if dbName != "" {
+		schema = dbName
+	}
+
+	var b strings.Builder
+	quotedTable := p.Quote(tableName)
+
+	// PG connections bind a single database; tables resolve via the session
+	// search_path (default public). dbName on this connection is the database
+	// name, not a schema — resolve the actual current schema instead.
+	if curSchema, err := pgCurrentSchema(conn); err == nil && curSchema != "" {
+		schema = curSchema
+	}
+
+	if opts.Structure {
+		createSQL, derr := pgCreateTableSQL(conn, schema, tableName, quotedTable)
+		if derr != nil {
+			return "", derr
+		}
+		b.WriteString("--\n-- Structure for ")
+		b.WriteString(tableName)
+		b.WriteString("\n--\nDROP TABLE IF EXISTS ")
+		b.WriteString(quotedTable)
+		b.WriteString(" CASCADE;\n")
+		b.WriteString(createSQL)
+		if !strings.HasSuffix(createSQL, ";") {
+			b.WriteByte(';')
+		}
+		b.WriteString("\n\n")
+	}
+
+	if opts.Data {
+		cols, colTypes, derr := pgTableColumns(conn, schema, tableName)
+		if derr != nil {
+			return "", derr
+		}
+		if len(cols) > 0 {
+			b.WriteString("--\n-- Data for ")
+			b.WriteString(tableName)
+			b.WriteString("\n--\n")
+			colList := make([]string, len(cols))
+			for i, c := range cols {
+				colList[i] = p.Quote(c)
+			}
+			prefix := "INSERT INTO " + quotedTable + " (" + strings.Join(colList, ", ") + ") VALUES "
+
+			rows, err := conn.QueryContext(ctx, "SELECT "+strings.Join(colList, ", ")+" FROM "+quotedTable)
+			if err != nil {
+				return "", err
+			}
+			defer rows.Close()
+
+			for rows.Next() {
+				vals := make([]any, len(cols))
+				ptrs := make([]any, len(cols))
+				for i := range vals {
+					ptrs[i] = &vals[i]
+				}
+				if err := rows.Scan(ptrs...); err != nil {
+					return "", err
+				}
+				b.WriteString(prefix)
+				b.WriteByte('(')
+				for i, v := range vals {
+					if i > 0 {
+						b.WriteString(", ")
+					}
+					b.WriteString(dumpPgValue(v, colTypes[i]))
+				}
+				b.WriteString(");\n")
+			}
+			if err := rows.Err(); err != nil {
+				return "", err
+			}
+			b.WriteByte('\n')
+		}
+	}
+
+	return b.String(), nil
+}
+
+// pgCurrentSchema returns the first schema on the session search_path.
+func pgCurrentSchema(conn *sql.Conn) (string, error) {
+	var s string
+	err := conn.QueryRowContext(context.Background(), "SELECT current_schema()").Scan(&s)
+	return s, err
+}
+
+// pgCreateTableSQL builds a CREATE TABLE statement from pg_catalog, including
+// column types (via format_type), defaults, NOT NULL, and table constraints
+// (PK / UNIQUE / CHECK / FK) via pg_get_constraintdef.
+func pgCreateTableSQL(conn *sql.Conn, schema, tableName, quotedTable string) (string, error) {
+	rows, err := conn.QueryContext(context.Background(), `
+		SELECT a.attname,
+		       format_type(a.atttypid, a.atttypmod),
+		       a.attnotnull,
+		       pg_get_expr(a.adbin, a.attrelid) AS default
+		FROM pg_attribute a
+		JOIN pg_class t ON a.attrelid = t.oid
+		JOIN pg_namespace n ON t.relnamespace = n.oid
+		WHERE t.relname = $1 AND n.nspname = $2
+		  AND a.attnum > 0 AND NOT a.attisdropped
+		ORDER BY a.attnum`, tableName, schema)
+	if err != nil {
+		return "", err
+	}
+	defer rows.Close()
+
+	var b strings.Builder
+	b.WriteString("CREATE TABLE ")
+	b.WriteString(quotedTable)
+	b.WriteString(" (\n")
+	colLines := []string{}
+	for rows.Next() {
+		var name, ty string
+		var notnull bool
+		var dflt sql.NullString
+		if err := rows.Scan(&name, &ty, &notnull, &dflt); err != nil {
+			return "", err
+		}
+		quotedName, _ := SafePgIdent(name)
+		line := "  " + quotedName + " " + ty
+		if dflt.Valid && dflt.String != "" {
+			line += " DEFAULT " + dflt.String
+		}
+		if notnull {
+			line += " NOT NULL"
+		}
+		colLines = append(colLines, line)
+	}
+	if err := rows.Err(); err != nil {
+		return "", err
+	}
+
+	constraints, err := pgConstraintDefs(conn, schema, tableName)
+	if err != nil {
+		return "", err
+	}
+	colLines = append(colLines, constraints...)
+
+	b.WriteString(strings.Join(colLines, ",\n"))
+	b.WriteString("\n)")
+	return b.String(), nil
+}
+
+// pgConstraintDefs returns table constraint clauses (PK/UNIQUE/CHECK/FK)
+// via pg_get_constraintdef.
+func pgConstraintDefs(conn *sql.Conn, schema, tableName string) ([]string, error) {
+	rows, err := conn.QueryContext(context.Background(), `
+		SELECT pg_get_constraintdef(c.oid)
+		FROM pg_constraint c
+		JOIN pg_class t ON c.conrelid = t.oid
+		JOIN pg_namespace n ON t.relnamespace = n.oid
+		WHERE t.relname = $1 AND n.nspname = $2
+		ORDER BY c.contype`, tableName, schema)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var def sql.NullString
+		if err := rows.Scan(&def); err != nil {
+			return nil, err
+		}
+		if def.Valid && def.String != "" {
+			out = append(out, "  "+def.String)
+		}
+	}
+	return out, rows.Err()
+}
+
+// pgTableColumns returns column names and types for a table.
+func pgTableColumns(conn *sql.Conn, schema, tableName string) ([]string, []string, error) {
+	rows, err := conn.QueryContext(context.Background(), `
+		SELECT a.attname, format_type(a.atttypid, a.atttypmod)
+		FROM pg_attribute a
+		JOIN pg_class t ON a.attrelid = t.oid
+		JOIN pg_namespace n ON t.relnamespace = n.oid
+		WHERE t.relname = $1 AND n.nspname = $2
+		  AND a.attnum > 0 AND NOT a.attisdropped
+		ORDER BY a.attnum`, tableName, schema)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer rows.Close()
+	var names, types []string
+	for rows.Next() {
+		var name, ty string
+		if err := rows.Scan(&name, &ty); err != nil {
+			return nil, nil, err
+		}
+		names = append(names, name)
+		types = append(types, ty)
+	}
+	return names, types, rows.Err()
+}
+
+// dumpPgValue renders a scanned cell as a PostgreSQL literal. Booleans become
+// TRUE/FALSE; bytea becomes '\x..'; timestamps drop the T/Z separators.
+func dumpPgValue(v any, typeToken string) string {
+	if v == nil {
+		return "NULL"
+	}
+	switch val := v.(type) {
+	case []byte:
+		return "'\\x" + hexLower(val) + "'"
+	case string:
+		return quotedString(val)
+	case bool:
+		if val {
+			return "TRUE"
+		}
+		return "FALSE"
+	case time.Time:
+		return "'" + val.Format("2006-01-02 15:04:05.999999") + "'"
+	default:
+		return scanToString(v)
+	}
 }

--- a/backend/database/provider_rqlite.go
+++ b/backend/database/provider_rqlite.go
@@ -1,6 +1,7 @@
 package database
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"net/url"
@@ -346,5 +347,146 @@ var rqliteIntTypes = []string{
 }
 
 func (p *rqliteProvider) DumpTable(db *sql.DB, dbName, tableName string, opts DumpOptions) (string, error) {
-	return "", &errDumpUnsupported{"rqlite"}
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return "", err
+	}
+	defer conn.Close()
+
+	var b strings.Builder
+	quotedTable := p.Quote(tableName)
+
+	if opts.Structure {
+		var createSQL string
+		kind := tableKindSQLite(conn, tableName)
+		err := conn.QueryRowContext(ctx,
+			"SELECT sql FROM sqlite_master WHERE type=? AND name=? AND name NOT LIKE 'sqlite_%' LIMIT 1",
+			kind, tableName).Scan(&createSQL)
+		if err != nil && err != sql.ErrNoRows {
+			return "", err
+		}
+		if createSQL != "" {
+			b.WriteString("--\n-- Structure for ")
+			b.WriteString(tableName)
+			b.WriteString("\n--\nDROP ")
+			if kind == "view" {
+				b.WriteString("VIEW")
+			} else {
+				b.WriteString("TABLE")
+			}
+			b.WriteString(" IF EXISTS ")
+			b.WriteString(quotedTable)
+			b.WriteString(";\n")
+			b.WriteString(createSQL)
+			if !strings.HasSuffix(createSQL, ";") {
+				b.WriteByte(';')
+			}
+			b.WriteString("\n\n")
+		}
+	}
+
+	if opts.Data {
+		cols, derr := sqliteTableColumns(conn, tableName, quotedTable)
+		if derr != nil {
+			return "", derr
+		}
+		if len(cols) > 0 {
+			b.WriteString("--\n-- Data for ")
+			b.WriteString(tableName)
+			b.WriteString("\n--\n")
+			colList := make([]string, len(cols))
+			for i, c := range cols {
+				colList[i] = p.Quote(c)
+			}
+			prefix := "INSERT INTO " + quotedTable + " (" + strings.Join(colList, ", ") + ") VALUES "
+
+			rows, err := conn.QueryContext(ctx, "SELECT "+strings.Join(colList, ", ")+" FROM "+quotedTable)
+			if err != nil {
+				return "", err
+			}
+			defer rows.Close()
+
+			for rows.Next() {
+				vals := make([]any, len(cols))
+				ptrs := make([]any, len(cols))
+				for i := range vals {
+					ptrs[i] = &vals[i]
+				}
+				if err := rows.Scan(ptrs...); err != nil {
+					return "", err
+				}
+				b.WriteString(prefix)
+				b.WriteByte('(')
+				for i, v := range vals {
+					if i > 0 {
+						b.WriteString(", ")
+					}
+					b.WriteString(dumpRqliteValue(v))
+				}
+				b.WriteString(");\n")
+			}
+			if err := rows.Err(); err != nil {
+				return "", err
+			}
+			b.WriteByte('\n')
+		}
+	}
+
+	return b.String(), nil
+}
+
+// tableKindSQLite returns "table" or "view" from sqlite_master.
+func tableKindSQLite(conn *sql.Conn, tableName string) string {
+	var t string
+	err := conn.QueryRowContext(context.Background(),
+		"SELECT type FROM sqlite_master WHERE name=? AND name NOT LIKE 'sqlite_%' LIMIT 1", tableName).Scan(&t)
+	if err == nil && t == "view" {
+		return "view"
+	}
+	return "table"
+}
+
+// sqliteTableColumns returns column names via PRAGMA table_info.
+func sqliteTableColumns(conn *sql.Conn, tableName, quotedTable string) ([]string, error) {
+	rows, err := conn.QueryContext(context.Background(), "PRAGMA table_info("+quotedTable+")")
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var cols []string
+	for rows.Next() {
+		var cid int
+		var name, ctype string
+		var notnull int
+		var dflt sql.NullString
+		var pk int
+		if err := rows.Scan(&cid, &name, &ctype, &notnull, &dflt, &pk); err != nil {
+			return nil, err
+		}
+		cols = append(cols, name)
+	}
+	return cols, rows.Err()
+}
+
+// dumpRqliteValue renders a scanned cell as a SQLite literal. Blobs become
+// x'..' hex literals; booleans and numbers pass through; everything else is
+// a quoted string.
+func dumpRqliteValue(v any) string {
+	if v == nil {
+		return "NULL"
+	}
+	switch val := v.(type) {
+	case []byte:
+		return "x'" + hexLower(val) + "'"
+	case string:
+		return quotedString(val)
+	case bool:
+		if val {
+			return "1"
+		}
+		return "0"
+	default:
+		return scanToString(v)
+	}
 }

--- a/backend/database/provider_sqlserver.go
+++ b/backend/database/provider_sqlserver.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
+	"time"
 
 	_ "github.com/microsoft/go-mssqldb"
 )
@@ -505,5 +506,180 @@ var sqlserverIntTypes = []string{
 }
 
 func (p *sqlserverProvider) DumpTable(db *sql.DB, dbName, tableName string, opts DumpOptions) (string, error) {
-	return "", &errDumpUnsupported{"sqlserver"}
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return "", err
+	}
+	defer conn.Close()
+
+	if err := p.PrepareExec(conn, dbName); err != nil {
+		return "", err
+	}
+
+	var b strings.Builder
+	quotedTable := p.Quote(tableName)
+
+	if opts.Structure {
+		createSQL, derr := sqlserverCreateTableSQL(conn, dbName, tableName, quotedTable)
+		if derr != nil {
+			return "", derr
+		}
+		b.WriteString("--\n-- Structure for ")
+		b.WriteString(tableName)
+		b.WriteString("\n--\nDROP TABLE IF EXISTS ")
+		b.WriteString(quotedTable)
+		b.WriteString(";\n")
+		b.WriteString(createSQL)
+		if !strings.HasSuffix(createSQL, ";") {
+			b.WriteByte(';')
+		}
+		b.WriteString("\n\n")
+	}
+
+	if opts.Data {
+		cols, colTypes, derr := sqlserverTableColumns(conn, dbName, tableName)
+		if derr != nil {
+			return "", derr
+		}
+		if len(cols) > 0 {
+			b.WriteString("--\n-- Data for ")
+			b.WriteString(tableName)
+			b.WriteString("\n--\n")
+			colList := make([]string, len(cols))
+			for i, c := range cols {
+				colList[i] = p.Quote(c)
+			}
+			prefix := "INSERT INTO " + quotedTable + " (" + strings.Join(colList, ", ") + ") VALUES "
+
+			rows, err := conn.QueryContext(ctx, "SELECT "+strings.Join(colList, ", ")+" FROM "+quotedTable)
+			if err != nil {
+				return "", err
+			}
+			defer rows.Close()
+
+			for rows.Next() {
+				vals := make([]any, len(cols))
+				ptrs := make([]any, len(cols))
+				for i := range vals {
+					ptrs[i] = &vals[i]
+				}
+				if err := rows.Scan(ptrs...); err != nil {
+					return "", err
+				}
+				b.WriteString(prefix)
+				b.WriteByte('(')
+				for i, v := range vals {
+					if i > 0 {
+						b.WriteString(", ")
+					}
+					b.WriteString(dumpSqlserverValue(v, colTypes[i]))
+				}
+				b.WriteString(");\n")
+			}
+			if err := rows.Err(); err != nil {
+				return "", err
+			}
+			b.WriteByte('\n')
+		}
+	}
+
+	return b.String(), nil
+}
+
+// sqlserverCreateTableSQL builds a CREATE TABLE statement from INFORMATION_SCHEMA.
+func sqlserverCreateTableSQL(conn *sql.Conn, dbName, tableName, quotedTable string) (string, error) {
+	rows, err := conn.QueryContext(context.Background(), `
+		SELECT COLUMN_NAME, DATA_TYPE, IS_NULLABLE, COLUMN_DEFAULT,
+		       CHARACTER_MAXIMUM_LENGTH, NUMERIC_PRECISION, NUMERIC_SCALE
+		FROM INFORMATION_SCHEMA.COLUMNS
+		WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ?
+		ORDER BY ORDINAL_POSITION`, dbName, tableName)
+	if err != nil {
+		return "", err
+	}
+	defer rows.Close()
+
+	var b strings.Builder
+	b.WriteString("CREATE TABLE ")
+	b.WriteString(quotedTable)
+	b.WriteString(" (\n")
+	first := true
+	for rows.Next() {
+		var name, dataType, isNullable string
+		var colDefault sql.NullString
+		var charMaxLen, numPrec, numScale sql.NullString
+		if err := rows.Scan(&name, &dataType, &isNullable, &colDefault, &charMaxLen, &numPrec, &numScale); err != nil {
+			return "", err
+		}
+		if !first {
+			b.WriteString(",\n")
+		}
+		first = false
+		b.WriteString("  [")
+		b.WriteString(name)
+		b.WriteString("] ")
+		b.WriteString(sqlserverFormatType(dataType, charMaxLen.String, numPrec.String, numScale.String))
+		if colDefault.Valid && colDefault.String != "" {
+			b.WriteString(" DEFAULT ")
+			b.WriteString(colDefault.String)
+		}
+		if strings.ToUpper(isNullable) == "NO" {
+			b.WriteString(" NOT NULL")
+		} else {
+			b.WriteString(" NULL")
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return "", err
+	}
+	b.WriteString("\n)")
+	return b.String(), nil
+}
+
+// sqlserverTableColumns returns column names and raw type tokens.
+func sqlserverTableColumns(conn *sql.Conn, dbName, tableName string) ([]string, []string, error) {
+	rows, err := conn.QueryContext(context.Background(), `
+		SELECT COLUMN_NAME, DATA_TYPE
+		FROM INFORMATION_SCHEMA.COLUMNS
+		WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ?
+		ORDER BY ORDINAL_POSITION`, dbName, tableName)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer rows.Close()
+	var names, types []string
+	for rows.Next() {
+		var name, ty string
+		if err := rows.Scan(&name, &ty); err != nil {
+			return nil, nil, err
+		}
+		names = append(names, name)
+		types = append(types, strings.ToUpper(ty))
+	}
+	return names, types, rows.Err()
+}
+
+// dumpSqlserverValue renders a scanned cell as a T-SQL literal. Unicode text
+// uses the N'..' prefix so nvarchar columns keep non-ASCII; varbinary becomes
+// a bare 0x.. literal (T-SQL has no _binary keyword).
+func dumpSqlserverValue(v any, typeToken string) string {
+	if v == nil {
+		return "NULL"
+	}
+	switch val := v.(type) {
+	case []byte:
+		return "0x" + hexLower(val)
+	case string:
+		return "N'" + strings.ReplaceAll(val, "'", "''") + "'"
+	case bool:
+		if val {
+			return "1"
+		}
+		return "0"
+	case time.Time:
+		return "'" + val.Format("2006-01-02 15:04:05.999999") + "'"
+	default:
+		return scanToString(v)
+	}
 }


### PR DESCRIPTION
## Summary / 概述

将「导出表为 .sql」从 MySQL 扩展到 PostgreSQL / Oracle / SQL Server / rqlite，对齐 #544 的「多库方言」待做项。导出入口（表右键「导出结构 / 结构+数据」）本就对所有 SQL 库显示，此前非 MySQL 点击报 `export not supported`，现在全部可用。

## 各方言实现 / Per-dialect

CREATE 语句来源与值转义差异大，每个 provider 自带转义；`executor.go` 新增共享 `quotedString`（单引号双写，各方言通用）和 `hexLower`。

| 方言 | CREATE 来源 | 值转义要点 |
|------|------------|-----------|
| MySQL | `SHOW CREATE TABLE/VIEW`（已有） | `_binary 0x..`（已有） |
| PostgreSQL | `pg_catalog`：`format_type` 拿完整列类型 + `pg_get_constraintdef` 拿 PK/UNIQUE/CHECK/FK + `pg_get_expr` 默认值 | bool→`TRUE/FALSE`、bytea→`'\x..'`、时间去 `T`/`Z` |
| Oracle | `DBMS_METADATA.GET_DDL('TABLE'/'VIEW', ...)`（先 `ALTER SESSION SET LONG`） | blob→`HEXTORAW('..')`、时间→`TIMESTAMP '...'` |
| SQL Server | `INFORMATION_SCHEMA.COLUMNS` 手拼（复用 `sqlserverFormatType`、保留 DEFAULT） | nvarchar→`N'..'`、varbinary→裸 `0x..`、bit→`0/1` |
| rqlite | `sqlite_master.sql` 直接拿原文 | blob→`x'..'` |

### PostgreSQL schema 说明
PG 连接单库绑定，表经 search_path 解析；`dbName` 是库名非 schema 名，故用 `current_schema()` 取实际 schema，避免导出找不到表。

## Changes / 改动文件
- `backend/database/executor.go` — 共享 `quotedString` / `hexLower`
- `backend/database/provider_postgres.go` — DumpTable + pgCreateTableSQL / pgConstraintDefs / pgTableColumns / pgCurrentSchema / dumpPgValue
- `backend/database/provider_oracle.go` — DumpTable + oracleTableKind / oracleTableColumns / dumpOracleValue
- `backend/database/provider_sqlserver.go` — DumpTable + sqlserverCreateTableSQL / sqlserverTableColumns / dumpSqlserverValue
- `backend/database/provider_rqlite.go` — DumpTable + tableKindSQLite / sqliteTableColumns / dumpRqliteValue

## Validation / 验证
- `go build ./backend/... ./` 通过
- `go test ./backend/database/` 通过（splitter 单测无回归）
- frontend `vite build` 通过、type-check 无新增错误

## Scope / 范围
- 仅表级导出（结构 / 结构+数据）；整库导出、CSV 导入、查询结果导出仍见 #544
- 值转义各库自带，未参数化公共 `quoteSQLValue`（差异维度太多，flag 化不如各 provider 直观）
- 大表整表读入内存返回 string，沿用现有 DumpTable 契约，未做流式

Partially addresses #544.
