### PR TITLE
fix(connection): save edits on connect, add connect-only, prefill from search

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -12,7 +12,7 @@
       @tab-dragstart="onTabDragStart"
     />
     <div class="main-content">
-      <Sidebar ref="sidebarRef" :visible="sidebarVisible" @toggle="sidebarVisible = !sidebarVisible" @connect="onConnect" @connect-serial="showSerialDialog = true" @connect-sftp="(c: any) => { const p = tabStore.activeTab; onConnectSftp(c, p?.type === 'start' ? p : undefined) }" @connect-ftp="(c: any) => { const p = tabStore.activeTab; onConnectFtp(c, p?.type === 'start' ? p : undefined) }" @connect-smb="(c: any) => { const p = tabStore.activeTab; onConnectSmb(c, p?.type === 'start' ? p : undefined) }" @connect-webdav="(c: any) => { const p = tabStore.activeTab; onConnectWebdav(c, p?.type === 'start' ? p : undefined) }" @connect-s3="(c: any) => { const p = tabStore.activeTab; onConnectS3(c, p?.type === 'start' ? p : undefined) }" @connect-rdp="(c: any) => { const p = tabStore.activeTab; onConnectRDP(c, p?.type === 'start' ? p : undefined) }" @connect-vnc="(c: any) => { const p = tabStore.activeTab; onConnectVNC(c, p?.type === 'start' ? p : undefined) }" @connect-spice="(c: any) => { const p = tabStore.activeTab; onConnectSPICE(c, p?.type === 'start' ? p : undefined) }" @connect-x11-desktop="(c: any) => { const p = tabStore.activeTab; onConnectX11Desktop(c, p?.type === 'start' ? p : undefined) }" @connect-d-b="(c: any) => { const p = tabStore.activeTab; onConnectDB(c, p?.type === 'start' ? p : undefined) }" @connect-monitor="(c: any) => { const p = tabStore.activeTab; onConnectMonitor(c, p?.type === 'start' ? p : undefined) }" @connect-k8s="(c: any) => { const p = tabStore.activeTab; onConnectK8s(c, p?.type === 'start' ? p : undefined) }" />
+      <Sidebar ref="sidebarRef" :visible="sidebarVisible" @toggle="sidebarVisible = !sidebarVisible" @connect="onConnect" @connect-only="onConnectOnly" @connect-serial="showSerialDialog = true" @connect-sftp="(c: any) => { const p = tabStore.activeTab; onConnectSftp(c, p?.type === 'start' ? p : undefined) }" @connect-ftp="(c: any) => { const p = tabStore.activeTab; onConnectFtp(c, p?.type === 'start' ? p : undefined) }" @connect-smb="(c: any) => { const p = tabStore.activeTab; onConnectSmb(c, p?.type === 'start' ? p : undefined) }" @connect-webdav="(c: any) => { const p = tabStore.activeTab; onConnectWebdav(c, p?.type === 'start' ? p : undefined) }" @connect-s3="(c: any) => { const p = tabStore.activeTab; onConnectS3(c, p?.type === 'start' ? p : undefined) }" @connect-rdp="(c: any) => { const p = tabStore.activeTab; onConnectRDP(c, p?.type === 'start' ? p : undefined) }" @connect-vnc="(c: any) => { const p = tabStore.activeTab; onConnectVNC(c, p?.type === 'start' ? p : undefined) }" @connect-spice="(c: any) => { const p = tabStore.activeTab; onConnectSPICE(c, p?.type === 'start' ? p : undefined) }" @connect-x11-desktop="(c: any) => { const p = tabStore.activeTab; onConnectX11Desktop(c, p?.type === 'start' ? p : undefined) }" @connect-d-b="(c: any) => { const p = tabStore.activeTab; onConnectDB(c, p?.type === 'start' ? p : undefined) }" @connect-monitor="(c: any) => { const p = tabStore.activeTab; onConnectMonitor(c, p?.type === 'start' ? p : undefined) }" @connect-k8s="(c: any) => { const p = tabStore.activeTab; onConnectK8s(c, p?.type === 'start' ? p : undefined) }" />
       <div class="tab-area">
         <template v-if="activeTab">
           <KeepAlive>
@@ -119,7 +119,7 @@
       </div>
       <AISidebar ref="aiSidebarRef" @open-settings="openSettings" />
     </div>
-    <ConnectionForm v-model="showConnectionForm" :edit-config="editConfig" :default-group-id="pendingGroupId" @save="onSaveOnly" @connect="(c: ConnectionConfig, ko?: boolean) => { const wasEdit = !!editConfig; editConfig = null; onConnect(c, ko, wasEdit) }" @cancel="editConfig = null" />
+    <ConnectionForm v-model="showConnectionForm" :edit-config="editConfig" :default-group-id="pendingGroupId" @save="onSaveOnly" @connect="(c: ConnectionConfig, ko?: boolean) => { const wasEdit = !!editConfig?.id; editConfig = null; onConnect(c, ko, wasEdit) }" @connect-only="onConnectOnly" @cancel="editConfig = null" />
 
     <CredentialPrompt
       v-model:visible="credentialVisible"
@@ -1243,12 +1243,19 @@ function k8sConnectionForTab(tab: any): ConnectionConfig {
 }
 
 function onSaveOnly(config: ConnectionConfig) {
-  if (editConfig.value) {
+  if (editConfig.value?.id) {
     connectionStore.update(config.id, config)
   } else {
     connectionStore.add(config)
   }
   RecordRecentConnection(config.id)
+}
+
+// Transient connection ("connect only"): connect a new form config without
+// persisting it to the connection list. Reuses onConnect with persist=false.
+function onConnectOnly(config: ConnectionConfig) {
+  editConfig.value = null
+  onConnect(config, undefined, false, false)
 }
 
 // Atomically remove a start tab and place a newly-created tab in its position.
@@ -1265,29 +1272,36 @@ function closeStartAndReposition(prevTab: any): (newTabId: string) => void {
   }
 }
 
-async function onConnect(config: ConnectionConfig, keepOpen?: boolean, wasEdit?: boolean) {
+async function onConnect(config: ConnectionConfig, keepOpen?: boolean, wasEdit?: boolean, persist = true) {
   const prev = tabStore.activeTab
   const prevStart = (prev?.type === 'start' && !keepOpen) ? prev : undefined
   // Persist form changes BEFORE dispatching by type. The type-specific
   // handlers below only call connectionStore.add(), which is a silent
   // no-op for existing ids and would otherwise drop edits made in the
-  // "Save & Connect" flow.
-  if (wasEdit) {
-    connectionStore.update(config.id, config)
-  } else {
-    connectionStore.add(config)
+  // "Save & Connect" flow. When persist=false (transient "connect only"
+  // session) skip both the store write and the recent-connection entry.
+  if (persist) {
+    if (wasEdit) {
+      connectionStore.update(config.id, config)
+    } else {
+      connectionStore.add(config)
+    }
+  } else if (!config.id) {
+    // Give the transient session a stable id for panel/tab wiring even
+    // though it will not be persisted to the connection list.
+    config.id = `conn-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`
   }
-  if (config.type === 'ftp') { await onConnectFtp(config, prevStart); return }
-  if (config.type === 'smb') { await onConnectSmb(config, prevStart); return }
-  if (config.type === 'webdav') { await onConnectWebdav(config, prevStart); return }
-  if (config.type === 's3') { await onConnectS3(config, prevStart); return }
-  if (config.type === 'rdp') { await onConnectRDP(config, prevStart); return }
-  if (config.type === 'vnc') { await onConnectVNC(config, prevStart); return }
-  if (config.type === 'spice') { await onConnectSPICE(config, prevStart); return }
-  if (config.type === 'x11-desktop') { await onConnectX11Desktop(config, prevStart); return }
-  if (config.type === 'database') { await onConnectDB(config, prevStart); return }
-  if (config.type === 'k8s') { await onConnectK8s(config, prevStart); return }
-  if (config.type === 'container') { onConnectContainer(config, prevStart); return }
+  if (config.type === 'ftp') { await onConnectFtp(config, prevStart, persist); return }
+  if (config.type === 'smb') { await onConnectSmb(config, prevStart, persist); return }
+  if (config.type === 'webdav') { await onConnectWebdav(config, prevStart, persist); return }
+  if (config.type === 's3') { await onConnectS3(config, prevStart, persist); return }
+  if (config.type === 'rdp') { await onConnectRDP(config, prevStart, persist); return }
+  if (config.type === 'vnc') { await onConnectVNC(config, prevStart, persist); return }
+  if (config.type === 'spice') { await onConnectSPICE(config, prevStart, persist); return }
+  if (config.type === 'x11-desktop') { await onConnectX11Desktop(config, prevStart, persist); return }
+  if (config.type === 'database') { await onConnectDB(config, prevStart, persist); return }
+  if (config.type === 'k8s') { await onConnectK8s(config, prevStart, persist); return }
+  if (config.type === 'container') { onConnectContainer(config, prevStart, persist); return }
 
   // Credential check
   const resolved = await ensureCredentials(config)
@@ -1331,7 +1345,7 @@ async function onConnect(config: ConnectionConfig, keepOpen?: boolean, wasEdit?:
     ? tabStore.replaceStartTab(prev.id, panel.title, panel.id)
     : tabStore.createTerminalTab(panel.title, panel.id)
   panelStore.movePanelToTab(panel.id, tab.id)
-  RecordRecentConnection(config.id)
+  if (persist) RecordRecentConnection(config.id)
 
   // Wait for BaseTerminal to mount + fitAddon.fit() to compute the real
   // xterm cols/rows (which itself waits for document.fonts.ready + 2 rAFs
@@ -1497,8 +1511,8 @@ async function onConnectSftp(config: ConnectionConfig, prevStart?: any) {
   }
 }
 
-async function onConnectFtp(config: ConnectionConfig, prevStart?: any) {
-  connectionStore.add(config)
+async function onConnectFtp(config: ConnectionConfig, prevStart?: any, persist = true) {
+  if (persist) connectionStore.add(config)
 
   const resolved = await ensureCredentials(config)
   if (!resolved) return
@@ -1510,7 +1524,7 @@ async function onConnectFtp(config: ConnectionConfig, prevStart?: any) {
   const tab = tabStore.createFtpTab(displayTitle, panel.id)
   if (reposition) reposition(tab.id)
   panelStore.movePanelToTab(panel.id, tab.id)
-  RecordRecentConnection(config.id)
+  if (persist) RecordRecentConnection(config.id)
 
   try {
     const info = await CreateSession('ftp', config)
@@ -1522,8 +1536,8 @@ async function onConnectFtp(config: ConnectionConfig, prevStart?: any) {
   }
 }
 
-async function onConnectSmb(config: ConnectionConfig, prevStart?: any) {
-  connectionStore.add(config)
+async function onConnectSmb(config: ConnectionConfig, prevStart?: any, persist = true) {
+  if (persist) connectionStore.add(config)
 
   const resolved = await ensureCredentials(config)
   if (!resolved) return
@@ -1535,7 +1549,7 @@ async function onConnectSmb(config: ConnectionConfig, prevStart?: any) {
   const tab = tabStore.createFtpTab(displayTitle, panel.id)
   if (reposition) reposition(tab.id)
   panelStore.movePanelToTab(panel.id, tab.id)
-  RecordRecentConnection(config.id)
+  if (persist) RecordRecentConnection(config.id)
 
   try {
     const info = await CreateSession('smb', config)
@@ -1547,8 +1561,8 @@ async function onConnectSmb(config: ConnectionConfig, prevStart?: any) {
   }
 }
 
-async function onConnectWebdav(config: ConnectionConfig, prevStart?: any) {
-  connectionStore.add(config)
+async function onConnectWebdav(config: ConnectionConfig, prevStart?: any, persist = true) {
+  if (persist) connectionStore.add(config)
 
   const resolved = await ensureCredentials(config)
   if (!resolved) return
@@ -1560,7 +1574,7 @@ async function onConnectWebdav(config: ConnectionConfig, prevStart?: any) {
   const tab = tabStore.createFtpTab(displayTitle, panel.id)
   if (reposition) reposition(tab.id)
   panelStore.movePanelToTab(panel.id, tab.id)
-  RecordRecentConnection(config.id)
+  if (persist) RecordRecentConnection(config.id)
 
   try {
     const info = await CreateSession('webdav', config)
@@ -1572,8 +1586,8 @@ async function onConnectWebdav(config: ConnectionConfig, prevStart?: any) {
   }
 }
 
-async function onConnectS3(config: ConnectionConfig, prevStart?: any) {
-  connectionStore.add(config)
+async function onConnectS3(config: ConnectionConfig, prevStart?: any, persist = true) {
+  if (persist) connectionStore.add(config)
 
   const panel = panelStore.createPanel(config, 'sftp')
   const displayTitle = config.name || (config.s3Bucket ? `s3://${config.s3Bucket}` : config.host)
@@ -1582,7 +1596,7 @@ async function onConnectS3(config: ConnectionConfig, prevStart?: any) {
   const tab = tabStore.createFtpTab(displayTitle, panel.id)
   if (reposition) reposition(tab.id)
   panelStore.movePanelToTab(panel.id, tab.id)
-  RecordRecentConnection(config.id)
+  if (persist) RecordRecentConnection(config.id)
 
   try {
     const info = await CreateSession('s3', config)
@@ -1594,8 +1608,8 @@ async function onConnectS3(config: ConnectionConfig, prevStart?: any) {
   }
 }
 
-async function onConnectRDP(config: ConnectionConfig, prevStart?: any) {
-  connectionStore.add(config)
+async function onConnectRDP(config: ConnectionConfig, prevStart?: any, persist = true) {
+  if (persist) connectionStore.add(config)
 
   const resolved = await ensureCredentials(config)
   if (!resolved) return
@@ -1609,7 +1623,7 @@ async function onConnectRDP(config: ConnectionConfig, prevStart?: any) {
   const tab = tabStore.createRDPTab(displayTitle, panel.id)
   if (reposition) reposition(tab.id)
   panelStore.movePanelToTab(panel.id, tab.id)
-  RecordRecentConnection(config.id)
+  if (persist) RecordRecentConnection(config.id)
 
   try {
     const info = await CreateSession('rdp', config)
@@ -1622,8 +1636,8 @@ async function onConnectRDP(config: ConnectionConfig, prevStart?: any) {
   }
 }
 
-async function onConnectVNC(config: ConnectionConfig, prevStart?: any) {
-  connectionStore.add(config)
+async function onConnectVNC(config: ConnectionConfig, prevStart?: any, persist = true) {
+  if (persist) connectionStore.add(config)
 
   const resolved = await ensureCredentials(config)
   if (!resolved) return
@@ -1656,10 +1670,10 @@ async function onConnectVNC(config: ConnectionConfig, prevStart?: any) {
   const tab = tabStore.createVNCTab(displayTitle, panel.id)
   if (reposition) reposition(tab.id)
   panelStore.movePanelToTab(panel.id, tab.id)
-  RecordRecentConnection(config.id)
+  if (persist) RecordRecentConnection(config.id)
 }
-async function onConnectSPICE(config: ConnectionConfig, prevStart?: any) {
-  connectionStore.add(config)
+async function onConnectSPICE(config: ConnectionConfig, prevStart?: any, persist = true) {
+  if (persist) connectionStore.add(config)
 
   const resolved = await ensureCredentials(config)
   if (!resolved) return
@@ -1688,11 +1702,11 @@ async function onConnectSPICE(config: ConnectionConfig, prevStart?: any) {
   const tab = tabStore.createSPICETab(displayTitle, panel.id)
   if (reposition) reposition(tab.id)
   panelStore.movePanelToTab(panel.id, tab.id)
-  RecordRecentConnection(config.id)
+  if (persist) RecordRecentConnection(config.id)
 }
 
-async function onConnectX11Desktop(config: ConnectionConfig, prevStart?: any) {
-  connectionStore.add(config)
+async function onConnectX11Desktop(config: ConnectionConfig, prevStart?: any, persist = true) {
+  if (persist) connectionStore.add(config)
 
   // Ensure the X11 desktop config itself has saved credentials before
   // handing off to X11DesktopConnect.
@@ -1707,7 +1721,7 @@ async function onConnectX11Desktop(config: ConnectionConfig, prevStart?: any) {
   const tab = tabStore.createX11DesktopTab(displayTitle, panel.id)
   if (reposition) reposition(tab.id)
   panelStore.movePanelToTab(panel.id, tab.id)
-  RecordRecentConnection(config.id)
+  if (persist) RecordRecentConnection(config.id)
 
   // The X11DesktopTabContent owns CreateSession + X11DesktopConnect.
   // It runs when the tab mounts and has access to the resolved config.
@@ -1740,8 +1754,8 @@ async function onConnectMonitor(config: ConnectionConfig, prevStart?: any) {
   }
 }
 
-async function onConnectDB(config: ConnectionConfig, prevStart?: any) {
-  connectionStore.add(config)
+async function onConnectDB(config: ConnectionConfig, prevStart?: any, persist = true) {
+  if (persist) connectionStore.add(config)
 
   const resolved = await ensureCredentials(config)
   if (!resolved) return
@@ -1765,7 +1779,7 @@ async function onConnectDB(config: ConnectionConfig, prevStart?: any) {
     tab.type = 'elasticsearch'
   }
   panelStore.movePanelToTab(panel.id, tab.id)
-  RecordRecentConnection(config.id)
+  if (persist) RecordRecentConnection(config.id)
 
   try {
     let sessionType: string
@@ -1865,8 +1879,8 @@ function onPanelReconnectEvent(e: Event) {
   else if (panel.type === 'sftp') reconnectSftpPanel(panel)
 }
 
-async function onConnectK8s(config: ConnectionConfig, prevStart?: any) {
-  connectionStore.add(config)
+async function onConnectK8s(config: ConnectionConfig, prevStart?: any, persist = true) {
+  if (persist) connectionStore.add(config)
 
   const displayTitle = config.name || 'K8s'
   const panel = panelStore.createPanel(config, 'k8s')
@@ -1876,11 +1890,11 @@ async function onConnectK8s(config: ConnectionConfig, prevStart?: any) {
   const tab = tabStore.createK8sTab(displayTitle, panel.id, config.id, nsDefault)
   if (reposition) reposition(tab.id)
   panelStore.movePanelToTab(panel.id, tab.id)
-  RecordRecentConnection(config.id)
+  if (persist) RecordRecentConnection(config.id)
 }
 
-function onConnectContainer(config: ConnectionConfig, prevStart?: any) {
-  connectionStore.add(config)
+function onConnectContainer(config: ConnectionConfig, prevStart?: any, persist = true) {
+  if (persist) connectionStore.add(config)
 
   const displayTitle = config.name || 'Container'
   const panel = panelStore.createPanel(config, 'container')
@@ -1889,7 +1903,7 @@ function onConnectContainer(config: ConnectionConfig, prevStart?: any) {
   const tab = tabStore.createContainerTab(displayTitle, panel.id, config.id, config.containerRuntime ?? 'docker')
   if (reposition) reposition(tab.id)
   panelStore.movePanelToTab(panel.id, tab.id)
-  RecordRecentConnection(config.id)
+  if (persist) RecordRecentConnection(config.id)
 }
 
 

--- a/frontend/src/components/ConnectionForm.vue
+++ b/frontend/src/components/ConnectionForm.vue
@@ -540,6 +540,7 @@
       >
         {{ t('conn.testConnection') }}
       </el-button>
+      <el-button v-if="!isEdit" @click="onConnectOnly">{{ t('conn.connectOnly') }}</el-button>
       <el-button @click="onSave">{{ t('conn.saveOnly') }}</el-button>
       <el-button type="primary" @click="onConnect">{{ t('conn.saveConnect') }}</el-button>
     </template>
@@ -785,6 +786,7 @@ const emit = defineEmits<{
   'update:modelValue': [value: boolean]
   save: [config: ConnectionConfig]
   connect: [config: ConnectionConfig]
+  connectOnly: [config: ConnectionConfig]
 }>()
 
 const visible = computed({
@@ -1434,6 +1436,21 @@ function onSave() {
     }
   } catch (e: any) {
     // Host empty, silently return
+  }
+}
+
+function onConnectOnly() {
+  if (!validateContainer()) return
+  if (!validateX11Desktop()) return
+  try {
+    const config = normalizeForm()
+    emit('connectOnly', config)
+    visible.value = false
+    if (!props.editConfig) {
+      resetForm()
+    }
+  } catch (e: any) {
+    // Host empty
   }
 }
 

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -285,7 +285,7 @@
       </div>
     </template>
 
-    <ConnectionForm v-model="showForm" :edit-config="editConfig" :default-group-id="newConnGroupId" @save="onSave" @connect="onConnectFromForm" />
+    <ConnectionForm v-model="showForm" :edit-config="editConfig" :default-group-id="newConnGroupId" @save="onSave" @connect="onConnectFromForm" @connect-only="(c: ConnectionConfig) => { showForm = false; editConfig = undefined; emit('connectOnly', c) }" />
     <ExportDialog v-model:visible="showExportDialog" />
     <ImportDialog v-model:visible="showImportDialog" />
     <CustomThemeEditor v-model="themeEditorVisible" :source-theme-id="themeEditorSourceId" />
@@ -481,7 +481,7 @@ import { useLocalStateStore } from '../stores/localStateStore'
 defineProps<{
   visible: boolean
 }>()
-const emit = defineEmits(['connect', 'connectSftp', 'connectFtp', 'connectSmb', 'connectWebdav', 'connectS3', 'connectRdp', 'connectVnc', 'connectSpice', 'connectX11Desktop', 'connectDB', 'connectMonitor', 'connectSerial', 'connectK8s', 'toggle'])
+const emit = defineEmits(['connect', 'connectOnly', 'connectSftp', 'connectFtp', 'connectSmb', 'connectWebdav', 'connectS3', 'connectRdp', 'connectVnc', 'connectSpice', 'connectX11Desktop', 'connectDB', 'connectMonitor', 'connectSerial', 'connectK8s', 'toggle'])
 const connectionStore = useConnectionStore()
 const settingsStore = useSettingsStore()
 const panelStore = usePanelStore()
@@ -1760,9 +1760,14 @@ function onNewConnSelect(cmd: string) {
 
 function onNewConnCommand(cmd: string) {
   if (cmd === 'new-connection') {
-    showForm.value = true
-    editConfig.value = undefined
-    newConnGroupId.value = undefined
+    // Match quick-connect behavior: when the search box has content, parse it
+    // into the new-connection form so fields are pre-filled; otherwise open a
+    // blank form.
+    if (searchQuery.value.trim()) {
+      openNewFormFromSearch()
+    } else {
+      openNewForm()
+    }
   } else if (cmd === 'new-serial') {
     emit('connectSerial')
   } else if (cmd === 'new-group') {
@@ -1836,7 +1841,7 @@ function openNewFormFromSearch() {
 }
 
 function onSave(config: ConnectionConfig) {
-  if (editConfig.value) {
+  if (editConfig.value?.id) {
     connectionStore.update(config.id, config)
   } else {
     connectionStore.add(config)
@@ -1846,7 +1851,7 @@ function onSave(config: ConnectionConfig) {
 }
 
 function onConnectFromForm(config: ConnectionConfig) {
-  if (editConfig.value) {
+  if (editConfig.value?.id) {
     connectionStore.update(config.id, config)
   } else {
     connectionStore.add(config)

--- a/frontend/src/components/StartTabContent.vue
+++ b/frontend/src/components/StartTabContent.vue
@@ -33,7 +33,7 @@
 
     <!-- Action buttons -->
     <div class="start-action-btns">
-      <button class="start-action-btn primary" @click="emit('new-connection', tab.viewMode === 'group' ? { groupId: tab.groupId } : undefined)">
+      <button class="start-action-btn primary" @click="emit('new-connection', { groupId: tab.viewMode === 'group' ? tab.groupId : undefined, host: (searchQuery || '').trim() || undefined })">
         <el-icon><Plus :size="14" /></el-icon>
         {{ t('header.newConnection') }}
       </button>

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -64,6 +64,7 @@
   "conn.saveConnect": "Speichern & Verbinden",
   "conn.save": "Speichern",
   "conn.saveOnly": "Nur speichern",
+  "conn.connectOnly": "Nur verbinden",
   "conn.testConnection": "Verbindung testen",
   "conn.hostRequired": "Host ist erforderlich",
   "conn.advanced": "Erweitert",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -64,6 +64,7 @@
   "conn.saveConnect": "Save & Connect",
   "conn.save": "Save",
   "conn.saveOnly": "Save Only",
+  "conn.connectOnly": "Connect Only",
   "conn.testConnection": "Test Connection",
   "conn.hostRequired": "Host is required",
   "conn.advanced": "Advanced",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -64,6 +64,7 @@
   "conn.saveConnect": "Guardar y Conectar",
   "conn.save": "Guardar",
   "conn.saveOnly": "Solo Guardar",
+  "conn.connectOnly": "Solo Conectar",
   "conn.testConnection": "Probar conexión",
   "conn.hostRequired": "El host es obligatorio",
   "conn.advanced": "Avanzado",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -64,6 +64,7 @@
   "conn.saveConnect": "Enregistrer et connecter",
   "conn.save": "Enregistrer",
   "conn.saveOnly": "Enregistrer uniquement",
+  "conn.connectOnly": "Connecter uniquement",
   "conn.testConnection": "Tester la connexion",
   "conn.hostRequired": "L'hôte est requis",
   "conn.advanced": "Avancé",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -64,6 +64,7 @@
   "conn.saveConnect": "保存して接続",
   "conn.save": "保存",
   "conn.saveOnly": "保存のみ",
+  "conn.connectOnly": "接続のみ",
   "conn.testConnection": "接続テスト",
   "conn.hostRequired": "ホストは必須です",
   "conn.advanced": "詳細設定",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -64,6 +64,7 @@
   "conn.saveConnect": "저장 후 연결",
   "conn.save": "저장",
   "conn.saveOnly": "저장만 하기",
+  "conn.connectOnly": "연결만 하기",
   "conn.testConnection": "연결 테스트",
   "conn.hostRequired": "호스트를 입력해 주세요",
   "conn.advanced": "고급 설정",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -64,6 +64,7 @@
   "conn.saveConnect": "Сохранить и подключиться",
   "conn.save": "Сохранить",
   "conn.saveOnly": "Только сохранить",
+  "conn.connectOnly": "Только подключиться",
   "conn.testConnection": "Проверить соединение",
   "conn.hostRequired": "Укажите хост",
   "conn.advanced": "Дополнительно",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -64,6 +64,7 @@
   "conn.saveConnect": "保存并连接",
   "conn.save": "保存",
   "conn.saveOnly": "仅保存",
+  "conn.connectOnly": "仅连接",
   "conn.testConnection": "测试连接",
   "conn.hostRequired": "主机地址不能为空",
   "conn.advanced": "高级配置",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -64,6 +64,7 @@
   "conn.saveConnect": "儲存並連線",
   "conn.save": "儲存",
   "conn.saveOnly": "僅儲存",
+  "conn.connectOnly": "僅連線",
   "conn.testConnection": "測試連線",
   "conn.hostRequired": "主機位址不能為空",
   "conn.advanced": "進階設定",


### PR DESCRIPTION
## Summary

Fixes the **Save & Connect** flow in the connection form and aligns the **New Connection** entry points with quick connect.

### Changes
- **Save & Connect fix (#645):** persist edited configs by their id so connecting with "Save & Connect" actually saves the changes before the session opens. Previously edits to an existing connection followed by "Save & Connect" were dropped because the update keyed on an empty id.
- **Connect Only:** new button that opens a transient session without saving it to the connection list. A `persist` flag is threaded through every `onConnect*` handler, and the recent-connection log is skipped for transient sessions.
- **New Connection prefill:** the "New Connection" button in the start tab and the sidebar now prefill the form from the search box when it has content, matching quick-connect behavior. An empty search still opens a blank form, and the group-view `groupId` logic is preserved.

### Verification
- `npm run build` passes.

Resolves #645
---
## 摘要

修复连接表单的「保存并连接」流程，并让「新建连接」各入口与快速连接行为一致。

### 变更
- **保存并连接修复（#645）：** 按连接 id 持久化编辑后的配置，确保「保存并连接」在打开会话前真正保存修改。此前编辑已有连接后再点「保存并连接」，会因按空 id 更新而丢失改动。
- **仅连接（Connect Only）：** 新增按钮，打开一个不会保存到连接列表的临时连接会话。`persist` 标志贯穿所有 `onConnect*` 处理器；临时会话跳过最近连接记录。
- **新建连接预填：** 起始页与侧边栏的「新建连接」在搜索框有内容时从搜索框内容预填表单，与快速连接行为一致；搜索框为空时仍打开空表单，分组的 `groupId` 逻辑保持不变。

### 验证
- `npm run build` 通过。

关闭 #645
