### PR TITLE
Fix stale error toast & add quick-command remark + larger dialog

### DIFF
--- a/backend/store/quick_commands_store.go
+++ b/backend/store/quick_commands_store.go
@@ -11,6 +11,7 @@ const quickCommandsFileName = "quickCommands.json"
 type QuickCommand struct {
 	ID        string `json:"id"`
 	Name      string `json:"name,omitempty"`
+	Remark    string `json:"remark,omitempty"`
 	Command   string `json:"command"`
 	GroupID   string `json:"groupId,omitempty"`
 	SortOrder int    `json:"sortOrder"`

--- a/frontend/src/components/ConnectionForm.vue
+++ b/frontend/src/components/ConnectionForm.vue
@@ -1465,7 +1465,7 @@ async function onTest() {
     msg.success(desc)
   } catch (e: any) {
     testStatus.value = 'error'
-    msg.error(String(e?.message || e), true)
+    msg.error(String(e?.message || e))
   }
 }
 

--- a/frontend/src/components/QuickCommandEditDialog.vue
+++ b/frontend/src/components/QuickCommandEditDialog.vue
@@ -2,7 +2,7 @@
   <el-dialog append-to-body
     v-model="visible"
     :title="editingId ? t('quickCommands.editCommand') : t('quickCommands.addCommand')"
-    width="480px"
+    width="620px"
     :close-on-click-modal="false"
     @close="resetForm"
   >
@@ -12,6 +12,14 @@
           v-model="formName"
           :placeholder="t('quickCommands.namePlaceholder')"
           maxlength="50"
+        />
+      </el-form-item>
+      <el-form-item :label="t('quickCommands.remark')">
+        <el-input
+          v-model="formRemark"
+          type="textarea"
+          :rows="2"
+          :placeholder="t('quickCommands.remarkPlaceholder')"
         />
       </el-form-item>
       <el-form-item :label="t('quickCommands.group')">
@@ -30,7 +38,7 @@
         <el-input
           v-model="formCommand"
           type="textarea"
-          :rows="4"
+          :rows="10"
           :placeholder="t('quickCommands.commandPlaceholder')"
           class="command-textarea"
         />
@@ -75,6 +83,7 @@ const props = defineProps<{
   initialName?: string
   initialCommand?: string
   initialGroupId?: string
+  initialRemark?: string
 }>()
 
 const emit = defineEmits<{
@@ -87,6 +96,7 @@ const visible = computed({
 })
 
 const formName = ref('')
+const formRemark = ref('')
 const formCommand = ref('')
 const formGroupId = ref<string | undefined>(undefined)
 const errorMsg = ref('')
@@ -94,6 +104,7 @@ const errorMsg = ref('')
 watch(visible, (v) => {
   if (v) {
     formName.value = props.initialName || ''
+    formRemark.value = props.initialRemark || ''
     formCommand.value = props.initialCommand || ''
     formGroupId.value = props.initialGroupId || undefined
     errorMsg.value = ''
@@ -106,10 +117,11 @@ function handleSave() {
     errorMsg.value = t('quickCommands.commandRequired')
     return
   }
+  const remark = formRemark.value.trim()
   if (props.editingId) {
-    store.updateCommand(props.editingId, formName.value || undefined, cmd, formGroupId.value || undefined)
+    store.updateCommand(props.editingId, formName.value || undefined, cmd, formGroupId.value || undefined, remark)
   } else {
-    store.addCommand(formName.value || undefined, cmd, formGroupId.value || undefined)
+    store.addCommand(formName.value || undefined, cmd, formGroupId.value || undefined, remark)
   }
   visible.value = false
   resetForm()
@@ -136,6 +148,7 @@ function confirmNewGroup() {
 
 function resetForm() {
   formName.value = ''
+  formRemark.value = ''
   formCommand.value = ''
   formGroupId.value = undefined
   errorMsg.value = ''

--- a/frontend/src/components/QuickCommandsPanel.vue
+++ b/frontend/src/components/QuickCommandsPanel.vue
@@ -215,6 +215,7 @@
       :initial-name="editingCmdName"
       :initial-command="editingCmdCommand"
       :initial-group-id="editingCmdGroupId"
+      :initial-remark="editingCmdRemark"
     />
   </div>
 </template>
@@ -270,6 +271,7 @@ const editingCmdId = ref<string | undefined>(undefined)
 const editingCmdName = ref<string | undefined>(undefined)
 const editingCmdCommand = ref('')
 const editingCmdGroupId = ref<string | undefined>(undefined)
+const editingCmdRemark = ref<string | undefined>(undefined)
 
 onMounted(async () => {
   await store.load()
@@ -425,6 +427,7 @@ function editCommand(cmd: QuickCommand) {
   editingCmdName.value = cmd.name
   editingCmdCommand.value = cmd.command
   editingCmdGroupId.value = cmd.groupId
+  editingCmdRemark.value = cmd.remark
   editDialogVisible.value = true
   ctxMenuVisible.value = false
 }
@@ -441,6 +444,7 @@ function addCommand(groupId?: string) {
   editingCmdName.value = undefined
   editingCmdCommand.value = ''
   editingCmdGroupId.value = groupId
+  editingCmdRemark.value = undefined
   editDialogVisible.value = true
   ctxMenuVisible.value = false
 }
@@ -519,7 +523,7 @@ async function onGroupDrop(groupId: string, e: DragEvent) {
   const targetGroupId = groupId === '__ungrouped__' ? undefined : groupId
   const cmd = store.commands.find(c => c.id === cmdId)
   if (cmd) {
-    store.updateCommand(cmd.id, cmd.name, cmd.command, targetGroupId)
+    store.updateCommand(cmd.id, cmd.name, cmd.command, targetGroupId, cmd.remark)
   }
 }
 

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -1010,6 +1010,8 @@
   "quickCommands.noGroup": "Keine Gruppe",
   "quickCommands.command": "Befehl",
   "quickCommands.name": "Name",
+  "quickCommands.remark": "Anmerkung",
+  "quickCommands.remarkPlaceholder": "Optional, zusätzliche Beschreibung für diesen Befehl",
   "quickCommands.namePlaceholder": "Optional, Befehl wird angezeigt wenn leer",
   "quickCommands.commandPlaceholder": "z.B. df -h",
   "quickCommands.run": "Ausführen",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1010,6 +1010,8 @@
   "quickCommands.noGroup": "No Group",
   "quickCommands.command": "Command",
   "quickCommands.name": "Name",
+  "quickCommands.remark": "Remark",
+  "quickCommands.remarkPlaceholder": "Optional description for this command",
   "quickCommands.namePlaceholder": "Optional, command text shown if empty",
   "quickCommands.commandPlaceholder": "e.g. df -h",
   "quickCommands.run": "Run",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -1010,6 +1010,8 @@
   "quickCommands.noGroup": "Sin grupo",
   "quickCommands.command": "Comando",
   "quickCommands.name": "Nombre",
+  "quickCommands.remark": "Nota",
+  "quickCommands.remarkPlaceholder": "Opcional, descripción adicional de este comando",
   "quickCommands.namePlaceholder": "Opcional, muestra el comando si está vacío",
   "quickCommands.commandPlaceholder": "ej: df -h",
   "quickCommands.run": "Ejecutar",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -1010,6 +1010,8 @@
   "quickCommands.noGroup": "Sans groupe",
   "quickCommands.command": "Commande",
   "quickCommands.name": "Nom",
+  "quickCommands.remark": "Remarque",
+  "quickCommands.remarkPlaceholder": "Facultatif, description de cette commande",
   "quickCommands.namePlaceholder": "Optionnel, affiche la commande si vide",
   "quickCommands.commandPlaceholder": "ex: df -h",
   "quickCommands.run": "Exécuter",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -1010,6 +1010,8 @@
   "quickCommands.noGroup": "グループなし",
   "quickCommands.command": "コマンド",
   "quickCommands.name": "名前",
+  "quickCommands.remark": "備考",
+  "quickCommands.remarkPlaceholder": "任意、このコマンドの補足説明",
   "quickCommands.namePlaceholder": "任意、空の場合はコマンドを表示",
   "quickCommands.commandPlaceholder": "例: df -h",
   "quickCommands.run": "実行",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -1010,6 +1010,8 @@
   "quickCommands.noGroup": "그룹 없음",
   "quickCommands.command": "명령",
   "quickCommands.name": "이름",
+  "quickCommands.remark": "비고",
+  "quickCommands.remarkPlaceholder": "선택 사항, 이 명령에 대한 참고 사항",
   "quickCommands.namePlaceholder": "선택 사항, 비어 있으면 명령 표시",
   "quickCommands.commandPlaceholder": "예: df -h",
   "quickCommands.run": "실행",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -1010,6 +1010,8 @@
   "quickCommands.noGroup": "Без группы",
   "quickCommands.command": "Команда",
   "quickCommands.name": "Имя",
+  "quickCommands.remark": "Примечание",
+  "quickCommands.remarkPlaceholder": "Необязательно, доп. описание команды",
   "quickCommands.namePlaceholder": "Необязательно, команда отображается если пусто",
   "quickCommands.commandPlaceholder": "напр. df -h",
   "quickCommands.run": "Выполнить",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -1010,6 +1010,8 @@
   "quickCommands.noGroup": "无分组",
   "quickCommands.command": "命令",
   "quickCommands.name": "名称",
+  "quickCommands.remark": "备注",
+  "quickCommands.remarkPlaceholder": "可选，对该命令的补充说明",
   "quickCommands.namePlaceholder": "可选，为空时显示命令文本",
   "quickCommands.commandPlaceholder": "如 df -h",
   "quickCommands.run": "执行",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -1010,6 +1010,8 @@
   "quickCommands.noGroup": "無群組",
   "quickCommands.command": "命令",
   "quickCommands.name": "名稱",
+  "quickCommands.remark": "備註",
+  "quickCommands.remarkPlaceholder": "可選，對該命令的補充說明",
   "quickCommands.namePlaceholder": "可選，為空時顯示命令文字",
   "quickCommands.commandPlaceholder": "如 df -h",
   "quickCommands.run": "執行",

--- a/frontend/src/services/message.ts
+++ b/frontend/src/services/message.ts
@@ -2,20 +2,18 @@ import { ElMessage } from 'element-plus'
 
 const CLOSABLE = { showClose: true, duration: 5000, offset: 50 }
 
-// persist=true keeps the toast until the user closes it (duration 0) instead of
-// auto-dismissing — e.g. a connection-test result whose outcome must be readable.
-type PersistMsg = (m: string, persist?: boolean) => void
+type Msg = (m: string) => void
 
-const persistMsg =
-  (kind: 'success' | 'error' | 'warning' | 'info'): PersistMsg =>
-  (m, persist = false) =>
-    ElMessage[kind]({ message: m, ...CLOSABLE, duration: persist ? 0 : CLOSABLE.duration })
+const msgKind =
+  (kind: 'success' | 'error' | 'warning' | 'info'): Msg =>
+  (m) =>
+    ElMessage[kind]({ message: m, ...CLOSABLE })
 
 export const msg = {
-  success: persistMsg('success'),
-  error: persistMsg('error'),
-  warning: persistMsg('warning'),
-  info: persistMsg('info'),
+  success: msgKind('success'),
+  error: msgKind('error'),
+  warning: msgKind('warning'),
+  info: msgKind('info'),
   // Stays until closed so a long path can be read and copied. The message is
   // wrapped in a span with inline no-drag so the WKWebView hands mouse events
   // back to the DOM instead of initiating a window drag on macOS frameless

--- a/frontend/src/stores/quickCommandStore.ts
+++ b/frontend/src/stores/quickCommandStore.ts
@@ -5,6 +5,7 @@ import { SaveQuickCommands, LoadQuickCommands } from '../../bindings/github.com/
 export interface QuickCommand {
   id: string
   name?: string
+  remark?: string
   command: string
   groupId?: string
   sortOrder: number
@@ -84,10 +85,11 @@ export const useQuickCommandStore = defineStore('quickCommands', () => {
     save()
   }
 
-  function addCommand(name: string | undefined, command: string, groupId?: string): QuickCommand {
+  function addCommand(name: string | undefined, command: string, groupId?: string, remark?: string): QuickCommand {
     const cmd: QuickCommand = {
       id: genId('qcc'),
       name: name || undefined,
+      remark: remark || undefined,
       command,
       groupId,
       sortOrder: commands.value.filter(c => c.groupId === groupId).length,
@@ -97,12 +99,13 @@ export const useQuickCommandStore = defineStore('quickCommands', () => {
     return cmd
   }
 
-  function updateCommand(id: string, name: string | undefined, command: string, groupId?: string) {
+  function updateCommand(id: string, name: string | undefined, command: string, groupId?: string, remark?: string) {
     const c = commands.value.find(x => x.id === id)
     if (c) {
       c.name = name || undefined
       c.command = command
       c.groupId = groupId
+      if (remark !== undefined) c.remark = remark || undefined
       save()
     }
   }

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -2007,6 +2007,7 @@ export namespace store {
 	export class QuickCommand {
 	    id: string;
 	    name?: string;
+	    remark?: string;
 	    command: string;
 	    groupId?: string;
 	    sortOrder: number;
@@ -2019,6 +2020,7 @@ export namespace store {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.id = source["id"];
 	        this.name = source["name"];
+	        this.remark = source["remark"];
 	        this.command = source["command"];
 	        this.groupId = source["groupId"];
 	        this.sortOrder = source["sortOrder"];


### PR DESCRIPTION
Closes #669
Closes #675
Closes #635

## Summary

Two independent fixes bundled for review:

1. **Auto-dismiss the connection-test error toast (issue #669)** — the failure toast previously stayed open until manually closed because it used the `persist` flag (duration 0). This drops that flag so errors auto-dismiss after 5s like the success toast, and simplifies the shared `msg` wrapper to a consistent 5s duration for all toasts.

2. **Quick-command enhancements (issues #675 + #635)** — add an optional **remark** field to quick commands (persisted end-to-end, backwards compatible) and enlarge the quick-command edit dialog / command textarea so long commands are easier to edit.

## Changes

- `frontend/src/services/message.ts`, `frontend/src/components/ConnectionForm.vue`: error toast auto-dismisses after 5s.
- `backend/store/quick_commands_store.go`, `frontend/src/stores/quickCommandStore.ts`, `frontend/src/components/QuickCommandEditDialog.vue`, `frontend/src/components/QuickCommandsPanel.vue`, `frontend/wailsjs/go/models.ts`: quick command `remark` field added end-to-end (incl. preserved on drag-to-group).
- `QuickCommandEditDialog.vue`: dialog width 480px → 620px, command textarea 4 → 10 rows.
- All 9 i18n locale files: add `quickCommands.remark` / `quickCommands.remarkPlaceholder`.

## Verification

- Backend store package compiles.
- All 9 locale JSON files parse and added keys are present.
- Frontend typecheck introduces no new errors (remaining errors are pre-existing in unrelated files).

---
## 摘要

本次 PR 打包了两个独立的改动:

1. **连接测试失败的提示自动关闭(issue #669)** —— 失败提示之前因为使用 `persist` 标志(duration 0)而一直停留到手动关闭。本次去掉该标志,让失败提示与成功提示一致,5 秒后自动消失;并简化了公共 `msg` 封装,统一所有 toast 为 5 秒时长。

2. **快捷命令增强(issues #675 + #635)** —— 为快捷命令新增可选的**备注**字段(端到端持久化,向后兼容),并将快捷命令编辑窗口/命令输入框放大,方便编辑长命令。

## 改动内容

- `frontend/src/services/message.ts`、`frontend/src/components/ConnectionForm.vue`:错误提示 5 秒自动关闭。
- `backend/store/quick_commands_store.go`、`frontend/src/stores/quickCommandStore.ts`、`frontend/src/components/QuickCommandEditDialog.vue`、`frontend/src/components/QuickCommandsPanel.vue`、`frontend/wailsjs/go/models.ts`:端到端新增快捷命令 `remark` 字段(拖拽改分组时保留)。
- `QuickCommandEditDialog.vue`:弹窗宽度 480px→620px,命令输入框 4 行→10 行。
- 9 个 i18n 语言文件:新增 `quickCommands.remark` / `quickCommands.remarkPlaceholder`。

## 验证

- 后端 store 包编译通过。
- 9 个语言 JSON 均能解析且新键存在。
- 前端类型检查未引入新错误(其余报错均来自未改动的无关文件)。
