### PR TITLE
fix(broadcast): broadcast pasted input across synced panels

### DIFF
--- a/frontend/src/components/BaseTerminal.vue
+++ b/frontend/src/components/BaseTerminal.vue
@@ -1771,11 +1771,29 @@ function bracketPaste(text: string): string {
 
 async function pasteToSession(text: string) {
   if (props.mode === 'ssh' || props.mode === 'local') {
+    // Normalize line endings: \r\n -> \r to prevent extra newlines
+    // when pasting into editors like vim (Windows clipboard often has \r\n)
+    const normalized = text.replace(/\r\n/g, '\n').replace(/\r/g, '')
+
+    // Broadcast mode: write to every target panel instead of only this
+    // session (issue #597 — pasted command must sync like keyboard input).
+    if (props.broadcastActive && props.workspaceId) {
+      const targets = tabStore.getBroadcastPanelIdsInWorkspace(props.workspaceId)
+      if (targets.length > 0) {
+        for (const pid of targets) {
+          const p = panelStore.getPanel(pid)
+          if (p?.sessionId && (p.type === 'ssh' || p.type === 'local')) {
+            // Bracket per target session — each has its own paste mode.
+            const wrap = getManagedTerminal(p.sessionId)?.terminal.modes.bracketedPasteMode
+            SessionWrite(p.sessionId, wrap ? '\x1b[200~' + normalized + '\x1b[201~' : normalized)
+          }
+        }
+        return
+      }
+    }
+
     const sid = props.sessionId
     if (sid) {
-      // Normalize line endings: \r\n -> \r to prevent extra newlines
-      // when pasting into editors like vim (Windows clipboard often has \r\n)
-      const normalized = text.replace(/\r\n/g, '\n').replace(/\r/g, '')
       SessionWrite(sid, bracketPaste(normalized))
     }
   }
@@ -1888,24 +1906,7 @@ const menu = useTerminalMenu({
   menuElement: contextMenuEl,
   onPaste: async (text) => {
     if (props.mode === 'ssh' || props.mode === 'local') {
-      if (props.broadcastActive && props.workspaceId) {
-        const targets = tabStore.getBroadcastPanelIdsInWorkspace(props.workspaceId)
-        if (targets.length > 0) {
-          const filtered = filterTerminalInput(text, false)
-          for (const pid of targets) {
-            const p = panelStore.getPanel(pid)
-            if (p?.sessionId && (p.type === 'ssh' || p.type === 'local')) {
-              // Bracket per target session — each has its own paste mode.
-              const wrap = getManagedTerminal(p.sessionId)?.terminal.modes.bracketedPasteMode
-              SessionWrite(p.sessionId, wrap ? '\x1b[200~' + filtered + '\x1b[201~' : filtered)
-            }
-          }
-        } else {
-          await pasteToSession(text)
-        }
-      } else {
-        await pasteToSession(text)
-      }
+      await pasteToSession(text)
     } else {
       pasteToTerminal(text)
     }


### PR DESCRIPTION
Fixes #597

## Problem
In a split view with synced panels, keyboard input was broadcast to all panels but pasted commands only reached the focused session. Broadcast logic existed only in the right-click menu's `onPaste` handler; the other paste paths (Ctrl+Shift+V shortcut, middle-click, macOS Cmd+V) all went through `pasteToSession`, which had no broadcast branch.

## Change
- Merge the broadcast branch into `pasteToSession` so it writes to every synced panel (each bracketed by its own paste mode) when broadcast is active
- Make the menu's `onPaste` reuse `pasteToSession` instead of duplicating the logic

Every paste path now syncs like keyboard input.

## Validation
Frontend builds cleanly (`npm run build`). Pre-existing type errors unrelated to this change.

---
## 问题
分屏同步操作时，键盘输入命令会同步到所有面板，但粘贴的命令只到达焦点会话，未同步。广播逻辑此前只存在于右键菜单的 `onPaste` 中；其余粘贴路径（Ctrl+Shift+V 快捷键、中键粘贴、macOS Cmd+V）都走 `pasteToSession`，它没有广播分支。

## 改动
- 将广播逻辑合并进 `pasteToSession`，广播激活时写入所有同步面板（各按自身粘贴模式包裹）
- 右键菜单 `onPaste` 改为复用 `pasteToSession`，消除重复代码

所有粘贴路径现在与键盘输入一样支持广播同步。

## 验证
前端构建通过（`npm run build`）。类型检查中的报错均为改动前已存在的历史问题，与本次无关。