### PR TITLE
fix(header): left-align macOS tab bar and drop traffic-light spacer under system title bar

### DIFF
--- a/frontend/src/components/AppHeader.vue
+++ b/frontend/src/components/AppHeader.vue
@@ -5,7 +5,7 @@
     @dblclick="onDblClick"
   >
     <!-- macOS: spacer for native traffic lights -->
-    <div v-if="platform === 'darwin'" class="mac-traffic-light-spacer" />
+    <div v-if="platform === 'darwin' && !localStateStore.state.systemTitleBar" class="mac-traffic-light-spacer" />
 
     <!-- Connections button (icon only, leftmost) -->
     <button class="header-btn" @click="emit('toggle-sidebar')" :title="t('header.connections') + shortcutSuffix('toggleSidebar')">
@@ -14,7 +14,7 @@
 
 
     <!-- Tabs list -->
-    <div class="header-tabs" :class="{ 'tabs-centered': platform === 'darwin' }">
+    <div class="header-tabs">
       <TabsList
         @close-tab="(id: string) => emit('close-tab', id)"
         @close-tab-batch="(ids: string[]) => emit('close-tab-batch', ids)"
@@ -428,10 +428,6 @@ onUnmounted(() => {
   overflow: hidden;
   justify-content: flex-start;
   align-items: center;
-}
-
-.header-tabs.tabs-centered {
-  justify-content: center;
 }
 
 .header-btn {


### PR DESCRIPTION
## Summary / 概述

On macOS the AppHeader forced the tab list to `justify-content:center` (the `tabs-centered` class), so the tab bar floated in the middle of the window instead of lining up from the left like Windows/Linux. This drops the centered override so tabs left-align across all platforms.

macOS 下 AppHeader 给 tab 列表强制加了 `justify-content:center`（`tabs-centered` 类），导致标签栏整体居中靠在窗口中间，而非像 Windows/Linux 那样从左侧排开。本次移除该居中覆盖，使三端 tab 栏统一左对齐。

## Changes / 改动

- Remove the `tabs-centered` class binding and its CSS rule (`justify-content:center`) on `.header-tabs` — `frontend/src/components/AppHeader.vue`
- Hide the 72px `mac-traffic-light-spacer` when the native system title bar is enabled: there are no overlay traffic lights to reserve space for, so the spacer only pushed the connection/settings buttons inward for nothing — `frontend/src/components/AppHeader.vue`

- 移除 `.header-tabs` 上的 `tabs-centered` 类绑定及对应 CSS（`justify-content:center`）
- 开启系统原生标题栏时隐藏 72px 的 `mac-traffic-light-spacer`：此时没有需要避让的覆盖式交通灯，占位条只会把连接/设置按钮白白往里推

## Validation / 验证

- macOS：开启应用，确认顶部 tab 栏从左侧（交通灯占位之后）左对齐，不再居中
- macOS：设置中开启「使用系统标题栏」后，确认左侧不再多出 72px 空位，按钮紧贴原生标题栏
- Windows/Linux：未触碰该平台分支逻辑，行为不变（回归确认左对齐）

## Notes / 说明

The centered override has been present since `4a82b0c feat: merge tab bar into titlebar` (2026-06-02); it is not a regression from recent pulls.

Closes #612