### PR TITLE
fix(credentials): reuse keychain key, harden keychain/bootstrap setup

### DIFF
--- a/app.go
+++ b/app.go
@@ -327,8 +327,18 @@ func (a *App) initCredentials(dataDir string, upgrade bool) {
 	cred := credentials.New(dataDir, sync.NewKeychain())
 
 	if upgrade {
+		// Only this once (the upgrade migration) is worth logging; ordinary
+		// starts share the same AutoUnlock path and would be noise.
+		m, _ := credentials.ReadMeta(dataDir)
+		if m != nil {
+			log.Writef("[upgrade] existing credentials.meta mode=%q", m.Mode)
+		} else {
+			log.Writef("[upgrade] no credentials.meta → auto-setup keychain")
+		}
 		// Existing user: silently auto-upgrade to default + keychain mode.
-		_ = store.WriteBootstrap("default", "")
+		if err := store.WriteBootstrap("default", ""); err != nil {
+			log.Writef("bootstrap write failed (default pointer): %v", err)
+		}
 		// Idempotency (review Critical #1): Setup generates a NEW random key and
 		// overwrites the keychain entry. If a prior upgrade already ran but
 		// bootstrap.json was lost (deleted / <exe>/data unwritable / portable zip
@@ -359,6 +369,12 @@ func (a *App) initCredentials(dataDir string, upgrade bool) {
 	}
 
 	a.credentialStore = cred
+	// Only log when startup lands in a state that prompts a credential dialog
+	// (setup/keychain-lost), so a normal unlocked start stays silent.
+	if st := cred.Status(); st.NeedsSetup || st.KeychainLost {
+		log.Writef("[cred-dialog] mode=%q unlocked=%v keychainLost=%v needsSetup=%v",
+			st.Mode, st.Unlocked, st.KeychainLost, st.NeedsSetup)
+	}
 	if a.connectionStore != nil {
 		a.connectionStore.SetPasswordStore(cred)
 		// Fall back to the pre-enc:v1 keychain (conn/<id>) so passwords from

--- a/app_credentials.go
+++ b/app_credentials.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/wailsapp/wails/v2/pkg/runtime"
 	"github.com/ys-ll/uniterm/backend/credentials"
+	"github.com/ys-ll/uniterm/backend/log"
 	"github.com/ys-ll/uniterm/backend/store"
 	"github.com/ys-ll/uniterm/backend/sync"
 )
@@ -55,7 +56,9 @@ func (a *App) SetDataDir(kind, customDir string, migrate bool) error {
 	// On first run: init stores at the target and return.
 	if a.dataDir == "" {
 		a.dataDir = target
-		_ = store.WriteBootstrap(kind, customDir)
+		if err := store.WriteBootstrap(kind, customDir); err != nil {
+			log.Writef("bootstrap write failed (data dir pointer): %v", err)
+		}
 		a.initStores(target, false)
 		runtime.EventsEmit(a.ctx, "app:dataDirReady", target)
 		return nil
@@ -84,7 +87,9 @@ func (a *App) SetDataDir(kind, customDir string, migrate bool) error {
 	} else if !dirUnlockable(target) {
 		return errors.New("cannot unlock credentials in the target directory")
 	}
-	_ = store.WriteBootstrap(kind, customDir)
+	if err := store.WriteBootstrap(kind, customDir); err != nil {
+		log.Writef("bootstrap write failed (migrate pointer): %v", err)
+	}
 	// Remove the source only after bootstrap points at the target; any earlier
 	// failure leaves the old dir intact so the user can retry without loss.
 	if migrate {

--- a/backend/credentials/store.go
+++ b/backend/credentials/store.go
@@ -1,11 +1,13 @@
 package credentials
 
 import (
+	"bytes"
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	stdsync "sync"
 
@@ -79,14 +81,21 @@ func (s *Store) AutoUnlock() error {
 	var key []byte
 	switch meta.Mode {
 	case ModeKeychain:
-		k, ok := s.getKey("keychain-key/" + h)
-		if !ok {
+		k, err := s.getKey("keychain-key/" + h)
+		if err != nil {
+			// Transient read failure (e.g. macOS keychain permission was
+			// temporarily denied). NOT the same as a lost key: surfacing it
+			// avoids the KeychainLost→reset flow that would wipe stored
+			// passwords.
+			return err
+		}
+		if k == nil {
 			s.set(meta.Mode, meta.Salt, nil)
-			return nil // KeychainLost
+			return nil // KeychainLost (truly missing)
 		}
 		key = k
 	case ModeMasterPassword:
-		if k, ok := s.getKey("master-key/" + h); ok {
+		if k, err := s.getKey("master-key/" + h); err == nil && k != nil {
 			key = k
 		}
 	default:
@@ -97,18 +106,34 @@ func (s *Store) AutoUnlock() error {
 }
 
 // Setup establishes a NEW mode. Used on first run and after reset.
+// It must NEVER orphan existing enc:v1 ciphertext: if the data dir already
+// holds encrypted secrets, a bare key swap would make them undecryptable.
+//   - keychain: reuse a surviving keychain key when one exists; otherwise only
+//     allow a fresh key when there is no existing ciphertext.
+//   - master-password: refuse when existing ciphertext is present (the correct
+//     path is SwitchCredentialMode, which re-encrypts).
 func (s *Store) Setup(mode, masterPassword string) error {
+	hasSecrets := s.storeHasSecrets()
 	var key, salt []byte
 	switch mode {
 	case ModeKeychain:
-		var err error
-		key, err = randomKey()
-		if err != nil {
-			return err
+		existing, err := s.getKey("keychain-key/" + s.DirHash())
+		if err == nil && existing != nil {
+			key = existing // reuse the surviving key so existing ciphertext stays readable
+		} else if hasSecrets {
+			return errors.New("existing encrypted data but no keychain key; refusing to overwrite")
+		} else {
+			key, err = randomKey()
+			if err != nil {
+				return err
+			}
 		}
 	case ModeMasterPassword:
 		if masterPassword == "" {
 			return errors.New("master password required")
+		}
+		if hasSecrets {
+			return errors.New("existing encrypted data; use switch-credential-mode to re-encrypt instead of setup")
 		}
 		var err error
 		salt, err = unitsync.GenerateSalt()
@@ -211,16 +236,48 @@ func (s *Store) set(mode string, salt, key []byte) {
 	s.mu.Unlock()
 }
 
-func (s *Store) getKey(name string) ([]byte, bool) {
+// ErrKeychainNotFound marks a keychain entry that is truly absent (as opposed
+// to a transient read failure), so callers can distinguish "key lost" from
+// "keychain temporarily unreadable" — the latter must not trigger the
+// KeychainLost→reset flow that would wipe stored passwords.
+var ErrKeychainNotFound = errors.New("keychain entry not found")
+
+// getKey returns the decoded key for a keychain entry.
+//   - (nil, nil)         → no entry (ErrKeychainNotFound / empty value)
+//   - ([]byte, nil)      → entry found and decoded
+//   - (nil, other error) → transient read/parse failure
+func (s *Store) getKey(name string) ([]byte, error) {
 	v, err := s.keychain.Get(name)
-	if err != nil || v == "" {
-		return nil, false
+	if err != nil {
+		if errors.Is(err, ErrKeychainNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if v == "" {
+		return nil, nil
 	}
 	b, err := hex.DecodeString(v)
 	if err != nil {
-		return nil, false
+		return nil, err
 	}
-	return b, true
+	return b, nil
+}
+
+// storeHasSecrets reports whether any config file in the data dir already
+// contains in-place enc:v1 ciphertext. A bare Setup on such a dir would
+// orphan the existing ciphertext, so it must be guarded.
+func (s *Store) storeHasSecrets() bool {
+	for _, name := range []string{"connections.json", "settings.json", "identities.json", "proxies.json"} {
+		data, err := os.ReadFile(filepath.Join(s.dataDir, name))
+		if err != nil {
+			continue
+		}
+		if bytes.Contains(data, []byte(Prefix)) {
+			return true
+		}
+	}
+	return false
 }
 
 func randomKey() ([]byte, error) {

--- a/backend/credentials/store_test.go
+++ b/backend/credentials/store_test.go
@@ -1,6 +1,7 @@
 package credentials
 
 import (
+	"errors"
 	"sync"
 	"testing"
 )
@@ -17,7 +18,7 @@ func (f *fakeKeychain) Get(key string) (string, error) {
 	if v, ok := f.store[key]; ok {
 		return v, nil
 	}
-	return "", keychainErrNotFound
+	return "", ErrKeychainNotFound
 }
 func (f *fakeKeychain) Set(key, value string) error {
 	f.mu.Lock()
@@ -32,11 +33,13 @@ func (f *fakeKeychain) Delete(key string) error {
 	return nil
 }
 
-var keychainErrNotFound = &notFoundError{}
+// transientKeychain reports a non-notfound error on reads, simulating e.g. a
+// temporarily denied macOS keychain permission.
+type transientKeychain struct{}
 
-type notFoundError struct{}
-
-func (*notFoundError) Error() string { return "not found" }
+func (transientKeychain) Get(string) (string, error)  { return "", errors.New("keychain temporarily unavailable") }
+func (transientKeychain) Set(string, string) error    { return nil }
+func (transientKeychain) Delete(string) error         { return nil }
 
 func TestSetupKeychainMode(t *testing.T) {
 	dir := t.TempDir()

--- a/backend/store/bootstrap.go
+++ b/backend/store/bootstrap.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+
+	"github.com/ys-ll/uniterm/backend/log"
 )
 
 const bootstrapFileName = "bootstrap.json"
@@ -46,28 +48,78 @@ func bootstrapPath() (string, error) {
 	return filepath.Join(dir, "data", bootstrapFileName), nil
 }
 
+// userConfigBootstrapPath returns the bootstrap path in the user config dir
+// (<UserConfigDir>/uniTerm/bootstrap.json). Unlike the exe/data location it is
+// writable for installs under a read-only Program Files / Applications, which
+// is where default and custom data dirs (and their bootstrap pointer) belong.
+func userConfigBootstrapPath() (string, error) {
+	def, err := DefaultDataDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(def, bootstrapFileName), nil
+}
+
+// bootstrapTargetPaths decides where a bootstrap of the given kind is written
+// and which stale location to remove afterwards.
+//
+//	portable → lives with the exe (exe/data) so it follows a USB stick.
+//	everything else → lives in the user config dir (writable even from a
+//	read-only install dir).
+//
+// To keep only one valid pointer on disk (a mode switch must not silently
+// shadow one another at read time) the stale location is the other one.
+func bootstrapTargetPaths(kind, exe, userCfg string) (primary, stale string) {
+	exePath := filepath.Join(exe, "data", bootstrapFileName)
+	userPath := filepath.Join(userCfg, bootstrapFileName)
+	if kind == "portable" {
+		return exePath, userPath
+	}
+	return userPath, exePath
+}
+
+// bootstrapSearchOrder returns the candidate paths read at startup, newest
+// preference first: the user-config bootstrap (authoritative for installs),
+// then the exe/data one (portable fallback). Each is validated as it is read.
+func bootstrapSearchOrder(exe, userCfg string) []string {
+	exePath := filepath.Join(exe, "data", bootstrapFileName)
+	userPath := filepath.Join(userCfg, bootstrapFileName)
+	if exePath == userPath {
+		return []string{exePath}
+	}
+	return []string{userPath, exePath}
+}
+
 // ResolveDataDir determines where config files live.
-//   - Valid bootstrap.json → resolve its path.
-//   - No bootstrap + default dir has config files → Upgrade (existing user).
+//   - Valid bootstrap.json in (user-config, then exe/data) → resolve its path.
+//   - No valid bootstrap + default dir has config files → Upgrade (existing user).
 //   - Otherwise → FirstRun.
 func ResolveDataDir() (DataDir, error) {
-	bp, err := bootstrapPath()
+	exe, err := exeDir()
 	if err != nil {
 		return DataDir{}, err
 	}
-	if b, err := readBootstrap(bp); err == nil && b != nil {
-		if dir, err := resolvePath(b); err == nil && dir != "" && pathExists(dir) {
-			return DataDir{Path: dir, Type: b.Type}, nil
+	userCfg, err := userConfigBootstrapPath()
+	if err != nil {
+		return DataDir{}, err
+	}
+	for _, bp := range bootstrapSearchOrder(exe, userCfg) {
+		if b, err := readBootstrap(bp); err == nil && b != nil {
+			if dir, err := resolvePath(b); err == nil && dir != "" && pathExists(dir) {
+				return DataDir{Path: dir, Type: b.Type}, nil
+			}
+			// Invalid or missing path → try next location.
 		}
-		// Invalid or missing path → fall through.
 	}
 	def, err := DefaultDataDir()
 	if err != nil {
 		return DataDir{}, err
 	}
 	if hasConfigFiles(def) {
+		log.Writef("no valid bootstrap; default dir has config → upgrade dataDir=%s", def)
 		return DataDir{Path: def, Type: "default", Upgrade: true}, nil
 	}
+	log.Writef("no valid bootstrap and no config in default dir → first run")
 	return DataDir{FirstRun: true}, nil
 }
 
@@ -103,16 +155,20 @@ func resolvePath(b *bootstrap) (string, error) {
 	}
 }
 
-// WriteBootstrap writes <exe_dir>/data/bootstrap.json with the given kind.
+// WriteBootstrap writes the bootstrap pointer for the given kind to the
+// canonical location (user config dir for default/custom, exe/data for
+// portable) and removes the stale location so only one pointer exists.
 func WriteBootstrap(kind, customDir string) error {
-	dir, err := exeDir()
+	exe, err := exeDir()
 	if err != nil {
 		return err
 	}
-	dataDir := filepath.Join(dir, "data")
-	if err := os.MkdirAll(dataDir, 0755); err != nil {
+	userCfg, err := userConfigBootstrapPath()
+	if err != nil {
 		return err
 	}
+	primary, stale := bootstrapTargetPaths(kind, exe, userCfg)
+
 	b := bootstrap{Type: kind}
 	if kind == "custom" {
 		b.DataDir = customDir
@@ -121,7 +177,17 @@ func WriteBootstrap(kind, customDir string) error {
 	if err != nil {
 		return err
 	}
-	return atomicWriteFile(filepath.Join(dataDir, bootstrapFileName), data, 0600)
+	if err := os.MkdirAll(filepath.Dir(primary), 0755); err != nil {
+		return err
+	}
+	if err := atomicWriteFile(primary, data, 0600); err != nil {
+		return err
+	}
+	// A mode switch must not leave a second, shadowing pointer behind.
+	if stale != primary {
+		_ = os.Remove(stale)
+	}
+	return nil
 }
 
 func pathExists(path string) bool {


### PR DESCRIPTION
## 问题背景

在 macOS/Windows 升级到新版后，首次/二次启动时：若 `credentials.meta` 缺失或需重新设置凭证，`Store.Setup` 会**生成一把全新密钥直接覆盖钥匙串里的旧钥**，导致已存在的 `enc:v1` 密文永久解不开、连接列表变空（AES-GCM 无后门，无法从密文反向恢复）。同时 `bootstrap.json` 原写到 `<exe>/data`，在安装到只读的 Program Files / Applications 时报错被静默忽略，数据目录指针容易丢失。

## 修复内容

**凭证加密（防止新钥覆盖旧钥、防止误触发丢失重置）**
- `Store.Setup(keychain)`：先读钥匙串 `keychain-key/<hash>`，有旧钥则**直接复用**，不重新生成；避免覆盖已有密文。
- `Store.Setup`：当数据目录已存在 `enc:v1` 密文且无法找回旧钥时，拒绝裸设置（keychain 与 master-password 均如此），引导走 `SwitchCredentialMode` 安全重加密。
- `getKey`/`AutoUnlock`：区分「真缺失」与「瞬时读失败」（如 macOS 钥匙串权限被拒），瞬时失败不再被当作钥丢失而进入 KeychainLost→重置→清空密码的流程。
- 新增 `storeHasSecrets()` 只读探测密文，作为裸 `Setup` 的守卫依据。

**Bootstrap 写读位置（让指针在只读安装目录下也能可靠保存）**
- `WriteBootstrap` 按类型分流：default/custom 写**用户配置目录**，portable 写 exe/data；切换模式时删除旧位置，避免两份指针互相遮蔽。
- `ResolveDataDir` 读取顺序：用户配置目录优先，再回退 exe/data，均带目录存在性校验。
- 所有 `WriteBootstrap` 调用不再静默吞错，改为写入日志。

**日志**
- 仅记录「升级迁移」和「触发凭证弹窗」（needsSetup / keychainLost）两个关键时刻，普通启动保持安静，便于下次复现定位。

## 验证

`go build ./...` 通过；`backend/store`、`backend/credentials`、根包测试全绿。

---
## 问题背景

After upgrading to the new version, when `credentials.meta` is missing or credentials are being re-setup, `Store.Setup` generated a **fresh key that overwrote the surviving keychain key**, permanently orphaning existing `enc:v1` ciphertext and emptying the connection list (AES-GCM has no backdoor for recovery). In addition, `bootstrap.json` was written to `<exe>/data`, which fails silently under a read-only Program Files / Applications, losing the data-dir pointer.

## Changes

**Credential encryption (never overwrite an existing key; don't mistake transient failures for a lost key)**
- `Store.Setup(keychain)`: first read `keychain-key/<hash>` and **reuse** the surviving key instead of generating a new one.
- `Store.Setup`: refuse a bare setup (keychain or master-password) when the data dir already holds `enc:v1` ciphertext but no surviving key can be recovered, routing to `SwitchCredentialMode` for a safe re-encrypt.
- `getKey`/`AutoUnlock`: distinguish a truly missing entry from a transient read failure (e.g. a denied macOS keychain prompt) so a transient failure no longer triggers KeychainLost → reset → wipe.
- Added a read-only `storeHasSecrets()` probe as the guard for bare `Setup`.

**Bootstrap write/read placement (reliable pointer under read-only install dirs)**
- `WriteBootstrap` writes per kind: default/custom → user config dir; portable → exe/data; on a mode switch the stale location is removed so two pointers never shadow each other.
- `ResolveDataDir` reads user-config first, then exe/data, each validated for an existing directory.
- All `WriteBootstrap` call sites stop swallowing errors and log instead.

**Logging**
- Log only the upgrade migration and any credential-dialog prompt (needsSetup / keychainLost); ordinary starts stay quiet, making the upgrade/dialog paths easy to reproduce next time.

## Verification

`go build ./...` passes; tests for `backend/store`, `backend/credentials`, and the root package are all green.