### PR TITLE
fix(macos): build app menu after application.New to fix startup panic

### DIFF
--- a/main.go
+++ b/main.go
@@ -65,22 +65,6 @@ func main() {
 		maxW, maxH = 9999, 9999
 	}
 
-	// On macOS, install the standard App + Edit menus. The Edit menu is what
-	// routes the native Cmd+C/V/X/A/Z shortcuts to the first responder — every
-	// WKWebView text field (input/textarea/contenteditable) relies on it. An
-	// empty menu here used to suppress Wails' defaults but also killed those
-	// shortcuts app-wide, forcing per-component JS reimplementations. The menu
-	// lives in the top system menu bar, so it doesn't affect the frameless
-	// window. On Linux (GTK) a non-nil Menu creates an empty GtkMenuBar that
-	// shows as a thin white line in the frameless window, so leave it nil
-	// there. See issue #291.
-	var appMenu *application.Menu
-	if runtime.GOOS == "darwin" {
-		appMenu = application.NewMenu()
-		appMenu.AddRole(application.AppMenu)
-		appMenu.AddRole(application.EditMenu)
-	}
-
 	// Read persisted window geometry before creating the window — it's fixed at
 	// creation in v3 (services start before the window exists, so ServiceStartup
 	// can't position it). Race the load against a short timeout so a slow disk
@@ -147,6 +131,25 @@ func main() {
 			ProgramName: "uniterm",
 		},
 	})
+
+	// On macOS, install the standard App + Edit menus. This must run AFTER
+	// application.New(): menu roles dereference the global app instance and
+	// panic with a nil pointer otherwise (macOS-only — NewAppMenu returns nil
+	// on other platforms, which masked the crash). The Edit menu is what
+	// routes the native Cmd+C/V/X/A/Z shortcuts to the first responder — every
+	// WKWebView text field (input/textarea/contenteditable) relies on it. An
+	// empty menu here used to suppress Wails' defaults but also killed those
+	// shortcuts app-wide, forcing per-component JS reimplementations. The menu
+	// lives in the top system menu bar, so it doesn't affect the frameless
+	// window. On Linux (GTK) a non-nil Menu creates an empty GtkMenuBar that
+	// shows as a thin white line in the frameless window, so leave it nil
+	// there. See issue #291.
+	var appMenu *application.Menu
+	if runtime.GOOS == "darwin" {
+		appMenu = application.NewMenu()
+		appMenu.AddRole(application.AppMenu)
+		appMenu.AddRole(application.EditMenu)
+	}
 
 	if appMenu != nil {
 		w3app.Menu.SetApplicationMenu(appMenu)


### PR DESCRIPTION
## Summary / 摘要

**EN:** Since the Wails v3 migration (54744d5), the macOS packaged build crashes on launch — the process dies before any window appears. The macOS app-menu construction in `main()` ran **before** `application.New()`; Wails v3 menu roles dereference the global app instance (`globalApplication.options.Name` in `NewAboutMenuItem()`), which is still nil at that point, so every launch panics with a nil pointer dereference. The crash is macOS-only because `NewAppMenu()` returns nil on other platforms, which masked it.

**中文:** 自 Wails v3 迁移（54744d5）后，macOS 打包版启动即闪退。原因是 `main()` 中 macOS 菜单构建跑在 `application.New()` 之前；Wails v3 的菜单角色内部引用全局应用实例（`NewAboutMenuItem()` 读 `globalApplication.options.Name`），此时仍为 nil，导致每次启动都 nil pointer panic。由于 `NewAppMenu()` 在非 darwin 平台直接返回 nil，**崩溃仅在 macOS 出现**，其他平台构建时未暴露。

## Changes / 改动

- **EN:** Move the `NewMenu() + AddRole(...) + SetApplicationMenu(...)` block to after `application.New()` (before window creation), keeping the existing explanatory comment and adding why the ordering matters.
- **中文:** 将 `NewMenu() + AddRole(...) + SetApplicationMenu(...)` 整体移到 `application.New()` 之后（窗口创建之前），保留原注释并补充了顺序原因。

## Validation / 验证

- **EN:** Reproduced the panic in `~/.uniterm/uniterm.log` on every pre-fix launch (stack: `NewAboutMenuItem()` → `main.go:80`). After the fix, `task dev` launches successfully on macOS: process stays alive, window renders, and no new FATAL PANIC entries in the log. `go build ./...` passes.
- **中文:** 修复前 `~/.uniterm/uniterm.log` 每次启动都记录同一 panic（栈顶 `NewAboutMenuItem()`，指向 `main.go:80`）。修复后 macOS 上 `task dev` 启动成功：进程存活、窗口正常渲染、日志无新 FATAL PANIC。`go build ./...` 通过。

Closes #716