### PR TITLE
fix(store): recover legacy keychain passwords lost after enc:v1 upgrade

### DIFF
--- a/app.go
+++ b/app.go
@@ -338,13 +338,21 @@ func (a *App) initCredentials(dataDir string, upgrade bool) {
 		if meta, _ := credentials.ReadMeta(dataDir); meta == nil {
 			if err := cred.Setup(credentials.ModeKeychain, ""); err != nil {
 				log.Writef("credential auto-upgrade setup failed: %v", err)
-			} else {
-				if _, err := store.MigrateLegacyKeychainToInPlace(dataDir, sync.NewKeychain(), cred); err != nil {
-					log.Writef("legacy migration failed: %v", err)
-				}
+			} else if _, err := store.MigrateLegacyKeychainToInPlace(dataDir, sync.NewKeychain(), cred); err != nil {
+				log.Writef("legacy migration failed: %v", err)
 			}
 		} else if err := cred.AutoUnlock(); err != nil {
 			log.Writef("credential auto-unlock failed: %v", err)
+		}
+		// Re-run the legacy migration on every upgrade. It is idempotent (only
+		// backfills connections whose JSON password field is still empty) and
+		// closes the window where a user's first-launch migration failed and
+		// was then skipped forever because credentials.meta already existed.
+		// Only meaningful when the credential store holds a usable key.
+		if cred.Unlocked() {
+			if _, err := store.MigrateLegacyKeychainToInPlace(dataDir, sync.NewKeychain(), cred); err != nil {
+				log.Writef("legacy migration failed: %v", err)
+			}
 		}
 	} else if err := cred.AutoUnlock(); err != nil {
 		log.Writef("credential auto-unlock failed: %v", err)
@@ -353,6 +361,9 @@ func (a *App) initCredentials(dataDir string, upgrade bool) {
 	a.credentialStore = cred
 	if a.connectionStore != nil {
 		a.connectionStore.SetPasswordStore(cred)
+		// Fall back to the pre-enc:v1 keychain (conn/<id>) so passwords from
+		// the old scheme remain usable if the one-shot migration didn't run.
+		a.connectionStore.SetLegacyKeychain(sync.NewKeychain())
 	}
 	if a.settingsStore != nil {
 		a.settingsStore.SetPasswordStore(cred)

--- a/backend/store/connection_store.go
+++ b/backend/store/connection_store.go
@@ -24,7 +24,8 @@ type PasswordStore interface {
 
 type ConnectionStore struct {
 	configDir     string
-	passwordStore PasswordStore // nil = passwords kept in JSON (backward compat)
+	passwordStore PasswordStore       // nil = passwords kept in JSON (backward compat)
+	legacy         LegacyPasswordSource // optional fallback to pre-enc:v1 keychain entries
 	mu            sync.Mutex    // serializes Save + populatePasswords writes (STORE-05/06).
 	pwdMu         sync.RWMutex  // guards pwdCache for F-110 async keychain fill.
 	pwdCache      map[string]string
@@ -42,6 +43,13 @@ func NewConnectionStore(configDir string) (*ConnectionStore, error) {
 // are written to the store and cleared from the JSON file on save.
 func (s *ConnectionStore) SetPasswordStore(ps PasswordStore) {
 	s.passwordStore = ps
+}
+
+// SetLegacyKeychain wires the pre-enc:v1 keychain so a connection that lacks
+// an enc:v1 field can still recover its password from the legacy conn/<id>
+// entry. Lazy-migrates the value into enc:v1 on the next save.
+func (s *ConnectionStore) SetLegacyKeychain(kc LegacyPasswordSource) {
+	s.legacy = kc
 }
 
 func (s *ConnectionStore) filePath() string {
@@ -170,7 +178,26 @@ func (s *ConnectionStore) populatePasswords(data *session.ConnectionStoreData) e
 
 	for i := range data.Connections {
 		conn := &data.Connections[i]
-		if conn.AuthType != "password" || conn.Password == "" {
+		if conn.AuthType != "password" {
+			continue
+		}
+		if conn.Password == "" {
+			// No enc:v1 field. Under the pre-enc:v1 scheme the password lived
+			// in the keychain under conn/<id> and the JSON field was omitted;
+			// recover it here so the value stays visible without a manual
+			// re-entry. Falls back to "" when neither source has it.
+			if s.legacy != nil {
+				if pw, err := s.legacy.GetPassword(conn.ID); err == nil && pw != "" {
+					s.pwdMu.Lock()
+					if s.pwdCache == nil {
+						s.pwdCache = map[string]string{}
+					}
+					s.pwdCache[conn.ID] = pw
+					s.pwdMu.Unlock()
+					conn.Password = pw
+					needsSave = true // lazy-migrate into enc:v1 on next save
+				}
+			}
 			continue
 		}
 		if s.passwordStore == nil {
@@ -232,13 +259,30 @@ func (s *ConnectionStore) encryptForSaveLocked(data session.ConnectionStoreData)
 // EnsurePassword returns the cached decrypted password for a connection ID.
 // Load() fills the cache synchronously from encrypted fields, so this is a
 // defensive fallback for callers that construct configs without going through
-// Load. Returns "" when there is no cached entry (no stored password).
+// Load. On a cache miss it tries the legacy keychain (conn/<id>) so a connect
+// attempt can still recover a password that was never migrated into enc:v1.
+// Returns "" when there is no cached entry and no legacy keychain value.
 func (s *ConnectionStore) EnsurePassword(connID string) (string, error) {
 	s.pwdMu.RLock()
 	pw, ok := s.pwdCache[connID]
 	s.pwdMu.RUnlock()
-	if !ok {
+	if ok {
+		return pw, nil
+	}
+	if s.legacy == nil {
 		return "", nil
+	}
+	pw, err := s.legacy.GetPassword(connID)
+	if err != nil {
+		return "", nil
+	}
+	if pw != "" {
+		s.pwdMu.Lock()
+		if s.pwdCache == nil {
+			s.pwdCache = map[string]string{}
+		}
+		s.pwdCache[connID] = pw
+		s.pwdMu.Unlock()
 	}
 	return pw, nil
 }

--- a/backend/store/connection_store_legacy_test.go
+++ b/backend/store/connection_store_legacy_test.go
@@ -1,0 +1,116 @@
+package store
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ys-ll/uniterm/backend/credentials"
+	"github.com/ys-ll/uniterm/backend/session"
+)
+
+// fakeLegacyKC is a LegacyPasswordSource keyed by connection ID, mimicking the
+// pre-enc:v1 keychain (conn/<id>) holding plaintext passwords.
+type fakeLegacyKC struct{ pw map[string]string }
+
+func (f fakeLegacyKC) GetPassword(id string) (string, error)  { return f.pw[id], nil }
+func (fakeLegacyKC) GetModelAPIKey(string) (string, error)    { return "", nil }
+
+// TestLoadFallsBackToLegacyKeychain reproduces the upgrade regression: a
+// connection saved under the old scheme has no enc:v1 field (the password
+// lived in the keychain), and the one-shot migration never ran. Load() must
+// recover the password from the legacy keychain and lazy-migrate it to enc:v1
+// on the resulting save so it is not invisible.
+func TestLoadFallsBackToLegacyKeychain(t *testing.T) {
+	dir := t.TempDir()
+	s := &ConnectionStore{configDir: dir, passwordStore: fakeCipherStore{}}
+	s.SetLegacyKeychain(fakeLegacyKC{pw: map[string]string{"c1": "secret-pw"}})
+
+	// JSON with no password field — exactly the old keychain-mode shape.
+	mustWriteConnections(t, dir, session.ConnectionStoreData{
+		Connections: []session.ConnectionConfig{
+			{ID: "c1", Type: "ssh", AuthType: "password"},
+		},
+	})
+
+	data, err := s.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got := data.Connections[0].Password; got != "secret-pw" {
+		t.Fatalf("password = %q, want %q (legacy keychain fallback)", got, "secret-pw")
+	}
+
+	// EnsurePassword recovers it too, without going through a full Load.
+	s2 := &ConnectionStore{configDir: dir, passwordStore: fakeCipherStore{}}
+	s2.SetLegacyKeychain(fakeLegacyKC{pw: map[string]string{"c1": "secret-pw"}})
+	pw, err := s2.EnsurePassword("c1")
+	if err != nil {
+		t.Fatalf("EnsurePassword: %v", err)
+	}
+	if pw != "secret-pw" {
+		t.Fatalf("EnsurePassword = %q, want %q", pw, "secret-pw")
+	}
+}
+
+// TestLoadLegacyFallBackLazyMigrates verifies the recovered plaintext is
+// written back as enc:v1 so subsequent loads don't depend on the keychain.
+func TestLoadLegacyFallBackLazyMigrates(t *testing.T) {
+	dir := t.TempDir()
+	s := &ConnectionStore{configDir: dir, passwordStore: fakeCipherStore{}}
+	s.SetLegacyKeychain(fakeLegacyKC{pw: map[string]string{"c1": "secret-pw"}})
+
+	mustWriteConnections(t, dir, session.ConnectionStoreData{
+		Connections: []session.ConnectionConfig{
+			{ID: "c1", Type: "ssh", AuthType: "password"},
+		},
+	})
+	if _, err := s.Load(); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	raw, _ := os.ReadFile(filepath.Join(dir, storeFileName))
+	var d session.ConnectionStoreData
+	if err := json.Unmarshal(raw, &d); err != nil {
+		t.Fatalf("reparse: %v", err)
+	}
+	if !credentials.IsEncrypted(d.Connections[0].Password) {
+		t.Fatalf("password not lazy-migrated to enc:v1: %q", d.Connections[0].Password)
+	}
+	// The legacy keychain entry must survive (we don't delete on recovery).
+	if _, err := s.legacy.GetPassword("c1"); err != nil {
+		t.Fatalf("legacy keychain entry deleted during migration: %v", err)
+	}
+}
+
+// TestLoadEncV1PreferredOverLegacy ensures an existing enc:v1 field is used
+// and the legacy keychain is never consulted for that connection.
+func TestLoadEncV1PreferredOverLegacy(t *testing.T) {
+	dir := t.TempDir()
+	s := &ConnectionStore{configDir: dir, passwordStore: fakeCipherStore{}}
+	enc, _ := fakeCipherStore{}.Encrypt("enc-pw")
+	// Legacy holds a DIFFERENT value — it must be ignored.
+	s.SetLegacyKeychain(fakeLegacyKC{pw: map[string]string{"c1": "stale-legacy"}})
+
+	mustWriteConnections(t, dir, session.ConnectionStoreData{
+		Connections: []session.ConnectionConfig{
+			{ID: "c1", Type: "ssh", AuthType: "password", Password: enc},
+		},
+	})
+	data, err := s.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got := data.Connections[0].Password; got != "enc-pw" {
+		t.Fatalf("password = %q, want enc:v1 value %q", got, "enc-pw")
+	}
+}
+
+func mustWriteConnections(t *testing.T, dir string, data session.ConnectionStoreData) {
+	t.Helper()
+	s := &ConnectionStore{configDir: dir}
+	if err := s.writeJSONLocked(data); err != nil {
+		t.Fatalf("writeJSONLocked: %v", err)
+	}
+}

--- a/backend/store/legacy_migrate.go
+++ b/backend/store/legacy_migrate.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -25,28 +26,31 @@ func MigrateLegacyKeychainToInPlace(configDir string, legacy LegacyPasswordSourc
 	connPath := filepath.Join(configDir, storeFileName)
 	if data, err := os.ReadFile(connPath); err == nil {
 		var d session.ConnectionStoreData
-		if json.Unmarshal(data, &d) == nil {
-			changed := false
-			for i := range d.Connections {
-				conn := &d.Connections[i]
-				if conn.AuthType != "password" || conn.Password != "" {
-					continue
-				}
-				if pw, err := legacy.GetPassword(conn.ID); err == nil && pw != "" {
-					enc, err := cred.Encrypt(pw)
-					if err != nil {
-						return count, err
-					}
-					conn.Password = enc
-					count++
-					changed = true
-				}
+		if err := json.Unmarshal(data, &d); err != nil {
+			// Previously swallowed — surface it so a malformed file doesn't
+			// silently leave every connection's password unmigrated.
+			return count, fmt.Errorf("parse connections for migration: %w", err)
+		}
+		changed := false
+		for i := range d.Connections {
+			conn := &d.Connections[i]
+			if conn.AuthType != "password" || conn.Password != "" {
+				continue
 			}
-			if changed {
-				out, _ := json.MarshalIndent(d, "", "  ")
-				if err := atomicWriteFile(connPath, out, 0600); err != nil {
+			if pw, err := legacy.GetPassword(conn.ID); err == nil && pw != "" {
+				enc, err := cred.Encrypt(pw)
+				if err != nil {
 					return count, err
 				}
+				conn.Password = enc
+				count++
+				changed = true
+			}
+		}
+		if changed {
+			out, _ := json.MarshalIndent(d, "", "  ")
+			if err := atomicWriteFile(connPath, out, 0600); err != nil {
+				return count, err
 			}
 		}
 	}
@@ -55,28 +59,29 @@ func MigrateLegacyKeychainToInPlace(configDir string, legacy LegacyPasswordSourc
 	setPath := filepath.Join(configDir, settingsFileName)
 	if data, err := os.ReadFile(setPath); err == nil {
 		var s AppSettings
-		if json.Unmarshal(data, &s) == nil {
-			changed := false
-			for i := range s.AI.Models {
-				m := &s.AI.Models[i]
-				if m.APIKey != "" {
-					continue
-				}
-				if ak, err := legacy.GetModelAPIKey(m.ID); err == nil && ak != "" {
-					enc, err := cred.Encrypt(ak)
-					if err != nil {
-						return count, err
-					}
-					m.APIKey = enc
-					count++
-					changed = true
-				}
+		if err := json.Unmarshal(data, &s); err != nil {
+			return count, fmt.Errorf("parse settings for migration: %w", err)
+		}
+		changed := false
+		for i := range s.AI.Models {
+			m := &s.AI.Models[i]
+			if m.APIKey != "" {
+				continue
 			}
-			if changed {
-				out, _ := json.Marshal(s)
-				if err := atomicWriteFile(setPath, out, 0600); err != nil {
+			if ak, err := legacy.GetModelAPIKey(m.ID); err == nil && ak != "" {
+				enc, err := cred.Encrypt(ak)
+				if err != nil {
 					return count, err
 				}
+				m.APIKey = enc
+				count++
+				changed = true
+			}
+		}
+		if changed {
+			out, _ := json.Marshal(s)
+			if err := atomicWriteFile(setPath, out, 0600); err != nil {
+				return count, err
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

预发布版本（v1.8.0-alpha）中发现部分节点 root 密码丢失，SSH 连接和数据库连接均受影响。排查发现：`c67d443` 把密码存储从「keychain 存明文 + JSON 字段省略」切换到「JSON 内 `enc:v1:` 加密」后，新版 `populatePasswords` 只认 `enc:v1:`，不再读旧版 keychain 的 `conn/<id>` 明文条目；补救依赖一次性的 `MigrateLegacyKeychainToInPlace`，但该迁移存在窗口极窄 + 静默吞错两个缺陷，导致部分用户的密码留在 keychain 却对应用不可见。

In the pre-release (v1.8.0-alpha) some nodes' root passwords were lost, affecting both SSH and database connections. Root cause: `c67d443` switched password storage from plaintext-in-keychain to in-place `enc:v1:`. The new `populatePasswords` only recognizes `enc:v1:` and stopped reading the legacy keychain `conn/<id>` entries. The compensating one-shot `MigrateLegacyKeychainToInPlace` had two defects — a narrow window (ran only on first launch when `credentials.meta` was absent) and silent error swallowing — so any user whose first-launch migration failed could never recover.

## Changes

- **`backend/store/connection_store.go`**：新增 `SetLegacyKeychain`；`populatePasswords` 对无 `enc:v1:` 字段的 password 型连接回退读 keychain `conn/<id>`，惰性迁移写回 `enc:v1:`；`EnsurePassword` cache miss 时同样回退，连接路径兜底。（`enc:v1:` 优先，不读 keychain。）
- **`app.go`**：`initCredentials` 给 ConnectionStore 注入 `sync.NewKeychain()`；upgrade 时迁移无条件补跑（幂等，只回填空字段），关闭「首启失败永不再迁」窗口。
- **`backend/store/legacy_migrate.go`**：JSON 解析失败返回错误，不再静默跳过。
- **`backend/store/connection_store_legacy_test.go`**（新增）：覆盖 keychain 回退读取、惰性迁移、`enc:v1:` 优先、keychain 条目保留。

Legacy `conn/<id>` keychain entries are retained (rollback safety, consistent with the `c67d443` note).

## Validation

- `go test ./backend/...` 全绿，含 3 个新增回归测试（keychain 回退 / 惰性迁移 / `enc:v1:` 优先）。
- `go vet` + `go build` 干净。
- 现场验证：在受影响机器上，keychain 中 18 条 `conn/<id>` 明文条目仍在；当前 13 个连接密码已恢复为 `enc:v1:` 且全部可用当前 master key 解密（0 失败），剩余仅 local 终端等本无密码的连接。