### PR TITLE
fix(identities): show correct auth type label for keyText identities

### DIFF
--- a/frontend/src/components/SettingsTab.vue
+++ b/frontend/src/components/SettingsTab.vue
@@ -697,7 +697,7 @@
           <el-table-column prop="name" :label="t('conn.name')" />
           <el-table-column prop="username" :label="t('conn.user')" />
           <el-table-column :label="t('conn.authType')">
-            <template #default="{ row }">{{ row.authType === 'password' ? t('conn.password') : t('conn.keyPath') }}</template>
+            <template #default="{ row }">{{ row.authType === 'password' ? t('conn.password') : row.authType === 'keyText' ? t('conn.keyText') : t('conn.keyPath') }}</template>
           </el-table-column>
           <el-table-column :label="t('common.actions')" width="160">
             <template #default="{ row }">


### PR DESCRIPTION
## Summary
- The identity table in Settings → Keystore rendered the auth type with a binary password/key-path check, so identities imported via **key text** displayed the key-path label ("密钥路径") instead of "密钥文本".
- Map `keyText` to its own existing i18n label (`conn.keyText`); no new translations needed.

Fixes #723

---

## 摘要
- 修复设置 → 密钥库列表中认证方式的显示：原实现只区分 password 和密钥路径两种，通过「密钥文本」导入的身份错误地显示为「密钥路径」。
- 为 `keyText` 增加分支，显示已有的 `conn.keyText`（密钥文本）文案，无需新增翻译。

Fixes #723