### PR TITLE
fix(session): open duplicated tab instantly and unify duplicate entry points

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -204,6 +204,7 @@ import { disposeSessionStore } from './stores/sessionStore'
 import { useUpdateCheck } from './composables/useUpdateCheck'
 import { loadKeybindings, installGlobalListener, uninstallGlobalListener } from './composables/useKeyboardShortcuts'
 import { focusPanelTerminal, installTerminalFocusRestore } from './composables/useFocusTerminal'
+import { useDuplicateSession } from './composables/useDuplicateSession'
 import type { ShortcutAction } from './types/settings'
 import { useI18n } from './i18n'
 import { CreateSession, CloseSession, RDPHide, RDPShow, RDPSetPosition, RecordRecentConnection, GetPlatform, GetBackgroundImage, SessionStart, RelaunchApp } from '../wailsjs/go/main/App'
@@ -257,6 +258,7 @@ const tabStore = useTabStore()
 const activeTab = computed(() => tabStore.activeTab)
 const panelStore = usePanelStore()
 const sessionStore = useSessionStore()
+const { duplicateSession } = useDuplicateSession()
 const aiStore = useAIStore()
 const settingsStore = useSettingsStore()
 const localStateStore = useLocalStateStore()
@@ -863,39 +865,20 @@ const actionHandlers: Record<ShortcutAction, () => void> = {
   navigatePrev: () => navigatePanel(-1),
   navigateNext: () => navigatePanel(1),
   openSettings: () => openSettings(),
-  duplicateSession: async () => {
-    const pid = tabStore.getActivePanelId()
-    if (!pid) return
-    const panel = panelStore.getPanel(pid)
-    if (!panel?.config) return
-    const newPanel = panelStore.createPanel(
-      { ...panel.config } as ConnectionConfig,
-      panel.type
-    )
-    panelStore.updateTitle(newPanel.id, panel.title)
-    try {
-      const dupConfig: ConnectionConfig = {
-        ...panel.config,
-        initialCols: 0,
-        initialRows: 0,
-      }
-      const info = await CreateSession(panel.config.type, dupConfig)
-      panelStore.bindSession(newPanel.id, info.id)
-      sessionStore.initSession(info.id)
-      const newTab = tabStore.createTerminalTab(newPanel.title, newPanel.id)
-      panelStore.movePanelToTab(newPanel.id, newTab.id)
-      const size = await waitForTerminalSize(info.id)
-      if (size.cols > 0 && size.rows > 0) {
-        dupConfig.initialCols = size.cols
-        dupConfig.initialRows = size.rows
-      }
-      await SessionStart(info.id, dupConfig).catch((e) => {
-        console.error('Failed to start duplicated session:', e)
-        CloseSession(info.id).catch(() => {})
-      })
-    } catch (e) {
-      console.error('Failed to duplicate session:', e)
+  duplicateSession: () => {
+    // Same logic as the tab context menu's "复制会话": delegate to the shared
+    // duplicate routine so both entry points behave identically.
+    const tab = tabStore.activeTab
+    if (!tab) return
+    if (tab.type === 'workspace') {
+      // A workspace holds several panels; the shortcut duplicates the focused
+      // one (a terminal). Feed it to the shared routine as a terminal tab.
+      const pid = tabStore.getActivePanelId()
+      const panel = pid ? panelStore.getPanel(pid) : undefined
+      if (panel) duplicateSession({ type: 'terminal', panelId: pid, title: panel.title })
+      return
     }
+    duplicateSession(tab)
   },
 }
 

--- a/frontend/src/components/TabItem.vue
+++ b/frontend/src/components/TabItem.vue
@@ -58,7 +58,7 @@
         @click.stop
       >
         <!-- ① 标签类操作 -->
-        <div v-if="canDuplicate" class="menu-item" @click="duplicateTab">
+        <div v-if="canDuplicate" class="menu-item" @click="onDuplicate">
           {{ t('tab.duplicate') }}
           <span class="menu-shortcut">{{ menuShortcut('duplicateSession') }}</span>
         </div>
@@ -119,22 +119,16 @@ import { useK8sStore } from '../stores/k8sStore'
 import { useContainerStore } from '../stores/containerStore'
 import { useI18n } from '../i18n'
 import {
-  CreateSession,
-  CloseSession,
-  K8sExecSession,
-  ContainerExecSession,
   EnableSessionOutputLog,
   DisableSessionOutputLog,
   GetSessionOutputLogInfo,
   OpenPathInExplorer,
   RDPSetFullScreen,
-  SessionStart,
 } from '../../wailsjs/go/main/App'
 import { msg } from '../services/message'
 import { ClipboardSetText } from '../../wailsjs/runtime/runtime'
 import type { TerminalTab, SettingsTab, SFTPTab, RDPTab, VNCTab, SPICETab, DBTab, MonitorTab, WorkspaceTab } from '../types/workspace'
-import type { ConnectionConfig } from '../types/session'
-import { waitForTerminalSize } from '../services/terminalManager'
+import { useDuplicateSession } from '../composables/useDuplicateSession'
 import { SquareTerminal, Laptop, FolderUp, HardDrive, Cloud, Globe, Monitor, MonitorCloud, MonitorSmartphone, Settings, Database, DatabaseZap, Layers, Activity, Terminal, Zap, X, ArrowDownUp, LayoutDashboard, Cable, SquarePlus, Lock, ShipWheel, Box, Boxes, AppWindow } from '@lucide/vue'
 
 const props = defineProps<{
@@ -157,6 +151,7 @@ const sessionStore = useSessionStore()
 const k8sStore = useK8sStore()
 const containerStore = useContainerStore()
 const settingsStore = useSettingsStore()
+const { duplicateSession } = useDuplicateSession()
 const { t } = useI18n()
 
 const isMac = /Mac|iPhone|iPad/.test(navigator.userAgent)
@@ -435,102 +430,9 @@ async function copyHostAddress() {
   closeContextMenu()
 }
 
-async function duplicateTab() {
+function onDuplicate() {
   closeContextMenu()
-  const tab = props.tab
-  if (!('panelId' in tab)) return
-  const panel = panelStore.getPanel(tab.panelId)
-  if (!panel) return
-
-  // k8s tab has no backend session; it connects itself on mount from
-  // connectionId + namespace. Duplicate = a fresh panel + K8s tab reusing the
-  // same connection (a new independent session), matching other tab types.
-  if (tab.type === 'k8s') {
-    const newPanel = panelStore.createPanel(panel.config, 'k8s')
-    panelStore.updateTitle(newPanel.id, panel.title)
-    const k8sTab = tab as any
-    const newTab = tabStore.createK8sTab(newPanel.title, newPanel.id, k8sTab.connectionId, k8sTab.namespace || '')
-    panelStore.movePanelToTab(newPanel.id, newTab.id)
-    return
-  }
-
-  const newPanel = panelStore.createPanel(panel.config, panel.type)
-  panelStore.updateTitle(newPanel.id, panel.title)
-
-  // Create + bind the session BEFORE mounting the tab, so the terminal has a
-  // sessionId on first mount. Mounting first (empty sessionId) leaves the
-  // shared terminal keyed by '' and bindSession's later id change can't
-  // transfer it (the watch skips when oldId is falsy), so server output is
-  // dropped until an incidental resize rebuilds the reference.
-  let info
-  if (panel.config) {
-    try {
-      if (panel.type === 'k8s-exec' || panel.type === 'container-exec') {
-        // Exec panels can't be rebuilt via CreateSession (no such type); re-dial the exec stream.
-        const c = panel.config
-        info = panel.type === 'k8s-exec'
-          ? await K8sExecSession(c.k8sExecConnId, c.k8sNamespace || '', c.k8sExecPod, c.k8sExecContainer)
-          : await ContainerExecSession(c.containerExecConnId, c.containerExecContainerId, c.containerExecShell || 'sh')
-        panelStore.bindSession(newPanel.id, info.id)
-        sessionStore.initSession(info.id)
-        sessionStore.updateStatus(info.id, 'connected')
-      } else {
-        const sessionType = resolveSessionType(tab.type, panel.config)
-        const config: ConnectionConfig = {
-          ...panel.config,
-          initialCols: 0,
-          initialRows: 0,
-        }
-        info = await CreateSession(sessionType, config)
-        panelStore.bindSession(newPanel.id, info.id)
-        sessionStore.initSession(info.id)
-        if (tab.type === 'terminal') {
-          const size = await waitForTerminalSize(info.id)
-          if (size.cols > 0 && size.rows > 0) {
-            config.initialCols = size.cols
-            config.initialRows = size.rows
-          }
-          await SessionStart(info.id, config).catch((e) => {
-            console.error('Failed to start duplicated session:', e)
-            CloseSession(info.id).catch(() => {})
-          })
-        }
-      }
-    } catch (e) {
-      console.error('Failed to duplicate session:', e)
-      return
-    }
-  }
-
-  let newTab
-  if (tab.type === 'terminal') {
-    newTab = tabStore.createTerminalTab(newPanel.title, newPanel.id)
-  } else if (tab.type === 'sftp') {
-    newTab = tabStore.createFtpTab(newPanel.title, newPanel.id)
-  } else if (tab.type === 'database' || tab.type === 'mongodb' || tab.type === 'redis') {
-    newTab = tabStore.createDBTab(newPanel.title, newPanel.id)
-    newTab.type = tab.type
-  } else {
-    return
-  }
-  panelStore.movePanelToTab(newPanel.id, newTab.id)
-}
-
-// The session-type argument to CreateSession isn't always panel.config.type:
-// - database panels split into mysql/postgres/redis/mongodb by dbType;
-// - a file-transfer (sftp) tab shares the SSH connection, so its config.type
-//   is 'ssh' but the session must be created as 'sftp' (ftp/smb/webdav/s3
-//   already carry a matching config.type).
-function resolveSessionType(tabType: string, config: any): string {
-  if (tabType === 'database' || tabType === 'mongodb' || tabType === 'redis') {
-    if (config?.dbType === 'redis') return 'redis'
-    if (config?.dbType === 'mongodb') return 'mongodb'
-    return 'database'
-  }
-  if (tabType === 'sftp') {
-    return config?.type === 'ssh' ? 'sftp' : config?.type
-  }
-  return config?.type
+  duplicateSession(props.tab)
 }
 
 function openSftp() {

--- a/frontend/src/composables/useDuplicateSession.ts
+++ b/frontend/src/composables/useDuplicateSession.ts
@@ -1,0 +1,137 @@
+import {
+  CreateSession,
+  CloseSession,
+  K8sExecSession,
+  ContainerExecSession,
+  SessionStart,
+} from '../../wailsjs/go/main/App'
+import { usePanelStore } from '../stores/panelStore'
+import { useTabStore } from '../stores/tabStore'
+import { useSessionStore } from '../stores/sessionStore'
+import { waitForTerminalSize } from '../services/terminalManager'
+import type { ConnectionConfig } from '../types/session'
+
+// The session-type argument to CreateSession isn't always tab.config.type:
+// - database panels split into mysql/postgres/redis/mongodb by dbType;
+// - a file-transfer (sftp) tab shares the SSH connection, so its config.type
+//   is 'ssh' but the session must be created as 'sftp' (ftp/smb/webdav/s3
+//   already carry a matching config.type).
+function resolveSessionType(tabType: string, config: any): string {
+  if (tabType === 'database' || tabType === 'mongodb' || tabType === 'redis') {
+    if (config?.dbType === 'redis') return 'redis'
+    if (config?.dbType === 'mongodb') return 'mongodb'
+    return 'database'
+  }
+  if (tabType === 'sftp') {
+    return config?.type === 'ssh' ? 'sftp' : config?.type
+  }
+  return config?.type
+}
+
+/**
+ * Duplicate a session/tab. Shared by the tab context menu ("复制会话") and the
+ * keyboard shortcut (duplicateSession) so both paths behave identically.
+ *
+ * The new tab is created right after the session is bound but BEFORE it is
+ * started, so the duplicate appears immediately (matching opening from the
+ * connection list) while the SSH/PTY handshake runs in the background.
+ */
+export function useDuplicateSession() {
+  const panelStore = usePanelStore()
+  const tabStore = useTabStore()
+  const sessionStore = useSessionStore()
+
+  async function duplicateSession(tab: any) {
+    if (!tab || !('panelId' in tab)) return
+    const panel = panelStore.getPanel(tab.panelId)
+    if (!panel) return
+
+    // k8s tab has no backend session; it connects itself on mount from
+    // connectionId + namespace. Duplicate = a fresh panel + K8s tab reusing the
+    // same connection (a new independent session), matching other tab types.
+    if (tab.type === 'k8s') {
+      const newPanel = panelStore.createPanel(panel.config, 'k8s')
+      panelStore.updateTitle(newPanel.id, panel.title)
+      const newTab = tabStore.createK8sTab(newPanel.title, newPanel.id, tab.connectionId, tab.namespace || '')
+      panelStore.movePanelToTab(newPanel.id, newTab.id)
+      return
+    }
+
+    const newPanel = panelStore.createPanel(panel.config, panel.type)
+    panelStore.updateTitle(newPanel.id, panel.title)
+
+    // Create + bind the session BEFORE mounting the tab, so the terminal has a
+    // sessionId on first mount. Mounting first (empty sessionId) leaves the
+    // shared terminal keyed by '' and bindSession's later id change can't
+    // transfer it (the watch skips when oldId is falsy), so server output is
+    // dropped until an incidental resize rebuilds the reference.
+    let info
+    let config: ConnectionConfig | undefined
+    if (panel.config) {
+      try {
+        if (panel.type === 'k8s-exec' || panel.type === 'container-exec') {
+          // Exec panels can't be rebuilt via CreateSession (no such type); re-dial the exec stream.
+          const c = panel.config
+          info = panel.type === 'k8s-exec'
+            ? await K8sExecSession(c.k8sExecConnId, c.k8sNamespace || '', c.k8sExecPod, c.k8sExecContainer)
+            : await ContainerExecSession(c.containerExecConnId, c.containerExecContainerId, c.containerExecShell || 'sh')
+          panelStore.bindSession(newPanel.id, info.id)
+          sessionStore.initSession(info.id)
+          sessionStore.updateStatus(info.id, 'connected')
+        } else {
+          const sessionType = resolveSessionType(tab.type, panel.config)
+          config = {
+            ...panel.config,
+            initialCols: 0,
+            initialRows: 0,
+          }
+          info = await CreateSession(sessionType, config)
+          panelStore.bindSession(newPanel.id, info.id)
+          sessionStore.initSession(info.id)
+        }
+      } catch (e) {
+        console.error('Failed to duplicate session:', e)
+        return
+      }
+    }
+
+    // Create the tab now that the session is bound but BEFORE it is started, so
+    // the duplicate appears immediately (matching first-open) while the SSH/PTY
+    // handshake runs in the background — previously SessionStart was awaited
+    // first, so the tab only appeared after the whole connection established.
+    let newTab
+    if (tab.type === 'terminal') {
+      newTab = tabStore.createTerminalTab(newPanel.title, newPanel.id)
+    } else if (tab.type === 'sftp') {
+      newTab = tabStore.createFtpTab(newPanel.title, newPanel.id)
+    } else if (tab.type === 'database' || tab.type === 'mongodb' || tab.type === 'redis') {
+      newTab = tabStore.createDBTab(newPanel.title, newPanel.id)
+      newTab.type = tab.type
+    } else {
+      return
+    }
+    panelStore.movePanelToTab(newPanel.id, newTab.id)
+
+    // Start the connection after the tab is visible. The terminal has now
+    // mounted (with its sessionId bound), so waitForTerminalSize resolves with
+    // the real size instead of blocking forever on a terminal that didn't exist
+    // yet.
+    if (tab.type === 'terminal' && info && config) {
+      try {
+        const size = await waitForTerminalSize(info.id)
+        if (size.cols > 0 && size.rows > 0) {
+          config.initialCols = size.cols
+          config.initialRows = size.rows
+        }
+        await SessionStart(info.id, config).catch((e) => {
+          console.error('Failed to start duplicated session:', e)
+          CloseSession(info.id).catch(() => {})
+        })
+      } catch (e) {
+        console.error('Failed to duplicate session:', e)
+      }
+    }
+  }
+
+  return { duplicateSession }
+}


### PR DESCRIPTION
## What's fixed

Duplicating a session (right-click a tab → "复制会话", or Ctrl+Shift+D) used to wait ~1s+ before the new tab appeared.

**Root cause:** in the tab context menu's own `duplicateTab()`, the new tab was created only AFTER `await SessionStart`, and `waitForTerminalSize` ran before the new terminal existed — so it blocked the full timeout waiting for a size from a terminal that couldn't exist yet. The tab only appeared after the entire SSH/PTY handshake. Opening from the connection list was fast because there the tab is created BEFORE `SessionStart`.

## Changes

- Create the duplicate's tab right after the session is bound and BEFORE `SessionStart`, so it appears immediately while the connection establishes in the background (matching first-open).
- Consolidate the two duplicate implementations — the keyboard-shortcut `duplicateSession` (App.vue) and the context-menu duplicate (TabItem.vue) — into one shared `useDuplicateSession()` composable, used by both entry points.

Closes #584

---
## 修复内容

复制会话（tab 右键"复制会话"，或 Ctrl+Shift+D）之前要等约 1s+ 才出现新 tab。

**根因：** tab 右键菜单的 `duplicateTab()` 把新 tab 创建在 `await SessionStart` **之后**，且 `waitForTerminalSize` 在新终端还不存在时就执行，白白阻塞了完整超时等待一个不可能出现的尺寸。于是 tab 要等整条 SSH/PTY 握手完成后才出现。从连接列表打开之所以快，是因为那里 tab 在 `SessionStart` **之前**创建。

## 改动

- 复制会话在绑定 session 后、`SessionStart` 前就创建 tab，使其立即出现，连接在后台建立（与首次打开一致）。
- 把两份重复的复制逻辑——键盘快捷键 `duplicateSession`（App.vue）与右键菜单复制（TabItem.vue）——合并为一个共享 `useDuplicateSession()`，两个入口统一调用。

Closes #584