### PR TITLE
fix(terminal): close suggestion popup when clicking outside

### DIFF
--- a/frontend/src/components/BaseTerminal.vue
+++ b/frontend/src/components/BaseTerminal.vue
@@ -1174,7 +1174,7 @@ onMounted(() => {
   // Close suggestion popup when clicking outside
   onDocumentMouseDown = (event: MouseEvent) => {
     if (!suggestions.isVisible()) return
-    const baseTerminalEl = terminalRef.value?.parentElement
+    const baseTerminalEl = terminalRef.value?.closest('.base-terminal')
     const popupEl = baseTerminalEl?.querySelector('.terminal-suggestion-popup')
     if (popupEl && !popupEl.contains(event.target as Node)) {
       suggestions.close()


### PR DESCRIPTION
Fix `智能补全` (smart completion) popup not closing when clicking outside.

### Problem
The click-outside handler in `BaseTerminal.vue` queried `.terminal-suggestion-popup` from `terminalRef.parentElement` (the `.terminal-area` div). However, the popup is a sibling rendered inside `.base-terminal`, not a descendant of `.terminal-area`, so `querySelector` always returned `null` and the popup never closed on outside clicks — it could only be dismissed with ESC.

### Fix
- Resolve the popup from the `.base-terminal` ancestor via `terminalRef.closest('.base-terminal')`, matching how the popup positions itself.

Closes #648

---
### 问题
`BaseTerminal.vue` 中"点击框外关闭"的处理逻辑里，从 `terminalRef.parentElement`（即 `.terminal-area`）查询 `.terminal-suggestion-popup`。但补全弹窗实际上是 `.base-terminal` 内的兄弟节点，并非 `.terminal-area` 的后代，导致 `querySelector` 恒返回 `null`，点击外部永不生效，只能按 ESC 关闭。

### 修复
- 改为通过 `terminalRef.closest('.base-terminal')` 从 `.base-terminal` 祖先上解析弹窗，与弹窗自身的定位方式保持一致。

关闭 #648