### PR TITLE
fix(sync): include tunnels.json in cloud-sync config file set

### DIFF
--- a/backend/sync/crypto.go
+++ b/backend/sync/crypto.go
@@ -69,6 +69,14 @@ func EncryptConfigFiles(srcDir, destDir string, key []byte, kc *Keychain, ps Pas
 		return fmt.Errorf("encrypt quick commands: %w", err)
 	}
 
+	if err := encryptGenericFile(
+		filepath.Join(srcDir, "tunnels.json"),
+		filepath.Join(destDir, "tunnels.json"),
+		key,
+	); err != nil {
+		return fmt.Errorf("encrypt tunnels: %w", err)
+	}
+
 	if err := encryptIdentitiesFile(
 		filepath.Join(srcDir, "identities.json"),
 		filepath.Join(destDir, "identities.json"),
@@ -267,6 +275,14 @@ func DecryptConfigFiles(srcDir, destDir string, key []byte, ps PasswordStore) er
 		key,
 	); err != nil {
 		return fmt.Errorf("decrypt quick commands: %w", err)
+	}
+
+	if err := decryptGenericFile(
+		filepath.Join(srcDir, "tunnels.json"),
+		filepath.Join(destDir, "tunnels.json"),
+		key,
+	); err != nil {
+		return fmt.Errorf("decrypt tunnels: %w", err)
 	}
 
 	if err := decryptIdentitiesFile(

--- a/backend/sync/sync_service.go
+++ b/backend/sync/sync_service.go
@@ -539,7 +539,7 @@ func (s *SyncService) ConfigureRepo(repoURL, username, token, masterPassword str
 // getConfigModTime returns the latest modification time of config files in a directory.
 func getConfigModTime(dir string) time.Time {
 	var latest time.Time
-	for _, name := range []string{"connections.json", "settings.json", "quickCommands.json", "identities.json", "proxies.json"} {
+	for _, name := range []string{"connections.json", "settings.json", "quickCommands.json", "tunnels.json", "identities.json", "proxies.json"} {
 		info, err := os.Stat(filepath.Join(dir, name))
 		if err != nil {
 			continue
@@ -557,7 +557,7 @@ func getConfigModTime(dir string) time.Time {
 // treated as "empty" and silently overwritten on first sync
 // (SYNC-P0-1).
 func isConfigDirEmpty(dir string) bool {
-	for _, name := range []string{"connections.json", "settings.json", "quickCommands.json", "ai-sessions.json", "skills.json", "identities.json", "proxies.json"} {
+	for _, name := range []string{"connections.json", "settings.json", "quickCommands.json", "ai-sessions.json", "skills.json", "tunnels.json", "identities.json", "proxies.json"} {
 		path := filepath.Join(dir, name)
 		data, err := os.ReadFile(path)
 		if err != nil {
@@ -587,7 +587,7 @@ func isConfigDirEmpty(dir string) bool {
 // normalized to plaintext on the local side before comparison so both sides
 // are comparable.
 func compareConfigDirs(localDir, remoteDir string, kc *Keychain, ps PasswordStore) (bool, error) {
-	for _, name := range []string{"connections.json", "settings.json", "quickCommands.json", "identities.json", "proxies.json"} {
+	for _, name := range []string{"connections.json", "settings.json", "quickCommands.json", "tunnels.json", "identities.json", "proxies.json"} {
 		same, err := compareConfigFiles(filepath.Join(localDir, name), filepath.Join(remoteDir, name), kc, ps)
 		if err != nil {
 			return false, err
@@ -785,7 +785,7 @@ func (s *SyncService) ChangePassword(oldPassword, newPassword string) error {
 	// Re-encrypt every existing repo ciphertext: decrypt with oldKey,
 	// re-encrypt with newKey, atomic rename. A crash before the rename
 	// leaves the original ciphertext intact and decryptable with oldKey.
-	repoFiles := []string{"connections.json", "settings.json", "quickCommands.json", "identities.json", "proxies.json"}
+	repoFiles := []string{"connections.json", "settings.json", "quickCommands.json", "tunnels.json", "identities.json", "proxies.json"}
 	for _, name := range repoFiles {
 		srcPath := filepath.Join(s.repoPath, name)
 		ciphertext, err := os.ReadFile(srcPath)
@@ -890,7 +890,7 @@ func (s *SyncService) compareLocalWithRepo(encKey []byte) (bool, error) {
 
 // repoHasFiles returns true if the repo directory contains encrypted config files.
 func repoHasFiles(repoPath string) bool {
-	for _, name := range []string{"connections.json", "settings.json", "quickCommands.json", "identities.json", "proxies.json"} {
+	for _, name := range []string{"connections.json", "settings.json", "quickCommands.json", "tunnels.json", "identities.json", "proxies.json"} {
 		if _, err := os.Stat(filepath.Join(repoPath, name)); os.IsNotExist(err) {
 			return false
 		}


### PR DESCRIPTION
## Summary

Fixed the cloud-sync feature dropping user tunnel definitions during data-directory changes.

`tunnels.json` was missing from the sync encrypt/decrypt config file list. When a data-dir change is rehydrated through cloud sync (`EncryptConfigFiles` / `DecryptConfigFiles` in `crypto.go`, plus the sibling enumerations in `sync_service.go`), connections/settings/quick-commands/identities/proxies came through but tunnels were lost. Added it alongside `quickCommands.json` as a generic, no-secret config file.

- `backend/sync/crypto.go`: encrypt + decrypt `tunnels.json` via the existing generic file helpers
- `backend/sync/sync_service.go`: added `tunnels.json` to `getConfigModTime`, `isConfigDirEmpty`, `compareConfigDirs`, master-password re-encryption (`repoFiles`), and `repoHasFiles`

## 说明

修复云同步功能在数据目录切换时丢失用户隧道配置的问题。

`tunnels.json` 之前不在同步的配置清单里。当数据目录切换后靠云同步重建(`crypto.go` 的 `EncryptConfigFiles` / `DecryptConfigFiles`,以及 `sync_service.go` 中的相关枚举)时,connections/settings/quick-commands/identities/proxies 都能同步过来,唯独隧道配置丢失。本次把它作为无密钥字段的通用配置文件,与 `quickCommands.json` 一起纳入。

- `backend/sync/crypto.go`:通过现有通用文件辅助函数加密/解密 `tunnels.json`
- `backend/sync/sync_service.go`:在 `getConfigModTime`、`isConfigDirEmpty`、`compareConfigDirs`、主密码重加密(`repoFiles`)、`repoHasFiles` 中都补充了 `tunnels.json`

- Verification: `go vet ./sync/` and `go test ./sync/` pass.

- verified: sections