### PR TITLE
feat(theme): merge Xshell/MobaXterm/FinalShell themes into Dark/Light groups

### DIFF
--- a/frontend/src/composables/useTerminalThemeOptions.ts
+++ b/frontend/src/composables/useTerminalThemeOptions.ts
@@ -3,9 +3,8 @@ import { useSettingsStore } from '../stores/settingsStore'
 import { TERMINAL_THEMES } from '../types/settings'
 import type { TerminalThemeEntry } from '../types/settings'
 
-const DARK_THEMES = TERMINAL_THEMES.filter(t => t.type === 'dark' && t.group !== 'ssh')
-const LIGHT_THEMES = TERMINAL_THEMES.filter(t => t.type === 'light' && t.group !== 'ssh')
-const SSH_THEMES = TERMINAL_THEMES.filter(t => t.group === 'ssh')
+const DARK_THEMES = TERMINAL_THEMES.filter(t => t.type === 'dark')
+const LIGHT_THEMES = TERMINAL_THEMES.filter(t => t.type === 'light')
 
 /** Grouped terminal theme options for the theme <el-select>: built-in themes
  * split into Dark/Light, SSH client defaults, plus a Custom group for
@@ -26,7 +25,6 @@ export function useTerminalThemeOptions() {
     const groups = [
       { label: 'Dark', options: DARK_THEMES },
       { label: 'Light', options: LIGHT_THEMES },
-      { label: 'Xshell / MobaXterm / FinalShell', options: SSH_THEMES },
     ]
     if (customThemeEntries.value.length > 0) {
       groups.push({ label: 'Custom', options: customThemeEntries.value })

--- a/frontend/src/types/settings.ts
+++ b/frontend/src/types/settings.ts
@@ -260,7 +260,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   tabCloseButton: 'left'
 }
 
-export interface TerminalThemeEntry { label: string; value: string; type: 'dark' | 'light'; group?: 'builtin' | 'ssh' }
+export interface TerminalThemeEntry { label: string; value: string; type: 'dark' | 'light' }
 export const TERMINAL_THEMES: TerminalThemeEntry[] = [
   { label: 'uniTerm Dark', value: 'uniterm-dark', type: 'dark' },
   { label: 'uniTerm Light', value: 'uniterm-light', type: 'light' },
@@ -290,13 +290,13 @@ export const TERMINAL_THEMES: TerminalThemeEntry[] = [
   { label: 'Everforest Dark', value: 'everforest-dark', type: 'dark' },
   { label: 'Everforest Light', value: 'everforest-light', type: 'light' },
   // Popular SSH client defaults
-  { label: 'Xshell XTerm', value: 'xshell-xterm', type: 'dark', group: 'ssh' },
-  { label: 'Xshell ANSI on Black', value: 'xshell-ansi-black', type: 'dark', group: 'ssh' },
-  { label: 'Xshell New Black', value: 'xshell-new-black', type: 'dark', group: 'ssh' },
-  { label: 'MobaXterm Default', value: 'mobaxterm-default', type: 'dark', group: 'ssh' },
-  { label: 'MobaXterm Ubuntu', value: 'mobaxterm-ubuntu', type: 'dark', group: 'ssh' },
-  { label: 'FinalShell Dark', value: 'finalshell-dark', type: 'dark', group: 'ssh' },
-  { label: 'FinalShell Light', value: 'finalshell-light', type: 'light', group: 'ssh' },
+  { label: 'Xshell XTerm', value: 'xshell-xterm', type: 'dark' },
+  { label: 'Xshell ANSI on Black', value: 'xshell-ansi-black', type: 'dark' },
+  { label: 'Xshell New Black', value: 'xshell-new-black', type: 'dark' },
+  { label: 'MobaXterm Default', value: 'mobaxterm-default', type: 'dark' },
+  { label: 'MobaXterm Ubuntu', value: 'mobaxterm-ubuntu', type: 'dark' },
+  { label: 'FinalShell Dark', value: 'finalshell-dark', type: 'dark' },
+  { label: 'FinalShell Light', value: 'finalshell-light', type: 'light' },
 ]
 
 export const FONT_OPTIONS: { label: string; value: string }[] = [


### PR DESCRIPTION
## Summary

Remove the dedicated **Xshell / MobaXterm / FinalShell** option group from the terminal theme picker and its underlying `group: 'ssh'` tag. The seven themes now fall into the standard **Dark**/**Light** groups according to their own `type`:
- Dark: Xshell XTerm, Xshell ANSI on Black, Xshell New Black, MobaXterm Default, MobaXterm Ubuntu, FinalShell Dark
- Light: FinalShell Light

Theme ids and their color palettes in `useTerminal.ts` are unchanged, so existing saved theme selections keep working — only the grouping label is dropped.

### Changes
- `frontend/src/types/settings.ts`: removed `group: 'ssh'` from the seven entries and the now-unused `group` field from `TerminalThemeEntry`.
- `frontend/src/composables/useTerminalThemeOptions.ts`: removed the `SSH_THEMES` constant and the "Xshell / MobaXterm / FinalShell" optgroup; the Dark/Light filters now select purely by `type`.

### Verification
- Cleaned Vite cache and rebuilt the frontend: `✓ built` with no type/build errors.

---
## 摘要

移除终端主题选择器中的 **Xshell / MobaXterm / FinalShell** 分组及其 `group: 'ssh'` 标签。七个主题现在按自身 `type` 归入标准 **Dark** / **Light** 分组：
- Dark：Xshell XTerm、Xshell ANSI on Black、Xshell New Black、MobaXterm Default、MobaXterm Ubuntu、FinalShell Dark
- Light：FinalShell Light

主题 id 与 `useTerminal.ts` 中的配色保持不变，已保存的主题选择无需迁移——仅去掉了分组标签。

### 变更
- `frontend/src/types/settings.ts`：移除七个条目的 `group: 'ssh'` 及 `TerminalThemeEntry` 中不再使用的 `group` 字段。
- `frontend/src/composables/useTerminalThemeOptions.ts`：移除 `SSH_THEMES` 常量与 "Xshell / MobaXterm / FinalShell" 分组；Dark/Light 过滤改为仅按 `type` 选择。

### 验证
- 清理 Vite 缓存并重新构建前端：`✓ built`，无类型/构建错误。