### PR TITLE
feat(tab): add "Reconnect" option to tab context menu

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -783,6 +783,11 @@ onMounted(async () => {
     const d = e.detail; const c = d?.config || d; if (c) { const prev = tabStore.activeTab; onConnectS3(c, prev?.type === 'start' ? prev : undefined) }
   }) as EventListener)
 
+  // DB/Redis/Mongo tabs create their connection in App.vue (onConnectDB), not in
+  // a content component, so their right-click 「重连」(Reconnect) is handled here.
+  // Terminal and desktop-protocol panels handle the same event themselves.
+  window.addEventListener('panel:reconnect', onPanelReconnectEvent)
+
   await checkCredentials()
 })
 
@@ -911,6 +916,7 @@ onUnmounted(() => {
   window.removeEventListener('split:resize-end', RDPShowForOverlay)
   window.removeEventListener('rdp:sync-position', rdpResetTracking)
   window.removeEventListener('rdp:fullscreen-enter', onRdpFullScreenEnter)
+  window.removeEventListener('panel:reconnect', onPanelReconnectEvent)
   // Wails EventsOn teardown (FE-03)
   unsubRdpFullscreenExit?.()
   unsubRdpMoveResizeStart?.()
@@ -1667,6 +1673,82 @@ async function onConnectDB(config: ConnectionConfig, prevStart?: any) {
     panelStore.updateStatus(panel.id, 'error')
     msg.error(`${t('db.connectFailed')}: ${errMsg}`)
   }
+}
+
+// Force-reconnect a database/redis/mongodb panel from the tab's right-click
+// 「重连」(Reconnect) menu. These sessions are created in App.vue (onConnectDB),
+// so — unlike terminal/desktop panels — no content component owns the lifecycle:
+// close the old session, then create a fresh one and rebind the same panel.
+async function reconnectDatabasePanel(panel: { id: string; sessionId: string | null; config: ConnectionConfig | null }) {
+  const oldId = panel.sessionId
+  if (oldId) {
+    try { await CloseSession(oldId) } catch (_) {}
+  }
+  const cfg = panel.config
+  if (!cfg) return
+  let sessionType = 'database'
+  if (cfg.dbType === 'redis') sessionType = 'redis'
+  else if (cfg.dbType === 'mongodb') sessionType = 'mongodb'
+  try {
+    const info = await CreateSession(sessionType, cfg)
+    panelStore.bindSession(panel.id, info.id)
+    sessionStore.initSession(info.id)
+  } catch (e: any) {
+    panelStore.updateStatus(panel.id, 'error')
+    msg.error(`${t('db.connectFailed')}: ${e?.message || String(e)}`)
+  }
+}
+
+// Force-reconnect a monitor panel. The session is created in App.vue
+// (onConnectMonitor), so it's re-initiated here like the database panels.
+async function reconnectMonitorPanel(panel: { id: string; sessionId: string | null; config: ConnectionConfig | null }) {
+  const oldId = panel.sessionId
+  if (oldId) {
+    try { await CloseSession(oldId) } catch (_) {}
+  }
+  const cfg = panel.config
+  if (!cfg) return
+  try {
+    const info = await CreateSession('monitor', cfg)
+    panelStore.bindSession(panel.id, info.id)
+    sessionStore.initSession(info.id)
+  } catch (e: any) {
+    panelStore.updateStatus(panel.id, 'error')
+    msg.error(`${t('tab.reconnectFailed')}: ${e?.message || String(e)}`)
+  }
+}
+
+// Force-reconnect a file-transfer panel (sftp/ftp/smb/webdav/s3). Like database
+// and monitor, the session is created in App.vue; its type string equals
+// config.type. The tab content reads the session from the panel reactively.
+async function reconnectSftpPanel(panel: { id: string; sessionId: string | null; config: ConnectionConfig | null }) {
+  const oldId = panel.sessionId
+  if (oldId) {
+    try { await CloseSession(oldId) } catch (_) {}
+  }
+  const cfg = panel.config
+  if (!cfg || !cfg.type) return
+  try {
+    const info = await CreateSession(cfg.type, cfg)
+    panelStore.bindSession(panel.id, info.id)
+    sessionStore.initSession(info.id)
+  } catch (e: any) {
+    panelStore.updateStatus(panel.id, 'error')
+    msg.error(`${t('tab.reconnectFailed')}: ${e?.message || String(e)}`)
+  }
+}
+
+function onPanelReconnectEvent(e: Event) {
+  const panelId = (e as CustomEvent)?.detail?.panelId
+  if (!panelId) return
+  const panel = panelStore.getPanel(panelId)
+  if (!panel) return
+  // These session types are created in App.vue (not in a content component), so
+  // their right-click 「重连」(Reconnect) is handled here. Terminal and desktop-
+  // protocol panels handle the same event themselves.
+  if (panel.type === 'database') reconnectDatabasePanel(panel)
+  else if (panel.type === 'monitor') reconnectMonitorPanel(panel)
+  else if (panel.type === 'sftp') reconnectSftpPanel(panel)
 }
 
 async function onConnectK8s(config: ConnectionConfig, prevStart?: any) {

--- a/frontend/src/components/ContainerTabContent.vue
+++ b/frontend/src/components/ContainerTabContent.vue
@@ -318,8 +318,25 @@ function shortId(id: string) {
   return raw.length > 12 ? raw.slice(0, 12) : raw
 }
 
-onMounted(() => store.open(props.tab))
+function onReconnectEvent(e: Event) {
+  const panelId = (e as CustomEvent)?.detail?.panelId
+  if (panelId && panelId === props.tab.panelId) reconnect()
+}
+
+// Force-reconnect: close the current container connection, then re-open it
+// (open() re-initializes loading/error state and reconnects the client).
+async function reconnect() {
+  try { store.close(props.tab.id) } catch (_) {}
+  await store.open(props.tab)
+}
+
+onMounted(() => {
+  store.open(props.tab)
+  // Tab right-click 「重连」(Reconnect) menu → forced reconnect of this tab.
+  window.addEventListener('panel:reconnect', onReconnectEvent)
+})
 onBeforeUnmount(() => {
+  window.removeEventListener('panel:reconnect', onReconnectEvent)
   pullHandle?.stop()
   store.close(props.tab.id)
 })

--- a/frontend/src/components/K8sTabContent.vue
+++ b/frontend/src/components/K8sTabContent.vue
@@ -254,8 +254,29 @@ async function connect() {
   }
 }
 
-onMounted(connect)
+function onReconnectEvent(e: Event) {
+  const panelId = (e as CustomEvent)?.detail?.panelId
+  if (panelId && panelId === props.tab.panelId) reconnect()
+}
+
+// Force-reconnect: tear down the current cluster connection, then re-run the
+// normal connect() (which already resets error state and re-resolves tunnel
+// credentials on each call).
+async function reconnect() {
+  if (connId.value) {
+    try { k8sClient.disconnect(connId.value) } catch (_) {}
+    connId.value = ''
+  }
+  await connect()
+}
+
+onMounted(() => {
+  connect()
+  // Tab right-click 「重连」(Reconnect) menu → forced reconnect of this tab.
+  window.addEventListener('panel:reconnect', onReconnectEvent)
+})
 onBeforeUnmount(() => {
+  window.removeEventListener('panel:reconnect', onReconnectEvent)
   if (resizing) {
     document.removeEventListener('mousemove', onResizeMove)
     document.removeEventListener('mouseup', onResizeEnd)

--- a/frontend/src/components/Panel.vue
+++ b/frontend/src/components/Panel.vue
@@ -451,13 +451,39 @@ async function retryConnection() {
   }
 }
 
+// Force-disconnect the current session and re-initiate the connection, invoked
+// from the tab's right-click 「重连」(Reconnect) menu. Unlike the Enter-to-retry
+// path, it first kills the in-flight attempt with CloseSession so a stale
+// "connecting" session can't linger in the backend.
+async function forceReconnect() {
+  if (!props.panel.config) return
+  baseTerminalRef.value?.setRetryOnEnter(false)
+  const oldId = props.panel.sessionId
+  if (oldId) {
+    try { await CloseSession(oldId) } catch (_) {}
+  }
+  retryAttempt = 0
+  await retryConnection()
+}
+
+// Reconnect menu in the tab right-click menu dispatches a 'panel:reconnect'
+// CustomEvent carrying the target panel id; only the matching panel acts.
+function onReconnectEvent(e: Event) {
+  const panelId = (e as CustomEvent)?.detail?.panelId
+  if (panelId && panelId === props.panel.id) {
+    forceReconnect()
+  }
+}
+
 onMounted(() => {
   document.addEventListener('click', onDocumentClick)
+  window.addEventListener('panel:reconnect', onReconnectEvent)
   refreshOutputLogState()
 })
 
 onUnmounted(() => {
   document.removeEventListener('click', onDocumentClick)
+  window.removeEventListener('panel:reconnect', onReconnectEvent)
 })
 
 // Watch panel sessionId changes and retry resize

--- a/frontend/src/components/RDPTabContent.vue
+++ b/frontend/src/components/RDPTabContent.vue
@@ -172,11 +172,20 @@ onMounted(() => {
       status.value = 'error'
     }
   })
+
+  // Tab right-click 「重连」(Reconnect) menu → forced reconnect of this panel.
+  window.addEventListener('panel:reconnect', onReconnectEvent)
 })
+
+function onReconnectEvent(e: Event) {
+  const panelId = (e as CustomEvent)?.detail?.panelId
+  if (panelId && panelId === props.panelId) reconnect()
+}
 
 onUnmounted(() => {
   unsubStatus?.()
   unsubData?.()
+  window.removeEventListener('panel:reconnect', onReconnectEvent)
   clearConnectTimer()
 })
 

--- a/frontend/src/components/RedisTabContent.vue
+++ b/frontend/src/components/RedisTabContent.vue
@@ -603,9 +603,20 @@ function onNewListDragOver(idx: number) {
 function onNewListDrop(_idx: number) { newDragIdx = -1 }
 
 // --- Init ---
-let initialised = false
+// Re-scan whenever the session id changes: on first mount AND on reconnect
+// (a fresh session bound to the panel). Clear the cached keyspace/navigation
+// state before loading the new connection's keys.
+let lastSessionId: string | null = null
 watch(() => props.sessionId, async (newId) => {
-  if (newId && !initialised) { initialised = true; await fetchDBSize(); await doScan(0) }
+  if (!newId || newId === lastSessionId) return
+  lastSessionId = newId
+  keys.value = []
+  cursorStack.value = []
+  currentPage.value = 1
+  nextCursor.value = 0
+  hasMore.value = false
+  await fetchDBSize()
+  await doScan(0)
 })
 </script>
 

--- a/frontend/src/components/SPICETabContent.vue
+++ b/frontend/src/components/SPICETabContent.vue
@@ -181,6 +181,11 @@ watch(scaleViewport, () => {
   }
 })
 
+function onReconnectEvent(e: Event) {
+  const panelId = (e as CustomEvent)?.detail?.panelId
+  if (panelId && panelId === props.panelId) reconnect()
+}
+
 onMounted(() => {
   if (props.sessionId) {
     currentSessionId.value = props.sessionId
@@ -234,6 +239,9 @@ onMounted(() => {
     }
   })
 
+  // Tab right-click 「重连」(Reconnect) menu → forced reconnect of this panel.
+  window.addEventListener('panel:reconnect', onReconnectEvent)
+
   // Observe canvas creation for auto-scale
   if (spiceContainer.value) {
     const mo = new MutationObserver(() => {
@@ -246,6 +254,7 @@ onMounted(() => {
 
 onBeforeUnmount(() => {
   unsubStatus?.()
+  window.removeEventListener('panel:reconnect', onReconnectEvent)
 
   if (spiceContainer.value) {
     const ro = (spiceContainer.value as any).__scaleObserver

--- a/frontend/src/components/TabItem.vue
+++ b/frontend/src/components/TabItem.vue
@@ -63,6 +63,7 @@
           {{ t('tab.duplicate') }}
           <span class="menu-shortcut">{{ menuShortcut('duplicateSession') }}</span>
         </div>
+        <div v-if="canReconnect" class="menu-item" @click="onReconnect">{{ t('tab.reconnect') }}</div>
         <div v-if="hasServerHost" class="menu-item" @click="copyHostAddress">{{ t('tab.copyHostAddress') }}</div>
         <div v-if="tab.type === 'terminal'" class="menu-item" @click="toggleAiLock">
           {{ isAILocked ? t('terminal.aiLocked') : t('terminal.lockAI') }}
@@ -272,6 +273,28 @@ const canDuplicate = computed(() => {
   return type === 'terminal' || type === 'sftp' || type === 'database' || type === 'mongodb' || type === 'redis' || type === 'k8s'
 })
 
+// Reconnectable panels — terminal types that Panel.vue can re-initiate.
+const TTY_RECONNECT_TYPES: readonly string[] = ['ssh', 'telnet', 'serial', 'mosh', 'local', 'k8s-exec', 'container-exec']
+
+// Whether the tab has a right-click 「重连」(Reconnect). Terminal panels are
+// re-initiated by Panel.vue via the 'panel:reconnect' event; desktop-protocol
+// tabs (rdp/vnc/spice/x11) run their own reconnect inside their content component.
+const canReconnect = computed(() => {
+  const type = props.tab.type
+  if (type === 'rdp' || type === 'vnc' || type === 'spice' || type === 'x11-desktop') return true
+  if (type === 'database' || type === 'mongodb' || type === 'redis' || type === 'sftp' || type === 'monitor') {
+    return 'panelId' in props.tab && !!panelStore.getPanel(props.tab.panelId)
+  }
+  if (type === 'k8s' || type === 'container') {
+    return 'panelId' in props.tab
+  }
+  if (type === 'terminal' && 'panelId' in props.tab) {
+    const p = panelStore.getPanel(props.tab.panelId)
+    return !!p && TTY_RECONNECT_TYPES.includes(p.type)
+  }
+  return false
+})
+
 // SSH connection only — used to show the "连接功能" group of menu items.
 const isSsh = computed(() => {
   if (props.tab.type !== 'terminal') return false
@@ -434,6 +457,16 @@ async function copyHostAddress() {
 function onDuplicate() {
   closeContextMenu()
   duplicateSession(props.tab)
+}
+
+// Dispatch a 'panel:reconnect' event so the owning content (Panel.vue for
+// terminals, the desktop tab-content components for rdp/vnc/spice/x11) can
+// force-disconnect and re-initiate the connection.
+function onReconnect() {
+  closeContextMenu()
+  const panelId = 'panelId' in props.tab ? props.tab.panelId : ''
+  if (!panelId) return
+  window.dispatchEvent(new CustomEvent('panel:reconnect', { detail: { panelId } }))
 }
 
 function openSftp() {

--- a/frontend/src/components/VNCTabContent.vue
+++ b/frontend/src/components/VNCTabContent.vue
@@ -259,6 +259,11 @@ function onPaste(e: ClipboardEvent) {
   }
 }
 
+function onReconnectEvent(e: Event) {
+  const panelId = (e as CustomEvent)?.detail?.panelId
+  if (panelId && panelId === props.panelId) reconnect()
+}
+
 onMounted(() => {
   if (props.sessionId) {
     currentSessionId.value = props.sessionId
@@ -319,12 +324,16 @@ onMounted(() => {
         break
     }
   })
+
+  // Tab right-click 「重连」(Reconnect) menu → forced reconnect of this panel.
+  window.addEventListener('panel:reconnect', onReconnectEvent)
 })
 
 onBeforeUnmount(() => {
   themeObserver?.disconnect()
   themeObserver = null
   unsubStatus?.()
+  window.removeEventListener('panel:reconnect', onReconnectEvent)
 
   if (rfb && vncContainer.value && vncContainer.value.childElementCount > 0) {
     const container = document.createElement('div')

--- a/frontend/src/components/X11DesktopTabContent.vue
+++ b/frontend/src/components/X11DesktopTabContent.vue
@@ -134,6 +134,11 @@ async function reconnect() {
   await start()
 }
 
+function onReconnectEvent(e: Event) {
+  const panelId = (e as CustomEvent)?.detail?.panelId
+  if (panelId && panelId === props.panelId) reconnect()
+}
+
 onMounted(() => {
   if (props.sessionId) {
     currentSessionId.value = props.sessionId
@@ -157,10 +162,14 @@ onMounted(() => {
         break
     }
   })
+
+  // Tab right-click 「重连」(Reconnect) menu → forced reconnect of this panel.
+  window.addEventListener('panel:reconnect', onReconnectEvent)
 })
 
 onBeforeUnmount(() => {
   unsubStatus?.()
+  window.removeEventListener('panel:reconnect', onReconnectEvent)
   if (currentSessionId.value) {
     try { CloseSession(currentSessionId.value) } catch (_) {}
     panelStore.bindSession(props.panelId, '')

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -104,6 +104,8 @@
   "window.maximize": "Maximieren",
   "window.close": "Schließen",
   "tab.duplicate": "Duplizieren",
+  "tab.reconnect": "Neu verbinden",
+  "tab.reconnectFailed": "Neuverbindung fehlgeschlagen: {error}",
   "tab.copyHostAddress": "Hostadresse kopieren",
   "tab.hostCopied": "Hostadresse kopiert: {host}",
   "tab.rename": "Umbenennen",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -104,6 +104,8 @@
   "window.maximize": "Maximize",
   "window.close": "Close",
   "tab.duplicate": "Duplicate",
+  "tab.reconnect": "Reconnect",
+  "tab.reconnectFailed": "Reconnect failed: {error}",
   "tab.copyHostAddress": "Copy Host Address",
   "tab.hostCopied": "Host address copied: {host}",
   "tab.rename": "Rename",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -104,6 +104,8 @@
   "window.maximize": "Maximizar",
   "window.close": "Cerrar",
   "tab.duplicate": "Duplicar",
+  "tab.reconnect": "Reconectar",
+  "tab.reconnectFailed": "Error al reconectar: {error}",
   "tab.copyHostAddress": "Copiar dirección del host",
   "tab.hostCopied": "Dirección del host copiada: {host}",
   "tab.rename": "Renombrar",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -104,6 +104,8 @@
   "window.maximize": "Agrandir",
   "window.close": "Fermer",
   "tab.duplicate": "Dupliquer",
+  "tab.reconnect": "Reconnecter",
+  "tab.reconnectFailed": "Échec de la reconnexion : {error}",
   "tab.copyHostAddress": "Copier l'adresse de l'hôte",
   "tab.hostCopied": "Adresse de l'hôte copiée : {host}",
   "tab.rename": "Renommer",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -104,6 +104,8 @@
   "window.maximize": "最大化",
   "window.close": "閉じる",
   "tab.duplicate": "複製",
+  "tab.reconnect": "再接続",
+  "tab.reconnectFailed": "再接続に失敗しました：{error}",
   "tab.copyHostAddress": "ホストアドレスをコピー",
   "tab.hostCopied": "ホストアドレスをコピーしました：{host}",
   "tab.rename": "名前を変更",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -104,6 +104,8 @@
   "window.maximize": "최대화",
   "window.close": "닫기",
   "tab.duplicate": "복제",
+  "tab.reconnect": "재연결",
+  "tab.reconnectFailed": "재연결 실패: {error}",
   "tab.copyHostAddress": "호스트 주소 복사",
   "tab.hostCopied": "호스트 주소가 복사되었습니다: {host}",
   "tab.rename": "이름 변경",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -104,6 +104,8 @@
   "window.maximize": "Развернуть",
   "window.close": "Закрыть",
   "tab.duplicate": "Дублировать",
+  "tab.reconnect": "Переподключиться",
+  "tab.reconnectFailed": "Не удалось переподключиться: {error}",
   "tab.copyHostAddress": "Скопировать адрес хоста",
   "tab.hostCopied": "Адрес хоста скопирован: {host}",
   "tab.rename": "Переименовать",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -104,6 +104,8 @@
   "window.maximize": "最大化",
   "window.close": "关闭",
   "tab.duplicate": "复制会话",
+  "tab.reconnect": "重新连接",
+  "tab.reconnectFailed": "重连失败：{error}",
   "tab.copyHostAddress": "复制主机地址",
   "tab.hostCopied": "已复制主机地址：{host}",
   "tab.rename": "重命名",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -104,6 +104,8 @@
   "window.maximize": "最大化",
   "window.close": "關閉",
   "tab.duplicate": "複製會話",
+  "tab.reconnect": "重新連線",
+  "tab.reconnectFailed": "重新連線失敗：{error}",
   "tab.copyHostAddress": "複製主機位址",
   "tab.hostCopied": "已複製主機位址：{host}",
   "tab.rename": "重新命名",


### PR DESCRIPTION
Closes #600

## Summary
Add a **Reconnect** item to the tab right-click menu that forcibly disconnects the current connection and re-initiates it, without waiting for the stuck attempt to fail.

## Changes
- **TabItem**: show the "Reconnect" item for every connectable tab type
- **Terminal panels** (ssh/telnet/serial/mosh/local/exec): `CloseSession` the old session first, then reuse the existing `retryConnection()` path
- **Desktop protocols** (rdp/vnc/spice/x11): route to each content component's existing `reconnect()`
- **File transfer** (sftp/ftp/smb/webdav/s3), **monitor**, and **database** (database/redis/mongodb): re-created in `App.vue` via `CreateSession`
- **k8s / container**: disconnect and re-open from their content components
- Redis tab now re-scans when its session id changes on reconnect
- Added `tab.reconnect` / `tab.reconnectFailed` i18n keys in all locales

## Verification
- Frontend clean-cache `npm run build` passes
- Reconnect options cover: terminal (ssh/telnet/serial/mosh/local/exec), rdp/vnc/spice/x11, database/redis/mongodb, sftp/ftp/smb/webdav/s3, monitor, k8s, container

---
## 概述
在标签右键菜单新增**重新连接**选项，强制断开当前连接并重新发起连接，无需等待旧连接彻底失败。

## 变更内容
- **TabItem**：对所有可连接类型的标签显示「重新连接」项
- **终端面板**（ssh/telnet/serial/mosh/local/exec）：先 `CloseSession` 旧会话，再复用已有 `retryConnection()` 重连
- **桌面协议**（rdp/vnc/spice/x11）：路由到各内容组件已有的 `reconnect()`
- **文件传输**（sftp/ftp/smb/webdav/s3）、**监控** 与 **数据库**（database/redis/mongodb）：在 `App.vue` 中重新 `CreateSession`
- **k8s / container**：从内容组件断开并重新打开
- Redis 标签在重连切换新 sessionId 后重新扫描
- 新增 `tab.reconnect` / `tab.reconnectFailed` 国际化键（全部语言）

## 验证
- 前端清理缓存 `npm run build` 通过
- 重连覆盖类型：终端（ssh/telnet/serial/mosh/local/exec）、rdp/vnc/spice/x11、database/redis/mongodb、sftp/ftp/smb/webdav/s3、monitor、k8s、container