### PR TITLE
fix(ai): capture command output from screen buffer; honor model timeout unclamped

### DIFF
--- a/frontend/src/components/AIMessage.vue
+++ b/frontend/src/components/AIMessage.vue
@@ -283,11 +283,16 @@ function formatToolName(tc: { function: { name: string; arguments: string } }): 
   const translated = t(key) !== key ? t(key) : name
   try {
     const args = JSON.parse(tc.function.arguments)
-    if (name === 'execute_command' && args.timeout) {
-      return `${translated} [${args.timeout}s]`
-    }
-    if (name === 'collect_output' && args.timeout) {
-      return `${translated} [${args.timeout}s]`
+    // Show the effective wait: the model-provided timeout when present, or
+    // the runtime fallback defaults from agent.ts (execute_command 60s,
+    // collect_output 30s) — so the badge never disappears just because the
+    // model omitted the optional argument.
+    if (name === 'execute_command' || name === 'collect_output') {
+      const t = args.timeout
+      const seconds = typeof t === 'number' && Number.isFinite(t) && t > 0
+        ? t
+        : (name === 'execute_command' ? 60 : 30)
+      return `${translated} [${seconds}s]`
     }
   } catch {}
   return translated

--- a/frontend/src/services/agent.ts
+++ b/frontend/src/services/agent.ts
@@ -116,7 +116,7 @@ function validateExecuteCommandInput(raw: unknown): ExecuteCommandInput {
   const obj = validateObject(raw, 'execute_command input')
   return {
     command: validateRequiredString(obj.command, 'command'),
-    timeout: typeof obj.timeout === 'number' && Number.isFinite(obj.timeout) ? obj.timeout : 60,
+    timeout: typeof obj.timeout === 'number' && Number.isFinite(obj.timeout) && obj.timeout > 0 ? obj.timeout : 60,
     head_lines: typeof obj.head_lines === 'number' && Number.isFinite(obj.head_lines) ? obj.head_lines : 50,
     tail_lines: typeof obj.tail_lines === 'number' && Number.isFinite(obj.tail_lines) ? obj.tail_lines : 300,
     panel: typeof obj.panel === 'string' ? obj.panel : undefined,
@@ -665,8 +665,9 @@ export async function runAgent(userInput: string, skillName?: string, skillBody?
         throw e
       }
       const command = validated.command
-      const timeoutSec = validated.timeout
-      const timeoutMs = Math.max(5000, Math.min(timeoutSec * 1000, 300000))
+      // Honor the model-provided timeout as-is (no clamping); the validator
+      // falls back to 60s when the argument is missing or invalid.
+      const timeoutMs = validated.timeout * 1000
       const headLines = validated.head_lines
       const tailLines = validated.tail_lines
       const risk = getRisk(tu)
@@ -795,8 +796,9 @@ export async function runAgent(userInput: string, skillName?: string, skillBody?
         })
       }
     } else if (tu.name === 'collect_output') {
-      const timeoutSec = (tu.input.timeout as number) || 30
-      const timeoutMs = Math.max(5000, Math.min(timeoutSec * 1000, 120000))
+      // Honor the model-provided timeout as-is (no clamping); `|| 30` falls
+      // back to 30s when the argument is missing or invalid.
+      const timeoutMs = ((tu.input.timeout as number) || 30) * 1000
       const headLines = (tu.input.head_lines as number) ?? 100
       const tailLines = (tu.input.tail_lines as number) ?? 300
       try {

--- a/frontend/src/services/terminalAgent.test.ts
+++ b/frontend/src/services/terminalAgent.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
 // Use vi.hoisted to allow factory references to variables defined at top level
 const { mockSessionWrite } = vi.hoisted(() => {
@@ -16,20 +16,47 @@ vi.mock('../../bindings/github.com/ys-ll/uniterm/app', () => ({
   SessionWrite: mockSessionWrite,
 }))
 
-// ---- mock terminal manager (prompt-line capture) ----
+// ---- mock terminal manager (prompt-line capture + screen-buffer reads) ----
+// The fake terminal exposes a scripted screen buffer: `fakeScreen` models the
+// buffer rows xterm.js would hold after parsing the PTY stream. Tests set it
+// to the *final* screen state while feeding raw (possibly redraw-heavy) data
+// through the session:data events.
 const PROMPT = '[root@node140 ~]#'
-const mockGetManagedTerminal = vi.fn(() => ({
-  terminal: {
+
+let fakeScreen: string[] = [PROMPT + ' ']
+let fakeBufferType: 'normal' | 'alternate' = 'normal'
+
+function setFakeScreen(lines: string[], type: 'normal' | 'alternate' = 'normal') {
+  fakeScreen = lines
+  fakeBufferType = type
+}
+
+function makeFakeTerminal() {
+  const screen = fakeScreen
+  const type = fakeBufferType
+  return {
+    rows: screen.length,
     buffer: {
       active: {
+        type,
         baseY: 0,
         cursorY: 0,
-        getLine: (_n: number) => ({
-          translateToString: (_trim?: boolean) => PROMPT,
-        }),
+        length: screen.length,
+        getLine: (n: number) => {
+          if (n < 0 || n >= screen.length) return undefined
+          return {
+            translateToString: (trim?: boolean) =>
+              trim ? screen[n].replace(/\s+$/, '') : screen[n],
+          }
+        },
       },
     },
-  },
+  }
+}
+
+const mockGetManagedTerminal = vi.fn(() => ({
+  terminal: makeFakeTerminal(),
+  lineOffset: 0,
 }))
 vi.mock('../services/terminalManager', () => ({
   getManagedTerminal: (...args: any[]) => mockGetManagedTerminal(...(args as [])),
@@ -72,7 +99,7 @@ vi.mock('../stores/sessionStore', () => ({
 }))
 
 // ---- import after mocks ----
-import { watchOutput, executeCommand, truncateOutput } from './terminalAgent'
+import { watchOutput, executeCommand, truncateOutput, startCommand, sendTerminalKey } from './terminalAgent'
 import type { ExecuteResult, WatchResult } from './terminalAgent'
 // ---- helpers ----
 const MOCK_TIMESTAMP = 1700000000000
@@ -173,6 +200,7 @@ describe('ExecuteResult interface', () => {
 describe('watchOutput', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    setFakeScreen([PROMPT + ' '])
   })
 
   it('returns promise and cleanup', () => {
@@ -188,7 +216,10 @@ describe('watchOutput', () => {
       return () => { }
     })
 
-    const { promise } = watchOutput('s1', PROMPT, 5000)
+    const { promise } = watchOutput('s1', PROMPT, 5000, undefined, 0)
+
+    // Final screen state after the command: echoed command, output, new prompt.
+    setFakeScreen([`${PROMPT} echo hi`, 'hi', `${PROMPT} `])
 
     // Echoed command line, then output, then the prompt returns.
     capturedCallback!({ data: fakeData('s1', `${PROMPT} echo hi\nhi\n${PROMPT} `) })
@@ -201,6 +232,48 @@ describe('watchOutput', () => {
     expect(result.output).not.toMatch(/\[root@node140 ~\]#\s*$/)
   })
 
+  it('captures the final screen state, not raw ConPTY redraw frames (issue 624)', async () => {
+    let capturedCallback: ((payload: { id: string; data: string }) => void) | null = null
+    vi.mocked(Events.On).mockImplementation((_eventName, callback) => {
+      capturedCallback = callback
+      return () => { }
+    })
+
+    const { promise } = watchOutput('s1', PROMPT, 5000, undefined, 0)
+
+    // What the user actually sees on screen after the command completes.
+    setFakeScreen([
+      `${PROMPT} reg query X`,
+      'HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Terminal Server',
+      `${PROMPT} `,
+    ])
+
+    // Windows Server 2016 ConPTY redraws a wrapping line by moving the cursor
+    // left (ESC[nD) and re-emitting progressively shorter tails — the raw
+    // stream is full of intermediate redraw frames the screen never shows.
+    const redrawFragments = [
+      'Server\\WinStation\\SYSTEM\\CurrentControlSet\\Control\\Terminal',
+      'Server\\WinStationSYSTEM\\CurrentControlSet\\Control\\Terminal',
+      'Server\\WinStationYSTEM\\CurrentControlSet\\Control\\Terminal',
+      'Server\\WinStationM\\CurrentControlSet\\Control\\Terminal',
+      'Server\\WinStationtControlSet\\Control\\Terminal',
+    ].join('\r\n')
+    capturedCallback!({
+      data: fakeData(
+        's1',
+        `${PROMPT} reg query X\r\n${redrawFragments}\r\nHKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Terminal Server\r\n${PROMPT} `
+      ),
+    })
+
+    const result: WatchResult = await promise
+    expect(result.timedOut).toBe(false)
+    expect(result.output).toBe(
+      `${PROMPT} reg query X\nHKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Terminal Server`
+    )
+    // None of the redraw fragments may leak into the AI-visible output.
+    expect(result.output).not.toContain('WinStation')
+  })
+
   it('resolves via idle heuristic when prompt differs (e.g. dynamic prompt)', async () => {
     vi.useFakeTimers()
     let capturedCallback: ((payload: { id: string; data: string }) => void) | null = null
@@ -211,8 +284,10 @@ describe('watchOutput', () => {
 
     const { promise } = watchOutput('s1', PROMPT, 5000)
 
+    setFakeScreen([`${PROMPT} echo hi`, 'hi', '[user@host ~]$ '])
     capturedCallback!({ data: fakeData('s1', `${PROMPT} echo hi\nhi\n[user@host ~]$ `) })
     vi.advanceTimersByTime(800)
+    vi.advanceTimersByTime(100) // screen-read settle delay
 
     const result: WatchResult = await promise
     expect(result.timedOut).toBe(false)
@@ -233,6 +308,7 @@ describe('watchOutput', () => {
     // Only the prompt so far (no echoed command line before it) → keep waiting.
     capturedCallback!({ data: fakeData('s1', `${PROMPT} `) })
     vi.advanceTimersByTime(1000)
+    vi.advanceTimersByTime(100) // screen-read settle delay
 
     const result: WatchResult = await promise
     expect(result.timedOut).toBe(true)
@@ -250,8 +326,10 @@ describe('watchOutput', () => {
     const { promise } = watchOutput('s1', '', 1000)
 
     // Even output that looks like a prompt must not trigger detection.
+    setFakeScreen([`${PROMPT} echo hi`, 'hi', `${PROMPT} `])
     capturedCallback!({ data: fakeData('s1', `${PROMPT} echo hi\nhi\n${PROMPT} `) })
     vi.advanceTimersByTime(1000)
+    vi.advanceTimersByTime(100) // screen-read settle delay
 
     const result: WatchResult = await promise
     expect(result.timedOut).toBe(true)
@@ -269,8 +347,10 @@ describe('watchOutput', () => {
 
     const { promise } = watchOutput('s1', PROMPT, 1000)
 
+    setFakeScreen(['partial output'])
     capturedCallback!({ data: fakeData('s1', 'partial output') })
     vi.advanceTimersByTime(1000)
+    vi.advanceTimersByTime(100) // screen-read settle delay
 
     const result: WatchResult = await promise
     expect(result.timedOut).toBe(true)
@@ -286,10 +366,12 @@ describe('watchOutput', () => {
       return () => { }
     })
 
+    setFakeScreen([''])
     const { promise } = watchOutput('s1', PROMPT, 1000)
 
     capturedCallback!({ data: fakeData('s2', 'wrong session data') })
     vi.advanceTimersByTime(1000)
+    vi.advanceTimersByTime(100) // screen-read settle delay
 
     const result: WatchResult = await promise
     expect(result.output).toBe('')
@@ -327,6 +409,13 @@ describe('executeCommand', () => {
     vi.mocked(mockGetRemoteOS).mockReturnValue(undefined)
     mockActiveTab.type = 'terminal'
     mockActiveTab.panelId = 'panel-1'
+    setFakeScreen([PROMPT + ' '])
+  })
+
+  // A failing assertion inside a fake-timer test must not leak fake timers
+  // into the next test (settle timers would never fire and it would hang).
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   it('throws when no active session', async () => {
@@ -359,6 +448,7 @@ describe('executeCommand', () => {
     expect(capturedCallback).not.toBeNull()
 
     // Prompt reappears after the echoed command + output → completion.
+    setFakeScreen([`${PROMPT} echo hello`, 'hello', `${PROMPT} `])
     capturedCallback!({ data: fakeData('test-session-id', `${PROMPT} echo hello\nhello\n${PROMPT} `) })
 
     const result = await cmdPromise
@@ -406,8 +496,13 @@ describe('executeCommand', () => {
     await Promise.resolve()
     expect(capturedCallback).not.toBeNull()
 
+    // Command still running at timeout: screen holds the output lines so far
+    // (no trailing prompt row yet). Five lines so head=2/tail=2 keeps
+    // line1+line2 and line4+line5.
+    setFakeScreen(['line1', 'line2', 'line3', 'line4', 'line5'])
     capturedCallback!({ data: fakeData('test-session-id', 'some output line1\nline2\nline3\nline4\nline5') })
     vi.advanceTimersByTime(1000)
+    vi.advanceTimersByTime(100) // screen-read settle delay
 
     const result: ExecuteResult = await cmdPromise
     expect(result.exitCode).toBe(-1)
@@ -440,6 +535,8 @@ describe('executeCommand', () => {
     await Promise.resolve()
     expect(capturedCallback).not.toBeNull()
 
+    // Echoed command + long output + returning prompt on the final screen.
+    setFakeScreen([`${PROMPT} some-cmd`, ...lines, `${PROMPT} `])
     // Echoed command + long output + returning prompt triggers completion.
     capturedCallback!({ data: fakeData('test-session-id', `${PROMPT} some-cmd\n` + output + `\n${PROMPT} `) })
 
@@ -460,5 +557,81 @@ describe('executeCommand', () => {
     expect(result.output).not.toMatch(/\n\[root@node140 ~\]#\s*$/)
 
     restore()
+  })
+})
+
+describe('startCommand', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(Events.On).mockReturnValue(() => {})
+    setFakeScreen([PROMPT + ' '])
+  })
+
+  it('returns the screen content collected during the window', async () => {
+    vi.useFakeTimers()
+
+    const p = startCommand('tail -f app.log')
+
+    // startCommand awaits SessionWrite before subscribing/scheduling — flush.
+    await Promise.resolve()
+
+    // Output streams in during the 3s collect window and lands on screen.
+    setFakeScreen([`${PROMPT} tail -f app.log`, 'log line A', 'log line B'])
+    vi.advanceTimersByTime(3000)
+    vi.advanceTimersByTime(100) // screen-read settle delay
+
+    const result = await p
+    expect(result.started).toBe(true)
+    expect(result.output).toContain('log line A')
+    expect(result.output).toContain('log line B')
+    vi.useRealTimers()
+  })
+
+  it('returns the final screen state even when the stream carries redraw frames', async () => {
+    vi.useFakeTimers()
+    let capturedCallback: ((payload: { id: string; data: string }) => void) | null = null
+    vi.mocked(Events.On).mockImplementation((_eventName, callback) => {
+      capturedCallback = callback
+      return () => { }
+    })
+
+    const p = startCommand('cmd-with-redraws')
+    await Promise.resolve() // flush the SessionWrite await inside startCommand
+
+    setFakeScreen([`${PROMPT} cmd-with-redraws`, 'final state only'])
+    capturedCallback!({
+      data: fakeData('test-session-id', 'frame1\rframe2\rframe3\r\nfinal state only'),
+    })
+    vi.advanceTimersByTime(3000)
+    vi.advanceTimersByTime(100) // screen-read settle delay
+
+    const result = await p
+    expect(result.output).toBe(`${PROMPT} cmd-with-redraws\nfinal state only`)
+    expect(result.output).not.toContain('frame1')
+    vi.useRealTimers()
+  })
+})
+
+describe('sendTerminalKey', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(Events.On).mockReturnValue(() => {})
+    setFakeScreen([PROMPT + ' '])
+  })
+
+  it('captures the screen response after ctrl_c', async () => {
+    vi.useFakeTimers()
+
+    const p = sendTerminalKey(undefined, 'ctrl_c', true)
+    await Promise.resolve() // flush the SessionWrite await inside sendTerminalKey
+
+    // The interrupted program stops and the shell prompt returns.
+    setFakeScreen([`${PROMPT} ^C`, `${PROMPT} `])
+    vi.advanceTimersByTime(1000)
+    vi.advanceTimersByTime(100) // screen-read settle delay
+
+    const result = await p
+    expect(result.output).toContain('^C')
+    vi.useRealTimers()
   })
 })

--- a/frontend/src/services/terminalAgent.ts
+++ b/frontend/src/services/terminalAgent.ts
@@ -72,6 +72,95 @@ function toDisplayLines(clean: string): string[] {
   })
 }
 
+// Short wait before reading the xterm screen buffer after completion is
+// detected. xterm.js parses PTY writes asynchronously, so a chunk that is
+// queued when the detector fires may not be reflected in the buffer yet.
+const SCREEN_SETTLE_MS = 100
+
+// Prompt + absolute buffer-row snapshot taken right before a command is sent.
+// `startRow` is the row the command echo starts on, expressed as an absolute
+// row (buffer row + accumulated scrollback-trim offset) so it stays valid
+// even if rows scroll off the top of the buffer while the command runs.
+export interface PromptSnapshot {
+  promptLine: string
+  startRow: number
+}
+
+// Read the current prompt line and the absolute row it sits on. Called right
+// before a command is sent, when the cursor sits on the (freshly drawn)
+// prompt with no input yet, so the cursor line's text is exactly the prompt
+// string. ANSI sequences are stripped so the captured prompt matches the
+// stripped output used in watchOutput. Returns promptLine '' and startRow -1
+// when unavailable, which disables exact prompt detection and screen-buffer
+// capture for that command (idle heuristic still applies).
+function capturePromptSnapshot(sessionId: string): PromptSnapshot {
+  const managed = getManagedTerminal(sessionId)
+  const terminal = managed?.terminal
+  if (!terminal) return { promptLine: '', startRow: -1 }
+  const buffer = terminal.buffer.active
+  const line = buffer.getLine(buffer.baseY + buffer.cursorY)
+  const promptLine = line ? stripAnsi(line.translateToString(true)).trimEnd() : ''
+  const startRow = (managed.lineOffset || 0) + buffer.baseY + buffer.cursorY
+  return { promptLine, startRow }
+}
+
+// Read the visible command output from the xterm screen buffer, starting at
+// the absolute row captured before the command ran, down to the last
+// non-blank row. Unlike reconstructing text from the raw PTY stream, this
+// reflects what the user actually sees: ConPTY redraws (cursor-left re-emits
+// on old Windows Server builds, \r overwrites, erase sequences) have already
+// been resolved by the terminal emulator.
+//
+// Returns null when no terminal/buffer is available so callers can fall back
+// to raw-stream reconstruction.
+function readScreenFromRow(sessionId: string, absStartRow: number): string | null {
+  const managed = getManagedTerminal(sessionId)
+  const terminal = managed?.terminal
+  if (!terminal || absStartRow < 0) return null
+  const buffer = terminal.buffer.active
+  let first: number
+  let last: number
+  if (buffer.type === 'alternate') {
+    // Full-screen program (vim, top, ...): the viewport is the whole picture
+    // and absolute rows don't apply across the buffer switch.
+    first = buffer.baseY
+    last = buffer.length - 1
+  } else {
+    // Compensate for scrollback rows trimmed since the snapshot was taken.
+    first = Math.max(0, absStartRow - (managed.lineOffset || 0))
+    last = buffer.length - 1
+    while (last >= first && isRowBlank(buffer, last)) last--
+    if (last < first) return ''
+  }
+  const lines: string[] = []
+  for (let i = first; i <= last; i++) {
+    const line = buffer.getLine(i)
+    if (line) lines.push(line.translateToString(true))
+  }
+  return lines.join('\n')
+}
+
+function isRowBlank(
+  buffer: { getLine(n: number): { translateToString(trim?: boolean): string } | undefined },
+  row: number
+): boolean {
+  const line = buffer.getLine(row)
+  return !line || line.translateToString().trim() === ''
+}
+
+// Turn captured screen text into the output handed to the AI. On success the
+// trailing blank rows and the final prompt line are dropped (completion was
+// reported by the prompt reappearing — the prompt is terminal chrome, not
+// command output); on timeout everything is kept.
+function extractScreenOutput(screen: string, timedOut: boolean): string {
+  const lines = screen.split('\n')
+  if (!timedOut) {
+    while (lines.length > 0 && lines[lines.length - 1].trimEnd() === '') lines.pop()
+    if (lines.length > 0) lines.pop()
+  }
+  return lines.join('\n').trim()
+}
+
 // Watch session output and resolve when the command finishes.
 //
 // Completion is detected by the shell prompt reappearing: `promptLine` is the
@@ -96,13 +185,15 @@ export function watchOutput(
   sessionId: string,
   promptLine: string,
   timeoutMs: number,
-  shouldCancel?: () => boolean
+  shouldCancel?: () => boolean,
+  startRow: number = -1
 ): { promise: Promise<WatchResult>; cleanup: () => void } {
   const IDLE_MS = 800
   const CANCEL_POLL_MS = 150
   let timeoutId: ReturnType<typeof setTimeout>
   let idleTimeoutId: ReturnType<typeof setTimeout> | null = null
   let cancelPollId: ReturnType<typeof setTimeout> | null = null
+  let settleId: ReturnType<typeof setTimeout> | null = null
   let unsubscribe: (() => void) | null = null
   let resolved = false
   let output = ''
@@ -116,6 +207,10 @@ export function watchOutput(
     if (cancelPollId) {
       clearTimeout(cancelPollId)
       cancelPollId = null
+    }
+    if (settleId) {
+      clearTimeout(settleId)
+      settleId = null
     }
     unsubscribe?.()
     resolved = true
@@ -143,18 +238,33 @@ export function watchOutput(
         resolve({ output: '', timedOut: false, cancelled: true })
         return
       }
-      const lines = toDisplayLines(stripAnsi(output))
-      if (!timedOut) {
-        // The command finished when the shell prompt reappeared at the bottom.
-        // That prompt line belongs to the terminal, not the command output —
-        // completion is now reported explicitly by the caller's end-message
-        // (see executeCommand in agent.ts), so drop the prompt (and any
-        // trailing blanks) before returning the output to the AI.
-        while (lines.length > 0 && lines[lines.length - 1].trimEnd() === '') lines.pop()
-        if (lines.length > 0) lines.pop()
-      }
-      const normalized = lines.join('\n').trim()
-      resolve({ output: normalized, timedOut })
+      // Give xterm.js a moment to finish parsing writes that were queued when
+      // the detector fired, then read what the screen actually shows instead
+      // of reconstructing text from the raw stream — the raw stream carries
+      // every intermediate ConPTY redraw frame (cursor-left re-emits on old
+      // Windows Server builds, progress-bar \r overwrites, ...) that the
+      // screen never displays. Falls back to the raw stream when no terminal
+      // buffer is available.
+      settleId = setTimeout(() => {
+        settleId = null
+        const screen = readScreenFromRow(sessionId, startRow)
+        if (screen !== null) {
+          resolve({ output: extractScreenOutput(screen, timedOut), timedOut })
+          return
+        }
+        const lines = toDisplayLines(stripAnsi(output))
+        if (!timedOut) {
+          // The command finished when the shell prompt reappeared at the bottom.
+          // That prompt line belongs to the terminal, not the command output —
+          // completion is now reported explicitly by the caller's end-message
+          // (see executeCommand in agent.ts), so drop the prompt (and any
+          // trailing blanks) before returning the output to the AI.
+          while (lines.length > 0 && lines[lines.length - 1].trimEnd() === '') lines.pop()
+          if (lines.length > 0) lines.pop()
+        }
+        const normalized = lines.join('\n').trim()
+        resolve({ output: normalized, timedOut })
+      }, SCREEN_SETTLE_MS)
     }
 
     const checkIdle = () => {
@@ -313,22 +423,6 @@ function getShellNewline(shellPath?: string, remoteOS?: string): string {
   }
 }
 
-// Read the current prompt line from the terminal buffer. Called right before a
-// command is sent, when the cursor sits on the (freshly drawn) prompt with no
-// input yet, so the cursor line's text is exactly the prompt string. ANSI
-// sequences are stripped so the captured prompt matches the stripped output
-// used in watchOutput. Returns '' when unavailable, which disables exact prompt
-// detection for that command (idle heuristic still applies).
-function capturePromptLine(sessionId: string): string {
-  const managed = getManagedTerminal(sessionId)
-  const terminal = managed?.terminal
-  if (!terminal) return ''
-  const buffer = terminal.buffer.active
-  const line = buffer.getLine(buffer.baseY + buffer.cursorY)
-  if (!line) return ''
-  return stripAnsi(line.translateToString(true)).trimEnd()
-}
-
 export async function executeCommand(
   command: string,
   timeoutMs: number = 60000,
@@ -338,13 +432,15 @@ export async function executeCommand(
   panelTitle?: string
 ): Promise<ExecuteResult> {
   const { sessionId, shellPath, remoteOS } = resolveActiveSession(panelTitle)
-  const promptLine = capturePromptLine(sessionId)
+  // Snapshot the prompt + its buffer row BEFORE the command is written, so
+  // watchOutput knows where the command output starts on screen.
+  const { promptLine, startRow } = capturePromptSnapshot(sessionId)
   const fullCommand = buildCommand(command, shellPath, remoteOS)
   const newline = getShellNewline(shellPath, remoteOS)
 
   await SessionWrite(sessionId, fullCommand + newline)
 
-  const { promise } = watchOutput(sessionId, promptLine, timeoutMs, shouldCancel)
+  const { promise } = watchOutput(sessionId, promptLine, timeoutMs, shouldCancel, startRow)
   const result = await promise
 
   if (result.cancelled) {
@@ -378,6 +474,9 @@ export interface StartResult {
 
 export async function startCommand(command: string, panelTitle?: string): Promise<StartResult> {
   const { sessionId, shellPath, remoteOS } = resolveActiveSession(panelTitle)
+  // Snapshot the prompt row BEFORE the command is written so the screen read
+  // below starts where the command echo begins.
+  const { startRow } = capturePromptSnapshot(sessionId)
   const newline = getShellNewline(shellPath, remoteOS)
 
   await SessionWrite(sessionId, command + newline)
@@ -385,15 +484,18 @@ export async function startCommand(command: string, panelTitle?: string): Promis
   // Collect output for 3 seconds, then return
   return new Promise((resolve) => {
     let output = ''
-    const unsubscribe =Events.On('session:data', (ev) => { const payload: { id: string; data: string } = ev.data; 
+    const unsubscribe =Events.On('session:data', (ev) => { const payload: { id: string; data: string } = ev.data;
       if (payload.id !== sessionId) return
       output += payload.data
      })
 
     setTimeout(() => {
       unsubscribe()
+      // Prefer the screen buffer (redraw-resolved) over the raw stream; the
+      // 3s window is far past the parse settle time, so read directly.
+      const screen = readScreenFromRow(sessionId, startRow)
       resolve({
-        output: stripAnsi(output).trim(),
+        output: (screen !== null ? screen : stripAnsi(output)).trim(),
         started: true,
       })
     }, 3000)
@@ -462,9 +564,9 @@ export async function collectOutput(
   panelTitle?: string
 ): Promise<CollectResult> {
   const { sessionId } = resolveActiveSession(panelTitle)
-  const promptLine = capturePromptLine(sessionId)
+  const { promptLine, startRow } = capturePromptSnapshot(sessionId)
 
-  const { promise } = watchOutput(sessionId, promptLine, timeoutMs, shouldCancel)
+  const { promise } = watchOutput(sessionId, promptLine, timeoutMs, shouldCancel, startRow)
   const result = await promise
 
   if (result.cancelled) {
@@ -489,6 +591,10 @@ export async function sendTerminalKey(
   panelTitle?: string
 ): Promise<SendKeyResult> {
   const { sessionId, shellPath, remoteOS } = resolveActiveSession(panelTitle)
+
+  // Snapshot the prompt row before writing so the ctrl_c / ctrl_d response
+  // below can be read off the screen buffer.
+  const { startRow } = capturePromptSnapshot(sessionId)
 
   let data: string
   if (control) {
@@ -519,13 +625,16 @@ export async function sendTerminalKey(
   if (control === 'ctrl_c' || control === 'ctrl_d') {
     return new Promise((resolve) => {
       let output = ''
-      const unsubscribe =Events.On('session:data', (ev) => { const payload: { id: string; data: string } = ev.data; 
+      const unsubscribe =Events.On('session:data', (ev) => { const payload: { id: string; data: string } = ev.data;
         if (payload.id !== sessionId) return
         output += payload.data
        })
       setTimeout(() => {
         unsubscribe()
-        resolve({ output: stripAnsi(output).trim() || '(input sent)' })
+        // Prefer the screen buffer (redraw-resolved) over the raw stream; the
+        // 1s window is past the parse settle time, so read directly.
+        const screen = readScreenFromRow(sessionId, startRow)
+        resolve({ output: (screen !== null ? screen : stripAnsi(output)).trim() || '(input sent)' })
       }, 1000)
     })
   }


### PR DESCRIPTION
## Summary
- Fixes #624 (output duplication part): AI-visible command output is now read from the xterm.js screen buffer instead of being reconstructed from the raw PTY byte stream
- The tool-call IN badge now always shows the effective timeout (model value, or runtime default when the model omits it), and model-provided timeouts are honored without clamping

## Details

### Screen-buffer output capture (issue 624)
Reconstructing command output from the raw PTY stream leaks every intermediate ConPTY redraw frame. Windows Server 2016's older conhost redraws growing/wrapping lines using cursor-left re-emits, so the AI received dozens of duplicated/shifted fragments (e.g. `Server\WinStation...` lines) while the terminal screen showed a single clean line.

- `watchOutput`, `startCommand` and `sendTerminalKey` (ctrl_c/ctrl_d) now read the final output from the xterm.js screen buffer, starting at a prompt-row snapshot taken before the command is written (absolute row, compensated for scrollback trimming)
- Completion detection still runs on the raw stream, since xterm.js parses writes asynchronously (100 ms settle before reading the buffer)
- Alternate-screen apps (vim, top, ...) are captured as the full viewport; raw-stream reconstruction remains as fallback when no terminal buffer is available

### Timeout badge + unclamped timeouts
- `execute_command` / `collect_output` badges always display the effective wait: model value if provided, otherwise the runtime default (60s / 30s)
- Removed the 5s–300s / 5s–120s clamps: model-provided timeouts are honored as-is, falling back to the default only when the argument is missing or invalid

## Testing
- Frontend suite: 25 files / 237 tests pass (includes a new regression test reproducing the issue-624 redraw fragments and asserting clean screen-buffer output)
- No Windows Server 2016 environment available locally — real-world verification on a 2016 OpenSSH host is recommended (`reg query` or any wide-output command)

---
## 摘要
- 修复 #624（输出重复部分）：AI 可见的命令输出改为从 xterm.js 屏幕缓冲区读取，不再从原始 PTY 字节流重建
- 工具调用 IN 徽标现在始终显示实际生效的超时（模型传了显示模型值，没传显示运行时默认值），且模型提供的超时值不再被钳制

## 详情

### 屏幕缓冲区输出捕获（issue 624）
从原始 PTY 流重建命令输出会泄漏每一帧 ConPTY 重绘残片。Windows Server 2016 的老版 conhost 在行增长/换行时用"光标左移+重发"重绘，导致界面只显示一行，AI 却收到几十行错位重复的片段（如 `Server\WinStation...`）。

- `watchOutput`、`startCommand`、`sendTerminalKey`（ctrl_c/ctrl_d）改为从 xterm.js 屏幕缓冲区读取最终输出，起点是发命令前记录的 prompt 行快照（绝对行号，含 scrollback 裁剪补偿）
- 完成检测仍在原始流上进行（xterm.js 异步解析写入，读缓冲前等待 100ms settle）
- alt-screen 程序（vim、top 等）按整个视口捕获；无终端缓冲时回退到原始流重建

### 超时徽标 + 取消钳制
- `execute_command` / `collect_output` 徽标始终显示实际生效的超时：模型传了显示模型值，没传或无效时显示默认值（60s / 30s）
- 移除 5s–300s / 5s–120s 钳制：模型传什么就用什么，仅在参数缺失或无效时回落默认值

## 测试
- 前端测试套件：25 个文件 / 237 个测试全部通过（含复现 issue 624 重绘残片并断言屏幕缓冲输出干净的新回归测试）
- 本地无 Windows Server 2016 环境，建议在 2016 OpenSSH 主机上实测验证（`reg query` 或任意宽输出命令）