### PR TITLE
fix(tunnel): resolve jump-host credentials by auth type

### DIFF
--- a/app.go
+++ b/app.go
@@ -1949,7 +1949,10 @@ func (a *App) setupJumpHostTunnel(sessionID string, sessionType string, config *
 	}
 
 	// Resolve an identity reference into a concrete password/key config
-	// before handing the jump host to the tunnel service.
+	// before handing the jump host to the tunnel service. Identity is
+	// authoritative from the 密钥库(identity store); inline credentials
+	// never override it.
+	wasIdentity := tunnelSSHConfig.AuthType == "identity"
 	if tunnelSSHConfig.AuthType == "identity" {
 		m, err := a.materializeIdentity(*tunnelSSHConfig)
 		if err != nil {
@@ -1967,13 +1970,16 @@ func (a *App) setupJumpHostTunnel(sessionID string, sessionType string, config *
 		}
 	}
 
-	// Apply inline tunnel credentials if the frontend provided them
-	// (e.g. credential prompt "connect" without saving).
-	if config.TunnelSSHUser != "" {
-		tunnelSSHConfig.User = config.TunnelSSHUser
-	}
-	if config.TunnelSSHPassword != "" {
-		tunnelSSHConfig.Password = config.TunnelSSHPassword
+	// Inline tunnel credentials (ephemeral prompt "connect" without saving)
+	// only fill gaps — they never override already-resolved values, and
+	// never touch an identity-resolved config.
+	if !wasIdentity {
+		if config.TunnelSSHUser != "" && tunnelSSHConfig.User == "" {
+			tunnelSSHConfig.User = config.TunnelSSHUser
+		}
+		if config.TunnelSSHPassword != "" && tunnelSSHConfig.Password == "" {
+			tunnelSSHConfig.Password = config.TunnelSSHPassword
+		}
 	}
 
 	// VNC/SPICE use libvirt display numbers (port < 100 → 5900+N).
@@ -4865,45 +4871,7 @@ func (a *App) K8sConnect(source string, sourceIsPath bool, contextName string,
 		return a.k8sManager.Connect(a.ctx, raw, contextName)
 	}
 
-	// ── SSH Tunnel for K8s ─────────────────────────────────────
-	if a.tunnelService == nil {
-		return "", fmt.Errorf("tunnel service not initialized")
-	}
-	if a.connectionStore == nil {
-		return "", fmt.Errorf("connection store not initialized")
-	}
-	data, err := a.connectionStore.Load()
-	if err != nil {
-		return "", fmt.Errorf("load connections for tunnel: %w", err)
-	}
-	var tunnelSSHConfig *session.ConnectionConfig
-	for _, c := range data.Connections {
-		if c.ID == tunnelSSHConnID {
-			tunnelSSHConfig = &c
-			break
-		}
-	}
-	if tunnelSSHConfig == nil {
-		return "", fmt.Errorf("tunnel SSH connection not found: %s", tunnelSSHConnID)
-	}
-
-	// Resolve an identity reference into a concrete password/key config
-	// before the user/password overrides below so those still take precedence.
-	if tunnelSSHConfig.AuthType == "identity" {
-		m, err := a.materializeIdentity(*tunnelSSHConfig)
-		if err != nil {
-			return "", err
-		}
-		tunnelSSHConfig = &m
-	}
-
-	if tunnelSSHUser != "" {
-		tunnelSSHConfig.User = tunnelSSHUser
-	}
-	if tunnelSSHPassword != "" {
-		tunnelSSHConfig.Password = tunnelSSHPassword
-	}
-
+	// ── SSH Tunnel for K8s (reuses the shared jump-host tunnel logic) ──
 	// 从 kubeconfig 解出 apiserver host/port 作为隧道目标
 	kc, err := k8s.ParseBytes(raw)
 	if err != nil {
@@ -4929,12 +4897,18 @@ func (a *App) K8sConnect(source string, sourceIsPath bool, contextName string,
 	// 用同一个 key 既做 K8s connID 也做 TunnelService 的 sessionID，
 	// 方便 Disconnect 时的 onClose 回调直接 Stop 同名隧道。
 	tunnelKey := uuid.New().String()
-	localPort, err := a.tunnelService.Start(tunnelKey, *tunnelSSHConfig, targetHost, targetPort, nil)
-	if err != nil {
-		return "", fmt.Errorf("tunnel start: %w", err)
+	tunnelConfig := session.ConnectionConfig{
+		TunnelSSHConnID:   tunnelSSHConnID,
+		TunnelSSHUser:     tunnelSSHUser,
+		TunnelSSHPassword: tunnelSSHPassword,
+		Host:              targetHost,
+		Port:              targetPort,
 	}
-	log.Writef("[K8sConnect] tunnel established for k8s=%s via ssh=%s, localPort=%d",
-		tunnelKey, tunnelSSHConnID, localPort)
+	// 与其它连接类型共享同一段隧道逻辑：按认证类型解析跳板机凭据并拉起隧道。
+	if err := a.setupJumpHostTunnel(tunnelKey, "k8s", &tunnelConfig); err != nil {
+		return "", err
+	}
+	localPort := tunnelConfig.Port
 
 	var dialer net.Dialer
 	dialOverride := func(ctx context.Context, _ /*network*/, _ /*addr*/ string) (net.Conn, error) {
@@ -5083,38 +5057,22 @@ func (a *App) ContainerConnect(connectionID string) error {
 		sshCfg = &m
 	}
 
-	// 跳板机：被引用连接自身的 tunnel 配置
-	if sshCfg.TunnelSSHConnID != "" && a.tunnelService != nil {
-		var tunnelCfg *session.ConnectionConfig
-		for _, c := range data.Connections {
-			if c.ID == sshCfg.TunnelSSHConnID {
-				tunnelCfg = &c
-				break
-			}
-		}
-		if tunnelCfg == nil {
-			return fmt.Errorf("tunnel SSH connection not found: %s", sshCfg.TunnelSSHConnID)
-		}
-		if tunnelCfg.AuthType == "identity" {
-			m, err := a.materializeIdentity(*tunnelCfg)
-			if err != nil {
-				return err
-			}
-			tunnelCfg = &m
-		}
-		localPort, err := a.tunnelService.Start(connectionID, *tunnelCfg, sshCfg.Host, sshCfg.Port, nil)
-		if err != nil {
-			return fmt.Errorf("tunnel start: %w", err)
-		}
-		sshCfg.Host = "127.0.0.1"
-		sshCfg.Port = localPort
-		if err := a.containerManager.ConnectSSH(connectionID, rt, "", *sshCfg); err != nil {
-			a.tunnelService.Stop(connectionID) // 与 K8sConnect 一致：连接失败时回收隧道
+	// 跳板机：复用统一的 setupJumpHostTunnel（与其它连接类型同一段逻辑）。
+	// 它会按认证类型解析被引用跳板机连接的凭据并拉起隧道，同时改写
+	// sshCfg.Host/Port 指向本地监听口。
+	hasTunnel := sshCfg.TunnelSSHConnID != ""
+	if hasTunnel {
+		if err := a.setupJumpHostTunnel(connectionID, "container", sshCfg); err != nil {
 			return err
 		}
-		return nil
 	}
-	return a.containerManager.ConnectSSH(connectionID, rt, "", *sshCfg)
+	if err := a.containerManager.ConnectSSH(connectionID, rt, "", *sshCfg); err != nil {
+		if hasTunnel && a.tunnelService != nil {
+			a.tunnelService.Stop(connectionID) // 与其它连接一致：连接失败时回收隧道
+		}
+		return err
+	}
+	return nil
 }
 
 func (a *App) ContainerDisconnect(connectionID string) {

--- a/frontend/src/composables/useTunnelCredentials.ts
+++ b/frontend/src/composables/useTunnelCredentials.ts
@@ -15,6 +15,10 @@ type ShowCredentialDialog = (
 function needsCred(cfg: ConnectionConfig): boolean {
   if (cfg.type !== 'ssh' && cfg.type !== 'mosh' && cfg.type !== 'sftp' && cfg.type !== 'ftp') return false
   if ((cfg.type === 'ssh' || cfg.type === 'mosh') && cfg.authType === 'key') return false
+  // 身份认证：账密来自身份库(密钥库)，由后端 materializeIdentity 解析，无需补全提示。
+  // 与 App.vue needsCredentialCheck 保持一致 —— 否则 identity 连接的 user/password 字段
+  // 为空会被误判为"缺少凭据"而弹窗，弹窗里的临时/旧密码又会压过后端从密钥库解析出的正确值。
+  if (cfg.authType === 'identity') return false
   return !cfg.user || !cfg.password
 }
 


### PR DESCRIPTION
Fixes #687

### Problem
When connecting to Kubernetes via an SSH jump host that uses an **identity**
(密钥库/identity store) credential, uniTerm 1.8 cost used the jump host's **stale
saved password** (`connections.json` `enc:v1`) instead of the credential in the
identity store / keyring. Two causes compounded:

1. **Frontend** — `useTunnelCredentials.needsCred` was missing the
   `authType === 'identity'` exclusion that `App.vue.needsCredentialCheck`
   already has. An identity-based jump host has empty `user`/`password` fields
   (they live in the referenced identity), so it was wrongly flagged as
   "needs credentials", triggered a prompt, and the prompt's ephemeral/stale
   password was forwarded to Go as `tunnelSSHPassword`.

2. **Backend** — `K8sConnect` resolved credentials from a hand-rolled duplicate
   of the tunnel logic that lacked both the identity authority and the keychain
   (`EnsurePassword`) fallback, and applied the frontend-inline
   `tunnelSSHPassword` as a hard override — clobbering the correctly
   identity-resolved credential.

### Fix
- **Unify tunnel setup**: K8s and container now route through the same
  `setupJumpHostTunnel` used by every other connection type, deleting their
  hand-written duplicates. Jump-host credentials are resolved once, by auth
  type: identity → identity store (密钥库), password → stored / keychain
  fallback.
- **Stop inline override**: inline credentials only fill gaps when a field is
  empty; they never override a resolved value and never touch an
  identity-resolved connection.
- **Frontend**: exclude identity jump hosts from the credential prompt
  (`needsCred` now matches `App.vue.needsCredentialCheck`).

### Verification
- `go build ./...` passes.
- `vue-tsc` shows no errors in the changed files (remaining errors are
  pre-existing and unrelated).

---
Fixes #687

### 问题描述
通过 SSH 跳板机对接 Kubernetes，且该跳板机使用**身份（密钥库）**认证时，uniTerm 1.8
误用了跳板机**已保存的旧密码**（`connections.json` 中的 `enc:v1`），而不是身份库/钥匙串里的凭据。
两个原因叠加导致：

1. **前端** — `useTunnelCredentials.needsCred` 缺少 `App.vue.needsCredentialCheck`
   已有的 `authType === 'identity'` 排除。身份型跳板机的 `user`/`password` 字段为空
   （凭据在被引用身份里），于是被误判为"缺凭据"而弹窗，弹窗里的临时/旧密码又作为
   `tunnelSSHPassword` 传给 Go。

2. **后端** — `K8sConnect` 用一段手写的重复隧道逻辑解析凭据，既缺身份权威解析，也缺
   钥匙串（`EnsurePassword`）兜底，并把前端内联的 `tunnelSSHPassword` 当作硬覆盖，
   压过了正确从密钥库解析出的凭据。

### 修复
- **统一隧道逻辑**：k8s 与 container 改为与其它连接类型共用同一段 `setupJumpHostTunnel`，
  删除各自手写重复。跳板机凭据按认证类型一次性解析：identity → 身份库（密钥库），
  password → 存储/钥匙串兜底。
- **停止内联覆盖**：内联凭据只在字段为空时填空，绝不覆盖已解析值，也不触碰身份解析的连接。
- **前端**：身份型跳板机不再弹窗（`needsCred` 与 `App.vue.needsCredentialCheck` 对齐）。

### 验证
- `go build ./...` 通过。
- `vue-tsc` 改动文件无报错（其余报错为历史既有、与本改动无关）。