### PR TITLE
fix(sftp): progressive loading for file list to prevent crash on large directories

### DIFF
--- a/frontend/src/components/SFTPFileList.vue
+++ b/frontend/src/components/SFTPFileList.vue
@@ -43,7 +43,7 @@
       <el-table
         ref="tableRef"
         :key="locale"
-        :data="filteredFiles"
+        :data="visibleFiles"
         size="small"
         :row-class-name="getRowClassName"
         @row-click="onRowClick"
@@ -133,7 +133,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed } from 'vue'
+import { ref, computed, watch, onMounted, nextTick } from 'vue'
 import { Folder, File, Link, RefreshCw, Eye, Upload } from '@lucide/vue'
 import { useI18n } from '../i18n'
 import SFTPPathBreadcrumb from './SFTPPathBreadcrumb.vue'
@@ -222,6 +222,66 @@ const filteredFiles = computed(() => {
   const q = filterText.value.trim().toLowerCase()
   if (!q) return list
   return list.filter(f => f.name.toLowerCase().includes(q))
+})
+
+// --- Progressive loading ---------------------------------------------------
+// A directory can contain tens of thousands of entries. Rendering the whole
+// list into el-table at once creates an unbounded number of DOM rows, which
+// freezes / crashes the renderer (issue 478). So we only hand el-table a slice
+// of the filtered list and grow it as the user scrolls near the bottom, keeping
+// the rendered DOM bounded regardless of the total entry count.
+const PAGE_SIZE = 200
+const INITIAL_PAGES = 1
+const NEAR_BOTTOM_PX = 300
+
+const visibleCount = ref(INITIAL_PAGES)
+const visibleFiles = computed(() => filteredFiles.value.slice(0, visibleCount.value * PAGE_SIZE))
+
+let scrollWrapEl: HTMLElement | null = null
+
+// el-table scrolls through an internal .el-scrollbar once it has a height; that
+// element is where we must listen for scroll (native scroll does not bubble).
+function bindTableScroll() {
+  const el = (tableRef.value?.$el ?? null) as HTMLElement | null
+  scrollWrapEl = el?.querySelector('.el-scrollbar__wrap') ?? null
+  if (scrollWrapEl && !scrollWrapEl.dataset.lazyBinded) {
+    scrollWrapEl.dataset.lazyBinded = '1'
+    scrollWrapEl.addEventListener('scroll', onTableScroll, { passive: true })
+  }
+}
+
+function onTableScroll() {
+  // Defer to the next frame so the threshold is computed against the scroll
+  // height AFTER any just-triggered batch has been added to the DOM.
+  requestAnimationFrame(loadMoreIfNeeded)
+}
+
+function loadMoreIfNeeded() {
+  if (!scrollWrapEl) return
+  const { scrollTop, clientHeight, scrollHeight } = scrollWrapEl
+  if (scrollHeight - scrollTop - clientHeight < NEAR_BOTTOM_PX) {
+    visibleCount.value += 1
+  }
+}
+
+// Reset to a fresh first batch whenever the underlying dataset or the filter
+// changes, so the table always starts at the top again.
+watch(filteredFiles, () => {
+  visibleCount.value = INITIAL_PAGES
+  // The scroll wrap survives data swaps, but the Keyed locale swap below
+  // remounts el-table and its scrollbar, so re-resolve the listener target.
+  nextTick(bindTableScroll)
+})
+
+// <el-table :key="locale"> remounts the table on locale switch, creating a new
+// scrollbar element that needs the scroll listener re-attached.
+watch(locale, () => {
+  visibleCount.value = INITIAL_PAGES
+  nextTick(bindTableScroll)
+})
+
+onMounted(() => {
+  nextTick(bindTableScroll)
 })
 
 function isSelected(row: FileItem): boolean {


### PR DESCRIPTION
Closes #478

## Summary
Rendering the whole filtered file list into `el-table` at once created an unbounded number of DOM rows, which froze and eventually crashed the renderer when a directory contained thousands of entries (issue 478).

The fix keeps the DOM bounded by only handing `el-table` a growing slice of the filtered list:

- **Slice-based progressive loading**: `:data` now uses `visibleFiles = filteredFiles.slice(0, visibleCount * 200)` (200 rows/page), so at most a few hundred rows are in the DOM regardless of total entry count.
- **Scroll-to-load-more**: listens on el-table's internal `.el-scrollbar__wrap` (native scroll doesn't bubble) and appends another 200 rows when within 300px of the bottom.
- **Batch reset**: resets to the first page on dataset/filter changes (`watch(filteredFiles)`) and on locale switch (`watch(locale)`, since `:key="locale"` remounts the table and its scrollbar).
- No feedback loop — `visibleCount` does not feed back into `filteredFiles`, so scroll-grow doesn't reset the batch.

Existing interactions (sorting, shift/ctrl multi-select, right-click file/dir/batch menu, in-row drag, `..` pinned row) are unchanged because only the data entry point changed, not the row-level contract.

Backend, bindings, and JSON transfer are untouched.

## Changes
- `frontend/src/components/SFTPFileList.vue`: +62/-2, slice-based progressive loading + scroll listener + batch reset.

## Verification
- `vite build` passes (3849 modules).
- Manual runtime verification against a directory with tens of thousands of entries is still recommended (first paint, scroll-to-bottom append, filter reset, directory-switch reset).

---
## 摘要
将整个过滤后的文件列表一次性渲染进 `el-table` 会产生无上限的 DOM 行，当目录包含数千条目时渲染器会被冻结并最终崩溃（issue 478）。

本次修复保持 DOM 有界，只把过滤后列表的一个自增长的切片交给 `el-table`：

- **切片式渐进加载**：`:data` 改用 `visibleFiles = filteredFiles.slice(0, visibleCount * 200)`（每页 200 行），无论总条数多少，DOM 中始终只有几百行。
- **滚动到底加载更多**：监听 el-table 内部 `.el-scrollbar__wrap`（原生 scroll 不冒泡），距底部 300px 内追加 200 行。
- **批次重置**：数据/筛选变化时（`watch(filteredFiles)`）及切换语言时（`watch(locale)`，因 `:key=\"locale\"` 会重建表格及其滚动条）重置回第一页。
- 无反馈循环——`visibleCount` 不反哺 `filteredFiles`，滚动增批不会误触发重置。

既有交互（排序、shift/ctrl 多选、右键 file/dir/batch 菜单、行内拖拽、`..` 置顶行）全部不变，因为只改了数据入口，未改行级契约。

后端、绑定、JSON 传输均未改动。

## 变更文件
- `frontend/src/components/SFTPFileList.vue`：+62/-2，切片式渐进加载 + 滚动监听 + 批次重置。

## 验证
- `vite build` 通过（3849 个模块）。
- 仍建议对一个含数万条文件的目录做运行时实测（首屏、滚到底追加、筛选重置、切目录重置）。