### PR TITLE
fix(history): join wrapped lines in command extraction to avoid truncation

### DIFF
--- a/frontend/src/composables/useTerminalInput.test.ts
+++ b/frontend/src/composables/useTerminalInput.test.ts
@@ -15,8 +15,11 @@ beforeAll(() => {
   }
 })
 
-function mkTerminal(opts: { cursorY?: number; lines: string[]; rows?: number } = { lines: [] }) {
+function mkTerminal(opts: {
+  cursorY?: number; lines: string[]; rows?: number; wrapped?: number[]
+} = { lines: [] }) {
   const { cursorY = 0, lines, rows = 24 } = opts
+  const wrapped = new Set(opts.wrapped ?? [])
   return {
     rows,
     buffer: {
@@ -25,6 +28,7 @@ function mkTerminal(opts: { cursorY?: number; lines: string[]; rows?: number } =
         baseY: 0,
         getLine: (y: number) => lines[y] === undefined ? undefined : {
           translateToString: () => lines[y],
+          isWrapped: () => wrapped.has(y),
         },
       },
     },
@@ -193,6 +197,46 @@ describe('useTerminalInput', () => {
       }), (cmd) => extracted.push(cmd))
       t.handleInput('\r')
       expect(extracted).toEqual([])
+    })
+
+    it('joins wrapped continuation rows into the full command', () => {
+      const extracted: string[] = []
+      // A long command that overflows the panel width wraps onto following
+      // rows (marked isWrapped). The history must reconstruct the whole
+      // command, not just the first row's tail after the prompt.
+      const t = makeInput(mkTerminal({
+        cursorY: 5,
+        lines: [
+          'user@host:~$ echo aaaa',
+          'bbbbbbbbbbbbbbbbbb',
+          'cccccccccccccccccccc',
+          'dddddddddddddddddd',
+          'eeeeeeeeeeeeeeeeeeee',
+        ],
+        wrapped: [1, 2, 3, 4],
+      }), (cmd) => extracted.push(cmd))
+      t.handleInput('\r')
+      expect(extracted).toEqual([
+        'echo aaaabbbbbbbbbbbbbbbbbbccccccccccccccccccccdddddddddddddddddd' +
+        'eeeeeeeeeeeeeeeeeeee',
+      ])
+    })
+
+    it('stops joining wrapped rows once a non-wrapped row is reached', () => {
+      const extracted: string[] = []
+      const t = makeInput(mkTerminal({
+        cursorY: 4,
+        lines: [
+          'user@host:~$ cat foo',
+          'bar',
+          'zz',
+        ],
+        // row 1 is the wrap of the prompt command; row 2 is a fresh command
+        // (not wrapped) and must NOT be appended.
+        wrapped: [1],
+      }), (cmd) => extracted.push(cmd))
+      t.handleInput('\r')
+      expect(extracted).toEqual(['cat foobar'])
     })
   })
 })

--- a/frontend/src/composables/useTerminalInput.ts
+++ b/frontend/src/composables/useTerminalInput.ts
@@ -55,27 +55,31 @@ export function useTerminalInput(terminal: Terminal | null, options: UseTerminal
       // Scan visible area from bottom to top — always finds the latest
       // prompt regardless of cursor position. (Cursor-based scanning was
       // tried in e4d31b7 but proved unreliable for prompt detection.)
-      const tryLine = (y: number): string | null => {
-        if (y < 0) return null
-        const line = buffer.getLine(y)
-        if (!line) return null
-        const rawText = line.translateToString().trim()
-        if (!rawText) return null
-        const cleanText = stripAnsi(rawText)
-        const match = cleanText.match(PROMPT_RE)
-        if (!match) return null
-        const command = match[2].trim()
-        if (command && !command.includes('__AI_DONE_') && command.length <= MAX_COMMAND_LENGTH) {
-          return command
-        }
-        return null
-      }
       const bottomY = (buffer.baseY ?? 0) + rows - 1
       for (let dy = 0; dy < rows; dy++) {
         const y = bottomY - dy
         if (y < 0) break
-        const hit = tryLine(y)
-        if (hit !== null) return hit
+        const line = buffer.getLine(y)
+        if (!line) continue
+        const rawText = line.translateToString().trim()
+        if (!rawText) continue
+        const cleanText = stripAnsi(rawText)
+        const match = cleanText.match(PROMPT_RE)
+        if (!match) continue
+        const command = match[2].trim()
+        if (!command || command.includes('__AI_DONE_')) continue
+        // A long command that overflows the panel width wraps onto the rows
+        // below the prompt. Walk down while each row is marked as a wrapped
+        // continuation (isWrapped) and append it so the full command is
+        // captured instead of being truncated at the wrap point (issue 639).
+        let full = command
+        for (let cy = y + 1; cy < bottomY; cy++) {
+          const cont = buffer.getLine(cy)
+          if (!cont || typeof cont.isWrapped !== 'function' || !cont.isWrapped()) break
+          full += stripAnsi(cont.translateToString().trim())
+        }
+        if (full.length > MAX_COMMAND_LENGTH) continue
+        return full
       }
     } catch {
       // Ignore errors


### PR DESCRIPTION
Closes #639

### Problem
Long commands that overflow the terminal panel width wrap onto multiple rows. Command-history extraction located the prompt row and captured only the text after the prompt on that single row, so the wrapped continuation lines were dropped and the recorded command was truncated exactly at the wrap point. This is most visible in broadcast mode, where panels are narrower.

### Fix
After locating the prompt row, walk downward and append each row that is marked as a wrapped continuation (`isWrapped()`) until the first non-wrapped row is reached. The full command is now captured instead of being truncated at the wrap point.

### Tests
- `joins wrapped continuation rows into the full command`
- `stops joining wrapped rows once a non-wrapped row is reached`

---

### 问题
命令超宽换行后会占据终端多行。历史命令提取只定位到提示符所在的行，仅捕获该行提示符之后的内容，导致换行续行丢失，历史中的命令在换行处被截断。广播模式下面板较窄时尤为明显。

### 修复
定位到提示符所在行后向下遍历，将每一行被标记为换行续行（`isWrapped()`）的内容依次拼接到命令末尾，直到遇到第一个非换行行，从而保留完整命令。

### 测试
- `joins wrapped continuation rows into the full command`
- `stops joining wrapped rows once a non-wrapped row is reached`