### PR TITLE
fix(highlight): highlight indented lines and paths with special chars

### DIFF
--- a/frontend/src/composables/useHighlight.test.ts
+++ b/frontend/src/composables/useHighlight.test.ts
@@ -5,6 +5,28 @@ import { highlight } from './useHighlight'
 // not exact bytes (the colour palette is intentionally allowed to evolve).
 
 describe('highlight()', () => {
+  it('highlights a path containing the + special char (issue #651)', () => {
+    const input = 'compiler /usr/local/gcc-11.5.0/bin/g++ -std=c++17\n'
+    const out = highlight(input)
+    // The path anchor consumes the preceding whitespace (`(?:^|\s)`), so the
+    // coloured span starts with a space.
+    expect(out).toContain('\x1b[35m /usr/local/gcc-11.5.0/bin/g++\x1b[24;39m')
+  })
+
+  it('highlights a path containing @ and ~ (issue #651)', () => {
+    const input = 'load /tmp/cache@1.tgz and ~/proj-2/app.exe now\n'
+    const out = highlight(input)
+    expect(out).toContain('\x1b[35m /tmp/cache@1.tgz\x1b[24;39m')
+    expect(out).toContain('\x1b[35m ~/proj-2/app.exe\x1b[24;39m')
+  })
+
+  it('does not treat a bare an+b expression as a path (issue #651)', () => {
+    const input = 'compute an+b + c then d+e\n'
+    const out = highlight(input)
+    // Not starting with `/` or `~/` — must not match the path pattern.
+    expect(out).not.toContain('\x1b[35m')
+  })
+
   it('highlights braces in plain prose', () => {
     const out = highlight('hello {world}')
     expect(out).toContain('\x1b[95m') // brace colour from palette
@@ -37,8 +59,23 @@ describe('highlight()', () => {
   })
 
   it('skips indented code lines (4+ leading spaces)', () => {
+    // 4-space indented lines are treated as code: braces stay uncoloured
+    // (their SGR resets confuse TUI apps), but other tokens are highlighted.
     const input = '    let {a} = obj\n    const b = {c: 1}\n'
-    expect(highlight(input)).toBe(input)
+    const out = highlight(input)
+    // No brace (bright magenta) colour injected anywhere on the indented lines.
+    expect(out).not.toContain('\x1b[95m')
+    // Non-brace tokens still get highlighted (the `1` becomes bright cyan).
+    expect(out).toContain('\x1b[96m1\x1b[24;39m')
+  })
+
+  it('highlights the IP in 4-space-indented `ip a` output (issue #644)', () => {
+    // ip a prints `inet …` lines indented by 4 spaces; those used to be
+    // skipped entirely, so the masked IP got no colour.
+    const input = '    inet 10.1.0.13/24 brd 10.1.0.255 scope global dynamic eth0\n'
+    const out = highlight(input)
+    expect(out).toContain('\x1b[32m10.1.0.13\x1b[24;39m')
+    expect(out).toContain('\x1b[32m10.1.0.255\x1b[24;39m')
   })
 
   it('still highlights prose after a fence closes', () => {

--- a/frontend/src/composables/useHighlight.ts
+++ b/frontend/src/composables/useHighlight.ts
@@ -59,7 +59,10 @@ const PATTERNS: { sgr: string; regexes: RegExp[] }[] = [
   // feature unsupported by the JavaScriptCore in macOS ≤12.3 (Safari 15.4
   // WebView), where the whole module fails to parse and the terminal shows
   // a black screen. Anchor the start with a consuming (^|\s) group instead.
-  { sgr: C.path,    regexes: [/(?:^|\s)(?:\/|~\/)[\w.\/-]+(?=[\s:;"')\]}]|$)/g] },
+  // Character class includes `+`, `~`, `@` so paths like
+  // `/usr/local/gcc-11.5.0/bin/g++` or `/tmp/cache@1.tgz` are recognised
+  // whole (issue #651), not truncated at the first special symbol.
+  { sgr: C.path,    regexes: [/(?:^|\s)(?:\/|~\/)[\w.+~@/-]+(?=[\s:;"')\]}]|$)/g] },
   { sgr: C.datetime, regexes: [
     /\b\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}(?::\d{2})?(?:[.,]\d+)?Z?\b/g,
     /\b(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun)\s+(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s+\d{1,2}\s+\d{2}:\d{2}:\d{2}\s+\d{4}\b/g,
@@ -104,10 +107,13 @@ function sgrFgEffect(seq: string): 'set' | 'clear' | 'unchanged' {
   return effect
 }
 
-function highlightPlainSegment(text: string): string {
+type HighlightSegmentOpts = { skipBrace?: boolean }
+
+function highlightPlainSegment(text: string, opts: HighlightSegmentOpts = {}): string {
   type MatchEntry = { start: number; end: number; sgr: string }
   const allMatches: MatchEntry[] = []
-  for (const { sgr, regexes } of PATTERNS) {
+  const patterns = opts.skipBrace ? PATTERNS.filter((p) => p.sgr !== C.brace) : PATTERNS
+  for (const { sgr, regexes } of patterns) {
     for (const regex of regexes) {
       regex.lastIndex = 0
       let m: RegExpExecArray | null
@@ -138,7 +144,7 @@ function highlightPlainSegment(text: string): string {
   return highlighted
 }
 
-function highlightPlainText(text: string): string {
+function highlightPlainText(text: string, opts: HighlightSegmentOpts = {}): string {
   const segments = segmentText(text)
   let result = ''
   // Track whether the upstream application already set a non-default
@@ -155,7 +161,7 @@ function highlightPlainText(text: string): string {
       }
       result += seg.text
     } else if (!colored) {
-      result += highlightPlainSegment(seg.text)
+      result += highlightPlainSegment(seg.text, opts)
     } else {
       result += seg.text
     }
@@ -199,7 +205,12 @@ export function highlight(text: string): string {
           fenceChar = m[1][0] as '`' | '~'
           result += line
         } else if (INDENTED_CODE_LINE.test(line)) {
-          result += line
+          // Indented lines used to pass through entirely, which left 4-space
+          // indented command output (e.g. `ip a`) with no highlighting at all
+          // (issue #644). Brace/bracket colour still injects SGR noise that
+          // some TUI apps misinterpret, so keep skipping it here — but colour
+          // the remaining tokens (IP, number, path, …) normally.
+          result += highlightPlainText(line, { skipBrace: true })
         } else {
           result += highlightPlainText(line)
         }


### PR DESCRIPTION
## Summary

Fix two terminal syntax-highlighting bugs in `frontend/src/composables/useHighlight.ts`.

**Issue 644** — Masked IP in 4-space-indented output (e.g. `ip a`) was not highlighted at all. The `inet 10.1.0.13/24 …` lines start with 4 spaces, so the `INDENTED_CODE_LINE` heuristic treated them as indented code and passed them through untouched (skipping every highlight on the line). Indented lines are now highlighted normally, while brace/bracket colour is still skipped to keep TUI apps (vim/k9s) free of SGR redraw noise.

**Issue 651** — Paths containing special characters like `+`/`@`/`~` were never recognised as paths: `/usr/local/gcc-11.5.0/bin/g++` and `/tmp/cache@1.tgz` got truncated at the first `+`/`@`. The path character class now includes `+ ~ @`, so such paths are matched whole.

Also adds regression tests for both cases.

## Changes

- `frontend/src/composables/useHighlight.ts`: thread a `{ skipBrace }` option through `highlightPlainSegment`/`highlightPlainText`; apply it to indented lines to colour non-brace tokens while keeping brackets untouched; broaden the path character class to `[\w.+~@/-]`.
- `frontend/src/composables/useHighlight.test.ts`: update the indented-code expectation; add `ip a`, `g++`/`@`-path, and no-false-positive cases.

## Test

`npx vitest run` — 246 passed (26 files), no regressions.

---
## 摘要

修复前端 `frontend/src/composables/useHighlight.ts` 里两个终端语法高亮问题。

**Issue 644** — 带掩码的 IP 出现在 4 空格缩进输出（如 `ip a`）里时毫无高亮。`inet 10.1.0.13/24 …` 这类行以 4 空格开头，被 `INDENTED_CODE_LINE` 启发式当成缩进代码整行透传，整行所有高亮都被跳过。现在缩进行照常高亮，但花括号/中括号着色仍被跳过，避免给 TUI 应用（vim/k9s）制造 SGR 重绘噪声。

**Issue 651** — 含 `+`/`@`/`~` 等特殊符号的路径从未被识别为路径：`/usr/local/gcc-11.5.0/bin/g++`、`/tmp/cache@1.tgz` 在第一个 `+`/`@` 处就被切断。路径字符集现在加入 `+ ~ @`，此类路径可被完整匹配。

同时为两个问题补充回归测试。

## 变更

- `frontend/src/composables/useHighlight.ts`：给 `highlightPlainSegment`/`highlightPlainText` 增加 `{ skipBrace }` 选项；对缩进行应用它，使括号不着色而其余 token 正常高亮；路径字符集扩为 `[\w.+~@/-]`。
- `frontend/src/composables/useHighlight.test.ts`：更新缩进代码断言；新增 `ip a`、`g++`/`@` 路径、不误判用例。

## 测试

`npx vitest run` — 246 通过（26 个文件），无回归。


## Related issues

Closes #644
Closes #651

