### PR TITLE
fix(header): detect platform synchronously to fix macOS title bar layout

### DIFF
--- a/frontend/src/components/AppHeader.vue
+++ b/frontend/src/components/AppHeader.vue
@@ -244,7 +244,15 @@ const emit = defineEmits<{
   'tab-dragstart': [e: DragEvent, tabId: string]
 }>()
 
-const platform = ref<'windows' | 'darwin' | 'linux'>('windows')
+// Detect synchronously so the layout is correct on first render,
+// even if the Wails Environment() call is slow or fails.
+function detectPlatformSync(): 'windows' | 'darwin' | 'linux' {
+  const ua = navigator.userAgent
+  if (/Mac|iPhone|iPad/.test(ua)) return 'darwin'
+  if (/Linux/.test(ua)) return 'linux'
+  return 'windows'
+}
+const platform = ref<'windows' | 'darwin' | 'linux'>(detectPlatformSync())
 const isMaximised = ref(false)
 
 // On Windows/Linux the app draws its own window controls — but not when the


### PR DESCRIPTION
## Summary / 摘要

**EN:** On some machines the packaged macOS .app briefly (or permanently, when the Wails `Environment()` bridge call fails) renders the header with the Windows layout: the `platform` ref defaults to `'windows'` and is only corrected asynchronously in `onMounted`. This drops the `.platform-darwin` class (header 44px instead of 52px) and the traffic-light spacer, so the native traffic lights overlap the tab bar. `wails dev` never reproduces this because the bridge is always ready before mount.

**中文:** 部分用户的 macOS 打包版首启时，交通灯按钮压在标签栏上、header 高度错误。原因是 `platform` 初始值硬编码为 `'windows'`，依赖 `onMounted` 里异步的 `Environment()` 更正；打包 .app 中 bridge 偶发未就绪或调用失败时 fallback 仍是 `'windows'`，导致 `.platform-darwin` 与交通灯占位 spacer 均不生效。`wails dev` 下 bridge 总是先就绪，本地无法复现。

## Changes / 改动

- **EN:** Detect the platform synchronously from `navigator.userAgent` for the initial value of `platform`, so the first render is already correct; keep the `Environment()` call in `onMounted` as a correction fallback.
- **中文:** 用同步可用的 `navigator.userAgent` 作为 `platform` 初始值，首帧渲染即正确；`onMounted` 中的 `Environment()` 保留作校正兜底。

## Validation / 验证

- **EN:** `git diff` reviewed — 9-line change confined to `AppHeader.vue`; the sync detection mirrors the existing `isMac` userAgent check in the same file. On macOS WKWebView the UA always contains "Mac", so the darwin layout now applies on first paint regardless of bridge readiness.
- **中文:** 改动仅 9 行、限于 `AppHeader.vue`；同步检测逻辑与同文件已有的 `isMac` userAgent 判断一致。macOS WKWebView 的 UA 恒含 "Mac"，首帧即应用 darwin 布局，不再依赖 bridge 就绪时序。

Closes #627