### PR TITLE
fix(sftp): reliably auto-detect UTF-8 instead of misjudging it as GBK

### DIFF
--- a/frontend/src/components/SFTPTabContent.vue
+++ b/frontend/src/components/SFTPTabContent.vue
@@ -327,35 +327,18 @@ function detectEncoding(bytes: Uint8Array): { encoding: Encoding, hasBom: boolea
   for (let i = 0; i < checkLen; i++) { if (bytes[i] === 0) nullCount++ }
   if (nullCount > checkLen * 0.3) return { encoding: 'utf-16le', hasBom: false }
 
-  // Try UTF-8 first (most common). Use non-fatal mode so valid UTF-8
-  // sequences are accepted even if some bytes might be interpreted as
-  // legacy encodings. WebView2's TextDecoder(fatal:true) may be overly
-  // strict for certain byte sequences.
+  // Detect UTF-8 by strict-decoding the whole file. fatal decode throws as soon
+  // as it hits an invalid sequence, so it is reliable for GBK (which almost
+  // always fails) and, unlike a fixed-size sample, never misjudges a valid
+  // UTF-8 file whose bytes happen to end mid a multi-byte character near the
+  // sample boundary (issue #701).
   try {
-    const sample = bytes.slice(0, 8192)
-    // Quick check: valid UTF-8 lead/trail byte pattern
-    let i = 0
-    let valid = true
-    while (i < sample.length) {
-      const b = sample[i]
-      if (b < 0x80) { i++; continue }
-      let trailing: number
-      if ((b & 0xE0) === 0xC0) trailing = 1
-      else if ((b & 0xF0) === 0xE0) trailing = 2
-      else if ((b & 0xF8) === 0xF0) trailing = 3
-      else { valid = false; break }
-      if (i + trailing >= sample.length) { valid = false; break }
-      for (let j = 1; j <= trailing; j++) {
-        if ((sample[i + j] & 0xC0) !== 0x80) { valid = false; break }
-      }
-      if (!valid) break
-      i += trailing + 1
-    }
-    if (valid) return { encoding: 'utf-8', hasBom: false }
-  } catch { /* fall through */ }
-
-  // Try GBK/GB18030 — common for Chinese text on Windows
-  return { encoding: 'gbk', hasBom: false }
+    new TextDecoder('utf-8', { fatal: true }).decode(bytes)
+    return { encoding: 'utf-8', hasBom: false }
+  } catch {
+    // Not valid UTF-8 — most likely GBK for Chinese text on Windows.
+    return { encoding: 'gbk', hasBom: false }
+  }
 }
 
 function detectLineEnding(text: string): LineEnding {


### PR DESCRIPTION
## Summary

Fixes auto-detection of file encoding in the SFTP online editor (issue #701). Valid UTF-8 files without a BOM were often opened as GBK (garbled), forcing a manual switch to UTF-8.

The old detector validated UTF-8 with a hand-rolled byte check over a fixed 8192-byte sample. If a valid UTF-8 file crossed that sample boundary mid a multi-byte character, the check failed and the file fell back to GBK.

The detector now strict-decodes the entire file with `TextDecoder('utf-8', { fatal: true })`, which throws on the first invalid sequence. Valid UTF-8 is recognized reliably, GBK still falls through to GBK, and BOM / UTF-16 heuristics are unchanged.

## Verification

- Script-produced edge cases behave correctly: small UTF-8 → UTF-8, valid UTF-8 straddling the old 8192-sample boundary → UTF-8 (was GBK), GBK → GBK.
- Frontend + `wails3 build` pass.

Closes #701

---
## 摘要

修复 SFTP 在线编辑器对文件编码的自动识别（issue #701）。无 BOM 的合法 UTF-8 文件常被当作 GBK 打开而乱码，需手动切回 UTF-8。

旧实现用一套手写字节校验器在固定 8192 字节采样上判断 UTF-8；当合法 UTF-8 文件在该采样边界处恰好切开一个多字节字符时，校验失败，回退成 GBK。

新实现改用 `TextDecoder('utf-8', { fatal: true })` 对整个文件严格解码，遇到第一个非法序列即抛错。合法 UTF-8 能被可靠识别，GBK 文件仍会落到 GBK，BOM/UTF-16 启发式保持不变。

## 验证

- 脚本构造的边界用例均正确：小型 UTF-8 → UTF-8；跨越旧 8192 采样边界的合法 UTF-8 → UTF-8（原为 GBK）；GBK → GBK。
- 前端与 `wails3 build` 构建通过。

Closes #701