### PR TITLE
fix(k8s): allow access to namespaces when list permission is restricted

### DIFF
--- a/frontend/src/components/ConnectionForm.vue
+++ b/frontend/src/components/ConnectionForm.vue
@@ -256,6 +256,21 @@
                   </el-button>
                 </div>
               </el-form-item>
+
+              <el-form-item :label="t('conn.k8sNamespace')">
+                <el-select
+                  v-model="form.k8sNamespace"
+                  filterable
+                  allow-create
+                  default-first-option
+                  clearable
+                  placeholder="Namespace"
+                  style="width: 100%"
+                  @change="onK8sNamespaceInput"
+                >
+                  <el-option v-for="ns in k8sNamespaceOptions" :key="ns" :value="ns" :label="ns" />
+                </el-select>
+              </el-form-item>
             </template>
             <!-- ── Container 字段 ── -->
             <template v-if="form.type === 'container'">
@@ -1012,6 +1027,18 @@ const k8sContextsError = ref('')
 // Guard against watchers wiping restored state during edit-hydration.
 const hydrating = ref(false)
 
+// True once the user hand-edits the namespace field, so that switching the
+// k8s context later doesn't silently overwrite a value they typed.
+const k8sNamespaceTouched = ref(false)
+// Namespace suggestions drawn from the contexts' declared defaults plus the
+// current field value. allow-create lets the user type any namespace.
+const k8sNamespaceOptions = computed(() => {
+  const set = new Set<string>()
+  if (form.k8sNamespace) set.add(form.k8sNamespace)
+  for (const c of k8sContexts.value) if (c.namespace) set.add(c.namespace)
+  return Array.from(set)
+})
+
 watch(() => props.editConfig, (config) => {
   if (config) {
     // Always reset first so fields absent from the config (e.g. an empty
@@ -1206,6 +1233,7 @@ function resetForm() {
   form.k8sConfigInline = ''
   form.k8sContext = ''
   form.k8sNamespace = 'default'
+  k8sNamespaceTouched.value = false
   form.containerTransport = 'ssh'
   form.containerSSHConnId = undefined
   form.containerRuntime = 'docker'
@@ -1297,6 +1325,21 @@ watch(() => form.type, (t) => {
   if (t === 'k8s' && (form.k8sConfigPath || form.k8sConfigInline)) {
     reloadK8sContexts()
   }
+})
+
+function onK8sNamespaceInput() {
+  k8sNamespaceTouched.value = true
+}
+
+// Adopt the selected context's declared default namespace, unless the user has
+// already hand-typed a value. Editing an existing connection runs under
+// hydrating, where the stored namespace must win.
+watch(() => form.k8sContext, (ctxName) => {
+  if (hydrating.value) return
+  if (k8sNamespaceTouched.value) return
+  if (!ctxName) return
+  const ctx = k8sContexts.value.find(c => c.name === ctxName)
+  if (ctx && ctx.namespace) form.k8sNamespace = ctx.namespace
 })
 
 function generateUniqueName(name: string): string {

--- a/frontend/src/components/K8sBreadcrumb.vue
+++ b/frontend/src/components/K8sBreadcrumb.vue
@@ -6,6 +6,9 @@
       size="small"
       class="k8s-ns-select"
       placeholder="all namespaces"
+      filterable
+      allow-create
+      default-first-option
       clearable
       @update:model-value="v => $emit('update:namespace', v || '')"
     >

--- a/frontend/src/components/K8sTabContent.vue
+++ b/frontend/src/components/K8sTabContent.vue
@@ -15,6 +15,7 @@
           @pop="popTo"
           @update:namespace="setNamespace"
         />
+        <div v-if="namespaceError" class="k8s-ns-warning" role="status">{{ namespaceError }}</div>
         <K8sResourceList
           :conn-id="connId"
           :frame="topFrame"
@@ -73,25 +74,34 @@ const connId = ref<string>('')
 const error = ref('')
 const initialNamespace = ref<string>(props.tab.namespace || '')
 
-// Namespaces fetched live from the cluster once connected; falls back to a
-// small static set if the list call fails (RBAC-restricted, etc.).
+// Namespaces fetched live from the cluster once connected. If the list call
+// fails (e.g. RBAC restricted to specific namespaces), keep only the context's
+// default namespace so the dropdown still offers a valid target, and surface a
+// non-fatal hint telling the user they can type a namespace manually.
 const fetchedNamespaces = ref<string[]>([])
+const namespaceError = ref('')
 const namespaceOptions = computed(() => {
   const set = new Set<string>()
   for (const n of fetchedNamespaces.value) set.add(n)
-  if (!set.size) { set.add('default'); set.add('kube-system'); set.add('kube-public') }
   if (initialNamespace.value) set.add(initialNamespace.value)
-  return Array.from(set)
+  return Array.from(set).sort()
 })
 
 async function loadNamespaces() {
   if (!connId.value) return
+  namespaceError.value = ''
   try {
     const { status, data } = await k8sClient.requestJSON<any>(connId.value, 'GET', '/api/v1/namespaces?limit=500')
     if (status === 200 && data?.items) {
       fetchedNamespaces.value = data.items.map((n: any) => n.metadata?.name).filter(Boolean).sort()
+    } else {
+      fetchedNamespaces.value = []
+      namespaceError.value = `Failed to list namespaces (HTTP ${status}). You can type a namespace manually.`
     }
-  } catch { /* keep fallback */ }
+  } catch {
+    fetchedNamespaces.value = []
+    namespaceError.value = 'Failed to list namespaces — permission denied? You can type a namespace manually.'
+  }
 }
 
 // ── nav stack ──────────────────────────────────────────────────
@@ -330,5 +340,13 @@ onBeforeUnmount(() => {
 .k8s-connecting {
   padding: 12px;
   opacity: 0.7;
+}
+.k8s-ns-warning {
+  padding: 6px 12px;
+  font-size: 12px;
+  color: var(--el-color-warning, #e6a23c);
+  background: var(--el-color-warning-light-9, #fdf6ec);
+  border-bottom: 1px solid var(--el-color-warning-light-5, #faecd8);
+  flex-shrink: 0;
 }
 </style>


### PR DESCRIPTION
## Summary

When a kubeconfig user only has permission on specific namespaces (e.g. Rancher) and lacks cluster-level `list namespaces`, the namespace dropdown only showed `default`/`kube-system`/`kube-public`, omitted the context's default namespace, and was a read-only dropdown with silent failure. Users had no way to reach their own namespaces.

This PR makes all three requested outcomes work:

- **ConnectionForm**: exposes the previously hidden `k8sNamespace` field as an editable combobox and auto-fills it from the selected context's declared default namespace — without overwriting a manually typed value, and preserving the stored value when editing an existing connection.
- **K8sBreadcrumb**: the resource-page namespace select is now `filterable` + `allow-create`, so a namespace can be typed even without `list namespaces` permission.
- **K8sTabContent**: `list namespaces` failure now shows a clear non-fatal hint instead of silently falling back to hardcoded system namespaces; the fallback keeps only the context's default namespace.

## Changes
- `frontend/src/components/ConnectionForm.vue`
- `frontend/src/components/K8sBreadcrumb.vue`
- `frontend/src/components/K8sTabContent.vue`

## Verification
- `vue-tsc --noEmit`: zero new type errors (baseline 17 → 17, none in changed code).
- K8s-related vitest suites: 5 files / 41 tests pass.
- `npm run build`: 3849 modules, builds clean.

Closes #689

---

## 概述

当 kubeconfig 用户只有特定命名空间（如 Rancher）权限、缺少集群级 `list namespaces` 权限时，命名空间下拉框只显示 `default`/`kube-system`/`kube-public`，既没有 context 声明的默认命名空间，又是只读下拉、失败时静默吞错，用户完全无法访问自己的命名空间。

本 PR 实现 issue 提出的三个可接受结果：

- **ConnectionForm**：把原本隐藏的 `k8sNamespace` 字段补充为可输入下拉，并从所选 context 的声明默认命名空间自动回填——不会覆盖用户手填的值，编辑已有连接时保留已存值。
- **K8sBreadcrumb**：资源页命名空间下拉改为 `filterable` + `allow-create`，即使无 `list namespaces` 权限也能手动输入。
- **K8sTabContent**：`list namespaces` 失败时给出明确（非致命）提示，不再静默兜底到硬编码的系统命名空间；兜底仅保留 context 的默认命名空间。

## 变更文件
- `frontend/src/components/ConnectionForm.vue`
- `frontend/src/components/K8sBreadcrumb.vue`
- `frontend/src/components/K8sTabContent.vue`

## 验证
- `vue-tsc --noEmit`：零新增类型错误（基线 17 → 17，均不在改动代码）。
- K8s 相关 vitest：5 个文件 / 41 条用例全部通过。
- `npm run build`：3849 modules，构建通过。

关闭 #689