### PR TITLE
fix(monitor): show send-signal dropdown on first open

### DIFF
--- a/frontend/src/components/MonitorTabContent.vue
+++ b/frontend/src/components/MonitorTabContent.vue
@@ -312,12 +312,6 @@
         </div>
         <div class="detail-actions">
           <el-button @click="detailDrawerVisible = false">{{ t('common.cancel') }}</el-button>
-          <Menu ref="signalMenuRef" v-model:visible="signalMenuVisible">
-            <MenuItem @click="onSignal('term')">{{ t('monitor.signalTerm') }}</MenuItem>
-            <MenuItem @click="onSignal('kill')">{{ t('monitor.signalKill') }}</MenuItem>
-            <MenuItem @click="onSignal('hup')">{{ t('monitor.signalHup') }}</MenuItem>
-            <MenuItem @click="onSignal('int')">{{ t('monitor.signalInt') }}</MenuItem>
-          </Menu>
         </div>
       </div>
       <div v-else class="process-detail-empty">{{ t('monitor.noProcessSelected') }}</div>
@@ -334,6 +328,17 @@
 
     <Menu ref="ctxMenuRef" v-model:visible="ctxMenuVisible" v-slot="{ current }">
       <MenuItem @click="copyContextText(current)">{{ t('terminal.copy') }}</MenuItem>
+    </Menu>
+
+    <!-- Send-signal dropdown for the per-row table button. Kept OUTSIDE the
+         processDetail-scoped drawer (which v-if's until a row is clicked) so it
+         is always mounted and the button in the process table works on first
+         open, independent of whether a process detail has been loaded yet. -->
+    <Menu ref="signalMenuRef" v-model:visible="signalMenuVisible">
+      <MenuItem @click="onSignal('term')">{{ t('monitor.signalTerm') }}</MenuItem>
+      <MenuItem @click="onSignal('kill')">{{ t('monitor.signalKill') }}</MenuItem>
+      <MenuItem @click="onSignal('hup')">{{ t('monitor.signalHup') }}</MenuItem>
+      <MenuItem @click="onSignal('int')">{{ t('monitor.signalInt') }}</MenuItem>
     </Menu>
   </div>
 </template>


### PR DESCRIPTION
## Summary

The "send signal" dropdown in the monitor page's process list did nothing on the first open of the page. It only produced the dropdown after a process row was clicked to open a detail view.

Root cause: the dropdown `<Menu ref="signalMenuRef">` was nested inside the detail drawer's `v-if="processDetail"` branch, which is `null` until a row is clicked. On first open the Menu was never mounted, so `signalMenuRef.value` was `null` and `onTableSignal`'s `toggle(...)` silently no-op'd. Clicking a row populated `processDetail`, which mounted the Menu and made the button work.

Fix: move the signal dropdown outside the `v-if` block to an always-mounted location. The Menu is a Teleport-to-body dropdown positioned relative to the trigger button, so its position in the template does not affect rendering — the button is now decoupled from the detail panel's mount state.

---

## 摘要

监控页进程列表里的「发送信号」下拉按钮,在页面首次打开时点击没有反应,直到点击某个进程详情后才会弹出下拉菜单。

根因:下拉菜单 `<Menu ref="signalMenuRef">` 被嵌套在详情抽屉的 `v-if="processDetail"` 分支内,而首次打开时 `processDetail` 为 `null`,该 Menu 尚未挂载,`signalMenuRef.value` 为 `null`,`onTableSignal` 中的 `toggle(...)` 被静默跳过。点击某行后填充了 `processDetail`,Menu 才被挂载,按钮随之生效。

修复:把信号下拉菜单移出 `v-if` 块,放到始终挂载的位置。该 Menu 是 Teleport 到 body、相对触发按钮定位的下拉,放在模板任何位置都不影响渲染——按钮从此不再依赖详情面板的挂载时机。
