### PR TITLE
fix(terminal): re-fit terminal after native window resize ends

### DIFF
--- a/app.go
+++ b/app.go
@@ -177,6 +177,13 @@ func (a *App) ServiceStartup(ctx context.Context, options application.ServiceOpt
 		for evt := range a.moveResizeCh {
 			a.emit(evt)
 			if evt == "rdp:move-resize-end" {
+				// Notify the frontend that the native window stopped resizing
+				// (drag-to-restore / maximize / programmatic resize). The terminal
+				// re-fits on this signal because the browser does not always fire a
+				// final window.resize at the settled size after a native drag, which
+				// otherwise leaves the canvas at a stale small row count (issue #656).
+				// Platform-neutral name; on non-Windows it simply never fires.
+				a.emit("window:resize-end")
 				a.saveWindowStateFromRuntime()
 			}
 		}

--- a/frontend/src/components/BaseTerminal.vue
+++ b/frontend/src/components/BaseTerminal.vue
@@ -265,6 +265,7 @@ let onTerminalCopy: ((e: Event) => void) | null = null
 let onTerminalPaste: ((e: Event) => void) | null = null
 
 let resizeTimer: ReturnType<typeof setTimeout> | null = null
+let unsubNativeResizeEnd: (() => void) | null = null
 let isResizing = false
 let splitResizing = false
 let suppressResizeUntil = 0
@@ -659,6 +660,19 @@ function onWindowResize() {
     el.classList.remove('resizing')
     resize()
   }, 400)
+}
+
+// Native window finished resizing (drag-to-restore / maximize / programmatic
+// resize). Go emits this after WM_EXITSIZEMOVE / WM_SIZE settles, because the
+// browser does not always fire a final window.resize at the settled size after
+// a native drag — which would leave the canvas at a stale small row count with
+// blank space below (issue #656). Bypass the isResizing gate so this cleanup
+// fit always runs, then resolve for a clean re-fit at the true container size.
+function onNativeResizeEnd() {
+  if (resizeTimer) clearTimeout(resizeTimer)
+  isResizing = false
+  terminalRef.value?.classList.remove('resizing')
+  resizeTimer = setTimeout(() => resize(), 100)
 }
 
 function onSplitResizeStart() {
@@ -1371,6 +1385,11 @@ onMounted(() => {
   window.addEventListener('resize', onWindowResize)
   window.addEventListener('split:resize-start', onSplitResizeStart)
   window.addEventListener('split:resize-end', onSplitResizeEnd)
+  // Native window finished resizing (drag-to-restore / maximize). Go emits this
+  // after the WM_EXITSIZEMOVE / WM_SIZE loop settles; the browser doesn't always
+  // fire a final window.resize at the settled size, so this is the reliable
+  // trigger to re-fit the terminal (issue #656). Delivered as a Wails event.
+  unsubNativeResizeEnd = Events.On('window:resize-end', () => onNativeResizeEnd())
   onOpenSearch = (e: Event) => {
     if (!isActive.value) return
     const detail = (e as CustomEvent).detail
@@ -1736,6 +1755,8 @@ onUnmounted(() => {
   window.removeEventListener('resize', onWindowResize)
   window.removeEventListener('split:resize-start', onSplitResizeStart)
   window.removeEventListener('split:resize-end', onSplitResizeEnd)
+  unsubNativeResizeEnd?.()
+  unsubNativeResizeEnd = null
   if (onOpenSearch) window.removeEventListener('terminal:open-search', onOpenSearch)
   if (onExport) window.removeEventListener('terminal:export', onExport)
   if (onSendRz) window.removeEventListener('terminal:send-rz', onSendRz)


### PR DESCRIPTION
## Summary

Fixes #656 — after drag-restoring a maximized window, the SSH/local terminal could render only the top few lines with a large blank area below.

**Root cause:** xterm v6 sizes `.xterm-screen` from the last `terminal.resize(cols, rows)` call. When a maximized window is drag-restored, the browser does not always fire a final `window.resize` at the settled size; `resize()`'s `isResizing` gate then swallows the ResizeObserver notification, so no final re-fit runs and the canvas keeps a stale small row count.

**Fix:** Go already emits a resize-end signal from the native WndProc (`WM_EXITSIZEMOVE` / `WM_SIZE`), currently consumed only by the RDP overlay. This routes it to the frontend as a platform-neutral Wails `window:resize-end` event, and `BaseTerminal` re-fits on it bypassing the `isResizing` gate, resizing the terminal to the true settled container size. On macOS/Linux the event is never emitted, so the listener is a no-op.

**Changed files:** `app.go`, `frontend/src/components/BaseTerminal.vue`

**Verification:** Go build passes; frontend `vite build` passes. The 5 failing `aiStore` debounce tests are pre-existing and unrelated (verified they fail on clean `main` too).

---
## 概要

修复 #656 —— 最大化窗口通过拖标题栏还原后，SSH/本地终端只显示顶部几行、下方大块空白。

**根因：** xterm v6 的 `.xterm-screen` 高度由最近一次 `terminal.resize(cols, rows)` 决定。最大化窗口被拖拽还原时，浏览器不保证在最终尺寸上派发一次 `window.resize`；`resize()` 的 `isResizing` 栅栏又吞掉了 ResizeObserver 通知，导致没有最终一次 re-fit，canvas 停在过小的行数上。

**修复：** Go 侧 native WndProc 已有 resize-end 信号（`WM_EXITSIZEMOVE` / `WM_SIZE`），原先只喂给 RDP 覆盖层。现将其作为平台无关的 Wails `window:resize-end` 事件派发到前端，`BaseTerminal` 收到后绕过 `isResizing` 栅栏强制 re-fit，把终端缩放到窗口稳定后的真实尺寸。macOS/Linux 上该事件永不触发，监听为 no-op。

**改动文件：** `app.go`、`frontend/src/components/BaseTerminal.vue`

**验证：** Go 编译通过；前端 `vite build` 通过。5 个失败的 `aiStore` debounce 用例为存量问题（在干净 `main` 上同样失败），与本次改动无关。