### PR TITLE
fix(highlight): skip already-colored spans so dirs keep their color

### DIFF
--- a/frontend/src/composables/useHighlight.test.ts
+++ b/frontend/src/composables/useHighlight.test.ts
@@ -60,6 +60,25 @@ describe('highlight()', () => {
     expect(highlight(input)).toBe(input)
   })
 
+  it('skips already-colored spans (issue #587) instead of fragmenting them', () => {
+    // `ls` colors a directory blue; the app must NOT re-color its digits.
+    const input = '\x1b[01;34mchatGLM2-6B\x1b[0m\n'
+    expect(highlight(input)).toBe(input)
+  })
+
+  it('skips an extended-256-color span like a plain one', () => {
+    const input = '\x1b[38;5;39mport8-api\x1b[0m\n'
+    expect(highlight(input)).toBe(input)
+  })
+
+  it('still highlights default-colored text after and around a colored span', () => {
+    // The digit "6" sits outside the colored span, so it must still be styled.
+    const input = '\x1b[32mOK\x1b[0m 6\n'
+    const out = highlight(input)
+    expect(out).toContain('\x1b[96m6')
+    expect(out).toContain('\x1b[32mOK\x1b[0m ')
+  })
+
   it('handles multiple fences interleaved with prose', () => {
     const input = 'before {x}\n```\n{inside}\n```\nafter {y}\n'
     const out = highlight(input)

--- a/frontend/src/composables/useHighlight.ts
+++ b/frontend/src/composables/useHighlight.ts
@@ -2,6 +2,9 @@
 // color intact. Using \x1b[0m (full reset) would clear vim's visual selection
 // background and other SGR attributes set by terminal applications.
 const ANSI_RESET = '\x1b[24;39m'
+// Matches a single SGR color sequence (`CSI …m`). Any other CSI sequence
+// (cursor movement, erase, private modes…) does not change the foreground.
+const SGR_SEQ = /^\x1b\[[\d;]*m$/
 // Match ANSI escape sequences: CSI (ESC [ ... letter) and OSC (ESC ] ... BEL/ST)
 const ANSI_RE = /(\x1b\[[\x20-\x3F]*[\x40-\x7E]|\x1b[\]PX^_][^\x07\x1b]*(?:\x07|\x1b\\)|\x1b[\x20-\x2F][\x30-\x7E]|\x1b[\x30-\x7E])/g
 
@@ -71,45 +74,90 @@ const PATTERNS: { sgr: string; regexes: RegExp[] }[] = [
   { sgr: C.number,  regexes: [/\d+/g] },
 ]
 
+// Report how an SGR sequence affects the foreground color:
+//  - 'set'  a non-default foreground color is now active (30-37, 90-97, 38…)
+//  - 'clear' foreground reset to default (0, 39)
+//  - 'unchanged' leaves the foreground untouched (bold, underline, 48… bg…)
+// Sequences are evaluated in order, so e.g. `0;34` is 'set' and `34;0` 'clear'.
+function sgrFgEffect(seq: string): 'set' | 'clear' | 'unchanged' {
+  const body = seq.slice(2, -1)  // strip \x1b[ and trailing m
+  const params = body === '' ? [0] : body.split(';').map((s) => (s === '' ? 0 : parseInt(s, 10)))
+  let effect: 'set' | 'clear' | 'unchanged' = 'unchanged'
+  for (let i = 0; i < params.length; i++) {
+    const p = params[i]
+    if (p === 0 || p === 39) {
+      effect = 'clear'
+    } else if ((p >= 30 && p <= 37) || (p >= 90 && p <= 97)) {
+      effect = 'set'
+    } else if (p === 38) {
+      // Extended foreground: 38;5;N or 38;2;R;G;B
+      const kind = params[i + 1]
+      if (kind === 5) {
+        effect = 'set'
+        i += 2
+      } else if (kind === 2) {
+        effect = 'set'
+        i += 4
+      }
+    }
+  }
+  return effect
+}
+
+function highlightPlainSegment(text: string): string {
+  type MatchEntry = { start: number; end: number; sgr: string }
+  const allMatches: MatchEntry[] = []
+  for (const { sgr, regexes } of PATTERNS) {
+    for (const regex of regexes) {
+      regex.lastIndex = 0
+      let m: RegExpExecArray | null
+      while ((m = regex.exec(text)) !== null) {
+        allMatches.push({ start: m.index, end: m.index + m[0].length, sgr })
+        if (allMatches.length > 200) break
+      }
+      if (allMatches.length > 200) break
+    }
+    if (allMatches.length > 200) break
+  }
+  if (allMatches.length > 200) {
+    return text  // pass through unchanged
+  }
+  allMatches.sort((a, b) => a.start - b.start || b.end - a.end)
+  const filtered: MatchEntry[] = []
+  for (const match of allMatches) {
+    const last = filtered[filtered.length - 1]
+    if (!last || match.start >= last.end) {
+      filtered.push(match)
+    }
+  }
+  let highlighted = text
+  for (let i = filtered.length - 1; i >= 0; i--) {
+    const { start, end, sgr } = filtered[i]
+    highlighted = highlighted.slice(0, start) + sgr + highlighted.slice(start, end) + ANSI_RESET + highlighted.slice(end)
+  }
+  return highlighted
+}
+
 function highlightPlainText(text: string): string {
   const segments = segmentText(text)
   let result = ''
+  // Track whether the upstream application already set a non-default
+  // foreground color (e.g. `ls` coloring a directory name blue). Our keyword
+  // highlighting must skip such spans — re-coloring digits/braces inside an
+  // already-colored token would fragment the app's own color (issue #587).
+  // Only text still in the default foreground gets styled by us.
+  let colored = false
   for (const seg of segments) {
     if (seg.isCSI) {
+      if (SGR_SEQ.test(seg.text)) {
+        const effect = sgrFgEffect(seg.text)
+        if (effect !== 'unchanged') colored = effect === 'set'
+      }
       result += seg.text
+    } else if (!colored) {
+      result += highlightPlainSegment(seg.text)
     } else {
-      type MatchEntry = { start: number; end: number; sgr: string }
-      const allMatches: MatchEntry[] = []
-      for (const { sgr, regexes } of PATTERNS) {
-        for (const regex of regexes) {
-          regex.lastIndex = 0
-          let m: RegExpExecArray | null
-          while ((m = regex.exec(seg.text)) !== null) {
-            allMatches.push({ start: m.index, end: m.index + m[0].length, sgr })
-            if (allMatches.length > 200) break
-          }
-          if (allMatches.length > 200) break
-        }
-        if (allMatches.length > 200) break
-      }
-      if (allMatches.length > 200) {
-        result += seg.text  // pass through unchanged
-        continue
-      }
-      allMatches.sort((a, b) => a.start - b.start || b.end - a.end)
-      const filtered: MatchEntry[] = []
-      for (const match of allMatches) {
-        const last = filtered[filtered.length - 1]
-        if (!last || match.start >= last.end) {
-          filtered.push(match)
-        }
-      }
-      let highlighted = seg.text
-      for (let i = filtered.length - 1; i >= 0; i--) {
-        const { start, end, sgr } = filtered[i]
-        highlighted = highlighted.slice(0, start) + sgr + highlighted.slice(start, end) + ANSI_RESET + highlighted.slice(end)
-      }
-      result += highlighted
+      result += seg.text
     }
   }
   return result


### PR DESCRIPTION
Fixes #587.

Our own syntax highlighting re-colors plain text spans even when the upstream app already set a non-default foreground color (e.g. `ls` colors a directory name blue). This fragmented such tokens — the digits in `chatGLM2-6B` were re-highlighted as numbers, breaking the directory blue.

The fix tracks the SGR foreground state across segments and only applies our highlighting to spans still in the default foreground color. Already-colored spans pass through untouched.

Changes:
- Add `SGR_SEQ` + `sgrFgEffect()` to parse how a CSI sequence affects the foreground (`set`/`clear`/`unchanged`), including extended colors (`38;5;N`, `38;2;R;G;B`).
- Extract per-segment logic into `highlightPlainSegment()` and skip it when an active foreground color is set.
- Plain/default-colored text is still highlighted as before.

Tests: 3 new cases (blue directory not fragmented, extended-256-color span skipped, default-colored text after a colored span still highlighted). All 14 pass.

---

修复 #587。

我们自己的语法高亮会对"纯文本"片段重新上色，即使该片段已被上游应用设置了非默认前景色（例如 `ls` 会把目录名染成蓝色）。这会把这类 token 撑碎——`chatGLM2-6B` 里的数字会被当作 number 重新高亮，从而断开目录的蓝色。

本次修复在分段之间跟踪 SGR 前景色状态，只对仍处于默认前景色文本片段应用我们的高亮；已被上游上色的片段原样跳过、不再叠加。

改动：
- 新增 `SGR_SEQ` + `sgrFgEffect()`，解析 CSI 序列对前景色的影响（`set`/`clear`/`unchanged`），支持扩展色 `38;5;N`、`38;2;R;G;B`。
- 把单段处理逻辑抽为 `highlightPlainSegment()`，并在检测到已激活前景色时跳过。
- 普通/默认色文本仍照常高亮。

测试：新增 3 条（蓝色目录不被撑碎、256 扩展色片段被跳过、彩色片段后方默认色文本仍会高亮）。共 14 条全部通过。