### PR TITLE
feat(session): add raw TCP terminal session

### DIFF
--- a/backend/session/manager.go
+++ b/backend/session/manager.go
@@ -70,6 +70,9 @@ func (sm *SessionManager) Create(sessionType string, config ConnectionConfig) (S
 	case "serial":
 		s = NewSerialSession(config.ID)
 
+	case "tcp":
+		s = NewTCPSession(config.ID)
+
 	case "redis":
 		s = NewRedisSession(config.ID)
 

--- a/backend/session/tcp_session.go
+++ b/backend/session/tcp_session.go
@@ -1,0 +1,226 @@
+package session
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"sync"
+	"time"
+
+	"golang.org/x/text/encoding"
+	"golang.org/x/text/transform"
+)
+
+// TCPSession is a general-purpose "raw TCP" console: it opens a plain TCP
+// socket to host:port and shuttles raw bytes between it and the terminal with
+// no protocol negotiation. It is the modern stand-in for networking to a
+// device that speaks a plaintext/terminal protocol (serial-debug ports,
+// telnet-style control planes) without committing to a specific negotiation.
+// Reuses the same byte-stream structure as the serial session, including the
+// optional byte-helper options (encoding / newline / local echo).
+type TCPSession struct {
+	baseSession
+	conn     net.Conn
+	quit     chan struct{}
+	quitOnce sync.Once
+
+	encMu          sync.RWMutex
+	enc            encoding.Encoding
+	decoder        *encoding.Decoder
+	encoder        *encoding.Encoder
+	decodeLeftover []byte
+	decodeScratch  []byte
+	encScratch     []byte
+
+	newlineMode string // "cr" (default, no translation) | "crlf"
+	localEcho   bool
+}
+
+func NewTCPSession(id string) *TCPSession {
+	return &TCPSession{
+		baseSession: baseSession{
+			id:          id,
+			sessionType: "tcp",
+			status:      StatusDisconnected,
+		},
+		quit: make(chan struct{}),
+	}
+}
+
+func (s *TCPSession) Connect(config ConnectionConfig) error {
+	s.SetLogOnConnect(config.LogOnConnect)
+	if config.Host == "" {
+		s.setStatus(StatusError)
+		return fmt.Errorf("tcp host is required")
+	}
+	port := config.Port
+	if port <= 0 {
+		port = 23
+	}
+	s.newlineMode = config.NewlineMode
+	s.localEcho = config.LocalEcho
+	s.setupEncoding(config.Encoding)
+	s.setStatus(StatusConnecting)
+	s.title = fmt.Sprintf("%s:%d", config.Host, port)
+
+	addr := net.JoinHostPort(config.Host, fmt.Sprintf("%d", port))
+	conn, err := net.DialTimeout("tcp", addr, 10*time.Second)
+	if err != nil {
+		s.setStatus(StatusError)
+		return fmt.Errorf("tcp dial %s: %w", addr, err)
+	}
+	// conn is assigned once before readLoop starts; Write() on a closed conn
+	// returns an error, matching the SSH/Telnet convention of not nil-ing
+	// closed handles.
+	s.conn = conn
+	s.setStatus(StatusConnected)
+
+	go s.readLoop()
+	return nil
+}
+
+// setupEncoding configures the character encoding for this session.
+// name: "" / "utf-8" (passthrough) | "gbk" | "gb2312" | "gb18030" |
+// "big5" | "shift-jis" | "euc-jp" | "euc-kr".
+func (s *TCPSession) setupEncoding(name string) {
+	enc := encodingByName(name)
+	s.encMu.Lock()
+	defer s.encMu.Unlock()
+	s.enc = enc
+	if enc == nil {
+		s.decoder = nil
+		s.encoder = nil
+	} else {
+		s.decoder = enc.NewDecoder()
+		s.encoder = enc.NewEncoder()
+	}
+	s.decodeLeftover = nil
+}
+
+// decodeOutput converts a chunk of remote bytes to UTF-8 using the configured
+// decoder. Partial trailing multibyte sequences are buffered until the next
+// call. Must only be called from the single readLoop goroutine.
+func (s *TCPSession) decodeOutput(data []byte) []byte {
+	s.encMu.Lock()
+	defer s.encMu.Unlock()
+	if s.decoder == nil {
+		return data
+	}
+	s.decodeScratch = s.decodeScratch[:0]
+	s.decodeScratch = append(s.decodeScratch, s.decodeLeftover...)
+	s.decodeScratch = append(s.decodeScratch, data...)
+	src := s.decodeScratch
+
+	var out []byte
+	dst := make([]byte, 8192)
+	for {
+		nDst, nSrc, err := s.decoder.Transform(dst, src, false)
+		out = append(out, dst[:nDst]...)
+		src = src[nSrc:]
+		if err == transform.ErrShortDst {
+			continue
+		}
+		break
+	}
+	if len(src) > 0 {
+		s.decodeLeftover = append(s.decodeLeftover[:0], src...)
+	} else {
+		s.decodeLeftover = src[:0]
+	}
+	return out
+}
+
+// encodeInput converts user keystrokes (UTF-8) to the configured encoding
+// before writing to the remote. Each call handles a complete UTF-8 input.
+func (s *TCPSession) encodeInput(data []byte) []byte {
+	s.encMu.RLock()
+	encoder := s.encoder
+	s.encMu.RUnlock()
+	if encoder == nil {
+		return data
+	}
+	encoder.Reset()
+	s.encScratch = s.encScratch[:0]
+	nDst, _, err := encoder.Transform(s.encScratch, data, true)
+	if err != nil && err != transform.ErrShortSrc {
+		return data
+	}
+	return s.encScratch[:nDst]
+}
+
+func (s *TCPSession) readLoop() {
+	// 16 KiB reused read buffer; emitData copies the bytes so buf[:n] can be
+	// handed off without an extra allocation.
+	buf := make([]byte, 16384)
+	for {
+		select {
+		case <-s.quit:
+			return
+		default:
+		}
+		n, err := s.conn.Read(buf)
+		if n > 0 {
+			s.emitData(s.decodeOutput(buf[:n]))
+		}
+		if err != nil {
+			if err != io.EOF {
+				s.emitData([]byte(fmt.Sprintf("\r\n\x1b[31m[TCP read error: %v]\x1b[0m\r\n", err)))
+			} else {
+				s.emitData(disconnectNotice("Connection closed by remote host."))
+			}
+			s.Disconnect()
+			return
+		}
+	}
+}
+
+func (s *TCPSession) Write(data []byte) error {
+	if s.conn == nil {
+		return fmt.Errorf("tcp connection not connected")
+	}
+
+	encoded := s.encodeInput(data)
+
+	// Translate \r to \r\n when newline mode is CRLF.
+	if s.newlineMode == "crlf" {
+		var translated []byte
+		for _, b := range encoded {
+			if b == '\r' {
+				translated = append(translated, '\r', '\n')
+			} else {
+				translated = append(translated, b)
+			}
+		}
+		encoded = translated
+	}
+
+	_, err := s.conn.Write(encoded)
+
+	// Local echo: show typed characters in terminal when remote doesn't echo.
+	if err == nil && s.localEcho {
+		s.emitData(data)
+	}
+
+	return err
+}
+
+func (s *TCPSession) Disconnect() error {
+	s.quitOnce.Do(func() {
+		close(s.quit)
+		if s.conn != nil {
+			_ = s.conn.Close()
+		}
+		s.setStatus(StatusDisconnected)
+	})
+	return nil
+}
+
+func (s *TCPSession) Resize(cols, rows int) error {
+	// Raw TCP has no terminal-size negotiation; store for consistency (no-op).
+	s.SetPendingSize(cols, rows)
+	return nil
+}
+
+func (s *TCPSession) IsConnected() bool {
+	return s.Status() == StatusConnected
+}

--- a/backend/session/test_connection.go
+++ b/backend/session/test_connection.go
@@ -40,6 +40,8 @@ func ProbeConnection(config ConnectionConfig) (string, error) {
 		return probeSSH(config)
 	case "telnet":
 		return probeTelnet(config)
+	case "tcp":
+		return probeTCP(config)
 	case "ftp":
 		return probeFTP(config)
 	case "s3":
@@ -93,6 +95,17 @@ func probeTelnet(config ConnectionConfig) (string, error) {
 	}
 	conn.Close()
 	return fmt.Sprintf("telnet: %s:%d reachable", config.Host, config.Port), nil
+}
+
+// probeTCP checks that a plain TCP socket to host:port can be established.
+func probeTCP(config ConnectionConfig) (string, error) {
+	addr := net.JoinHostPort(config.Host, strconv.Itoa(config.Port))
+	conn, err := net.DialTimeout("tcp", addr, 15*time.Second)
+	if err != nil {
+		return "", fmt.Errorf("tcp: %w", err)
+	}
+	conn.Close()
+	return fmt.Sprintf("tcp: %s:%d reachable", config.Host, config.Port), nil
 }
 
 func probeFTP(config ConnectionConfig) (string, error) {

--- a/frontend/src/components/ConnectionForm.vue
+++ b/frontend/src/components/ConnectionForm.vue
@@ -82,7 +82,7 @@
                 <el-radio-button v-if="isElasticsearch" label="apikey">{{ t('conn.esAuthApiKey') }}</el-radio-button>
               </el-radio-group>
             </el-form-item>
-            <el-form-item v-if="form.authType !== 'identity' && form.type !== 'vnc' && form.type !== 'spice' && !(form.type === 'database' && form.dbType === 'rqlite') && form.type !== 'local' && form.type !== 'serial' && form.type !== 'k8s' && form.type !== 'container' && !isEsApiKey" :label="form.type === 's3' ? 'Access Key' : t('conn.user')">
+            <el-form-item v-if="form.authType !== 'identity' && form.type !== 'vnc' && form.type !== 'spice' && !(form.type === 'database' && form.dbType === 'rqlite') && form.type !== 'local' && form.type !== 'serial' && form.type !== 'tcp' && form.type !== 'k8s' && form.type !== 'container' && !isEsApiKey" :label="form.type === 's3' ? 'Access Key' : t('conn.user')">
               <el-input v-model="form.user" :placeholder="form.type === 's3' ? 'Access Key ID' : t('conn.userPlaceholder')" />
             </el-form-item>
             <el-form-item
@@ -106,7 +106,7 @@
                 </el-select>
               </el-form-item>
             </template>
-            <el-form-item v-if="form.type !== 'local' && form.type !== 'serial' && form.type !== 'k8s' && form.type !== 'container' && form.authType !== 'identity' && ((form.authType === 'password' && form.type !== 'rdp') || (form.type === 'rdp' && !form.rdpEnableNLA) || form.type === 'vnc' || form.type === 'spice' || form.type === 'database' || form.type === 'telnet' || form.type === 'ftp' || form.type === 'smb' || form.type === 'webdav' || form.type === 's3') && !(form.type === 'database' && form.dbType === 'rqlite')" :label="form.type === 's3' ? 'Secret Key' : (isEsApiKey ? t('conn.esApiKey') : t('conn.password'))">
+            <el-form-item v-if="form.type !== 'local' && form.type !== 'serial' && form.type !== 'tcp' && form.type !== 'k8s' && form.type !== 'container' && form.authType !== 'identity' && ((form.authType === 'password' && form.type !== 'rdp') || (form.type === 'rdp' && !form.rdpEnableNLA) || form.type === 'vnc' || form.type === 'spice' || form.type === 'database' || form.type === 'telnet' || form.type === 'ftp' || form.type === 'smb' || form.type === 'webdav' || form.type === 's3') && !(form.type === 'database' && form.dbType === 'rqlite')" :label="form.type === 's3' ? 'Secret Key' : (isEsApiKey ? t('conn.esApiKey') : t('conn.password'))">
               <el-input v-model="form.password" type="password" show-password :key="passwordInputKey" :placeholder="form.type === 's3' ? 'Secret Access Key' : (isEsApiKey ? t('conn.esApiKeyPlaceholder') : '')" />
             </el-form-item>
             <template v-if="isElasticsearch">
@@ -398,7 +398,7 @@
               </div>
             </el-form-item>
             <el-form-item
-              v-if="form.type === 'ssh' || form.type === 'telnet' || form.type === 'serial' || form.type === 'mosh' || form.type === 'local'"
+              v-if="form.type === 'ssh' || form.type === 'telnet' || form.type === 'serial' || form.type === 'mosh' || form.type === 'local' || form.type === 'tcp'"
               :label="t('conn.encoding')"
             >
               <el-select v-model="form.encoding" placeholder="Unicode (UTF-8)">
@@ -426,7 +426,7 @@
                 </el-select>
               </el-form-item>
             </template>
-            <template v-if="form.type === 'telnet' || form.type === 'serial'">
+            <template v-if="form.type === 'telnet' || form.type === 'serial' || form.type === 'tcp'">
               <el-form-item :label="t('conn.localEcho')">
                 <el-switch v-model="form.localEcho" />
               </el-form-item>
@@ -438,7 +438,7 @@
               </el-form-item>
             </template>
             <el-form-item
-              v-if="form.type === 'ssh' || form.type === 'telnet' || form.type === 'serial' || form.type === 'mosh'"
+              v-if="form.type === 'ssh' || form.type === 'telnet' || form.type === 'serial' || form.type === 'mosh' || form.type === 'tcp'"
               :label="t('conn.backspaceKey')"
             >
               <el-select v-model="form.backspaceKey">
@@ -517,7 +517,7 @@
               </el-select>
             </el-form-item>
             <el-form-item
-              v-if="['ssh','telnet','serial','mosh','local'].includes(form.type)"
+              v-if="['ssh','telnet','serial','mosh','local','tcp'].includes(form.type)"
               :label="t('conn.logOnConnect')"
             >
               <el-switch v-model="form.logOnConnect" />
@@ -591,7 +591,7 @@ import type { ConnectionConfig, PostLoginExpectStep } from '../types/session'
 import { OpenFileDialog, GetPlatform, ListSerialPorts, TestConnection } from '../../bindings/github.com/ys-ll/uniterm/app'
 import { ElInput } from 'element-plus'
 import { msg } from '../services/message'
-import { Plus, Trash2, ChevronDown, ChevronRight, FolderOpen, RefreshCw, Terminal, Monitor, Database, DatabaseZap, Layers, DatabaseSearch, SquareTerminal, Zap, Laptop, Cable, FolderUp, HardDrive, Cloud, Globe, MonitorCloud, MonitorSmartphone, Boxes, ShipWheel, AppWindow, CircleCheck, CircleX } from '@lucide/vue'
+import { Plus, Trash2, ChevronDown, ChevronRight, FolderOpen, RefreshCw, Terminal, Monitor, Database, DatabaseZap, Layers, DatabaseSearch, SquareTerminal, Zap, Laptop, Cable, FolderUp, HardDrive, Cloud, Globe, MonitorCloud, MonitorSmartphone, Boxes, ShipWheel, AppWindow, ArrowLeftRight, CircleCheck, CircleX } from '@lucide/vue'
 import { listContexts } from '../services/k8sClient'
 import type { K8sContextInfo } from '../types/k8s'
 import IdentityEditDialog from './IdentityEditDialog.vue'
@@ -641,6 +641,7 @@ const allSubTypes = computed((): Record<string, SubTypeInfo[]> => ({
     { type: 'mosh', label: 'Mosh', icon: Zap },
     { type: 'local', label: t('conn.localTerminal'), icon: Laptop },
     { type: 'serial', label: t('serial.title'), icon: Cable },
+    { type: 'tcp', label: 'TCP', icon: ArrowLeftRight },
   ],
   filetransfer: [
     { type: 'ftp', label: 'FTP', icon: FolderUp },
@@ -736,7 +737,7 @@ const showAdvanced = ref(false)
 
 // Connection types that support the "test connection" button (issue #377).
 // local/serial/mosh/vnc/rdp/spice/x11-desktop don't have a non-interactive probe.
-const TESTABLE_TYPES = ['ssh', 'telnet', 'ftp', 's3', 'webdav', 'smb', 'database', 'k8s', 'container']
+const TESTABLE_TYPES = ['ssh', 'telnet', 'ftp', 's3', 'webdav', 'smb', 'database', 'k8s', 'container', 'tcp']
 // Test-connection result state: 'checking' shows a spinner; 'success'/'error'
 // keep a colored status icon on the button until the next test or a reopen.
 const testStatus = ref<'idle' | 'checking' | 'success' | 'error'>('idle')
@@ -1096,6 +1097,7 @@ watch(() => form.type, (newType) => {
   else if (newType === 'database') form.port = 3306
   else if (newType === 'ftp') form.port = 21
   else if (newType === 'smb') form.port = 445
+  else if (newType === 'tcp') form.port = 23
   if (REMOTE_TYPES.includes(newType) || newType === 'database') {
     form.authType = 'password'
   }

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -298,6 +298,7 @@
       <MenuItem v-if="selectedConn && selectedConn.type === 'mosh'" @click="doConnect">{{ t('sidebar.connectMosh') }}</MenuItem>
       <MenuItem v-if="selectedConn && selectedConn.type === 'local'" @click="doConnect">{{ t('sidebar.connectLocal') }}</MenuItem>
       <MenuItem v-if="selectedConn && selectedConn.type === 'serial'" @click="emit('connectSerial')">{{ t('sidebar.connectSerial') }}</MenuItem>
+      <MenuItem v-if="selectedConn && selectedConn.type === 'tcp'" @click="doConnect">{{ t('sidebar.connectTcp') }}</MenuItem>
       <!-- File Transfer -->
       <MenuItem v-if="selectedConn && selectedConn.type === 'ssh'" @click="doConnectSFTP">{{ t('sidebar.connectSftp') }}</MenuItem>
       <MenuItem v-if="selectedConn && selectedConn.type === 'ftp'" @click="doConnectFTP">{{ t('sidebar.connectFtp') }}</MenuItem>
@@ -447,7 +448,7 @@
 
 <script setup lang="ts">
 import { ref, onMounted, onUnmounted, computed, watch, nextTick, provide } from 'vue'
-import { X, ChevronRight, ChevronDown, Filter, Check, Network, Zap, Clock, Plus, Palette, SquareTerminal, Terminal, FolderUp, HardDrive, Cloud, Globe, Monitor, MonitorCloud, MonitorSmartphone, Database, DatabaseZap, Layers, DatabaseSearch, Activity, Laptop, Cable, Pencil, MoreHorizontal, FolderTree, ShipWheel, Boxes, AppWindow } from '@lucide/vue'
+import { X, ChevronRight, ChevronDown, Filter, Check, Network, Zap, Clock, Plus, Palette, SquareTerminal, Terminal, FolderUp, HardDrive, Cloud, Globe, Monitor, MonitorCloud, MonitorSmartphone, Database, DatabaseZap, Layers, DatabaseSearch, Activity, Laptop, Cable, Pencil, MoreHorizontal, FolderTree, ShipWheel, Boxes, AppWindow, ArrowLeftRight } from '@lucide/vue'
 import { ElMessageBox } from 'element-plus'
 import { msg } from '../services/message'
 import { useConnectionStore } from '../stores/connectionStore'
@@ -1807,6 +1808,7 @@ function connIcon(conn: ConnectionConfig) {
     case 'mosh': return Zap
     case 'local': return Laptop
     case 'serial': return Cable
+    case 'tcp': return ArrowLeftRight
     case 'sftp': return FolderUp
     case 'ftp': return FolderUp
     case 'smb': return HardDrive

--- a/frontend/src/components/StartTabContent.vue
+++ b/frontend/src/components/StartTabContent.vue
@@ -96,6 +96,7 @@
                 <el-icon v-else-if="config.type === 'mosh'"><Zap :size="28" /></el-icon>
                 <el-icon v-else-if="config.type === 'local'"><Laptop :size="28" /></el-icon>
                 <el-icon v-else-if="config.type === 'serial'"><Cable :size="28" /></el-icon>
+                <el-icon v-else-if="config.type === 'tcp'"><ArrowLeftRight :size="28" /></el-icon>
                 <el-icon v-else-if="config.type === 'ftp' || config.type === 'sftp'"><FolderUp :size="28" /></el-icon>
                 <el-icon v-else-if="config.type === 'smb'"><HardDrive :size="28" /></el-icon>
                 <el-icon v-else-if="config.type === 's3'"><Cloud :size="28" /></el-icon>
@@ -184,6 +185,7 @@
                 <el-icon v-else-if="config.type === 'mosh'"><Zap :size="28" /></el-icon>
                 <el-icon v-else-if="config.type === 'local'"><Laptop :size="28" /></el-icon>
                 <el-icon v-else-if="config.type === 'serial'"><Cable :size="28" /></el-icon>
+                <el-icon v-else-if="config.type === 'tcp'"><ArrowLeftRight :size="28" /></el-icon>
                 <el-icon v-else-if="config.type === 'ftp' || config.type === 'sftp'"><FolderUp :size="28" /></el-icon>
                 <el-icon v-else-if="config.type === 'smb'"><HardDrive :size="28" /></el-icon>
                 <el-icon v-else-if="config.type === 's3'"><Cloud :size="28" /></el-icon>
@@ -259,6 +261,7 @@
               <el-icon v-else-if="config.type === 'mosh'"><Zap :size="28" /></el-icon>
               <el-icon v-else-if="config.type === 'local'"><Laptop :size="28" /></el-icon>
               <el-icon v-else-if="config.type === 'serial'"><Cable :size="28" /></el-icon>
+                <el-icon v-else-if="config.type === 'tcp'"><ArrowLeftRight :size="28" /></el-icon>
               <el-icon v-else-if="config.type === 'ftp' || config.type === 'sftp'"><FolderUp :size="28" /></el-icon>
               <el-icon v-else-if="config.type === 'smb'"><HardDrive :size="28" /></el-icon>
               <el-icon v-else-if="config.type === 's3'"><Cloud :size="28" /></el-icon>
@@ -321,6 +324,7 @@
       <MenuItem v-if="contextMenuConfig && contextMenuConfig.type === 'mosh'" :class="{ disabled: selectedIds.size > 1 }" @click="selectedIds.size <= 1 && doConnect(contextMenuConfig, $event)">{{ t('sidebar.connectMosh') }}</MenuItem>
       <MenuItem v-if="contextMenuConfig && contextMenuConfig.type === 'local'" :class="{ disabled: selectedIds.size > 1 }" @click="selectedIds.size <= 1 && doConnect(contextMenuConfig, $event)">{{ t('sidebar.connectLocal') }}</MenuItem>
       <MenuItem v-if="contextMenuConfig && contextMenuConfig.type === 'serial'" :class="{ disabled: selectedIds.size > 1 }" @click="selectedIds.size <= 1 && doConnectSerial(contextMenuConfig, $event)">{{ t('sidebar.connectSerial') }}</MenuItem>
+      <MenuItem v-if="contextMenuConfig && contextMenuConfig.type === 'tcp'" :class="{ disabled: selectedIds.size > 1 }" @click="selectedIds.size <= 1 && doConnect(contextMenuConfig, $event)">{{ t('sidebar.connectTcp') }}</MenuItem>
       <!-- File Transfer -->
       <MenuItem v-if="contextMenuConfig && contextMenuConfig.type === 'ssh'" :class="{ disabled: selectedIds.size > 1 }" @click="selectedIds.size <= 1 && doConnectSftp(contextMenuConfig)">{{ t('sidebar.connectSftp') }}</MenuItem>
       <MenuItem v-if="contextMenuConfig && contextMenuConfig.type === 'ftp'" :class="{ disabled: selectedIds.size > 1 }" @click="selectedIds.size <= 1 && doConnectFtp(contextMenuConfig)">{{ t('sidebar.connectFtp') }}</MenuItem>
@@ -431,7 +435,7 @@ import Menu from './Menu.vue'
 import MenuItem from './MenuItem.vue'
 import MenuSubmenu from './MenuSubmenu.vue'
 import MenuDivider from './MenuDivider.vue'
-import { Filter, Plus, Laptop, Cable, SquareTerminal, Terminal, Database, DatabaseZap, Layers, DatabaseSearch, Monitor, MonitorSmartphone, MonitorCloud, FolderUp, HardDrive, Cloud, Globe, Server, Folder, FolderOpen, Zap, MoreHorizontal, ChevronDown, ShipWheel, Boxes, AppWindow } from '@lucide/vue'
+import { Filter, Plus, Laptop, Cable, SquareTerminal, Terminal, Database, DatabaseZap, Layers, DatabaseSearch, Monitor, MonitorSmartphone, MonitorCloud, FolderUp, HardDrive, Cloud, Globe, Server, Folder, FolderOpen, Zap, MoreHorizontal, ChevronDown, ShipWheel, Boxes, AppWindow, ArrowLeftRight } from '@lucide/vue'
 
 const props = defineProps<{
   tab: StartTab

--- a/frontend/src/components/TabItem.vue
+++ b/frontend/src/components/TabItem.vue
@@ -123,7 +123,7 @@ import Menu from './Menu.vue'
 import MenuItem from './MenuItem.vue'
 import MenuDivider from './MenuDivider.vue'
 import { Clipboard } from '@wailsio/runtime'
-import { SquareTerminal, Laptop, FolderUp, HardDrive, Cloud, Globe, Monitor, MonitorCloud, MonitorSmartphone, Settings, Database, DatabaseZap, Layers, DatabaseSearch, Activity, Terminal, Zap, X, ArrowDownUp, LayoutDashboard, Cable, SquarePlus, Lock, ShipWheel, Box, Boxes, AppWindow } from '@lucide/vue'
+import { SquareTerminal, Laptop, FolderUp, HardDrive, Cloud, Globe, Monitor, MonitorCloud, MonitorSmartphone, Settings, Database, DatabaseZap, Layers, DatabaseSearch, Activity, Terminal, Zap, X, ArrowDownUp, LayoutDashboard, Cable, SquarePlus, Lock, ShipWheel, Box, Boxes, AppWindow, ArrowLeftRight } from '@lucide/vue'
 
 const props = defineProps<{
   tab: TerminalTab | SettingsTab | SFTPTab | RDPTab | VNCTab | SPICETab | DBTab | MonitorTab | WorkspaceTab
@@ -201,6 +201,7 @@ const tabIcon = computed(() => {
     if (panel?.type === 'k8s-exec' || panel?.type === 'container-exec') return Box
     if (panel?.type === 'local') return Laptop
     if (panel?.type === 'serial') return Cable
+    if (panel?.type === 'tcp') return ArrowLeftRight
     if (panel?.type === 'telnet') return Terminal
     if (panel?.type === 'mosh') return Zap
     return SquareTerminal
@@ -267,7 +268,7 @@ const canDuplicate = computed(() => {
 })
 
 // Reconnectable panels — terminal types that Panel.vue can re-initiate.
-const TTY_RECONNECT_TYPES: readonly string[] = ['ssh', 'telnet', 'serial', 'mosh', 'local', 'k8s-exec', 'container-exec']
+const TTY_RECONNECT_TYPES: readonly string[] = ['ssh', 'telnet', 'serial', 'mosh', 'local', 'tcp', 'k8s-exec', 'container-exec']
 
 // Whether the tab has a right-click 「重连」(Reconnect). Terminal panels are
 // re-initiated by Panel.vue via the 'panel:reconnect' event; desktop-protocol

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -718,6 +718,7 @@
   "session.logStopped": "Protokoll gestoppt, Datei: {path}",
   "session.logFailed": "Protokoll-Umschaltung fehlgeschlagen: {error}",
   "sidebar.connectSerial": "Seriell",
+  "sidebar.connectTcp": "Verbinden mit TCP",
   "monitor.performance": "Leistung",
   "monitor.processes": "Prozesse",
   "monitor.system": "Systeminfo",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -718,6 +718,7 @@
   "session.logStopped": "Log stopped, saved to {path}",
   "session.logFailed": "Failed to toggle log: {error}",
   "sidebar.connectSerial": "Serial",
+  "sidebar.connectTcp": "Connect TCP",
   "monitor.performance": "Performance",
   "monitor.processes": "Processes",
   "monitor.system": "System Info",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -718,6 +718,7 @@
   "session.logStopped": "Registro detenido, archivo en {path}",
   "session.logFailed": "Fallo al cambiar el registro: {error}",
   "sidebar.connectSerial": "Conectar serie",
+  "sidebar.connectTcp": "Conectar TCP",
   "monitor.performance": "Rendimiento",
   "monitor.processes": "Procesos",
   "monitor.system": "Información del Sistema",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -718,6 +718,7 @@
   "session.logStopped": "Enregistrement arrêté, fichier : {path}",
   "session.logFailed": "Échec du basculement du log : {error}",
   "sidebar.connectSerial": "Série",
+  "sidebar.connectTcp": "Connecter TCP",
   "monitor.performance": "Performances",
   "monitor.processes": "Processus",
   "monitor.system": "Infos système",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -718,6 +718,7 @@
   "session.logStopped": "記録を停止しました。{path} に保存",
   "session.logFailed": "ログの切り替えに失敗: {error}",
   "sidebar.connectSerial": "シリアル",
+  "sidebar.connectTcp": "TCP へ接続",
   "monitor.performance": "パフォーマンス",
   "monitor.processes": "プロセス",
   "monitor.system": "システム情報",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -718,6 +718,7 @@
   "session.logStopped": "기록 중지, {path}에 저장됨",
   "session.logFailed": "로그 전환 실패: {error}",
   "sidebar.connectSerial": "시리얼",
+  "sidebar.connectTcp": "TCP 연결",
   "monitor.performance": "성능",
   "monitor.processes": "프로세스",
   "monitor.system": "시스템 정보",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -718,6 +718,7 @@
   "session.logStopped": "Запись остановлена, файл: {path}",
   "session.logFailed": "Не удалось переключить журнал: {error}",
   "sidebar.connectSerial": "Подключиться по серийному порту",
+  "sidebar.connectTcp": "Подключиться TCP",
   "monitor.performance": "Производительность",
   "monitor.processes": "Процессы",
   "monitor.system": "Системная информация",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -718,6 +718,7 @@
   "session.logStopped": "已停止，文件保存至 {path}",
   "session.logFailed": "切换日志失败：{error}",
   "sidebar.connectSerial": "串口",
+  "sidebar.connectTcp": "连接 TCP",
   "monitor.performance": "性能",
   "monitor.processes": "进程",
   "monitor.system": "系统信息",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -718,6 +718,7 @@
   "session.logStopped": "已停止，檔案儲存至 {path}",
   "session.logFailed": "切換日誌失敗：{error}",
   "sidebar.connectSerial": "序列埠",
+  "sidebar.connectTcp": "連線 TCP",
   "monitor.performance": "效能",
   "monitor.processes": "處理程序",
   "monitor.system": "系統資訊",

--- a/frontend/src/types/session.ts
+++ b/frontend/src/types/session.ts
@@ -17,7 +17,7 @@ export interface ConnectionConfig {
   id: string
   name: string
   remark?: string
-  type: 'ssh' | 'telnet' | 'mosh' | 'rdp' | 'vnc' | 'spice' | 'database' | 'local' | 'sftp' | 'monitor' | 'ftp' | 'serial' | 'smb' | 'webdav' | 's3' | 'k8s' | 'container' | 'x11-desktop'
+  type: 'ssh' | 'telnet' | 'mosh' | 'rdp' | 'vnc' | 'spice' | 'database' | 'local' | 'sftp' | 'monitor' | 'ftp' | 'serial' | 'smb' | 'webdav' | 's3' | 'tcp' | 'k8s' | 'container' | 'x11-desktop'
   host: string
   port: number
   user: string

--- a/frontend/src/types/workspace.ts
+++ b/frontend/src/types/workspace.ts
@@ -1,4 +1,4 @@
-export type PanelType = 'ssh' | 'telnet' | 'mosh' | 'sftp' | 'settings' | 'rdp' | 'vnc' | 'spice' | 'local' | 'database' | 'monitor' | 'serial' | 'k8s' | 'k8s-exec' | 'container' | 'container-exec' | 'x11-desktop' | 'other'
+export type PanelType = 'ssh' | 'telnet' | 'mosh' | 'sftp' | 'settings' | 'rdp' | 'vnc' | 'spice' | 'local' | 'database' | 'monitor' | 'serial' | 'tcp' | 'k8s' | 'k8s-exec' | 'container' | 'container-exec' | 'x11-desktop' | 'other'
 export type PanelStatus = 'connecting' | 'connected' | 'disconnected' | 'error'
 
 import type { ConnectionConfig } from './session'

--- a/frontend/src/utils/quickConnect.ts
+++ b/frontend/src/utils/quickConnect.ts
@@ -29,6 +29,7 @@ const QUICK_PROTOCOLS: Record<string, { type: string; dbType?: string; defaultPo
   oracle: { type: 'database', dbType: 'oracle', defaultPort: 1521 },
   sqlserver: { type: 'database', dbType: 'sqlserver', defaultPort: 1433 },
   rqlite: { type: 'database', dbType: 'rqlite', defaultPort: 4001 },
+  tcp: { type: 'tcp', defaultPort: 23 },
 }
 
 // Helper: parse [user[:password]@]host[:port]
@@ -115,7 +116,7 @@ export function getTypeBaseType(key: string): string {
 // Map of base type → top-level filter category, mirroring the two-level type
 // layout of the new-connection form (ConnectionForm `categories`).
 export const TYPE_CATEGORY: Record<string, string> = {
-  ssh: 'terminal', telnet: 'terminal', mosh: 'terminal', local: 'terminal', serial: 'terminal', monitor: 'terminal',
+  ssh: 'terminal', telnet: 'terminal', mosh: 'terminal', local: 'terminal', serial: 'terminal', tcp: 'terminal', monitor: 'terminal',
   sftp: 'filetransfer', ftp: 'filetransfer', smb: 'filetransfer', s3: 'filetransfer', webdav: 'filetransfer',
   rdp: 'remote', vnc: 'remote', spice: 'remote', 'x11-desktop': 'remote',
   database: 'database',
@@ -179,6 +180,7 @@ export function getTypeFilterCatalog(t: (key: string) => string, isWin = false) 
         { key: 'mosh', label: 'Mosh' },
         { key: 'local', label: t('conn.localTerminal') },
         { key: 'serial', label: t('serial.title') },
+        { key: 'tcp', label: 'TCP' },
       ],
     },
     {


### PR DESCRIPTION
Adds a general-purpose **raw TCP** terminal session to uniTerm: opens a plain TCP socket to `host:port` and shuttles raw bytes with no protocol negotiation — a graphical netcat for services that speak a plain byte stream (serial-debug ports, telnet-style control planes, custom/self-hosted services).

What's included:
- **Backend**: `TCPSession` (implements the `Session` interface) + dispatch in `SessionManager`; optional byte helpers: character encoding (UTF-8/GBK/…), newline mode (CR/CRLF), local echo; a connect-test probe.
- **Frontend**: registers **TCP** under the Terminal category (icon, default port), type filter, per-protocol icons in sidebar / start page / tab bar, terminal reconnect menu, context-menu connect action, and hides credential fields (TCP has none).
- Verified: `go build` / `go vet` / `vite build` pass; end-to-end round-trip (local echo server) confirms send→receive, CRLF translation, and local echo.

---
新增 uniTerm 的通用 **TCP 直连** 终端会话:对 `host:port` 建立裸 TCP socket,不协商任何协议地双向透传字节,相当于图形化 netcat,用于那些讲裸字节流的目标(串口调试口、类 telnet 控制面、自研服务)。

改动内容:
- **后端**:`TCPSession`(实现 `Session` 接口)+ `SessionManager` 调度;可选字节辅助:字符编码(UTF-8/GBK/…)、换行模式(CR/CRLF)、本地回显;连接测试探针。
- **前端**:在终端分类注册 **TCP**(图标、默认端口)、类型筛选、边栏/开始页/标签栏协议图标、终端重连菜单、右键连接动作,并隐藏凭据字段(TCP 无凭据)。
- 已验证:`go build` / `go vet` / `vite build` 通过;本地回显服务器端到端验证了收发、CRLF 转换与本地回显。