### PR TITLE
fix(zmodem): wait for disk writes before completing sz downloads & batch-write

### DIFF
--- a/frontend/src/services/zmodemService.test.ts
+++ b/frontend/src/services/zmodemService.test.ts
@@ -57,54 +57,148 @@ vi.mock('../stores/zmodemStore', () => ({
 
 import { startZmodemService } from './zmodemService'
 
+const BATCH = 64 * 1024
+
+async function sleepTicks() {
+  for (let i = 0; i < 100; i++) {
+    await Promise.resolve()
+  }
+}
+
+function base64ToBytes(b64: string): number[] {
+  const bin = atob(b64)
+  const out = new Uint8Array(bin.length)
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i)
+  return Array.from(out)
+}
+
+// Builds a fake zmodem 'receive' session + offer for a download of the given
+// byte chunks. Returns handles the test can drive.
+function makeDownload(chunks: number[][]) {
+  const state: {
+    offerHandler?: (offer: any) => void | Promise<void>
+    accept?: any
+    zsession: any
+  } = {} as any
+  const offer = {
+    get_details: () => ({ name: 'large.bin', size: chunks.flat().length }),
+    accept: vi.fn(async (options?: { on_input?: (payload: number[]) => void }) => {
+      state.accept = { options }
+      for (const c of chunks) options?.on_input?.(c)
+    }),
+    skip: vi.fn(),
+  }
+  const zsession = {
+    type: 'receive',
+    on: vi.fn((event: string, handler: (offer: any) => void | Promise<void>) => {
+      if (event === 'offer') state.offerHandler = handler
+    }),
+    // The real session's start() resolves when the ZMODEM protocol ends (all
+    // file data received), which is decoupled from our disk writes. We fire
+    // the offer handler in the background and resolve immediately, mirroring
+    // that: on_input runs synchronously, but its writes may still be pending
+    // on disk.
+    start: vi.fn(() => {
+      state.offerHandler?.(offer)
+      return Promise.resolve()
+    }),
+    abort: vi.fn(),
+    close: vi.fn(),
+  }
+  state.zsession = zsession
+  return state
+}
+
 describe('startZmodemService', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     sentryInstances.length = 0
     mockOpenDirectoryDialog.mockResolvedValue('C:\\Downloads')
+    mockAppendFileBase64.mockResolvedValue(undefined)
   })
 
-  it('streams sz download chunks to disk without buffering the full file', async () => {
+  it('buffers small sz chunks into a single batched disk write', async () => {
     vi.useFakeTimers()
-    const chunks = [
-      new Uint8Array([1, 2, 3]),
-      new Uint8Array([4, 5]),
-    ]
-    let offerHandler: ((offer: any) => void | Promise<void>) | undefined
-    const offer = {
-      get_details: () => ({ name: 'large.bin', size: 5 }),
-      accept: vi.fn(async (options?: { on_input?: (payload: number[]) => void }) => {
-        options?.on_input?.(Array.from(chunks[0]))
-        options?.on_input?.(Array.from(chunks[1]))
-      }),
-      skip: vi.fn(),
-    }
-    const zsession = {
-      type: 'receive',
-      on: vi.fn((event: string, handler: (offer: any) => void | Promise<void>) => {
-        if (event === 'offer') offerHandler = handler
-      }),
-      start: vi.fn(async () => {
-        await offerHandler?.(offer)
-      }),
-      abort: vi.fn(),
-      close: vi.fn(),
-    }
+    const s = makeDownload([
+      [1, 2, 3],
+      [4, 5],
+    ])
     const onComplete = vi.fn()
     startZmodemService({ sessionId: 's1', onComplete })
 
-    sentryInstances[0].on_detect({ confirm: () => zsession })
-    await Promise.resolve()
-    await Promise.resolve()
-
+    sentryInstances[0].on_detect({ confirm: () => s.zsession })
+    await sleepTicks()
     await vi.runOnlyPendingTimersAsync()
     vi.useRealTimers()
 
-    expect(offer.accept).toHaveBeenCalledWith({ on_input: expect.any(Function) })
-    expect(mockAppendFileBase64).toHaveBeenCalledTimes(2)
-    expect(mockAppendFileBase64).toHaveBeenNthCalledWith(1, 'C:\\Downloads\\large.bin', 'AQID', 0)
-    expect(mockAppendFileBase64).toHaveBeenNthCalledWith(2, 'C:\\Downloads\\large.bin', 'BAU=', 3)
+    // Only a single batched Write — not one per tiny chunk.
+    expect(mockAppendFileBase64).toHaveBeenCalledTimes(1)
+    expect(mockAppendFileBase64).toHaveBeenNthCalledWith(1, 'C:\\Downloads\\large.bin', 'AQIDBAU=', 0)
     expect(mockWriteFileBase64).not.toHaveBeenCalled()
+    expect(onComplete).toHaveBeenCalledWith(['C:\\Downloads\\large.bin'])
+    expect(mockSessionEndZmodem).toHaveBeenCalledWith('s1')
+  })
+
+  it('flushes an in-flight batch once the buffer exceeds the batch size', async () => {
+    vi.useFakeTimers()
+    // 3 × 30KB = 90KB total → first flush at 64KB boundary, remainder at end.
+    const make = (v: number, len: number) => Array.from({ length: len }, () => v)
+    const s = makeDownload([
+      make(1, 30000),
+      make(2, 30000),
+      make(3, 30000),
+    ])
+    const onComplete = vi.fn()
+    startZmodemService({ sessionId: 's1', onComplete })
+
+    sentryInstances[0].on_detect({ confirm: () => s.zsession })
+    await sleepTicks()
+    await vi.runOnlyPendingTimersAsync()
+    vi.useRealTimers()
+
+    expect(mockAppendFileBase64).toHaveBeenCalledTimes(2)
+    const c0 = mockAppendFileBase64.mock.calls[0]
+    const c1 = mockAppendFileBase64.mock.calls[1]
+    expect(c0[2]).toBe(0)
+    expect(c1[2]).toBe(BATCH)
+    // Reassembled file content equals the source bytes, in order.
+    const reassembled = base64ToBytes(c0[1]).concat(base64ToBytes(c1[1]))
+    expect(reassembled.length).toBe(90000)
+    expect(reassembled[0]).toBe(1)
+    expect(reassembled[65536]).toBe(3)
+    expect(reassembled[89999]).toBe(3)
+  })
+
+  it('waits for the final disk write before completing the download', async () => {
+    vi.useFakeTimers()
+    const s = makeDownload([[1, 2, 3, 4, 5]])
+    const onComplete = vi.fn()
+
+    // Simulate a slow disk: the append write stays pending until we resolve it.
+    const appendResolvers: (() => void)[] = []
+    mockAppendFileBase64.mockImplementation(
+      () => new Promise<void>((res) => appendResolvers.push(res)),
+    )
+
+    startZmodemService({ sessionId: 's1', onComplete })
+
+    sentryInstances[0].on_detect({ confirm: () => s.zsession })
+    await sleepTicks()
+
+    // Let the 2s idle watchdog fire while the disk write is still pending.
+    await vi.runOnlyPendingTimersAsync()
+
+    // BUG: the old code completed here (files empty → "Zmodem transfer
+    // cancelled"). The fix must not call onComplete until the write drains.
+    expect(onComplete).not.toHaveBeenCalled()
+    expect(mockAppendFileBase64).toHaveBeenCalledTimes(1)
+
+    // Now the disk catches up.
+    appendResolvers[0]()
+    await sleepTicks()
+    await vi.runOnlyPendingTimersAsync()
+    vi.useRealTimers()
+
     expect(onComplete).toHaveBeenCalledWith(['C:\\Downloads\\large.bin'])
     expect(mockSessionEndZmodem).toHaveBeenCalledWith('s1')
   })

--- a/frontend/src/services/zmodemService.ts
+++ b/frontend/src/services/zmodemService.ts
@@ -233,6 +233,12 @@ async function handleSend(
 
 const CHUNK = 8192
 const READ_CHUNK = CHUNK * 16
+// Download writes are batched to this size. ZMODEM delivers file bytes in
+// ~1KB subpackets; writing each one to disk through the Wails bridge (one
+// open/stat/write/close round-trip per call) melts the CPU and makes disk
+// commit lag far behind network receipt. Buffering to a larger block pulls
+// commit back toward network speed.
+const DOWNLOAD_BATCH = 64 * 1024
 
 async function sendFileChunks(
   xfer: any, path: string, size: number, chunkSize: number,
@@ -279,7 +285,16 @@ async function handleReceive(
   let done!: () => void
   const donePromise = new Promise<void>(r => { done = r; abortCtl.done = r })
   let idleTimer: ReturnType<typeof setTimeout> | null = null
-  function resetIdle() { if (idleTimer) clearTimeout(idleTimer); idleTimer = setTimeout(done, 2000) }
+  // Every file's disk-write drain promise. The idle watchdog resolves done
+  // only after all of them settle, so it can never report completion (or
+  // "cancelled") while buffered bytes are still being written to disk.
+  const pendingSettles = new Set<Promise<void>>()
+  function resetIdle() {
+    if (idleTimer) clearTimeout(idleTimer)
+    idleTimer = setTimeout(() => {
+      Promise.all([...pendingSettles]).then(done)
+    }, 2000)
+  }
 
   try {
     const sep = saveDir.includes('\\') ? '\\' : '/'
@@ -302,25 +317,42 @@ async function handleReceive(
         direction: 'download', status: 'transferring', speed: 0,
         savePath: finalSavePath,
       })
+
+      // Buffered, batched writes. on_input only appends to `buffer`; the
+      // buffer is flushed to disk in DOWNLOAD_BATCH chunks (and once more when
+      // the offer ends). A single serialized chain drains every batch so write
+      // offsets stay contiguous with AppendFileBase64's append-offset guard.
       let received = 0
-      let writeChain = Promise.resolve()
+      let buffer: number[] = []
+      let bufferOffset = 0
+      let pendingWrites: Promise<void> = Promise.resolve()
       let writeError: unknown = null
+
+      const flush = () => {
+        while (buffer.length > 0) {
+          const take = Math.min(DOWNLOAD_BATCH, buffer.length)
+          const bytes = buffer.splice(0, take)
+          const offset = bufferOffset
+          bufferOffset += bytes.length
+          pendingWrites = pendingWrites
+            .then(() => AppendFileBase64(finalSavePath, arrayBufferToBase64(Uint8Array.from(bytes)), offset))
+            .catch((err) => { writeError = err })
+          pendingSettles.add(pendingWrites)
+        }
+      }
+
       const onInput = (payload: number[]) => {
-        const offset = received
-        const chunk = Uint8Array.from(payload)
-        received += chunk.length
+        for (const b of payload) buffer.push(b)
+        received += payload.length
         resetIdle()
         store.updateTransfer(sessionId, transferId, { transferred: received })
-        writeChain = writeChain.then(async () => {
-          if (writeError) return
-          await AppendFileBase64(finalSavePath, arrayBufferToBase64(chunk), offset)
-        }).catch((err) => {
-          writeError = err
-        })
+        if (buffer.length >= DOWNLOAD_BATCH) flush()
       }
+
       try {
         await offer.accept({ on_input: onInput })
-        await writeChain
+        flush()  // flush whatever remains buffered below the batch size
+        await pendingWrites
         if (writeError) throw writeError
         store.updateTransfer(sessionId, transferId, {
           status: 'completed', transferred: received,


### PR DESCRIPTION
Closes #602

## Summary

Fixes `sz` (Zmodem download) transfers from remote servers so the local file is no longer truncated and reported as "Zmodem transfer cancelled" mid-download in v1.7.0.

**Root cause:** The download completion was driven by a 2s protocol-idle watchdog that fired as soon as all bytes were *received*, without waiting for the per-subpacket disk writes (each `AppendFileBase64` does an open/stat/write/close round-trip per ~1KB subpacket) to drain. Once fired it tore the session down and truncated still-pending writes, leaving an incomplete file and printing "Zmodem transfer cancelled".

**Fixes in `frontend/src/services/zmodemService.ts` (`handleReceive`):**
1. Completion now resolves only after every file's batched append writes have reached the disk (`Promise.all(pendingSettles).then(done)`), so `onComplete` carries the committed file.
2. Received bytes are buffered and flushed to disk in 64KB blocks instead of one `AppendFileBase64` round-trip per ~1KB subpacket, pulling disk commit back toward network speed.

Writes stay on a single serialized chain, so `AppendFileBase64`'s "offset must equal current file size" guard is preserved (no reordered/corrupt output).

## Testing

- TDD: added 3 failing tests first (batched write, 64KB in-flight flush, completion waits for final disk write), confirmed RED, then implemented.
- `zmodemService.test.ts`: 3/3 pass.
- `tsc` clean for the changed service file.
- Pre-existing unrelated failures (`aiStore`, `llm.requestBody`) are present on `main` and untouched by this branch.

---

## 摘要

修复从远端服务器使用 `sz`（Zmodem 下载）拉取文件异常，v1.7.0 下载中途不再被截断并误报 "Zmodem transfer cancelled"。

**根因**：下载完成的判定由一个 2 秒协议空闲看门狗驱动，字节一旦*收到*就触发完成，而没有等待按子包拆分的磁盘写入（每个 ≤1KB 子包触发一次 `AppendFileBase64` 的 open/stat/write/close 往返）排空。一旦触发就拆掉会话、截断仍在排队的写入，留下残缺文件并打印 "Zmodem transfer cancelled"。

**改动**（`frontend/src/services/zmodemService.ts` 的 `handleReceive`）：
1. 所有文件批量写盘完成之后才判定完成（`Promise.all(pendingSettles).then(done)`），`onComplete` 必然携带已落盘文件。
2. 收到的字节按 64KB 块冲刷写盘，取代原来「每个 ~1KB 子包一次 `AppendFileBase64` 往返」，使磁盘写入速率贴近网络接收速率。

写入保持单链串行，`AppendFileBase64` 的「offset 必须等于当前文件大小」防错校验依然成立（不会乱序写出坏文件）。

## 测试

- TDD：先写 3 个失败测试（批量写入、64KB 阈值冲刷、完成等待最后写盘），确认 RED 后再实现。
- `zmodemService.test.ts`：3/3 通过。
- 改动文件 `tsc` 类型干净。
- 预存的无关注测试失败（`aiStore`、`llm.requestBody`）在 `main` 上已存在，本分支未改动。