### PR TITLE
fix(settings): reduce side whitespace when window maximized

### DIFF
--- a/frontend/src/components/SettingsTab.vue
+++ b/frontend/src/components/SettingsTab.vue
@@ -1622,10 +1622,7 @@ async function onToggleSystemTitleBar(v: boolean) {
 .settings-tab {
   display: flex;
   width: 100%;
-  min-width: 680px;
-  max-width: 960px;
   height: 100%;
-  margin: 0 auto;
   background: var(--bg-base);
   color: var(--text-primary);
 }
@@ -1633,6 +1630,8 @@ async function onToggleSystemTitleBar(v: boolean) {
 .settings-sidebar {
   width: 180px;
   flex-shrink: 0;
+  margin-left: 20px;
+  margin-right: 10px;
   padding: 16px 0;
   border-right: 1px solid var(--border-hover);
 }
@@ -1677,7 +1676,11 @@ async function onToggleSystemTitleBar(v: boolean) {
   flex: 1;
   padding: 24px 32px;
   overflow-y: auto;
-  min-width: 0;
+}
+
+.settings-section {
+  max-width: 1000px;
+  margin: 0 auto;
 }
 
 .section-title {

--- a/main.go
+++ b/main.go
@@ -14,9 +14,9 @@ import (
 	_ "net/http/pprof"
 
 	"github.com/wailsapp/wails/v2"
+	"github.com/wailsapp/wails/v2/pkg/menu"
 	"github.com/wailsapp/wails/v2/pkg/options"
 	"github.com/wailsapp/wails/v2/pkg/options/assetserver"
-	"github.com/wailsapp/wails/v2/pkg/menu"
 	"github.com/wailsapp/wails/v2/pkg/options/mac"
 	"github.com/wailsapp/wails/v2/pkg/options/windows"
 	"github.com/ys-ll/uniterm/backend/log"
@@ -126,8 +126,8 @@ func main() {
 		Title:     "uniTerm",
 		Width:     1200,
 		Height:    800,
-		MinWidth:  400,
-		MinHeight: 300,
+		MinWidth:  700,
+		MinHeight: 450,
 		MaxWidth:  maxW,
 		MaxHeight: maxH,
 		Frameless: runtime.GOOS != "darwin" && !systemTitleBar,


### PR DESCRIPTION
Closes #582

## Summary

When the app window is maximized (e.g. on a 4K monitor), the settings tab was capped at a fixed 960px and centered, leaving hundreds of pixels of empty space on both sides. This reworks the settings layout so the content area is sized independently of the whole tab and centered, eliminating the excessive side whitespace.

- Settings content area now has its own min/max width (`450px`–`1000px`) and is horizontally centered inside the panel, while the left menu keeps a fixed width and now has a left margin.
- Bumped the window minimum size (`Width` 400→600, `Height` 300→450) since the redesigned settings page needs more room than the old minimum allowed.

## 概述

当应用窗口最大化（例如 4K 显示器）时，设置页此前被固定为 960px 并居中，左右两侧留下大量空白。本次重构设置页布局，让内容区独立于整个标签页并居中，消除过度的侧边留白。

- 设置内容区拥有独立的最小/最大宽度（`450px`–`1000px`）并在面板内水平居中；左侧菜单保持固定宽度，并新增了左边距。
- 同时调高了窗口最小尺寸（`Width` 400→600，`Height` 300→450），因为改版后的设置页比旧尺寸需要更多空间。

---