### PR TITLE
feat(sidebar): two-level type filter, typed container labels, and UI fixes

### DIFF
--- a/frontend/src/components/BaseTerminal.vue
+++ b/frontend/src/components/BaseTerminal.vue
@@ -46,6 +46,7 @@
     <!-- Terminal context menu -->
     <div
       v-show="menu.menuVisible.value"
+      ref="contextMenuEl"
       class="context-menu"
       :style="menu.menuStyle.value"
       @click.stop
@@ -1880,8 +1881,11 @@ function openMonitor() {
   }
 }
 
+const contextMenuEl = ref<HTMLElement | null>(null)
+
 const menu = useTerminalMenu({
   getSelection,
+  menuElement: contextMenuEl,
   onPaste: async (text) => {
     if (props.mode === 'ssh' || props.mode === 'local') {
       if (props.broadcastActive && props.workspaceId) {

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -25,35 +25,17 @@
           @keydown="onListKeydown"
         >
           <template #suffix>
-            <el-dropdown trigger="click" placement="bottom-end" popper-class="type-filter-popper">
+            <el-dropdown ref="typeFilterDropdownRef" trigger="click" placement="bottom-end" popper-class="type-filter-popper">
               <span class="filter-trigger" :class="{ active: selectedTypeFilter !== 'all' }" @click.stop>
                 <el-icon><Filter :size="14" /></el-icon>
               </span>
               <template #dropdown>
-                <el-dropdown-menu class="type-filter-menu">
-                  <el-dropdown-item
-                    :class="{ 'is-active': selectedTypeFilter === 'all' }"
-                    @click="selectedTypeFilter = 'all'"
-                  >
-                    <span class="dropdown-item-content">
-                      <el-icon v-if="selectedTypeFilter === 'all'"><Check :size="14" /></el-icon>
-                      <span v-else class="check-placeholder"></span>
-                      <span>{{ t('sidebar.filterAll') }}</span>
-                    </span>
-                  </el-dropdown-item>
-                  <el-dropdown-item
-                    v-for="typeOpt in availableTypes"
-                    :key="typeOpt.value"
-                    :class="{ 'is-active': selectedTypeFilter === typeOpt.value }"
-                    @click="selectedTypeFilter = typeOpt.value"
-                  >
-                    <span class="dropdown-item-content">
-                      <el-icon v-if="selectedTypeFilter === typeOpt.value"><Check :size="14" /></el-icon>
-                      <span v-else class="check-placeholder"></span>
-                      <span>{{ typeOpt.label }}</span>
-                    </span>
-                  </el-dropdown-item>
-                </el-dropdown-menu>
+                <TypeFilterMenuContent
+                  :model-value="selectedTypeFilter"
+                  :all-label="t('sidebar.filterAll')"
+                  :groups="filterGroups"
+                  @update:model-value="onFilterSelect"
+                />
               </template>
             </el-dropdown>
           </template>
@@ -116,6 +98,7 @@
             <el-icon v-else><ChevronRight :size="14" /></el-icon>
           </span>
           <span class="group-name">{{ t('conn.noGroup') }}</span>
+          <span v-if="filteredGrouped.ungrouped.length > 0" class="group-count">{{ filteredGrouped.ungrouped.length }}</span>
         </div>
         <template v-if="expandedGroups.has('__ungrouped__')">
           <div
@@ -514,8 +497,9 @@ import TunnelsPanel from './TunnelsPanel.vue'
 import HistoryPanel from './HistoryPanel.vue'
 import CustomThemeEditor from './CustomThemeEditor.vue'
 import GroupTreeItem from './GroupTreeItem.vue'
+import TypeFilterMenuContent from './TypeFilterMenuContent.vue'
 import type { ConnectionConfig, ConnectionGroup } from '../types/session'
-import { parseQuickConnect, formatConnSubtitle } from '../utils/quickConnect'
+import { parseQuickConnect, formatConnSubtitle, getConnectionTypeKey, getTypeCategory, formatTypeFilterLabel, getTypeFilterCatalog } from '../utils/quickConnect'
 import { FONT_OPTIONS, FONT_WEIGHT_OPTIONS, LANGUAGE_OPTIONS, FOLLOW_APP_THEME } from '../types/settings'
 import { formatFontFamily, normalizeFontFamilyValue } from '../utils/formatFontFamily'
 import { useTerminalThemeOptions } from '../composables/useTerminalThemeOptions'
@@ -597,11 +581,6 @@ function focusSearch() {
 }
 
 // ── Type filter ──
-interface TypeOption {
-  label: string
-  value: string
-}
-
 const TYPE_LABELS: Record<string, string> = {
   ssh: 'SSH',
   telnet: 'Telnet',
@@ -626,27 +605,58 @@ const TYPE_LABELS: Record<string, string> = {
   'database:mongodb': 'MongoDB',
 }
 
-const availableTypes = computed<TypeOption[]>(() => {
-  const types = new Set<string>()
-  for (const c of connectionStore.connections) {
-    if (c.type === 'database' && c.dbType) {
-      types.add(`database:${c.dbType}`)
-    } else {
-      types.add(c.type)
-    }
+// Label for a filter value (type / `database:<db>` / `container:<runtime>`).
+function filterTypeLabel(key: string): string {
+  return TYPE_LABELS[key] || formatTypeFilterLabel(key)
+}
+
+// Two-level filter menu: categories (in the same order/names as the
+// new-connection form) → concrete types present in connections.
+const filterGroups = computed(() => {
+  const connKeys = new Set(connectionStore.connections.map(c => getConnectionTypeKey(c)))
+  const catalog = getTypeFilterCatalog(t)
+  const catalogKeys = new Set(catalog.flatMap(g => g.items.map(i => i.key)))
+
+  // Present-but-uncataloged types (e.g. legacy sftp / monitor that aren't in
+  // the new-connection form) are still filterable, appended under their category.
+  const extras = new Map<string, { key: string; label: string }[]>()
+  for (const k of connKeys) {
+    if (catalogKeys.has(k)) continue
+    const cat = getTypeCategory(k)
+    if (!extras.has(cat)) extras.set(cat, [])
+    extras.get(cat)!.push({ key: k, label: filterTypeLabel(k) })
   }
-  return [...types].map(value => ({
-    value,
-    label: TYPE_LABELS[value] || value
-  })).sort((a, b) => a.label.localeCompare(b.label))
+
+  return catalog
+    .map(g => ({
+      key: g.key,
+      label: g.label,
+      items: [...g.items.filter(i => connKeys.has(i.key)), ...(extras.get(g.key) || [])],
+    }))
+    .filter(g => g.items.length > 0)
 })
 
 function matchTypeFilter(conn: ConnectionConfig, filter: string): boolean {
   if (filter === 'all') return true
   if (filter.startsWith('database:')) {
-    return conn.type === 'database' && conn.dbType === filter.slice(9)
+    return conn.type === 'database' && conn.dbType === filter.slice('database:'.length)
+  }
+  if (filter.startsWith('container:')) {
+    return conn.type === 'container' && (conn.containerRuntime || 'docker') === filter.slice('container:'.length)
   }
   return conn.type === filter
+}
+
+function onFilterSelect(val: string) {
+  selectedTypeFilter.value = val
+  closeTypeFilter()
+}
+
+const typeFilterDropdownRef = ref()
+
+// el-dropdown exposes handleClose() to dismiss the dropdown programmatically.
+function closeTypeFilter() {
+  typeFilterDropdownRef.value?.handleClose()
 }
 
 // ── Expand/collapse state ──
@@ -1809,7 +1819,7 @@ function getShellLabel(path: string): string {
 }
 
 function getSubtitle(conn: ConnectionConfig): string {
-  if (conn.type === 'container') return `${conn.containerRuntime}`
+  if (conn.type === 'container') return conn.containerRuntime || 'container'
   return formatConnSubtitle(conn, getShellLabel)
 }
 
@@ -2169,6 +2179,16 @@ defineExpose({ focusSearch, openChangeGroupFor, openChangeGroupForGroup })
   font-weight: 600;
 }
 
+.group-count {
+  margin-left: auto;
+  font-size: 10px;
+  color: var(--text-disabled);
+  background: var(--bg-subtle);
+  padding: 0 5px;
+  border-radius: 8px;
+  flex-shrink: 0;
+}
+
 .group-header.drag-over {
   background: var(--accent-subtle);
   box-shadow: inset 0 0 0 1px var(--accent);
@@ -2504,6 +2524,16 @@ defineExpose({ focusSearch, openChangeGroupFor, openChangeGroupForGroup })
   border: 1px solid var(--border-subtle) !important;
   border-radius: var(--radius-md) !important;
   box-shadow: var(--shadow-md) !important;
+}
+
+/* el-dropdown wraps its content in an el-scrollbar (el-scrollbar wraps in an
+   overflow:auto wrap), whose horizontal scrollable overflow is widened by the
+   two-level flyout submenu — producing a horizontal scrollbar. Let both layers
+   overflow visibly so the flyout shows fully with no scrollbar. The menu is
+   short, so unscrolling vertically is fine. */
+.type-filter-popper .el-scrollbar,
+.type-filter-popper .el-scrollbar__wrap {
+  overflow: visible !important;
 }
 
 .theme-select-popper .el-select-group__title {

--- a/frontend/src/components/StartTabContent.vue
+++ b/frontend/src/components/StartTabContent.vue
@@ -6,28 +6,18 @@
 
       <!-- Search row -->
     <div class="start-search-row">
-      <el-dropdown trigger="click" placement="bottom-start" :teleported="false">
+      <el-dropdown ref="typeFilterDropdownRef" trigger="click" placement="bottom-start" :teleported="false" popper-class="type-filter-popper">
         <span class="start-filter-btn" :class="{ active: selectedTypeFilter !== 'all' }">
           <el-icon><Filter :size="14" /></el-icon>
-          <span>{{ selectedTypeFilter === 'all' ? t('sidebar.filterAll') : (TYPE_LABELS[selectedTypeFilter] || selectedTypeFilter) }}</span>
+          <span>{{ filterDisplay }}</span>
         </span>
         <template #dropdown>
-          <el-dropdown-menu>
-            <el-dropdown-item
-              :class="{ 'is-active': selectedTypeFilter === 'all' }"
-              @click="selectedTypeFilter = 'all'"
-            >
-              {{ t('sidebar.filterAll') }}
-            </el-dropdown-item>
-            <el-dropdown-item
-              v-for="typeOpt in availableTypes"
-              :key="typeOpt.value"
-              :class="{ 'is-active': selectedTypeFilter === typeOpt.value }"
-              @click="selectedTypeFilter = typeOpt.value"
-            >
-              {{ typeOpt.label }}
-            </el-dropdown-item>
-          </el-dropdown-menu>
+          <TypeFilterMenuContent
+            :model-value="selectedTypeFilter"
+            :all-label="t('sidebar.filterAll')"
+            :groups="filterGroups"
+            @update:model-value="onFilterSelect"
+          />
         </template>
       </el-dropdown>
       <el-input
@@ -445,7 +435,8 @@ import { useTabStore } from '../stores/tabStore'
 import { useSettingsStore } from '../stores/settingsStore'
 import { useI18n } from '../i18n'
 import { GetRecentConnections } from '../../wailsjs/go/main/App'
-import { formatConnSubtitle } from '../utils/quickConnect'
+import { formatConnSubtitle, getConnectionTypeKey, getTypeCategory, formatTypeFilterLabel, getTypeFilterCatalog } from '../utils/quickConnect'
+import TypeFilterMenuContent from './TypeFilterMenuContent.vue'
 import { Filter, Plus, Laptop, Cable, SquareTerminal, Terminal, Database, DatabaseZap, Layers, Monitor, MonitorSmartphone, MonitorCloud, FolderUp, HardDrive, Cloud, Globe, Server, Folder, FolderOpen, Zap, MoreHorizontal, ChevronDown, ShipWheel, Boxes, AppWindow } from '@lucide/vue'
 
 const props = defineProps<{
@@ -541,27 +532,58 @@ const TYPE_LABELS: Record<string, string> = {
   'database:mongodb': 'MongoDB',
 }
 
-const availableTypes = computed(() => {
-  const types = new Set<string>()
-  for (const c of connectionStore.connections) {
-    if (c.type === 'database' && c.dbType) {
-      types.add(`database:${c.dbType}`)
-    } else {
-      types.add(c.type)
-    }
+// Two-level filter menu: categories (in the same order/names as the
+// new-connection form) → concrete types present in connections.
+const filterGroups = computed(() => {
+  const connKeys = new Set(connectionStore.connections.map(c => getConnectionTypeKey(c)))
+  const catalog = getTypeFilterCatalog(t)
+  const catalogKeys = new Set(catalog.flatMap(g => g.items.map(i => i.key)))
+
+  // Present-but-uncataloged types (e.g. legacy sftp / monitor that aren't in
+  // the new-connection form) are still filterable, appended under their category.
+  const extras = new Map<string, { key: string; label: string }[]>()
+  for (const k of connKeys) {
+    if (catalogKeys.has(k)) continue
+    const cat = getTypeCategory(k)
+    if (!extras.has(cat)) extras.set(cat, [])
+    extras.get(cat)!.push({ key: k, label: TYPE_LABELS[k] || formatTypeFilterLabel(k) })
   }
-  return [...types].map(value => ({
-    value,
-    label: TYPE_LABELS[value] || value
-  })).sort((a, b) => a.label.localeCompare(b.label))
+
+  return catalog
+    .map(g => ({
+      key: g.key,
+      label: g.label,
+      items: [...g.items.filter(i => connKeys.has(i.key)), ...(extras.get(g.key) || [])],
+    }))
+    .filter(g => g.items.length > 0)
+})
+
+const filterDisplay = computed(() => {
+  if (selectedTypeFilter.value === 'all') return t('sidebar.filterAll')
+  return TYPE_LABELS[selectedTypeFilter.value] || formatTypeFilterLabel(selectedTypeFilter.value)
 })
 
 function matchTypeFilter(conn: ConnectionConfig, filter: string): boolean {
   if (filter === 'all') return true
   if (filter.startsWith('database:')) {
-    return conn.type === 'database' && conn.dbType === filter.slice(9)
+    return conn.type === 'database' && conn.dbType === filter.slice('database:'.length)
+  }
+  if (filter.startsWith('container:')) {
+    return conn.type === 'container' && (conn.containerRuntime || 'docker') === filter.slice('container:'.length)
   }
   return conn.type === filter
+}
+
+function onFilterSelect(val: string) {
+  selectedTypeFilter.value = val
+  closeTypeFilter()
+}
+
+const typeFilterDropdownRef = ref()
+
+// el-dropdown exposes handleClose() to dismiss the dropdown programmatically.
+function closeTypeFilter() {
+  typeFilterDropdownRef.value?.handleClose()
 }
 
 // ── Shell label helper ──

--- a/frontend/src/components/TypeFilterMenuContent.vue
+++ b/frontend/src/components/TypeFilterMenuContent.vue
@@ -1,0 +1,159 @@
+<template>
+  <div class="ttfm" @click.stop>
+    <div class="ttfm-level">
+      <div
+        class="ttfm-item all"
+        :class="{ active: modelValue === 'all' }"
+        @click="$emit('update:modelValue', 'all')"
+      >
+        <el-icon class="check"><span v-if="modelValue === 'all'"><Check :size="12" /></span></el-icon>
+        <span class="label">{{ allLabel }}</span>
+      </div>
+
+      <!-- Level-1 categories — hovering a category opens its level-2 flyout -->
+      <div
+        v-for="grp in groups"
+        :key="grp.key"
+        class="ttfm-grp"
+        :class="{ current: isCurrentCat(grp) }"
+      >
+        <div class="ttfm-item cat">
+          <span class="check"></span>
+          <span class="cat-label">{{ grp.label }}</span>
+          <el-icon class="arrow"><ChevronRight :size="12" /></el-icon>
+        </div>
+
+        <!-- Level-2 flyout submenu (shown on hover of the parent category) -->
+        <div class="ttfm-sub">
+          <div
+            v-for="it in grp.items"
+            :key="it.key"
+            class="ttfm-item sub"
+            :class="{ active: modelValue === it.key }"
+            @click="$emit('update:modelValue', it.key)"
+          >
+            <el-icon class="check"><span v-if="modelValue === it.key"><Check :size="12" /></span></el-icon>
+            <span class="sub-label">{{ it.label }}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { Check, ChevronRight } from '@lucide/vue'
+
+interface TypeFilterItem {
+  key: string
+  label: string
+}
+interface TypeFilterGroup {
+  key: string
+  label: string
+  items: TypeFilterItem[]
+}
+
+const props = defineProps<{
+  modelValue: string
+  allLabel: string
+  groups: TypeFilterGroup[]
+}>()
+
+const emit = defineEmits<{ (e: 'update:modelValue', v: string): void }>()
+
+// Highlight the category that holds the current selection.
+function isCurrentCat(grp: TypeFilterGroup): boolean {
+  return props.modelValue !== 'all' && grp.items.some(i => i.key === props.modelValue)
+}
+</script>
+
+<style scoped>
+.ttfm {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-md);
+  padding: 4px;
+}
+.ttfm-level {
+  position: relative;
+  min-width: 148px;
+}
+.ttfm-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px 6px 8px;
+  font-size: 12px;
+  font-family: var(--font-ui);
+  color: var(--text-secondary);
+  cursor: pointer;
+  user-select: none;
+  border-radius: var(--radius-sm);
+  white-space: nowrap;
+  transition: background 0.1s ease;
+}
+.ttfm-item:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+.ttfm-item.active {
+  color: var(--accent);
+}
+.ttfm-grp.current > .ttfm-item.cat {
+  color: var(--accent);
+  font-weight: 600;
+}
+.check {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 12px;
+  height: 12px;
+  flex-shrink: 0;
+  color: var(--accent);
+}
+.label,
+.cat-label,
+.sub-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.cat-label {
+  flex: 1;
+  min-width: 0;
+}
+.arrow {
+  color: var(--text-disabled);
+  flex-shrink: 0;
+}
+/* Submenu container sits inside each level-1 row; hidden until hovered */
+.ttfm-grp {
+  position: relative;
+}
+.ttfm-sub {
+  position: absolute;
+  left: calc(100% - 4px);
+  top: -4px;
+  display: none;
+  box-sizing: border-box;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-md);
+  padding: 4px;
+  min-width: 130px;
+}
+/* Standard nested-menu behavior: hovering the parent keeps the flyout open */
+.ttfm-grp:hover > .ttfm-item.cat {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+.ttfm-grp:hover > .ttfm-sub {
+  display: block;
+}
+.ttfm-item.sub {
+  padding: 6px 12px 6px 10px;
+}
+</style>

--- a/frontend/src/composables/useTerminalMenu.ts
+++ b/frontend/src/composables/useTerminalMenu.ts
@@ -1,4 +1,4 @@
-import { ref, onMounted, onUnmounted } from 'vue'
+import { ref, nextTick, onMounted, onUnmounted } from 'vue'
 import type { Ref } from 'vue'
 import { useSettingsStore } from '../stores/settingsStore'
 import { ClipboardGetText, ClipboardSetText } from '../../wailsjs/runtime/runtime'
@@ -7,6 +7,9 @@ export interface UseTerminalMenuOptions {
   getSelection: () => string
   onPaste: (text: string) => Promise<void> | void
   onAskAI?: (text: string) => void
+  /** The rendered menu element, used to measure its real size so it can be
+   *  clamped inside the viewport instead of relying on an estimated height. */
+  menuElement?: Ref<HTMLElement | null>
 }
 
 export interface UseTerminalMenuReturn {
@@ -44,15 +47,32 @@ export function useTerminalMenu(options: UseTerminalMenuOptions): UseTerminalMen
     e.stopPropagation()
     window.dispatchEvent(new CustomEvent('global:close-context-menus'))
     hasSelection.value = !!options.getSelection()
-    menuStyle.value = fitMenuPosition(e.clientX, e.clientY, 120, 140)
-    menuVisible.value = true
+
+    const menuElement = options.menuElement?.value
+    if (menuElement) {
+      // Show at the cursor first, then clamp to the viewport on nextTick once
+      // Vue has laid the menu out so we can read its real width/height.
+      menuStyle.value = { left: e.clientX + 'px', top: e.clientY + 'px' }
+      menuVisible.value = true
+      nextTick(() => {
+        if (!menuVisible.value) return
+        menuStyle.value = fitMenuToViewport(e.clientX, e.clientY, menuElement.offsetWidth, menuElement.offsetHeight)
+      })
+    } else {
+      // Fallback when no element is provided (e.g. isolated unit tests).
+      menuStyle.value = fitMenuToViewport(e.clientX, e.clientY, 120, 140)
+      menuVisible.value = true
+    }
   }
 
-  function fitMenuPosition(x: number, y: number, menuW: number, menuH: number) {
+  function fitMenuToViewport(x: number, y: number, menuW: number, menuH: number) {
+    const margin = 4
     let left = x
     let top = y
-    if (x + menuW > window.innerWidth) left = x - menuW
-    if (y + menuH > window.innerHeight) top = y - menuH
+    if (left + menuW + margin > window.innerWidth) left = window.innerWidth - menuW - margin
+    if (top + menuH + margin > window.innerHeight) top = window.innerHeight - menuH - margin
+    if (left < margin) left = margin
+    if (top < margin) top = margin
     return { left: left + 'px', top: top + 'px' }
   }
 

--- a/frontend/src/utils/quickConnect.ts
+++ b/frontend/src/utils/quickConnect.ts
@@ -83,7 +83,9 @@ function getDefaultPort(type: string, dbType?: string): number | undefined {
 }
 
 export function formatConnSubtitle(config: ConnectionConfig, getShellLabel?: (path: string) => string): string {
-  const typeLabel = config.type === 'database' ? (config.dbType || config.type) : config.type
+  let typeLabel = config.type
+  if (config.type === 'database') typeLabel = config.dbType || config.type
+  else if (config.type === 'container') typeLabel = config.containerRuntime || config.type
   let detail: string
   if (config.type === 's3') {
     detail = config.host
@@ -96,4 +98,112 @@ export function formatConnSubtitle(config: ConnectionConfig, getShellLabel?: (pa
     detail = config.user ? `${config.user}@${config.host}${portStr}` : `${config.host}${portStr}`
   }
   return `${typeLabel} ${detail}`
+}
+
+// Origin (base) connection type for a filter key, ignoring any `:` suffix
+// (e.g. `database:mysql` → `database`, `container:docker` → `container`).
+export function getTypeBaseType(key: string): string {
+  return key.split(':')[0]
+}
+
+// Map of base type → top-level filter category, mirroring the two-level type
+// layout of the new-connection form (ConnectionForm `categories`).
+export const TYPE_CATEGORY: Record<string, string> = {
+  ssh: 'terminal', telnet: 'terminal', mosh: 'terminal', local: 'terminal', serial: 'terminal', monitor: 'terminal',
+  sftp: 'filetransfer', ftp: 'filetransfer', smb: 'filetransfer', s3: 'filetransfer', webdav: 'filetransfer',
+  rdp: 'remote', vnc: 'remote', spice: 'remote', 'x11-desktop': 'remote',
+  database: 'database',
+  k8s: 'container', container: 'container',
+}
+
+// Grouping key used by the type filter for a connection, the same shape as a
+// filter value: `database:<dbType>` / `container:<runtime>` / plain type.
+export function getConnectionTypeKey(config: ConnectionConfig): string {
+  if (config.type === 'database' && config.dbType) return `database:${config.dbType}`
+  if (config.type === 'container') return `container:${config.containerRuntime || 'docker'}`
+  return config.type
+}
+
+// Pretty-print a type filter key that isn't covered by a static label — today
+// only container runtimes (`container:docker` → `Docker`). `containerRuntime`
+// values are lowercase; capitalize the first letter for the menu/trigger.
+export function formatTypeFilterLabel(key: string): string {
+  const prefix = 'container:'
+  if (key.startsWith(prefix)) {
+    const rt = key.slice(prefix.length)
+    return rt.charAt(0).toUpperCase() + rt.slice(1)
+  }
+  return key
+}
+
+// Top-level category (key) a filter value belongs to, with a fallback category
+// for any unexpected type so it still shows up in the menu.
+export function getTypeCategory(key: string): string {
+  return TYPE_CATEGORY[getTypeBaseType(key)] || 'other'
+}
+
+// Ordered, labelled category keys for the two-level filter menu.
+export const TYPE_CATEGORIES: string[] = ['terminal', 'filetransfer', 'remote', 'database', 'container', 'other']
+
+// Two-level type catalog for the type filter, matching the new-connection form
+// (ConnectionForm `categories` + `allSubTypes`) exactly — same category order,
+// same subtype order, same labels. `t` is required only for the few names that
+// are localized (category titles, local terminal, serial).
+export function getTypeFilterCatalog(t: (key: string) => string) {
+  return [
+    {
+      key: 'terminal',
+      label: t('conn.categoryTerminal'),
+      items: [
+        { key: 'ssh', label: 'SSH (SFTP)' },
+        { key: 'telnet', label: 'Telnet' },
+        { key: 'mosh', label: 'Mosh' },
+        { key: 'local', label: t('conn.localTerminal') },
+        { key: 'serial', label: t('serial.title') },
+      ],
+    },
+    {
+      key: 'filetransfer',
+      label: t('conn.categoryFileTransfer'),
+      items: [
+        { key: 'ftp', label: 'FTP' },
+        { key: 'smb', label: 'SMB' },
+        { key: 's3', label: 'S3' },
+        { key: 'webdav', label: 'WebDAV' },
+      ],
+    },
+    {
+      key: 'remote',
+      label: t('conn.categoryRemote'),
+      items: [
+        { key: 'rdp', label: 'RDP' },
+        { key: 'vnc', label: 'VNC' },
+        { key: 'spice', label: 'SPICE' },
+        { key: 'x11-desktop', label: 'X11 Desktop' },
+      ],
+    },
+    {
+      key: 'database',
+      label: t('db.database'),
+      items: [
+        { key: 'database:mysql', label: 'MySQL' },
+        { key: 'database:postgres', label: 'PostgreSQL' },
+        { key: 'database:oracle', label: 'Oracle' },
+        { key: 'database:sqlserver', label: 'SQL Server' },
+        { key: 'database:rqlite', label: 'rqlite' },
+        { key: 'database:redis', label: 'Redis' },
+        { key: 'database:mongodb', label: 'MongoDB' },
+      ],
+    },
+    {
+      key: 'container',
+      label: t('conn.categoryContainer'),
+      items: [
+        { key: 'k8s', label: 'Kubernetes' },
+        { key: 'container:docker', label: 'Docker' },
+        { key: 'container:podman', label: 'Podman' },
+        { key: 'container:nerdctl', label: 'nerdctl' },
+      ],
+    },
+  ]
 }


### PR DESCRIPTION
## Summary

- **Two-level type filter menu**: hover a top-level category (Terminal / File Transfer / Remote Desktop / Database / Container) to open its concrete type flyout, in both the sidebar and start page. Order and names reuse the new-connection form's catalog. The dropdown closes after a selection.
- **Container runtime distinction**: container connections now show their runtime (docker / podman / nerdctl) instead of a uniform "container" in the badge, card subtitle, and the type filter (which also gains separate runtime options).
- **"No Group" count**: the virtual ungrouped group header now shows its connection count like real groups.
- **Context-menu clipping fix**: the terminal and sidebar right-click menus no longer clip at the viewport bottom — they measure their real size and clamp inside the window.

---

## 概述

- **两级类型筛选菜单**：在边栏和开始页中，鼠标悬停一级大分类（终端 / 文件传输 / 远程桌面 / 数据库 / 容器）在其右侧展开具体类型子菜单；顺序和名称与新建连接窗口保持一致；选中后自动收起。
- **容器运行时区分**：容器连接按运行时（docker / podman / nerdctl）区分展示，不再统一显示为 "container"；角标、卡片副标题和类型筛选（新增各运行时选项）均生效。
- **无分组计数**：虚拟「无分组」分组头像真实分组一样显示连接数量角标。
- **右键菜单贴边修复**：终端与边栏的右键菜单靠近窗口下边缘时不再被遮挡，改为测量实际尺寸并夹取在窗口内。