### PR TITLE
fix: restore per-arch darwin dmgs and linux tar.gz in release build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,31 +140,41 @@ jobs:
         shell: bash
         run: |
           export PATH="$(go env GOPATH)/bin:$PATH"
-          # Universal binary (arm64 + amd64 via lipo) then .app bundle from Info.plist
+          # Universal binary (arm64 + amd64 via lipo); then a per-arch .app
+          # bundle from Info.plist. Each single-arch .app is what gets packaged
+          # into its own dmg below (matches the v1.8.0 single-arch dmgs).
           wails3 task darwin:build:universal VERSION="$VERSION"
-          wails3 task darwin:create:app:bundle
-          ls -la bin/uniTerm.app/Contents/MacOS bin/uniTerm.app/Contents/Info.plist
+          for arch in amd64 arm64; do
+            cp "bin/uniTerm-$arch" bin/uniTerm
+            wails3 task darwin:create:app:bundle
+            mv bin/uniTerm.app "bin/uniTerm-$arch.app"
+          done
+          ls -la bin/uniTerm-amd64.app/Contents/MacOS bin/uniTerm-arm64.app/Contents/MacOS
 
       - name: Package (macOS)
         if: matrix.slug == 'darwin'
         run: |
-          APP="bin/uniTerm.app"
-          chmod +x "$APP/Contents/MacOS/uniTerm"
+          # One dmg per arch. Stage under GITHUB_WORKSPACE (the large "/"
+          # volume) rather than /tmp: the hosted runner's /tmp is a small,
+          # separate volume and hdiutil regularly ran out of space there for a
+          # large .app. Fall back to a zipped .app when hdiutil still fails.
+          for arch in amd64 arm64; do
+            APP="bin/uniTerm-$arch.app"
+            chmod +x "$APP/Contents/MacOS/uniTerm"
 
-          # Stage in /tmp. hdiutil's dmg build frequently runs the hosted
-          # runner out of space for a large universal .app, so fall back to a
-          # plain zip of the .app (still a valid redistributable) when it fails.
-          STAGE="$(mktemp -d)"
-          cp -R "$APP" "$STAGE/uniTerm.app"
-          ln -s /Applications "$STAGE/Applications"
-          if hdiutil create -volname uniTerm -srcfolder "$STAGE" -ov -format UDZO "uniterm-darwin-${VERSION}.dmg"; then
-            echo "dmg created"
-          else
-            echo "hdiutil dmg failed (disk space) — shipping zipped .app instead"
-            rm -f "uniterm-darwin-${VERSION}.dmg"
-            ditto -c -k --sequesterRsrc --keepParent "$APP" "uniterm-darwin-${VERSION}.zip"
-          fi
-          rm -rf "$STAGE"
+            STAGE="${{ github.workspace }}/dmg_staging_${arch}"
+            mkdir -p "$STAGE"
+            cp -R "$APP" "$STAGE/uniTerm.app"
+            ln -s /Applications "$STAGE/Applications"
+            if hdiutil create -volname uniTerm -srcfolder "$STAGE" -ov -format UDZO "uniterm-darwin-${arch}-${VERSION}.dmg"; then
+              echo "dmg created ($arch)"
+            else
+              echo "hdiutil dmg failed ($arch) — shipping zipped .app instead"
+              rm -f "uniterm-darwin-${arch}-${VERSION}.dmg"
+              ditto -c -k --sequesterRsrc --keepParent "$APP" "uniterm-darwin-${arch}-${VERSION}.zip"
+            fi
+            rm -rf "$STAGE"
+          done
 
       ## ---- Package (kept per-platform; v2 NSIS installer feeds the v3 binaries) ----
 
@@ -229,7 +239,7 @@ jobs:
           upx --best --lzma bin/uniTerm
 
           cd bin
-          tar czf ../../uniterm-linux-${ARCH}-${VERSION}.tar.gz uniTerm
+          tar czf ../uniterm-linux-${ARCH}-${VERSION}.tar.gz uniTerm
           cd ..
 
           NFPM_VER="2.46.3"


### PR DESCRIPTION
## Summary

Restores the release artifacts that the wails v3 rewrite (PR #660) silently dropped:

1. **macOS DMG** – Regression: `hdiutil` failed with `No space left on device` and the step fell back to a `.zip`, so no `.dmg` was shipped. Because staging moved from the workspace to `/tmp` (a small, separate volume on the hosted runner). Now each architecture (amd64/arm64) is packaged into its own DMG, staged under `GITHUB_WORKSPACE` — matching the single-arch DMGs that v1.8.0 shipped.
2. **Linux tar.gz** – Regression: the `tar` output path `../../` (from `bin/`) escaped the repo root, so `upload-artifact` never matched `uniterm-*.tar.gz`; only `.deb`/`.rpm` were uploaded. Fixed to `../` so the archive lands in the repo root.

## Verification

Manual `workflow_dispatch` run on this branch (`32819191562`) succeeded:
- macOS job produced and uploaded `uniterm-darwin-amd64-*.dmg` and `uniterm-darwin-arm64-*.dmg` (no zip fallback triggered).
- Both Linux jobs uploaded 3 files each (`*.deb` + `*.rpm` + `*.tar.gz`).

---

## 概述

修复 wails v3 升级（PR #660）引入的两个发布产物缺失问题：

1. **macOS 的 dmg** —— 回归：`hdiutil` 报 `No space left on device` 后走了 `.zip` 兜底，导致没有 `.dmg` 发布。原因是暂存目录从工作区挪到了 `/tmp`（托管 runner 上一块独立的小卷）。现改为 amd64/arm64 各自打成 dmg，且暂存目录放回 `GITHUB_WORKSPACE`，与 v1.8.0 的单架构 dmg 一致。
2. **Linux 的 tar.gz** —— 回归：`tar` 输出路径 `../../`（从 `bin/` 出发）把文件写到了仓库根目录之外，`upload-artifact` 匹配不到 `uniterm-*.tar.gz`，只上传了 `.deb`/`.rpm`。改为 `../` 后 tar.gz 落在仓库根目录。

## 验证

在本分支上手动 `workflow_dispatch`（run `32819191562`）成功：
- macOS 任务生成并上传了 `uniterm-darwin-amd64-*.dmg` 与 `uniterm-darwin-arm64-*.dmg`（未触发 zip 兜底）。
- 两个 Linux 任务各上传 3 个文件（`.deb` + `.rpm` + `.tar.gz`）。