### PR TITLE
fix(session): support encrypted private keys in SFTP and monitor auth

### DIFF
--- a/backend/session/auth_test.go
+++ b/backend/session/auth_test.go
@@ -1,0 +1,68 @@
+package session
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// newEncryptedKeyFile writes an ed25519 private key protected by passphrase to
+// a new temp file and returns its path. Mirrors the "秘钥加密码" scenario from
+// issue #647: an SSH private key that requires a passphrase to decrypt.
+func newEncryptedKeyFile(t *testing.T, passphrase string) string {
+	t.Helper()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	block, err := ssh.MarshalPrivateKeyWithPassphrase(priv, "uniterm-test", []byte(passphrase))
+	if err != nil {
+		t.Fatalf("marshal encrypted key: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "id_ed25519")
+	if err := os.WriteFile(path, pem.EncodeToMemory(block), 0600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+	return path
+}
+
+// TestBuildAuthMethods locks in the behavior that SFTP and monitor sessions rely
+// on for "key + passphrase" authentication. Before the fix both built their auth
+// methods inline and decoded the key with ssh.ParsePrivateKey (no passphrase), so
+// an encrypted key could never authenticate — exactly the issue #647 report.
+func TestBuildAuthMethods(t *testing.T) {
+	keyPath := newEncryptedKeyFile(t, "secret-pass")
+
+	cases := []struct {
+		name    string
+		config  ConnectionConfig
+		wantErr bool
+	}{
+		{"encrypted key + correct passphrase", ConnectionConfig{AuthType: "key", KeyPath: keyPath, Password: "secret-pass"}, false},
+		{"encrypted key + no passphrase", ConnectionConfig{AuthType: "key", KeyPath: keyPath}, true},
+		{"encrypted key + wrong passphrase", ConnectionConfig{AuthType: "key", KeyPath: keyPath, Password: "wrong"}, true},
+		{"plain password", ConnectionConfig{AuthType: "password", Password: "pw"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			methods, err := buildAuthMethods(tc.config)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("buildAuthMethods() error = nil, want error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("buildAuthMethods() error = %v", err)
+			}
+			if len(methods) == 0 {
+				t.Fatalf("buildAuthMethods() returned 0 methods, want > 0")
+			}
+		})
+	}
+}

--- a/backend/session/monitor_session.go
+++ b/backend/session/monitor_session.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"math"
 	"net"
-	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -119,24 +118,10 @@ func (s *MonitorSession) Connect(config ConnectionConfig) error {
 	s.config = config
 	s.title = fmt.Sprintf("%s@%s", config.User, config.Host)
 
-	authMethods := []ssh.AuthMethod{}
-	switch config.AuthType {
-	case "password":
-		authMethods = append(authMethods, ssh.Password(config.Password))
-	case "key":
-		key, err := os.ReadFile(config.KeyPath)
-		if err != nil {
-			s.setStatus(StatusError)
-			return fmt.Errorf("read key: %w", err)
-		}
-		signer, err := ssh.ParsePrivateKey(key)
-		if err != nil {
-			s.setStatus(StatusError)
-			return fmt.Errorf("parse key: %w", err)
-		}
-		authMethods = append(authMethods, ssh.PublicKeys(signer))
-	case "agent":
-		authMethods = append(authMethods, ssh.Password(config.Password))
+	authMethods, err := buildAuthMethods(config)
+	if err != nil {
+		s.setStatus(StatusError)
+		return err
 	}
 
 	clientConfig := &ssh.ClientConfig{

--- a/backend/session/sftp_session.go
+++ b/backend/session/sftp_session.go
@@ -58,24 +58,10 @@ func (s *SFTPSession) Connect(config ConnectionConfig) error {
 	s.setStatus(StatusConnecting)
 	s.title = fmt.Sprintf("%s@%s", config.User, config.Host)
 
-	authMethods := []ssh.AuthMethod{}
-	switch config.AuthType {
-	case "password":
-		authMethods = append(authMethods, ssh.Password(config.Password))
-	case "key":
-		key, err := os.ReadFile(config.KeyPath)
-		if err != nil {
-			s.setStatus(StatusError)
-			return fmt.Errorf("read key: %w", err)
-		}
-		signer, err := ssh.ParsePrivateKey(key)
-		if err != nil {
-			s.setStatus(StatusError)
-			return fmt.Errorf("parse key: %w", err)
-		}
-		authMethods = append(authMethods, ssh.PublicKeys(signer))
-	case "agent":
-		authMethods = append(authMethods, ssh.Password(config.Password))
+	authMethods, err := buildAuthMethods(config)
+	if err != nil {
+		s.setStatus(StatusError)
+		return err
 	}
 
 	clientConfig := &ssh.ClientConfig{

--- a/backend/session/ssh_auth.go
+++ b/backend/session/ssh_auth.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"fmt"
 	"os"
 
 	"golang.org/x/crypto/ssh"
@@ -24,6 +25,26 @@ func makeSSHAuthMethods(config ConnectionConfig, kbCallback ssh.KeyboardInteract
 	}
 
 	return methods
+}
+
+// buildAuthMethods returns the auth methods used by non-interactive SIP sessions
+// (SFTP, server monitor) that dial via dialSSHTCP. It shares parsePrivateKeyFile
+// with the interactive SSH session so an encrypted private key + its passphrase
+// (config.Password) authenticates identically everywhere — the "秘钥加密码" case
+// from issue #647. Unlike makeSSHAuthMethods it has no keyboard-interactive
+// fallback (unattended), uses the passphrase as the authentication signal for
+// key files, and treats "agent" as password for backward compatibility.
+func buildAuthMethods(config ConnectionConfig) ([]ssh.AuthMethod, error) {
+	switch config.AuthType {
+	case "key":
+		signer, ok := parsePrivateKeyFile(config.KeyPath, config.Password)
+		if !ok {
+			return nil, fmt.Errorf("parse key: %s 不存在、无权限或口令错误", config.KeyPath)
+		}
+		return []ssh.AuthMethod{ssh.PublicKeys(signer)}, nil
+	default: // "", "password", "agent" and any unknown type fall back to password
+		return []ssh.AuthMethod{ssh.Password(config.Password)}, nil
+	}
 }
 
 // parsePrivateKeyFile reads the private key at path and parses it, using


### PR DESCRIPTION
Fixes #647

### Problem
SSH connections using a password-protected private key ("秘钥加密码") authenticate
fine in the interactive terminal, but the same connection fails for SFTP and the
server monitor. Both dialed their own SSH auth methods inline and decoded the key
with `ssh.ParsePrivateKey` **without** the passphrase — while `authType='key'` stores
the key passphrase in `Password` (see ConnectionForm's keyPassphrase field). A
passphrase-protected key therefore always failed to parse.

### Fix
- Extract a shared `buildAuthMethods` helper in `ssh_auth.go` that reuses the
  existing passphrase-aware `parsePrivateKeyFile`, so key + passphrase auth works
  identically to the interactive SSH session.
- Wire both `SFTPSession.Connect` and `MonitorSession.Connect` through it, keeping
  the `password` / `agent→password` fallbacks.
- Add a TDD test (`auth_test.go`) that builds a real encrypted ed25519 key and
  asserts correct / empty / wrong passphrase outcomes.

### Verification
- `go build ./...` and `go vet ./session/` clean.
- `go test ./...` passes for all packages except a pre-existing, environment-only
  failure in root `TestStartPprofIfDev_ProductionSkip` (port 6060 bound by a
  running dev instance; reproducible on a clean `origin/main` tree, unrelated to
  this change).

---
修复 #647

### 问题
使用「秘钥加密码」方式连接时，交互式终端能正常登录，但 SFTP 和服务器监控会失败。
二者各自手写认证分支，并在 `key` 场景用 `ssh.ParsePrivateKey` **不带口令**解密秘钥；
而前端 `authType='key'` 时口令存于 `Password` 字段（见 ConnectionForm 的 keyPassphrase）。
因此带口令的秘钥必然解析失败。

### 修复
- 在 `ssh_auth.go` 抽取共享的 `buildAuthMethods`，复用已有的带口令 `parsePrivateKeyFile`，
  使「秘钥＋口令」认证与交互 SSH 会话完全一致。
- `SFTPSession.Connect` 与 `MonitorSession.Connect` 均改走该方法，保留
  `password` / `agent→password` 兼容分支。
- 新增 TDD 测试（`auth_test.go`）：生成真实带口令 ed25519 秘钥，断言正确 / 空 / 错口令三种结果。

### 验证
- `go build ./...`、`go vet ./session/` 无告警。
- `go test ./...` 通过（除根包 `TestStartPprofIfDev_ProductionSkip` 一例既有的环境性失败——
  6060 端口被运行中的 dev 实例占用，在干净 `origin/main` 上同样可复现，与本改动无关）。
