### PR TITLE
feat(sftp): quick-locate files by typing first letter

### DIFF
--- a/frontend/src/components/SFTPFileList.vue
+++ b/frontend/src/components/SFTPFileList.vue
@@ -1,5 +1,11 @@
 <template>
-  <div class="sftp-file-list">
+  <div
+    ref="listRootRef"
+    class="sftp-file-list"
+    tabindex="0"
+    @keydown="onListKeydown"
+    @click="onListClick"
+  >
     <div class="filter-bar">
       <el-input
         v-model="filterText"
@@ -273,6 +279,82 @@ watch(filteredFiles, () => {
   nextTick(bindTableScroll)
 })
 
+// --- Quick locate (issue #700) ----------------------------------------------
+// Pressing a letter key while the list has focus jumps to the first entry whose
+// name starts with that letter (case-insensitive, dirs listed first), like
+// Windows Explorer. Pressing the same letter again cycles to the next match.
+const listRootRef = ref<HTMLElement | null>(null)
+const quickTargetName = ref<string | null>(null)
+let quickKey = ''
+let quickIndex = -1
+let quickTimer: ReturnType<typeof setTimeout> | null = null
+const QUICK_RESET_MS = 1200
+
+function onListClick(e: MouseEvent) {
+  // Focus the list on click so letter keys locate within it, but only when the
+  // click lands on the table itself (not the filter/breadcrumb/clipboard bars
+  // or other controls), so we never steal focus while the user is editing.
+  const t = e.target as HTMLElement
+  if (t.closest && !t.closest('.table-wrapper')) return
+  listRootRef.value?.focus({ preventScroll: true })
+}
+
+function onListKeydown(e: KeyboardEvent) {
+  const t = e.target as HTMLElement | null
+  // Never hijack typing that is going somewhere else (filter box, editors).
+  if (t && (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.tagName === 'SELECT' || t.isContentEditable)) return
+  if (e.ctrlKey || e.metaKey || e.altKey) return
+  const k = e.key
+  if (k.length !== 1 || !/[\x00-\x7F]/.test(k)) return // printable single char only
+  e.preventDefault()
+  locateByKey(k.toLowerCase())
+}
+
+function locateByKey(key: string) {
+  // Candidate indices in display order (skip the '..' row).
+  const matches: number[] = []
+  filteredFiles.value.forEach((f, i) => {
+    if (f.name !== '..' && f.name.toLowerCase().startsWith(key)) matches.push(i)
+  })
+  if (!matches.length) return
+
+  if (quickKey !== key) {
+    // New letter: start from the first match.
+    quickKey = key
+    quickIndex = matches[0]
+  } else {
+    // Same letter again: cycle to the next match.
+    const pos = matches.indexOf(quickIndex)
+    quickIndex = pos >= 0 ? matches[(pos + 1) % matches.length] : matches[0]
+  }
+
+  // Reset the "repeated same key" state after a short pause.
+  if (quickTimer) clearTimeout(quickTimer)
+  quickTimer = setTimeout(() => {
+    quickKey = ''
+    quickIndex = -1
+    quickTargetName.value = null
+  }, QUICK_RESET_MS)
+
+  scrollToIndex(quickIndex)
+}
+
+function scrollToIndex(index: number) {
+  const target = filteredFiles.value[index]
+  if (!target) return
+  // Make sure the row is actually rendered (progressive loading).
+  const pages = Math.ceil((index + 1) / PAGE_SIZE)
+  if (visibleCount.value < pages) visibleCount.value = pages
+  // Select it (reuses the existing selection highlight) and flag it briefly.
+  selectedItems.value = [target]
+  quickTargetName.value = target.name
+  nextTick(() => {
+    const el = (tableRef.value?.$el ?? null) as HTMLElement | null
+    const tr = el?.querySelectorAll('.el-table__body tr')[index] as HTMLElement | undefined
+    tr?.scrollIntoView({ block: 'nearest' })
+  })
+}
+
 // <el-table :key="locale"> remounts the table on locale switch, creating a new
 // scrollbar element that needs the scroll listener re-attached.
 watch(locale, () => {
@@ -409,10 +491,10 @@ function doUpload() { emit('upload'); ctxMenuVisible.value = false }
 function doRefresh() { emit('refresh'); ctxMenuVisible.value = false }
 
 function getRowClassName({ row }: { row: FileItem }): string {
-  if (props.cutItemNames && props.cutItemNames.includes(row.name)) {
-    return 'cut-item-row'
-  }
-  return ''
+  const cls: string[] = []
+  if (props.cutItemNames && props.cutItemNames.includes(row.name)) cls.push('cut-item-row')
+  if (row.name === quickTargetName.value) cls.push('quick-target-row')
+  return cls.join(' ')
 }
 
 function onDragStart(event: DragEvent, row: FileItem) {
@@ -435,6 +517,14 @@ function onDragStart(event: DragEvent, row: FileItem) {
   flex-direction: column;
   height: 100%;
   overflow: hidden;
+}
+/* The list root is focusable so letter keys can quick-locate; hide the ring. */
+.sftp-file-list:focus {
+  outline: none;
+}
+/* Brief highlight shown while a quick-located row is in view (issue #700). */
+:deep(.quick-target-row) td {
+  background-color: rgba(var(--color-primary, 64, 158, 255), 0.14);
 }
 .filter-bar {
   display: flex;


### PR DESCRIPTION
## Summary

Implements Windows-Explorer-style keyboard quick-location in the SFTP file list (issue #700): focus the list, press a letter, and jump to the first entry whose name starts with it; pressing the same letter again cycles to the next match.

## Behavior

- **Trigger** — clicking the list gives it focus (clicks on the filter/breadcrumb/control bars keep their existing focus); letter keys then locate within the list.
- **Matching** — searches the currently filtered/sorted list (case-insensitive, directories listed first, skipping `..`); folders count.
- **Cycle** — pressing the same letter again jumps to the next match; a short pause resets to the first match.
- **Jump** — if the match is beyond the progressive-loading slice, expands the rendered page, scrolls it into view, and selects it with a brief highlight.
- **Safety** — modifier-key combos are ignored and typing destined for an input/editor is never hijacked.

Lives in the shared `SFTPFileList` component, so it works in both SFTP panes (local + remote) and the file sidebar.

## Test

- Frontend + `wails3 build` pass; `bin/uniTerm.exe` produced.
- Keyboard behavior needs manual verification.

Closes #700

---
## 摘要

为 SFTP 文件列表实现类似 Windows 资源管理器的键盘快速定位（issue #700）：聚焦列表后按字母键，跳到第一个以该字母开头的条目；再次按同一字母则跳到下一个匹配。

## 行为

- **触发** — 点击列表使其获得焦点（点击筛选框/面包屑/工具栏仍保持各自焦点）；此后字母键即在列表内定位。
- **匹配** — 在「当前已过滤/排序的列表」中查找（忽略大小写、文件夹排前、跳过 `..`），文件夹也算命中。
- **循环** — 连续按同一字母跳到下一个匹配；短暂停顿后复位、重新从首个开始。
- **跳转** — 若目标超出渐进式渲染区间，先扩展渲染页数使该行进入 DOM，再滚动到并选中它，附带短暂高亮。
- **安全** — 忽略组合键，绝不劫持要进入输入框/编辑器的输入。

该逻辑放在共享的 `SFTPFileList` 组件里，因此 SFTP 标签页的本地/远端两个面板以及文件边栏都会生效。

## 测试

- 前端与 `wails3 build` 构建通过，已产出 `bin/uniTerm.exe`。
- 键盘行为需结合实例进行人工验证。

Closes #700