### PR TITLE
feat(connection): add a test-connection button to the new-connection dialog

### DIFF
--- a/backend/session/test_connection.go
+++ b/backend/session/test_connection.go
@@ -1,0 +1,259 @@
+package session
+
+// ProbeConnection tests whether a connection config can actually connect /
+// authenticate, WITHOUT opening a persistent session. It powers the frontend's
+// "Test connection" button (issue #377): the App.TestConnection Wails method
+// first materializes identity/proxy references (which requires the store), then
+// dispatches session-owned protocols to this function.
+//
+// Return values: on success a short human-readable description; on failure a
+// readable error that must NOT echo the password (Protocol errors are wrapped
+// as-is so drivers do the talking, but we never interpolate config.Password).
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/jlaffaye/ftp"
+	"github.com/redis/go-redis/v9"
+	"github.com/rhnvrm/simples3"
+	"github.com/studio-b12/gowebdav"
+	"golang.org/x/crypto/ssh"
+
+	"github.com/cloudsoda/go-smb2"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+
+	"github.com/ys-ll/uniterm/backend/database"
+)
+
+// ProbeConnection dispatches a connectivity probe by config.Type.
+// Types owned by the App dispatcher (k8s / container) are not handled here.
+func ProbeConnection(config ConnectionConfig) (string, error) {
+	switch config.Type {
+	case "ssh":
+		return probeSSH(config)
+	case "telnet":
+		return probeTelnet(config)
+	case "ftp":
+		return probeFTP(config)
+	case "s3":
+		return probeS3(config)
+	case "webdav":
+		return probeWebDAV(config)
+	case "smb":
+		return probeSMB(config)
+	case "redis":
+		return probeRedis(config)
+	case "mongodb":
+		return probeMongo(config)
+	case "database":
+		return probeDatabase(config)
+	default:
+		return "", fmt.Errorf("connection type %q does not support connection testing", config.Type)
+	}
+}
+
+func probeSSH(config ConnectionConfig) (string, error) {
+	// Non-interactive: keyboard-interactive challenges are rejected so a test
+	// can never block waiting for typed input in a modal dialog.
+	kb := func(user, instruction string, questions []string, echos []bool) ([]string, error) {
+		return nil, fmt.Errorf("interactive auth not allowed during connection test")
+	}
+	authMethods := makeSSHAuthMethods(config, kb)
+	addr := net.JoinHostPort(config.Host, strconv.Itoa(config.Port))
+	clientConfig := &ssh.ClientConfig{
+		User:            config.User,
+		Auth:            authMethods,
+		Timeout:         15 * time.Second,
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+	}
+	// Honor a materialized proxy (set by App.materializeProxy) on the first hop,
+	// mirroring the terminal session's dial path.
+	client, err := dialSSHWithCipherFallback(addr, clientConfig, func() (net.Conn, error) {
+		return dialFirstHop(addr, config.Proxy)
+	})
+	if err != nil {
+		return "", fmt.Errorf("ssh: %w", err)
+	}
+	defer client.Close()
+	return fmt.Sprintf("ssh: connected as %s@%s:%d", config.User, config.Host, config.Port), nil
+}
+
+func probeTelnet(config ConnectionConfig) (string, error) {
+	addr := net.JoinHostPort(config.Host, strconv.Itoa(config.Port))
+	conn, err := net.DialTimeout("tcp", addr, 15*time.Second)
+	if err != nil {
+		return "", fmt.Errorf("telnet: %w", err)
+	}
+	conn.Close()
+	return fmt.Sprintf("telnet: %s:%d reachable", config.Host, config.Port), nil
+}
+
+func probeFTP(config ConnectionConfig) (string, error) {
+	addr := fmt.Sprintf("%s:%d", config.Host, config.Port)
+	if config.Port <= 0 {
+		addr = fmt.Sprintf("%s:21", config.Host)
+	}
+	encryption := config.FtpEncryption
+	if encryption == "" {
+		encryption = "none"
+	}
+	tlsConfig := &tls.Config{InsecureSkipVerify: config.FtpSkipVerify}
+
+	var conn *ftp.ServerConn
+	var err error
+	switch encryption {
+	case "required":
+		conn, err = ftp.Dial(addr, ftp.DialWithTimeout(30*time.Second), ftp.DialWithExplicitTLS(tlsConfig))
+	case "auto":
+		conn, err = ftp.Dial(addr, ftp.DialWithTimeout(30*time.Second), ftp.DialWithExplicitTLS(tlsConfig))
+		if err != nil {
+			conn, err = ftp.Dial(addr, ftp.DialWithTimeout(30*time.Second))
+		}
+	default:
+		conn, err = ftp.Dial(addr, ftp.DialWithTimeout(30*time.Second))
+	}
+	if err != nil {
+		return "", fmt.Errorf("ftp: %w", err)
+	}
+	defer conn.Quit()
+	if err := conn.Login(config.User, config.Password); err != nil {
+		return "", fmt.Errorf("ftp login: %w", err)
+	}
+	return fmt.Sprintf("ftp: logged in as %s@%s", config.User, config.Host), nil
+}
+
+func probeS3(config ConnectionConfig) (string, error) {
+	c := simples3.New(config.S3Region, config.User, config.Password)
+	c.Endpoint = strings.TrimSuffix(config.Host, "/")
+	if config.S3URLStyle != "path" {
+		c.SetVirtualHostedStyle(true)
+	}
+	// ListBuckets is the lightest probe that validates endpoint reachability AND
+	// access-key validity.
+	if _, err := c.ListBuckets(simples3.ListBucketsInput{}); err != nil {
+		return "", fmt.Errorf("s3: %w", err)
+	}
+	return fmt.Sprintf("s3: credentials valid for %s", config.Host), nil
+}
+
+func probeWebDAV(config ConnectionConfig) (string, error) {
+	url := strings.TrimSuffix(config.Host, "/")
+	client := gowebdav.NewClient(url, config.User, config.Password)
+	if err := client.Connect(); err != nil {
+		return "", fmt.Errorf("webdav: %w", err)
+	}
+	return fmt.Sprintf("webdav: connected to %s", url), nil
+}
+
+func probeSMB(config ConnectionConfig) (string, error) {
+	port := config.Port
+	if port <= 0 {
+		port = 445
+	}
+	addr := net.JoinHostPort(config.Host, strconv.Itoa(port))
+	conn, err := net.DialTimeout("tcp", addr, 15*time.Second)
+	if err != nil {
+		return "", fmt.Errorf("smb dial: %w", err)
+	}
+	d := &smb2.Dialer{
+		Initiator: &smb2.NTLMInitiator{
+			User:     config.User,
+			Password: config.Password,
+			Domain:   config.SmbDomain,
+		},
+	}
+	sess, err := d.DialConn(context.Background(), conn, addr)
+	if err != nil {
+		conn.Close()
+		return "", fmt.Errorf("smb handshake: %w", err)
+	}
+	defer func() {
+		_ = sess.Logoff()
+		conn.Close()
+	}()
+	return fmt.Sprintf("smb: authenticated as %s@%s", config.User, config.Host), nil
+}
+
+func probeRedis(config ConnectionConfig) (string, error) {
+	var client *redis.Client
+	if config.RedisMode == "sentinel" {
+		var addrs []string
+		for _, a := range strings.Split(config.RedisSentinels, ",") {
+			if a = strings.TrimSpace(a); a != "" {
+				addrs = append(addrs, a)
+			}
+		}
+		if len(addrs) == 0 {
+			return "", fmt.Errorf("redis sentinel: no sentinel addresses")
+		}
+		if config.RedisMasterName == "" {
+			return "", fmt.Errorf("redis sentinel: master name required")
+		}
+		client = redis.NewFailoverClient(&redis.FailoverOptions{
+			MasterName:       config.RedisMasterName,
+			SentinelAddrs:    addrs,
+			SentinelUsername: config.SentinelUser,
+			SentinelPassword: config.SentinelPassword,
+			Username:         config.User,
+			Password:         config.Password,
+			DB:               0,
+		})
+	} else {
+		client = redis.NewClient(&redis.Options{
+			Addr:     fmt.Sprintf("%s:%d", config.Host, config.Port),
+			Username: config.User,
+			Password: config.Password,
+			DB:       0,
+		})
+	}
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if _, err := client.Ping(ctx).Result(); err != nil {
+		return "", fmt.Errorf("redis ping: %w", err)
+	}
+	return "redis: pong", nil
+}
+
+func probeMongo(config ConnectionConfig) (string, error) {
+	uri := buildMongoURI(config)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	client, err := mongo.Connect(ctx, options.Client().ApplyURI(uri))
+	if err != nil {
+		return "", fmt.Errorf("mongodb connect: %w", err)
+	}
+	defer client.Disconnect(context.Background())
+	if err := client.Ping(ctx, nil); err != nil {
+		return "", fmt.Errorf("mongodb ping: %w", err)
+	}
+	return fmt.Sprintf("mongodb: connected to %s:%d", config.Host, config.Port), nil
+}
+
+func probeDatabase(config ConnectionConfig) (string, error) {
+	dsn, err := database.BuildDSN(config.DBType, config.Host, config.User, config.Password, config.DBName, config.DBParams, config.Port)
+	if err != nil {
+		return "", err
+	}
+	db, err := database.NewDB(config.DBType, dsn)
+	if err != nil {
+		return "", err
+	}
+	defer db.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := db.PingContext(ctx); err != nil {
+		return "", fmt.Errorf("ping %s: %w", config.DBType, err)
+	}
+	return fmt.Sprintf("%s: connected to %s:%d", config.DBType, config.Host, config.Port), nil
+}

--- a/frontend/src/components/ConnectionForm.vue
+++ b/frontend/src/components/ConnectionForm.vue
@@ -502,6 +502,16 @@
     </div>
     <template #footer>
       <el-button @click="visible = false">{{ t('conn.cancel') }}</el-button>
+      <el-button
+        v-if="canTest"
+        :loading="testStatus === 'checking'"
+        :icon="testStatus === 'success' ? CircleCheck : testStatus === 'error' ? CircleX : undefined"
+        :class="{ 'test-success': testStatus === 'success', 'test-error': testStatus === 'error' }"
+        class="test-status-btn"
+        @click="onTest"
+      >
+        {{ t('conn.testConnection') }}
+      </el-button>
       <el-button @click="onSave">{{ t('conn.saveOnly') }}</el-button>
       <el-button type="primary" @click="onConnect">{{ t('conn.saveConnect') }}</el-button>
     </template>
@@ -544,9 +554,10 @@ import { useIdentityStore } from '../stores/identityStore'
 import { useProxyStore } from '../stores/proxyStore'
 import { useI18n } from '../i18n'
 import type { ConnectionConfig, PostLoginExpectStep } from '../types/session'
-import { OpenFileDialog, GetPlatform, ListSerialPorts } from '../../wailsjs/go/main/App'
-import { ElMessage, ElInput } from 'element-plus'
-import { Plus, Trash2, ChevronDown, ChevronRight, FolderOpen, RefreshCw, Terminal, Monitor, Database, DatabaseZap, Layers, SquareTerminal, Zap, Laptop, Cable, FolderUp, HardDrive, Cloud, Globe, MonitorCloud, MonitorSmartphone, Boxes, ShipWheel, AppWindow } from '@lucide/vue'
+import { OpenFileDialog, GetPlatform, ListSerialPorts, TestConnection } from '../../wailsjs/go/main/App'
+import { ElInput } from 'element-plus'
+import { msg } from '../services/message'
+import { Plus, Trash2, ChevronDown, ChevronRight, FolderOpen, RefreshCw, Terminal, Monitor, Database, DatabaseZap, Layers, SquareTerminal, Zap, Laptop, Cable, FolderUp, HardDrive, Cloud, Globe, MonitorCloud, MonitorSmartphone, Boxes, ShipWheel, AppWindow, CircleCheck, CircleX } from '@lucide/vue'
 import { listContexts } from '../services/k8sClient'
 import type { K8sContextInfo } from '../types/k8s'
 
@@ -677,6 +688,14 @@ const passwordInputKey = ref(0)
 const postLoginMode = ref<'script' | 'expect'>('script')
 const showAdvanced = ref(false)
 
+// Connection types that support the "test connection" button (issue #377).
+// local/serial/mosh/vnc/rdp/spice/x11-desktop don't have a non-interactive probe.
+const TESTABLE_TYPES = ['ssh', 'telnet', 'ftp', 's3', 'webdav', 'smb', 'database', 'k8s', 'container']
+// Test-connection result state: 'checking' shows a spinner; 'success'/'error'
+// keep a colored status icon on the button until the next test or a reopen.
+const testStatus = ref<'idle' | 'checking' | 'success' | 'error'>('idle')
+const canTest = computed(() => TESTABLE_TYPES.includes(form.type))
+
 // Serial port config (separate refs so allow-create doesn't produce strings)
 const serialPorts = ref<string[]>([])
 const serialScanning = ref(false)
@@ -732,6 +751,7 @@ const hostInputRef = ref<InstanceType<typeof ElInput> | null>(null)
 
 watch(visible, (val) => {
   if (val) {
+    testStatus.value = 'idle'
     passwordInputKey.value++
     // Apply group on open: the defaultGroupId watch won't fire when the value
     // is unchanged, so restore it here to avoid losing the group on the second
@@ -964,6 +984,8 @@ watch(() => props.defaultGroupId, (gid) => {
 
 // Auto-switch default port when changing type
 watch(() => form.type, (newType) => {
+  // A result icon for the previous type is stale; clear it.
+  testStatus.value = 'idle'
   if (newType !== 'ssh' && postLoginMode.value === 'expect') {
     postLoginMode.value = 'script'
   }
@@ -1258,7 +1280,7 @@ function removeExpectStep(index: number) {
 function validateContainer(): boolean {
   if (form.type !== 'container') return true
   if (form.containerTransport === 'ssh' && !form.containerSSHConnId) {
-    ElMessage.error(t('conn.containerSSHRefRequired'))
+    msg.error(t('conn.containerSSHRefRequired'))
     return false
   }
   if (form.containerTransport === 'ssh' && !sshConnections.value.length) return false
@@ -1268,10 +1290,31 @@ function validateContainer(): boolean {
 function validateX11Desktop(): boolean {
   if (form.type !== 'x11-desktop') return true
   if (form.x11DesktopDesktopType === 'custom' && !form.x11DesktopCustomCmd?.trim()) {
-    ElMessage.error(t('conn.x11DesktopCustomCmdRequired'))
+    msg.error(t('conn.x11DesktopCustomCmdRequired'))
     return false
   }
   return true
+}
+
+async function onTest() {
+  if (!validateContainer()) return
+  if (!validateX11Desktop()) return
+  let config: ConnectionConfig
+  try {
+    config = normalizeForm()
+  } catch {
+    // Host / required field empty; silently return like onSave/onConnect.
+    return
+  }
+  testStatus.value = 'checking'
+  try {
+    const desc = await TestConnection(config)
+    testStatus.value = 'success'
+    msg.success(desc)
+  } catch (e: any) {
+    testStatus.value = 'error'
+    msg.error(String(e?.message || e), true)
+  }
 }
 
 function onSave() {
@@ -1306,6 +1349,15 @@ function onConnect() {
 </script>
 
 <style scoped>
+/* Color the connection-test status icon (rendered via el-button's `icon` prop,
+   so spacing matches the native loading spinner) by result. */
+.test-status-btn.test-success :deep(.el-icon) {
+  color: var(--success);
+}
+.test-status-btn.test-error :deep(.el-icon) {
+  color: var(--error);
+}
+
 /* ── Layout ── */
 .conn-layout {
   display: flex;

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -64,6 +64,7 @@
   "conn.saveConnect": "Speichern & Verbinden",
   "conn.save": "Speichern",
   "conn.saveOnly": "Nur speichern",
+  "conn.testConnection": "Verbindung testen",
   "conn.hostRequired": "Host ist erforderlich",
   "conn.advanced": "Erweitert",
   "conn.postLoginScript": "Post-Login-Skript",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -64,6 +64,7 @@
   "conn.saveConnect": "Save & Connect",
   "conn.save": "Save",
   "conn.saveOnly": "Save Only",
+  "conn.testConnection": "Test Connection",
   "conn.hostRequired": "Host is required",
   "conn.advanced": "Advanced",
   "conn.postLoginScript": "Post-login Script",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -64,6 +64,7 @@
   "conn.saveConnect": "Guardar y Conectar",
   "conn.save": "Guardar",
   "conn.saveOnly": "Solo Guardar",
+  "conn.testConnection": "Probar conexión",
   "conn.hostRequired": "El host es obligatorio",
   "conn.advanced": "Avanzado",
   "conn.postLoginScript": "Script Posterior al Inicio de Sesión",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -64,6 +64,7 @@
   "conn.saveConnect": "Enregistrer et connecter",
   "conn.save": "Enregistrer",
   "conn.saveOnly": "Enregistrer uniquement",
+  "conn.testConnection": "Tester la connexion",
   "conn.hostRequired": "L'hôte est requis",
   "conn.advanced": "Avancé",
   "conn.postLoginScript": "Script post-connexion",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -64,6 +64,7 @@
   "conn.saveConnect": "保存して接続",
   "conn.save": "保存",
   "conn.saveOnly": "保存のみ",
+  "conn.testConnection": "接続テスト",
   "conn.hostRequired": "ホストは必須です",
   "conn.advanced": "詳細設定",
   "conn.postLoginScript": "ログイン後スクリプト",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -64,6 +64,7 @@
   "conn.saveConnect": "저장 후 연결",
   "conn.save": "저장",
   "conn.saveOnly": "저장만 하기",
+  "conn.testConnection": "연결 테스트",
   "conn.hostRequired": "호스트를 입력해 주세요",
   "conn.advanced": "고급 설정",
   "conn.postLoginScript": "로그인 후 스크립트",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -64,6 +64,7 @@
   "conn.saveConnect": "Сохранить и подключиться",
   "conn.save": "Сохранить",
   "conn.saveOnly": "Только сохранить",
+  "conn.testConnection": "Проверить соединение",
   "conn.hostRequired": "Укажите хост",
   "conn.advanced": "Дополнительно",
   "conn.postLoginScript": "Скрипт после входа",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -64,6 +64,7 @@
   "conn.saveConnect": "保存并连接",
   "conn.save": "保存",
   "conn.saveOnly": "仅保存",
+  "conn.testConnection": "测试连接",
   "conn.hostRequired": "主机地址不能为空",
   "conn.advanced": "高级配置",
   "conn.postLoginScript": "登录后执行",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -64,6 +64,7 @@
   "conn.saveConnect": "儲存並連線",
   "conn.save": "儲存",
   "conn.saveOnly": "僅儲存",
+  "conn.testConnection": "測試連線",
   "conn.hostRequired": "主機位址不能為空",
   "conn.advanced": "進階設定",
   "conn.postLoginScript": "登入後執行",

--- a/frontend/src/services/message.ts
+++ b/frontend/src/services/message.ts
@@ -2,11 +2,20 @@ import { ElMessage } from 'element-plus'
 
 const CLOSABLE = { showClose: true, duration: 5000, offset: 50 }
 
+// persist=true keeps the toast until the user closes it (duration 0) instead of
+// auto-dismissing — e.g. a connection-test result whose outcome must be readable.
+type PersistMsg = (m: string, persist?: boolean) => void
+
+const persistMsg =
+  (kind: 'success' | 'error' | 'warning' | 'info'): PersistMsg =>
+  (m, persist = false) =>
+    ElMessage[kind]({ message: m, ...CLOSABLE, duration: persist ? 0 : CLOSABLE.duration })
+
 export const msg = {
-  success(m: string) { ElMessage.success({ message: m, ...CLOSABLE }) },
-  error(m: string)   { ElMessage.error({ message: m, ...CLOSABLE }) },
-  warning(m: string) { ElMessage.warning({ message: m, ...CLOSABLE }) },
-  info(m: string)    { ElMessage.info({ message: m, ...CLOSABLE }) },
+  success: persistMsg('success'),
+  error: persistMsg('error'),
+  warning: persistMsg('warning'),
+  info: persistMsg('info'),
   // Stays until closed so a long path can be read and copied. The message is
   // wrapped in a span with inline no-drag so the WKWebView hands mouse events
   // back to the DOM instead of initiating a window drag on macOS frameless

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -485,6 +485,8 @@ export function SyncTestConnection():Promise<void>;
 
 export function SyncVerifyPassword(arg1:string,arg2:string,arg3:string):Promise<void>;
 
+export function TestConnection(arg1:session.ConnectionConfig):Promise<string>;
+
 export function TruncateTable(arg1:string,arg2:string,arg3:string):Promise<void>;
 
 export function UnlockCredentials(arg1:string):Promise<void>;

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -950,6 +950,10 @@ export function SyncVerifyPassword(arg1, arg2, arg3) {
   return window['go']['main']['App']['SyncVerifyPassword'](arg1, arg2, arg3);
 }
 
+export function TestConnection(arg1) {
+  return window['go']['main']['App']['TestConnection'](arg1);
+}
+
 export function TruncateTable(arg1, arg2, arg3) {
   return window['go']['main']['App']['TruncateTable'](arg1, arg2, arg3);
 }

--- a/test_connection.go
+++ b/test_connection.go
@@ -1,0 +1,270 @@
+package main
+
+// TestConnection implements the frontend's "test connection" button (issue #377).
+// It probes whether a connection config can connect / authenticate WITHOUT
+// opening a persistent session. Session-owned protocols (ssh, telnet, ftp, s3,
+// webdav, smb, redis, mongodb, database) are delegated to session.ProbeConnection
+// after identity/proxy references are materialized. k8s and container need the
+// app's managers (and the store for referenced SSH connections / k8s tunnels),
+// so they are handled here directly.
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/ys-ll/uniterm/backend/container"
+	"github.com/ys-ll/uniterm/backend/k8s"
+	"github.com/ys-ll/uniterm/backend/session"
+)
+
+// TestConnection returns a short human-readable description on success, or a
+// readable error (never echoing the password) on failure.
+func (a *App) TestConnection(config session.ConnectionConfig) (string, error) {
+	// Defensive: a new-connection form snapshot may carry an empty password even
+	// when the OS keychain already has one (mirrors CreateSession/SessionStart).
+	if config.Password == "" && config.ID != "" && a.connectionStore != nil {
+		if pw, err := a.connectionStore.EnsurePassword(config.ID); err == nil && pw != "" {
+			config.Password = pw
+		}
+	}
+	// Resolve identity / proxy references for the protocols that consume them
+	// (ssh-family). No-ops when not configured.
+	mc, err := a.materializeIdentity(config)
+	if err != nil {
+		return "", err
+	}
+	mc, err = a.materializeProxy(mc)
+	if err != nil {
+		return "", err
+	}
+
+	switch mc.Type {
+	case "k8s":
+		return a.testK8sConnection(mc)
+	case "container":
+		return a.testContainerConnection(mc)
+	default:
+		return session.ProbeConnection(mc)
+	}
+}
+
+// testContainerConnection probes the container engine reachability. Reuses the
+// same building blocks as ContainerConnect (NewProvider + ValidateRuntime), but
+// without registering a persistent connection. For SSH transport it loads the
+// referenced SSH connection from the store, materializes its identity, dials,
+// and runs the runtime probe on the remote host.
+func (a *App) testContainerConnection(config session.ConnectionConfig) (string, error) {
+	if a.connectionStore == nil {
+		return "", fmt.Errorf("connection store not initialized")
+	}
+	rt := container.Runtime(config.ContainerRuntime)
+
+	if config.ContainerTransport == "local" {
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+		runner := container.NewLocalRunner()
+		if err := container.ValidateRuntime(ctx, rt, runner); err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("container: %s engine reachable locally", rt), nil
+	}
+
+	// SSH transport: resolve the referenced SSH connection.
+	if config.ContainerSSHConnID == "" {
+		return "", fmt.Errorf("referenced SSH connection missing")
+	}
+	data, err := a.connectionStore.Load()
+	if err != nil {
+		return "", err
+	}
+	var sshCfg *session.ConnectionConfig
+	for _, c := range data.Connections {
+		if c.ID == config.ContainerSSHConnID {
+			sshCfg = &c
+			break
+		}
+	}
+	if sshCfg == nil {
+		return "", fmt.Errorf("referenced SSH connection not found: %s", config.ContainerSSHConnID)
+	}
+	if sshCfg.AuthType == "identity" {
+		m, err := a.materializeIdentity(*sshCfg)
+		if err != nil {
+			return "", err
+		}
+		sshCfg = &m
+	}
+
+	// Mirror ContainerConnect: honor the referenced connection's own jump-host
+	// tunnel before dialing through it.
+	if sshCfg.TunnelSSHConnID != "" && a.tunnelService != nil {
+		var tunnelCfg *session.ConnectionConfig
+		for _, c := range data.Connections {
+			if c.ID == sshCfg.TunnelSSHConnID {
+				tunnelCfg = &c
+				break
+			}
+		}
+		if tunnelCfg == nil {
+			return "", fmt.Errorf("tunnel SSH connection not found: %s", sshCfg.TunnelSSHConnID)
+		}
+		if tunnelCfg.AuthType == "identity" {
+			m, err := a.materializeIdentity(*tunnelCfg)
+			if err != nil {
+				return "", err
+			}
+			tunnelCfg = &m
+		}
+		key := uuid.New().String()
+		localPort, err := a.tunnelService.Start(key, *tunnelCfg, sshCfg.Host, sshCfg.Port, nil)
+		if err != nil {
+			return "", fmt.Errorf("tunnel start: %w", err)
+		}
+		defer a.tunnelService.Stop(key)
+		sshCfg.Host = "127.0.0.1"
+		sshCfg.Port = localPort
+	}
+
+	client, err := session.DialSSHClient(*sshCfg)
+	if err != nil {
+		return "", fmt.Errorf("container over ssh: %w", err)
+	}
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	runner := container.NewSSHRunner(client)
+	if err := container.ValidateRuntime(ctx, rt, runner); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("container: %s engine reachable via ssh %s@%s", rt, sshCfg.User, sshCfg.Host), nil
+}
+
+// testK8sConnection probes the kubernetes apiserver by building a client from
+// the kubeconfig (lazy, no I/O) and issuing a GET /version. Reuses ConnectWith /
+// Request / Disconnect so auth, tunnel dial override and TLS all behave exactly
+// like a real K8sConnect. An incorrect cluster name or credentials surface as
+// a non-2xx status or a dial error.
+func (a *App) testK8sConnection(config session.ConnectionConfig) (string, error) {
+	if a.k8sManager == nil {
+		return "", fmt.Errorf("k8s manager not initialized")
+	}
+
+	sourceIsPath := config.K8sConfigInline == ""
+	source := config.K8sConfigInline
+	if sourceIsPath {
+		source = config.K8sConfigPath
+	}
+	raw, err := readKubeconfigSource(source, sourceIsPath)
+	if err != nil {
+		return "", err
+	}
+	contextName := config.K8sContext
+	tunnelID := config.TunnelSSHConnID
+
+	if tunnelID == "" {
+		connID, err := a.k8sManager.ConnectWith(raw, contextName, k8s.ConnectOptions{})
+		if err != nil {
+			return "", err
+		}
+		defer a.k8sManager.Disconnect(connID)
+		return a.probeK8sAPIServer(connID, contextName)
+	}
+
+	// SSH tunnel for k8s (mirrors K8sConnect).
+	if a.tunnelService == nil || a.connectionStore == nil {
+		return "", fmt.Errorf("tunnel service or connection store not initialized")
+	}
+	data, err := a.connectionStore.Load()
+	if err != nil {
+		return "", fmt.Errorf("load connections for tunnel: %w", err)
+	}
+	var tunnelSSHConfig *session.ConnectionConfig
+	for _, c := range data.Connections {
+		if c.ID == tunnelID {
+			tunnelSSHConfig = &c
+			break
+		}
+	}
+	if tunnelSSHConfig == nil {
+		return "", fmt.Errorf("tunnel SSH connection not found: %s", tunnelID)
+	}
+	if tunnelSSHConfig.AuthType == "identity" {
+		m, err := a.materializeIdentity(*tunnelSSHConfig)
+		if err != nil {
+			return "", err
+		}
+		tunnelSSHConfig = &m
+	}
+
+	kc, err := k8s.ParseBytes(raw)
+	if err != nil {
+		return "", fmt.Errorf("kubeconfig: %w", err)
+	}
+	ctxName := contextName
+	if ctxName == "" {
+		ctxName = kc.CurrentContext
+	}
+	ctxEntry, ok := kc.Contexts[ctxName]
+	if !ok {
+		return "", fmt.Errorf("context %q not found", ctxName)
+	}
+	cluster, ok := kc.Clusters[ctxEntry.Cluster]
+	if !ok {
+		return "", fmt.Errorf("cluster %q not found", ctxEntry.Cluster)
+	}
+	targetHost, targetPort, err := k8s.ParseServerAddr(cluster.Server)
+	if err != nil {
+		return "", fmt.Errorf("parse apiserver url: %w", err)
+	}
+
+	tunnelKey := uuid.New().String()
+	localPort, err := a.tunnelService.Start(tunnelKey, *tunnelSSHConfig, targetHost, targetPort, nil)
+	if err != nil {
+		return "", fmt.Errorf("tunnel start: %w", err)
+	}
+
+	var dialer net.Dialer
+	dialOverride := func(ctx context.Context, _, _ string) (net.Conn, error) {
+		return dialer.DialContext(ctx, "tcp", k8s.LocalAddr(localPort))
+	}
+	onClose := func() { a.tunnelService.Stop(tunnelKey) }
+	connID, err := a.k8sManager.ConnectWith(raw, contextName, k8s.ConnectOptions{
+		PresetID:     tunnelKey,
+		DialOverride: dialOverride,
+		OnClose:      onClose,
+	})
+	if err != nil {
+		a.tunnelService.Stop(tunnelKey)
+		return "", err
+	}
+	defer a.k8sManager.Disconnect(connID)
+	return a.probeK8sAPIServer(connID, contextName)
+}
+
+// probeK8sAPIServer issues a GET /version on an existing k8s connection and maps
+// the result to a readable success/failure.
+func (a *App) probeK8sAPIServer(connID, contextName string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	status, _, err := a.k8sManager.Request(ctx, connID, "GET", "/version", nil, "")
+	if err != nil {
+		return "", fmt.Errorf("k8s apiserver: %w", err)
+	}
+	if status >= 400 {
+		label := contextName
+		if label == "" {
+			label = "current context"
+		}
+		return "", fmt.Errorf("k8s apiserver (%s) returned HTTP %d", label, status)
+	}
+	label := contextName
+	if label == "" {
+		label = "current context"
+	}
+	return fmt.Sprintf("k8s: connected to apiserver (context %q)", label), nil
+}


### PR DESCRIPTION
Closes #377

Adds a **Test Connection** button to the new/edit connection dialog so users can verify host, port and credentials before saving or connecting — no session is opened.

**Backend**
- New `App.TestConnection` Wails method probes connectivity/credentials per protocol and returns a readable result, closing every connection afterward.
- Session-owned protocols (`ssh`, `telnet`, `ftp`, `s3`, `webdav`, `smb`, `redis`, `mongodb`, `mysql/postgres/oracle/sqlserver/rqlite`) dispatch to `session.ProbeConnection` after identity/proxy references are materialized.
- `k8s` and `container` (docker/podman/nerdctl) are handled in the app dispatcher via the existing k8s/container managers — k8s uses a lazy client + `GET /version`, container probes the engine runtime.
- All probing reuses existing dial/auth code (ssh cipher fallback + proxy, database ping, redis/mongo ping, smb2 NTLM, ftp TLS, gowebdav, simples3).

**Frontend**
- Test button shown only for supported types, with a checking spinner and a persistent success/failure status icon.
- Success toast auto-dismisses; the failure toast stays open until dismissed. The unified `msg` wrapper gains an optional `persist` flag.

**Not covered**: `local` / `serial` / `mosh` / `vnc` / `rdp` / `spice` / `x11-desktop` (no non-interactive probe; button hidden).

---
在新建/编辑连接弹窗中新增**测试连接**按钮，保存或连接前即可验证主机、端口和凭据是否正确，无需打开会话。

**后端**
- 新增 `App.TestConnection` Wails 方法，按协议探测连通性/凭据并返回可读结果，结束后关闭所有连接。
- 会话类协议（`ssh`、`telnet`、`ftp`、`s3`、`webdav`、`smb`、`redis`、`mongodb`、`mysql/postgres/oracle/sqlserver/rqlite`）在物化解 identity/代理后分发给 `session.ProbeConnection`。
- `k8s` 与 `container`（docker/podman/nerdctl）在 App dispatcher 中借助现有 k8s/container manager 处理——k8s 用惰性客户端 + `GET /version`，container 探测引擎运行时。
- 全部探测复用现有拨号/认证代码（ssh 加密回退+代理、数据库 ping、redis/mongo ping、smb2 NTLM、ftp TLS、gowebdav、simples3）。

**前端**
- 测试按钮仅在支持的类型中显示，含检查中 spinner 与常驻的成功/失败状态图标。
- 成功提示自动关闭；失败提示保留至手动关闭。统一 `msg` 封装新增可选 `persist` 标志。

**不含**：`local` / `serial` / `mosh` / `vnc` / `rdp` / `spice` / `x11-desktop`（无法做非交互探测，按钮隐藏）。