### PR TITLE
fix: bring relaunched window to foreground and reserve tab close-button space

### DIFF
--- a/app.go
+++ b/app.go
@@ -299,6 +299,16 @@ func (a *App) initStores(dataDir string, upgrade bool) {
 	// Restore window position and size from last session
 	a.restoreWindow(a.ctx)
 
+	// Raise the window to the foreground once, shortly after launch. On Windows a
+	// relaunched instance can otherwise land behind other windows; the short delay
+	// keeps this one-shot raise inside the window where the old (foreground)
+	// process is still alive, which is what grants the set-foreground permission
+	// (see RelaunchApp). No-op on other platforms.
+	go func() {
+		time.Sleep(250 * time.Millisecond)
+		a.bringMainWindowToFront()
+	}()
+
 	// Drain any non-fatal init failures and surface them to the frontend so
 	// the user sees a banner instead of getting an NPE on the first store
 	// call. Additive only — stores that failed to init are still nil and
@@ -2285,14 +2295,16 @@ func (a *App) GetAppInfo() AppInfo {
 
 // RelaunchApp spawns a fresh instance, then quits the current one so settings
 // that are fixed at startup (e.g. the window title bar) can take effect. The
-// new process is started first; a short delay lets it finish spawning before
-// this instance exits, keeping the overlap window minimal.
+// new process is started first; a delay lets it finish spawning and raise its
+// own window to the foreground (see bringMainWindowToFront) before this instance
+// exits — while this process is still the foreground process, which is what
+// grants the new one set-foreground permission on Windows.
 func (a *App) RelaunchApp() {
 	if err := a.relaunchProcess(); err != nil {
 		log.Writef("relaunch failed: %v", err)
 	}
 	go func() {
-		time.Sleep(300 * time.Millisecond)
+		time.Sleep(800 * time.Millisecond)
 		runtime.Quit(a.ctx)
 	}()
 }

--- a/app_notwindows.go
+++ b/app_notwindows.go
@@ -14,6 +14,10 @@ func (a *App) subclassMainWindow() {}
 
 func (a *App) unsubclassMainWindow() {}
 
+// bringMainWindowToFront is a no-op on non-Windows platforms: the relaunched-
+// window-behind-others issue is Windows-specific and does not occur here.
+func (a *App) bringMainWindowToFront() {}
+
 func (a *App) GetAvailableShells() []string {
 	var shells []string
 	var seen = make(map[string]bool)

--- a/app_windows.go
+++ b/app_windows.go
@@ -147,6 +147,24 @@ func (a *App) findMainWindow() uintptr {
 	return result
 }
 
+// bringMainWindowToFront raises the main window to the foreground once. After a
+// relaunch the fresh instance can otherwise open behind other windows on Windows:
+// SetForegroundWindow is normally restricted, but a process spawned by the
+// currently-foreground process is one of the documented exceptions, so a single
+// raise works while the old instance (the foreground process) is still alive.
+// No-op when no main window has been created yet.
+func (a *App) bringMainWindowToFront() {
+	hwnd := a.findMainWindow()
+	if hwnd == 0 {
+		return
+	}
+	user32 := windows.NewLazySystemDLL("user32.dll")
+	procSetForegroundWindow := user32.NewProc("SetForegroundWindow")
+	procBringWindowToTop := user32.NewProc("BringWindowToTop")
+	procSetForegroundWindow.Call(hwnd)
+	procBringWindowToTop.Call(hwnd)
+}
+
 // emitMoveResize sends a move/resize event to the frontend without blocking.
 // It must never be called from within the WndProc modal resize/move loop.
 func (a *App) emitMoveResize(event string) {

--- a/frontend/src/components/TabItem.vue
+++ b/frontend/src/components/TabItem.vue
@@ -45,8 +45,9 @@
       @click.stop
     />
     <button
-      v-if="tabCloseRight && hovered && !tab.locked"
+      v-if="tabCloseRight"
       class="tab-close tab-close-right"
+      :class="{ 'tab-close-right-ghost': !hovered || tab.locked }"
       @click.stop="$emit('close', tab.id)"
     ><X /></button>
     <Teleport to="body">
@@ -666,10 +667,19 @@ onUnmounted(() => {
 }
 /* Close button on the right side of the tab (appearance setting).
    margin-left:auto pushes it flush to the far right edge of the tab
-   (inside the 12px horizontal padding), instead of hugging the name. */
+   (inside the 12px horizontal padding), instead of hugging the name.
+
+   The button is always present in the layout when the right-side setting is on
+   — ghosted (visibility:hidden) while not hovered OR the tab is locked — so its
+   slot is always reserved; showing the X only toggles visibility instead of
+   inserting/removing an element, which would otherwise re-truncate long names
+   and cause jitter (including the instant the tab is locked). */
 .tab-close.tab-close-right {
   margin-left: auto;
   margin-right: 0;
+}
+.tab-close-right-ghost {
+  visibility: hidden;
 }
 </style>
 


### PR DESCRIPTION
## Summary

Two separate fixes shipped in one branch:

1. **Relaunched window opens in the background (Windows)** — the system-title-bar toggle correctly reopens the app, but the fresh instance landed behind other windows. `SetForegroundWindow` is restricted on Windows, and the old foreground process exited before the new WebView2 window materialized, so the new window had no foreground entitlement. Now the new instance raises its own main window to the front once on startup while the old instance is still alive, and the old instance's quit delay is widened so the raise lands inside the set-foreground entitlement window.

2. **Tab jitter when the close button is on the right** — in right-side close-button mode, the X button was only inserted into the tab layout on hover, re-truncating long names and shifting the tab (including at the moment a tab is locked). The button now stays in the layout (visibility-hidden while not hovered or locked), so its width is always reserved and hovering/locking no longer changes the tab width.

## Files changed

- `app.go` — widen relaunch quit delay; raise window to foreground on startup
- `app_windows.go` — add `bringMainWindowToFront()` (SetForegroundWindow + BringWindowToTop)
- `app_notwindows.go` — no-op companion for non-Windows platforms
- `frontend/src/components/TabItem.vue` — reserve right close-button slot

## Verification

- `go build ./...` passes
- Frontend `vite build` passes
- Backend tests pass except `TestStartPprofIfDev_ProductionSkip`, which fails only in this environment because a running `uniTerm-dev.exe` holds port 6060 (unrelated; passes in CI)
- The 5 failing AI/LLM frontend tests are pre-existing on `main` (unrelated to this branch)

---
## 概要

本分支包含两处修复：

1. **Windows 重启后窗口位于后台** — 切换系统标题栏后应用能重启，但新窗口落在其它窗口后面。Windows 对 `SetForegroundWindow` 有限制，而旧前台进程在新 WebView2 窗口创建前就已退出，导致新窗口没有前台授权。现在新实例在启动时（旧实例仍存活期间）将自己置前一次，并加宽旧实例的退出延迟，确保这次置前落在 set-foreground 的授权窗口内。

2. **关闭按钮靠右时标签抖动** — 右关闭模式下，X 按钮只在 hover 时才插入布局，导致长名称被重新截断、标签移位（锁定瞬间也会）。现让按钮常驻布局（未 hover 或锁定时 `visibility:hidden`），其宽度始终被预留，hover / 锁定不再改变标签宽度。

## 修改文件

- `app.go` — 加宽重启退出延迟；启动时置前窗口
- `app_windows.go` — 新增 `bringMainWindowToFront()`（SetForegroundWindow + BringWindowToTop）
- `app_notwindows.go` — 非 Windows 平台的 no-op 配套
- `frontend/src/components/TabItem.vue` — 预留右侧关闭按钮槽位

## 验证

- `go build ./...` 通过
- 前端 `vite build` 通过
- 后端测试除 `TestStartPprofIfDev_ProductionSkip` 外均通过，该失败仅因本机运行的 `uniTerm-dev.exe` 占用 6060 端口（与本次改动无关，CI 中会通过）
- 5 个失败的 AI/LLM 前端测试在 `main` 上本就存在（与本次分支无关）
