### PR TITLE
fix(sync): clear stale user/password when connection auth is switched to identity

### DIFF
--- a/backend/store/connection_store.go
+++ b/backend/store/connection_store.go
@@ -67,6 +67,18 @@ func (s *ConnectionStore) Save(data session.ConnectionStoreData) error {
 	// Encrypt password fields in place before writing JSON.
 	for i := range connections {
 		conn := &connections[i]
+		if conn.AuthType == "identity" {
+			// Identity connections obtain both username and credentials solely
+			// from the referenced identity (MaterializeIdentity overrides User
+			// and Password at connect time). A stale password/user left when
+			// switching away from another auth mode is unused — and, if it still
+			// holds an enc:v1: field, would be carried verbatim into cloud sync
+			// (sync normalization only cleans authType=="password" connections),
+			// surfacing as a literal enc:v1: on other devices (issue #711).
+			conn.Password = ""
+			conn.User = ""
+			continue
+		}
 		if conn.AuthType != "password" {
 			continue
 		}

--- a/frontend/src/components/ConnectionForm.vue
+++ b/frontend/src/components/ConnectionForm.vue
@@ -1363,6 +1363,15 @@ function normalizeForm(): ConnectionConfig {
     form.serialParity = serialParityValue.value
   }
   const normalized = { ...form }
+  // Identity (密钥库) 的用户名与凭据完全由所引用的 identity 提供，连接时
+  // MaterializeIdentity 会以 identity 的 username/password 覆盖本字段。
+  // 从别的认证方式切到 identity 时，旧字段若残留 enc:v1: 密文，会被
+  // 云同步原样带进仓库（同步规范化只处理 authType=="password" 的连接），
+  // 导致他机显示字面量 enc:v1:xxx（issue #711）。保存时清掉两者以绝后患。
+  if (normalized.authType === 'identity') {
+    normalized.password = ''
+    normalized.user = ''
+  }
   normalized.postLoginExpectSteps = normalizeExpectSteps(form.postLoginExpectSteps || [])
   if (postLoginMode.value === 'script') {
     normalized.postLoginExpectSteps = []


### PR DESCRIPTION
Fixes the cloud-sync data-loss root cause reported in issue #711.

## Problem

Switching a connection's auth type to identity (密钥库/keychain) did not clear the previously saved `user`/`password` fields in connections.json. But **sync only normalizes connections whose `authType == "password"`** — identity (or key/apikey) connections are skipped entirely. So a stale `enc:v1:`-encrypted password left on an identity connection was carried **verbatim** into the shared repo (the repo is supposed to hold plaintext, protected only by the sync key), then redistributed to every device as a literal `enc:v1:xxx` string. Other machines could not decrypt it, so the connection appeared to have its password reverted/cleared — and the polluted state kept overwriting the real credential across syncs.

## Fix

Clear `password` and `user` on identity connections at save time, so a stale secret field never re-enters the sync repo:

- **frontend** — `ConnectionForm.normalizeForm()`: when `authType === 'identity'`, empty both fields (covers save / connect / test paths).
- **backend** — `ConnectionStore.Save()`: defense-in-depth, clear both fields for identity connections before persisting.

This is safe because `MaterializeIdentity` overrides `User` and `Password` from the referenced identity at connect time anyway; the connection-level fields are unused for identity auth.

## Verification

- `go build ./backend/store/` ✓
- `go test ./backend/store/` ✓ (no existing test asserts an identity connection retains its password/user)
- Diff is minimal (LF line endings restored; 12 +backend, 9 +frontend).

## Note

This fixes the root cause (no new stale secrets enter the repo). It does not retroactively rewrite the already-polluted field on devices that pulled a literal `enc:v1:`, nor scrub data already committed to the remote — that needs a separate sync-boundary hardening (fail-closed when an `enc:v1:` field cannot be normalized), which is intentionally out of scope here.

---

修复 issue #711 中云同步数据丢失的根因。

## 问题

把连接的认证类型切换为 identity（密钥库）时，connections.json 里原先保存的 `user`/`password` 字段没有被清空。而**同步只对 `authType == "password"` 的连接做规范化**（identity / key / apikey 整条跳过）。于是切到 identity 后残留的 `enc:v1:` 加密密码被**原样**带进共享仓库（仓库本应只存明文、由同步密钥整体保护），再分发到每台设备变成字面量 `enc:v1:xxx`。其他设备无法用本机密钥解密，表现为密码被还原/清空，且这份脏数据在多次同步后持续覆盖真实凭据。

## 修复

在保存时清空 identity 连接上的 `password` 和 `user`，让陈旧密钥字段不再进入同步仓库：

- **前端** —— `ConnectionForm.normalizeForm()`：当 `authType === 'identity'` 时清空两者（覆盖保存/连接/测试所有路径）。
- **后端** —— `ConnectionStore.Save()`：纵深防御，identity 连接落盘前同样清空。

安全无副作用：连接时 `MaterializeIdentity` 会用所引用 identity 的 `User`/`Password` 覆盖这两个字段，identity 认证下连接级字段本就不被使用。

## 验证

- `go build ./backend/store/` ✓
- `go test ./backend/store/` ✓（无现有测试断言 identity 连接保留 password/user）
- diff 干净（已还原 LF 行尾；后端 +12、前端 +9）。

## 说明

本次修复根因（不再产生新的脏字段入仓）。它不会追溯改写已在各设备上拉到的字面量 `enc:v1:`，也不会清掉已提交到远端的脏数据——那需要另一次的同步边界加固（遇到无法规范化的 `enc:v1:` 时报错而非放行），本意上不在本次范围内。