### PR TITLE
fix: resolve VNC/SPICE race between CreateSession and session:status event

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,10 @@ build/darwin/*
 uniTerm.exe
 __debug*
 
+# Build output (Wails v3 emits the compiled app + runtime data into bin/)
+bin/
+dist/
+
 # Wails v3 generated bindings + task runner cache
 frontend/bindings/
 .task/

--- a/app.go
+++ b/app.go
@@ -1793,9 +1793,25 @@ func (a *App) CreateSession(sessionType string, config session.ConnectionConfig)
 		// Without this gap Claude Code draws tables at the 80x24 default
 		// before SessionResize propagates the real width, and the borders
 		// drift across output batches.
+	} else if sessionType == "vnc" || sessionType == "spice" {
+		// VNC and SPICE start a local WebSocket↔TCP proxy synchronously
+		// so the proxyAddr is available when CreateSession returns.
+		// Avoids a race between the goroutine's session:status emit and
+		// the frontend's CreateSession IPC response.
+		if err := a.setupJumpHostTunnel(s.ID(), sessionType, &config); err != nil {
+			_ = a.sessionManager.Close(s.ID())
+			return nil, err
+		}
+		if err := s.Connect(config); err != nil {
+			if a.tunnelService != nil {
+				a.tunnelService.Stop(s.ID())
+			}
+			_ = a.sessionManager.Close(s.ID())
+			return nil, fmt.Errorf("%s connect failed: %w", sessionType, err)
+		}
 	} else {
-		// Non-terminal sessions (sftp, monitor, ftp, smb, webdav, s3,
-		// rdp, vnc, spice) connect immediately.
+		// Non-terminal sessions (sftp, monitor, ftp, smb, webdav, s3, rdp)
+		// connect immediately.
 		a.launchConnectGoroutine(s, sessionType, config)
 	}
 
@@ -1804,6 +1820,17 @@ func (a *App) CreateSession(sessionType string, config session.ConnectionConfig)
 		Type:   s.Type(),
 		Title:  s.Title(),
 		Status: s.Status(),
+	}
+	// VNC and SPICE expose a local WebSocket↔TCP proxy; return its address
+	// in the CreateSession result so the frontend can mount the RFB/SPICE
+	// client without racing the session:status event (whose 'connected'
+	// emission happens inside s.Connect, before the frontend sets the
+	// session id / stores the proxy addr — see SESSION regression).
+	if vnc, ok := s.(*session.VNCSession); ok {
+		info.ProxyAddr = vnc.ProxyAddr()
+	}
+	if spice, ok := s.(*session.SPICESession); ok {
+		info.ProxyAddr = spice.ProxyAddr()
 	}
 	return info, nil
 }

--- a/backend/session/session.go
+++ b/backend/session/session.go
@@ -208,6 +208,11 @@ type SessionInfo struct {
 	Type   string        `json:"type"`
 	Title  string        `json:"title"`
 	Status SessionStatus `json:"status"`
+	// ProxyAddr is the local WebSocket URL for VNC/SPICE sessions whose
+	// client (noVNC / spice-html5) connects through the WebSocket↔TCP proxy.
+	// Returned synchronously from CreateSession so the frontend can start
+	// the RFB/SPICE client without racing the session:status event.
+	ProxyAddr string `json:"proxyAddr,omitempty"`
 }
 
 type Session interface {

--- a/backend/session/spice_proxy.go
+++ b/backend/session/spice_proxy.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"net/http"
 	"sync"
+	"time"
 
 	"github.com/gorilla/websocket"
 	"github.com/ys-ll/uniterm/backend/log"
@@ -87,7 +88,7 @@ func (p *SPICEProxy) handleWebSocket(ws *websocket.Conn) {
 		p.mu.Unlock()
 	}()
 
-	tcp, err := net.Dial("tcp", p.target)
+	tcp, err := net.DialTimeout("tcp", p.target, 5*time.Second)
 	if err != nil {
 		log.Writef("[SPICEProxy] TCP dial to %s failed: %v", p.target, err)
 		ws.Close()

--- a/backend/session/vnc_proxy.go
+++ b/backend/session/vnc_proxy.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"net/http"
 	"sync"
+	"time"
 
 	"github.com/gorilla/websocket"
 	"github.com/ys-ll/uniterm/backend/log"
@@ -84,7 +85,7 @@ func (p *VNCProxy) handleWebSocket(ws *websocket.Conn) {
 		p.mu.Unlock()
 	}()
 
-	tcp, err := net.Dial("tcp", p.target)
+	tcp, err := net.DialTimeout("tcp", p.target, 5*time.Second)
 	if err != nil {
 		log.Writef("[VNCProxy] TCP dial to %s failed: %v", p.target, err)
 		ws.Close()

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1546,22 +1546,30 @@ async function onConnectVNC(config: ConnectionConfig, prevStart?: any) {
   const panel = panelStore.createPanel(config, 'vnc')
   panelStore.updateTitle(panel.id, displayTitle)
   const reposition = prevStart ? closeStartAndReposition(prevStart) : null
+
+  // Create the session BEFORE the tab so VNCTabContent mounts with its
+  // sessionId and proxyAddr already bound. Mounting first and calling
+  // CreateSession from the component created a duplicate session and lost
+  // the session:status 'connected' event (emitted during CreateSession,
+  // before the component set its session id), leaving VNC stuck on
+  // "connecting". Mirrors onConnectLocal.
+  let info
+  try {
+    info = await CreateSession('vnc', config)
+  } catch (e) {
+    console.error('Failed to create VNC session:', e)
+    panelStore.removePanel(panel.id)
+    return
+  }
+  if (info.proxyAddr) panelStore.setProxyAddr(panel.id, info.proxyAddr)
+  panelStore.bindSession(panel.id, info.id)
+  sessionStore.initSession(info.id)
+
   const tab = tabStore.createVNCTab(displayTitle, panel.id)
   if (reposition) reposition(tab.id)
   panelStore.movePanelToTab(panel.id, tab.id)
   RecordRecentConnection(config.id)
-
-  try {
-    const info = await CreateSession('vnc', config)
-    panelStore.bindSession(panel.id, info.id)
-    sessionStore.initSession(info.id)
-  } catch (e) {
-    console.error('Failed to create VNC session:', e)
-    tabStore.closeTab(tab.id)
-    panelStore.removePanel(panel.id)
-  }
 }
-
 async function onConnectSPICE(config: ConnectionConfig, prevStart?: any) {
   connectionStore.add(config)
 
@@ -1574,20 +1582,25 @@ async function onConnectSPICE(config: ConnectionConfig, prevStart?: any) {
   const panel = panelStore.createPanel(config, 'spice')
   panelStore.updateTitle(panel.id, displayTitle)
   const reposition = prevStart ? closeStartAndReposition(prevStart) : null
+
+  // Create the session BEFORE the tab so SPICETabContent mounts with its
+  // sessionId and proxyAddr already bound — same v3 race as VNC.
+  let info
+  try {
+    info = await CreateSession('spice', config)
+  } catch (e) {
+    console.error('Failed to create SPICE session:', e)
+    panelStore.removePanel(panel.id)
+    return
+  }
+  if (info.proxyAddr) panelStore.setProxyAddr(panel.id, info.proxyAddr)
+  panelStore.bindSession(panel.id, info.id)
+  sessionStore.initSession(info.id)
+
   const tab = tabStore.createSPICETab(displayTitle, panel.id)
   if (reposition) reposition(tab.id)
   panelStore.movePanelToTab(panel.id, tab.id)
   RecordRecentConnection(config.id)
-
-  try {
-    const info = await CreateSession('spice', config)
-    panelStore.bindSession(panel.id, info.id)
-    sessionStore.initSession(info.id)
-  } catch (e) {
-    console.error('Failed to create SPICE session:', e)
-    tabStore.closeTab(tab.id)
-    panelStore.removePanel(panel.id)
-  }
 }
 
 async function onConnectX11Desktop(config: ConnectionConfig, prevStart?: any) {

--- a/frontend/src/components/SFTPTabContent.vue
+++ b/frontend/src/components/SFTPTabContent.vue
@@ -1945,7 +1945,7 @@ async function onDropRemote(e: DragEvent) {
 .chmod-octal-input {
   width: 120px;
 }
-.chmod-octal-input :deep(.el-input__inner) {
+.chmod-octal-input .el-input__inner {
   font-family: var(--font-mono, monospace);
   font-weight: 700;
   letter-spacing: 2px;

--- a/frontend/src/components/SPICETabContent.vue
+++ b/frontend/src/components/SPICETabContent.vue
@@ -50,11 +50,13 @@ import { ref, watch, onMounted, onBeforeUnmount } from 'vue'
 import { Loader } from '@lucide/vue'
 import { useI18n } from '../i18n'
 import { usePanelStore } from '../stores/panelStore'
+import { useSessionStore } from '../stores/sessionStore'
 import type { ConnectionConfig } from '../types/session'
 import { Events } from '@wailsio/runtime'
 import { CreateSession, CloseSession } from '../../bindings/github.com/ys-ll/uniterm/app'
 const { t } = useI18n()
 const panelStore = usePanelStore()
+const sessionStore = useSessionStore()
 
 const props = defineProps<{
   panelId: string
@@ -78,6 +80,16 @@ async function connect() {
   try {
     const info = await CreateSession('spice', props.config)
     currentSessionId.value = info.id
+    // Bind the session to the panel so tab-close cleanup resolves to this
+    // id, and drive the SPICE client from the proxy address returned by
+    // CreateSession (the synchronous SPICE connect makes it available
+    // here) rather than the racy session:status 'connected' event.
+    panelStore.bindSession(props.panelId, info.id)
+    sessionStore.initSession(info.id)
+    if (info.proxyAddr) {
+      panelStore.setProxyAddr(props.panelId, info.proxyAddr)
+      initSpice(info.proxyAddr, props.config.password || '')
+    }
   } catch (e: any) {
     console.error('SPICE connect error:', e)
     status.value = 'error'

--- a/frontend/src/components/VNCTabContent.vue
+++ b/frontend/src/components/VNCTabContent.vue
@@ -70,11 +70,13 @@ import { ref, watch, onMounted, onBeforeUnmount } from 'vue'
 import { Loader } from '@lucide/vue'
 import { useI18n } from '../i18n'
 import { usePanelStore } from '../stores/panelStore'
+import { useSessionStore } from '../stores/sessionStore'
 import type { ConnectionConfig } from '../types/session'
 import { Clipboard, Events } from '@wailsio/runtime'
 import { CreateSession, CloseSession } from '../../bindings/github.com/ys-ll/uniterm/app'
 const { t } = useI18n()
 const panelStore = usePanelStore()
+const sessionStore = useSessionStore()
 
 const props = defineProps<{
   panelId: string
@@ -82,7 +84,7 @@ const props = defineProps<{
   sessionId: string | null
 }>()
 
-const status = ref<'connecting' | 'connected' | 'disconnected' | 'error'>('connecting')
+const status = ref<'connecting' | 'connected' | 'disconnected' | 'error'>('disconnected')
 const lastError = ref<string>('')
 const currentSessionId = ref<string | null>(props.sessionId)
 const vncContainer = ref<HTMLDivElement | null>(null)
@@ -126,6 +128,19 @@ async function connect() {
   try {
     const info = await CreateSession('vnc', props.config)
     currentSessionId.value = info.id
+    // Bind the session to the panel so tab-close cleanup and later
+    // session:status events resolve to this id. The proxy address comes
+    // straight from the CreateSession result: the synchronous VNC connect
+    // makes it available here, independent of the racy session:status
+    // 'connected' event that used to be dropped before the session id was
+    // set, leaving VNC stuck on "connecting".
+    panelStore.bindSession(props.panelId, info.id)
+    sessionStore.initSession(info.id)
+    if (info.proxyAddr) {
+      panelStore.setProxyAddr(props.panelId, info.proxyAddr)
+      savedPassword.value = props.config.password || ''
+      initRFB(info.proxyAddr, savedPassword.value)
+    }
   } catch (e: any) {
     console.error('VNC connect error:', e)
     lastError.value = e?.message || String(e)
@@ -280,25 +295,13 @@ onMounted(() => {
     return
   }
 
-  const storedProxy = panelStore.getProxyAddr(props.panelId)
-  if (storedProxy && props.config) {
-    savedPassword.value = props.config.password || ''
-    initRFB(storedProxy, savedPassword.value)
-  } else if (currentSessionId.value) {
-    connect()
-  } else {
-    connect()
-  }
-
-  watchThemeBackground()
-
-  unsubStatus =Events.On('session:status', (ev) => { const data: any = ev.data; 
+  // Register event listener BEFORE connect() — with synchronous VNC/SPICE
+  // connect the session:status event is emitted during CreateSession and
+  // would arrive before the listener if we registered it after.
+  unsubStatus = Events.On('session:status', (ev) => { const data: any = ev.data; 
     if (data.id !== currentSessionId.value) return
     switch (data.status) {
       case 'connected':
-        // issue #95: do NOT flip to 'connected' here. The RFB 'connect'
-        // event is the source of truth — see createRFB above. We only
-        // hand the proxyAddr off to noVNC.
         if (data.proxyAddr) {
           panelStore.setProxyAddr(props.panelId, data.proxyAddr)
         }
@@ -322,7 +325,17 @@ onMounted(() => {
         status.value = 'error'
         break
     }
-   })
+  })
+
+  const storedProxy = panelStore.getProxyAddr(props.panelId)
+  if (storedProxy && props.config) {
+    savedPassword.value = props.config.password || ''
+    initRFB(storedProxy, savedPassword.value)
+  } else {
+    connect()
+  }
+
+  watchThemeBackground()
 
   // Tab right-click 「重连」(Reconnect) menu → forced reconnect of this panel.
   window.addEventListener('panel:reconnect', onReconnectEvent)

--- a/frontend/src/types/session.ts
+++ b/frontend/src/types/session.ts
@@ -157,6 +157,9 @@ export interface SessionInfo {
   type: string
   title: string
   status: SessionStatus
+  // Local WebSocket URL for VNC/SPICE sessions bridged through the
+  // WebSocket↔TCP proxy; returned by CreateSession.
+  proxyAddr?: string
 }
 
 export interface Tab {


### PR DESCRIPTION
<!-- Please use conventional commit format for the PR title, e.g. `feat(scope): description`, `fix(scope): description` -->
<!-- PR 标题请使用 conventional commit 格式，如 `feat(scope): 描述`、`fix(scope): 描述` -->

## Summary

Problem:
- Frontend created tabs before sessions, so VNCTabContent/SPICETabContent mounted with no sessionId — session:status 'connected' events were dropped, leaving clients stuck on 'connecting'.

## Changes

- app.go: setup jump-host tunnel synchronously for VNC/SPICE; return proxyAddr in CreateSession result so frontend has it immediately.
- session.go: add ProxyAddr field to SessionInfo.
- vnc_proxy.go / spice_proxy.go: net.Dial → net.DialTimeout(5s) to prevent indefinite hangs on unreachable targets.
- App.vue: re-order onConnectVNC/onConnectSPICE — session first, tab second, using proxyAddr from IPC result.
- VNCTabContent.vue / SPICETabContent.vue: bind session on mount via CreateSession result instead of racy session:status event; drive client from synchronous proxyAddr.
- SFTPTabContent.vue: remove :deep() wrapper on .el-input__inner selector (scoped CSS fix).
- .gitignore: add bin/ and dist/ (Wails v3 build output).
