### PR TITLE
fix(linux): add desktop icon for deb/rpm and bare binary

### DIFF
--- a/.github/workflows/build-linux-webkit40.yml
+++ b/.github/workflows/build-linux-webkit40.yml
@@ -126,7 +126,7 @@ jobs:
           contents:
             - src: bin/uniTerm
               dst: /usr/bin/uniterm
-            - src: build/linux/uniterm.desktop
+            - src: build/linux/uniTerm.desktop
               dst: /usr/share/applications/uniterm.desktop
             - src: build/appicon.png
               dst: /usr/share/icons/hicolor/128x128/apps/uniterm.png

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -268,7 +268,7 @@ jobs:
           contents:
             - src: bin/uniTerm
               dst: /usr/bin/uniterm
-            - src: build/linux/uniterm.desktop
+            - src: build/linux/uniTerm.desktop
               dst: /usr/share/applications/uniterm.desktop
             - src: build/appicon.png
               dst: /usr/share/icons/hicolor/128x128/apps/uniterm.png

--- a/build/linux/uniTerm.desktop
+++ b/build/linux/uniTerm.desktop
@@ -1,8 +1,9 @@
 [Desktop Entry]
 Name=uniTerm
 Comment=Lightweight All-in-One Terminal Emulator
-Exec=/usr/bin/uniterm
-Icon=uniterm
+Exec=/usr/local/bin/uniTerm
+Icon=uniTerm
 Terminal=false
 Type=Application
 Categories=System;TerminalEmulator;
+StartupWMClass=uniterm

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"runtime/debug"
@@ -27,6 +28,12 @@ var devBuild = Version == "dev"
 
 //go:embed all:frontend/dist
 var assets embed.FS
+
+// Linux desktop icon, embedded so a bare binary (no deb/rpm) can register its
+// own desktop integration at startup instead of relying on installation.
+//
+//go:embed build/appicon.png
+var linuxAppIcon []byte
 
 func main() {
 	// Capture top-level panics
@@ -62,6 +69,14 @@ func main() {
 	maxW, maxH := 0, 0
 	if runtime.GOOS == "linux" {
 		maxW, maxH = 9999, 9999
+
+		// Linux desktop integration: deb/rpm installs place a .desktop entry in
+		// the XDG data dirs, so the dock/launcher icon comes from there. For a
+		// bare binary that is never installed, register the entry into the
+		// user's home so the app still shows an icon when launched directly.
+		if exe, err := os.Executable(); err == nil {
+			ensureLinuxDesktopIntegration(exe)
+		}
 	}
 
 	// On macOS, install the standard App + Edit menus. The Edit menu is what
@@ -138,6 +153,13 @@ func main() {
 		Windows: application.WindowsOptions{
 			WebviewUserDataPath: webviewDataPath,
 		},
+		// Fixed program name so the window's WM_CLASS stays "uniterm" — the
+		// .desktop files (installed or self-registered) set StartupWMClass to the
+		// same value, which is what lets the dock/taskbar associate the running
+		// window with the app icon.
+		Linux: application.LinuxOptions{
+			ProgramName: "uniterm",
+		},
 	})
 
 	if appMenu != nil {
@@ -196,4 +218,79 @@ func startPprofIfDev() {
 			log.Writef("pprof listener failed: %v", err)
 		}
 	}()
+}
+
+// linuxDesktopEntry is the [Desktop Entry] file written for a self-registered
+// (bare binary) install. Exec is filled with the running binary's path.
+const linuxDesktopEntry = `[Desktop Entry]
+Name=uniTerm
+Comment=Lightweight All-in-One Terminal Emulator
+Exec=%s
+Icon=uniTerm
+Terminal=false
+Type=Application
+Categories=System;TerminalEmulator;
+StartupWMClass=uniterm
+`
+
+// ensureLinuxDesktopIntegration registers a bare Linux binary into the user's
+// desktop environment so the dock/launcher shows an icon when the app is run
+// without being installed (deb/rpm). Desktop handlers (GNOME Shell, KDE, XFCE
+// Panel, file managers) only associate a running window with an icon through a
+// .desktop entry matched by StartupWMClass; GTK4/Wails has no runtime API to
+// set a window icon directly.
+//
+// Entries already present in the XDG data dirs (i.e. an installed package)
+// take precedence — in that case we do nothing rather than overwriting them.
+// Writing happens on the user's home ("portable app" / AppImage convention).
+func ensureLinuxDesktopIntegration(execPath string) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return
+	}
+	if linuxDesktopRegistered(home) {
+		return
+	}
+
+	appsDir := filepath.Join(home, ".local/share/applications")
+	iconDir := filepath.Join(home, ".local/share/icons/hicolor/128x128/apps")
+	os.MkdirAll(appsDir, 0700)
+	os.MkdirAll(iconDir, 0700)
+
+	desktopPath := filepath.Join(appsDir, "uniTerm.desktop")
+	iconPath := filepath.Join(iconDir, "uniTerm.png")
+
+	if err := os.WriteFile(desktopPath, []byte(fmt.Sprintf(linuxDesktopEntry, execPath)), 0644); err != nil {
+		log.Writef("linux desktop integration: write %s failed: %v", desktopPath, err)
+		return
+	}
+	if err := os.WriteFile(iconPath, linuxAppIcon, 0644); err != nil {
+		log.Writef("linux desktop integration: write %s failed: %v", iconPath, err)
+		return
+	}
+
+	// Best-effort refresh so the entry is picked up without a re-login. These
+	// tools may be missing/wrong on some distros; failures are not fatal.
+	exec.Command("update-desktop-database", appsDir).Run()
+	exec.Command("gtk-update-icon-cache", "-t", "-f", filepath.Join(home, ".local/share/icons/hicolor")).Run()
+}
+
+// linuxDesktopRegistered reports whether a uniTerm.desktop entry already exists
+// in any XDG data directory (system dirs from XDG_DATA_DIRS/defaults, plus the
+// user-level dir). An installed deb/rpm satisfies this, so a bare binary skips
+// self-registration and lets the packaged entry win.
+func linuxDesktopRegistered(home string) bool {
+	dataDirs := os.Getenv("XDG_DATA_DIRS")
+	if dataDirs == "" {
+		dataDirs = "/usr/local/share:/usr/share"
+	}
+	for _, dir := range filepath.SplitList(dataDirs) {
+		if p, err := os.Stat(filepath.Join(dir, "applications", "uniTerm.desktop")); err == nil && !p.IsDir() {
+			return true
+		}
+	}
+	if p, err := os.Stat(filepath.Join(home, ".local/share/applications", "uniTerm.desktop")); err == nil && !p.IsDir() {
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
Add Linux desktop icon integration so the app shows an icon in the dock/launcher.

## Changes
- **Fix `.desktop` file** (`build/linux/uniTerm.desktop`, renamed from `uniterm.desktop`):
  - `Exec=/usr/local/bin/uniTerm` (matches where nfpm installs the binary)
  - `Icon=uniTerm` matches the installed `uniTerm.png` (Linux icon lookup is case-sensitive)
  - added `StartupWMClass=uniterm` so the window manager associates the running window with the entry
- **deb/rpm**: the corrected entry is picked up by `nfpm.yaml` (src `./build/linux/uniTerm.desktop`) on install.
- **Bare binary**: `main.go` embeds `build/appicon.png` and self-registers a `.desktop` + icon into `~/.local/share/...` on first launch via `ensureLinuxDesktopIntegration()`. It skips when an entry already exists in the XDG data dirs (i.e. when installed as a package). `Linux.ProgramName: "uniterm"` pins WM_CLASS to match.
- Sync `.desktop` src path in the two (unreleased) workflow files.

Note: GTK4 removed the runtime window-icon API in Wails v3, so Linux icons come from `.desktop` integration only. A bare binary's first run may not show the icon until a relaunch — this is upstream Linux desktop behavior, not a bug.

---

为 Linux 添加桌面图标集成，使应用在 dock / 启动器中显示图标。

## 改动
- **修正 `.desktop` 文件**（`build/linux/uniTerm.desktop`，由 `uniterm.desktop` 重命名）：
  - `Exec=/usr/local/bin/uniTerm`（与 nfpm 安装二进制的位置一致）
  - `Icon=uniTerm` 与安装的 `uniTerm.png` 对齐（Linux 图标查找区分大小写）
  - 新增 `StartupWMClass=uniterm`，让窗口管理器把运行中的窗口关联到该条目
- **deb/rpm**：安装时通过 `nfpm.yaml`（src `./build/linux/uniTerm.desktop`）使用修正后的条目。
- **裸二进制**：`main.go` 内嵌 `build/appicon.png`，首次启动通过 `ensureLinuxDesktopIntegration()` 将 `.desktop` 与图标自注册到 `~/.local/share/...`。若 XDG 数据目录已有条目（即已通过安装包安装）则跳过。`Linux.ProgramName: "uniterm"` 锁定 WM_CLASS 以匹配。
- 同步两个（未发布）workflow 文件中的 `.desktop` src 路径。

注意：GTK4 在 Wails v3 中移除了运行时设置窗口图标的 API，因此 Linux 图标仅来自 `.desktop` 集成。裸二进制首次运行的当次可能需重启一次才显示图标——这是 Linux 桌面集成机制，并非 bug。