### PR TITLE
feat(terminal): screen preview on scrollbar hover

### DIFF
--- a/frontend/src/components/BaseTerminal.vue
+++ b/frontend/src/components/BaseTerminal.vue
@@ -99,6 +99,12 @@
 
     <!-- Zmodem transfer panel -->
     <ZmodemTransfer :session-id="props.sessionId || ''" @cancel="onZmodemCancel" />
+
+    <!-- Screen preview on scrollbar hover (issue #729) -->
+    <TerminalScreenPreview
+      :session-id="props.sessionId || ''"
+      :enabled="settingsStore.settings.terminal.screenPreview ?? true"
+    />
   </div>
 </template>
 
@@ -150,6 +156,7 @@ import { startZmodemService } from '../services/zmodemService'
 import { stampWrittenLines, stampCommandLine, currentAbsoluteLine } from '../services/terminalTimestamps'
 import { useZmodemStore } from '../stores/zmodemStore'
 import ZmodemTransfer from './ZmodemTransfer.vue'
+import TerminalScreenPreview from './TerminalScreenPreview.vue'
 import { Browser, Clipboard, Events } from '@wailsio/runtime'
 import { ChevronUp, ChevronDown, X } from '@lucide/vue'
 

--- a/frontend/src/components/SettingsTab.vue
+++ b/frontend/src/components/SettingsTab.vue
@@ -577,6 +577,16 @@
 
           <div class="setting-card">
             <div class="setting-info">
+              <div class="setting-title">{{ t('settings.screenPreview') }}</div>
+              <div class="setting-desc">{{ t('settings.screenPreviewDesc') }}</div>
+            </div>
+            <div class="setting-control">
+              <el-switch :model-value="settingsStore.settings.terminal.screenPreview ?? true" @update:model-value="(v: boolean) => { settingsStore.settings.terminal.screenPreview = v; settingsStore.save() }" />
+            </div>
+          </div>
+
+          <div class="setting-card">
+            <div class="setting-info">
               <div class="setting-title">{{ t('settings.sessionLogDir') }}</div>
               <div class="setting-desc">{{ t('settings.sessionLogDirDesc', { path: defaultLogDir }) }}</div>
             </div>

--- a/frontend/src/components/TerminalScreenPreview.vue
+++ b/frontend/src/components/TerminalScreenPreview.vue
@@ -1,0 +1,415 @@
+<template>
+  <div
+    v-show="visible"
+    class="terminal-screen-preview"
+    :style="popupStyle"
+    @mouseenter="onPopupEnter"
+    @mouseleave="hide"
+    @click="onJump"
+  >
+    <div
+      v-for="(row, i) in lines"
+      :key="i"
+      class="preview-line"
+      :style="{ height: cellHeightPx, lineHeight: cellHeightPx }"
+    >
+      <span
+        v-if="showTimestamps"
+        class="preview-col-time"
+        :style="{ width: timeColWidth }"
+      >{{ row.timestamp }}&nbsp;</span>
+      <span
+        v-if="showLineNumbers"
+        class="preview-col-num"
+        :style="{ width: numColWidth }"
+      >{{ row.lineNumber }}</span>
+      <span class="preview-content">
+        <template v-if="row.runs.length">
+          <span
+            v-for="(run, j) in row.runs"
+            :key="j"
+            :style="runStyle(run)"
+          >{{ run.text }}</span>
+        </template>
+        <span v-else class="preview-blank">&nbsp;</span>
+      </span>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+// Issue #729 — screen preview (屏幕回看): hovering the terminal scrollbar for
+// a moment pops up a small read-only preview of the scrollback at that
+// position (WindTerm/Termora-style). Clicking the preview scrolls the
+// terminal there. Pure display: never touches the pty stream or terminal
+// state, so TUI apps (vim, htop) are unaffected.
+import { ref, computed, watch, nextTick, onMounted, onBeforeUnmount } from 'vue'
+import type { Terminal } from '@xterm/xterm'
+import { getManagedTerminal } from '../services/terminalManager'
+import { useSettingsStore } from '../stores/settingsStore'
+import { formatTimestampMs, resolveRowTimestamp } from '../utils/terminalGutter'
+import {
+  buildPalette,
+  lineToRuns,
+  computePreviewStart,
+  pickVerticalTrackIndex,
+  type PreviewStyleRun,
+} from '../services/screenPreview'
+
+const props = defineProps<{ sessionId: string; enabled?: boolean }>()
+
+const PREVIEW_ROWS = 10
+const HOVER_DELAY = 250
+const HIDE_DELAY = 150
+
+const settingsStore = useSettingsStore()
+const showLineNumbers = computed(() => settingsStore.settings.terminal.showLineNumbers ?? false)
+const showTimestamps = computed(() => settingsStore.settings.terminal.showTimestamps ?? false)
+
+const visible = ref(false)
+const lines = ref<Array<{ runs: PreviewStyleRun[]; lineNumber: string; timestamp: string }>>([])
+const startRow = ref(0)
+const pos = ref({ left: 0, top: 0 })
+const size = ref({ width: 0, height: 0 })
+const cellHeightPx = ref('1.5em')
+const bgColor = ref('#1e1e1e')
+const fontCss = ref({ fontSize: '13px', fontFamily: 'monospace' })
+const numColWidth = ref('')
+const timeColWidth = ref('')
+
+const popupStyle = computed(() => ({
+  left: `${pos.value.left}px`,
+  top: `${pos.value.top}px`,
+  width: `${size.value.width}px`,
+  height: `${size.value.height}px`,
+  background: bgColor.value,
+  fontSize: fontCss.value.fontSize,
+  fontFamily: fontCss.value.fontFamily,
+}))
+
+function runStyle(run: PreviewStyleRun) {
+  return {
+    color: run.fg,
+    background: run.bg,
+    fontWeight: run.bold ? 600 : undefined,
+    fontStyle: run.italic ? 'italic' : undefined,
+    textDecoration: run.underline ? 'underline' : undefined,
+    opacity: run.dim ? 0.6 : undefined,
+  }
+}
+
+function getTerminal(): Terminal | null {
+  return getManagedTerminal(props.sessionId)?.terminal ?? null
+}
+
+/**
+ * Locate xterm's scrollbar element. xterm v6 renders a VS Code-style overlay
+ * scrollbar (`.xterm-scrollable-element > .scrollbar`) that is a *sibling* of
+ * `.xterm-viewport` — hovering it never produces events on the viewport, so
+ * hover detection must hit-test against this element instead.
+ */
+function findScrollbar(t: Terminal): HTMLElement | null {
+  const el = t.element
+  if (!el) return null
+  const nodes = el.querySelectorAll<HTMLElement>('.xterm-scrollable-element > .scrollbar')
+  const rects = Array.from(nodes).map((n) => n.getBoundingClientRect())
+  const idx = pickVerticalTrackIndex(rects)
+  return idx >= 0 ? nodes[idx] : null
+}
+
+let host: HTMLElement | null = null
+let hoverTimer: number | undefined
+let hideTimer: number | undefined
+let lastRatio = 0
+let lastClientY = 0
+
+function clearTimers() {
+  if (hoverTimer !== undefined) {
+    clearTimeout(hoverTimer)
+    hoverTimer = undefined
+  }
+  if (hideTimer !== undefined) {
+    clearTimeout(hideTimer)
+    hideTimer = undefined
+  }
+}
+
+function bind() {
+  unbind()
+  const t = getTerminal()
+  const el = t?.element
+  if (!el) return
+  host = el
+  el.addEventListener('mousemove', onMouseMove)
+  el.addEventListener('mouseleave', onMouseLeave)
+}
+
+function unbind() {
+  host?.removeEventListener('mousemove', onMouseMove)
+  host?.removeEventListener('mouseleave', onMouseLeave)
+  host = null
+  clearTimers()
+  visible.value = false
+}
+
+function cellHeight(t: Terminal): number {
+  try {
+    const h = (t as any)._core?._renderService?.dimensions?.css?.cell?.height
+    if (h > 0) return h
+  } catch { /* internal API — fall through */ }
+  return (t.options.fontSize ?? 13) * 1.5
+}
+
+function charWidth(t: Terminal): number {
+  try {
+    const w = (t as any)._core?._renderService?.dimensions?.css?.character?.width
+    if (w > 0) return w
+  } catch { /* internal API — fall through */ }
+  return (t.options.fontSize ?? 13) * 0.6
+}
+
+/**
+ * The scrollbar track under the pointer, or null when not hovering it.
+ * Geometry-based on purpose: mouse events over xterm v6's overlay scrollbar
+ * target the underlying `xterm-screen` (the scrollbar never becomes the event
+ * target), so only coordinate containment against the scrollbar's rect works.
+ * A small tolerance on the left edge makes the narrow (14px) strip easier to
+ * hit. Hovering the thumb (slider) returns null — the thumb marks the content
+ * that is already on screen, so there is nothing to preview there.
+ */
+function scrollbarRect(t: Terminal, e: MouseEvent): DOMRect | null {
+  const sb = findScrollbar(t)
+  if (!sb) return null
+  const r = sb.getBoundingClientRect()
+  const TOLERANCE = 6
+  if (
+    e.clientX < r.left - TOLERANCE ||
+    e.clientX > r.right + 2 ||
+    e.clientY < r.top ||
+    e.clientY > r.bottom
+  ) {
+    return null
+  }
+  const slider = sb.querySelector('.slider')
+  if (slider) {
+    const s = slider.getBoundingClientRect()
+    const PAD = 4
+    if (e.clientY >= s.top - PAD && e.clientY <= s.bottom + PAD) return null
+  }
+  return r
+}
+
+function onMouseMove(e: MouseEvent) {
+  if (!props.enabled) return hide()
+  const t = getTerminal()
+  if (!t || !host) return hide()
+
+  const rect = scrollbarRect(t, e)
+  if (!rect) return hide()
+  // Alt-screen apps (vim, htop) have no scrollback to preview.
+  if (t.buffer.active.type === 'alternate') return hide()
+  const total = t.buffer.active.length
+  if (total <= t.rows) return hide()
+
+  lastRatio = Math.min(1, Math.max(0, (e.clientY - rect.top) / rect.height))
+  lastClientY = e.clientY
+  clearTimers()
+  if (visible.value) {
+    show(t, rect)
+  } else {
+    hoverTimer = window.setTimeout(() => {
+      hoverTimer = undefined
+      const t2 = getTerminal()
+      if (t2?.element) show(t2, rect)
+    }, HOVER_DELAY)
+  }
+}
+
+function show(t: Terminal, sbRect: DOMRect) {
+  const total = t.buffer.active.length
+  const start = computePreviewStart(lastRatio, total, t.rows, PREVIEW_ROWS)
+  startRow.value = start
+
+  const palette = buildPalette(t.options.theme)
+  const buf = t.buffer.active
+  const managed = getManagedTerminal(props.sessionId)
+  const lineOffset = managed?.lineOffset ?? 0
+  const withNumbers = showLineNumbers.value
+  const withTimestamps = showTimestamps.value && managed
+  const tsFormat = settingsStore.settings.terminal.timestampFormat || 'HH:mm:ss'
+
+  const rendered: Array<{ runs: PreviewStyleRun[]; lineNumber: string; timestamp: string }> = []
+  for (let i = 0; i < PREVIEW_ROWS; i++) {
+    const bufferLine = start + i
+    const line = buf.getLine(bufferLine)
+    const isWrapped = line?.isWrapped ?? false
+    const runs = line ? lineToRuns(line, t.cols, palette) : []
+    // Mirror the gutter's semantics: wrapped continuation rows belong to the
+    // line above, so they carry no number/timestamp of their own.
+    const numbered = withNumbers && !isWrapped
+    const stamped = withTimestamps && !isWrapped
+    rendered.push({
+      runs,
+      lineNumber: numbered ? String(lineOffset + bufferLine + 1) : '',
+      timestamp: stamped
+        ? (() => {
+            const ts = managed
+              ? resolveRowTimestamp(
+                  bufferLine,
+                  lineOffset,
+                  (y) => buf.getLine(y),
+                  (abs) => managed.lineTimestamps.get(abs),
+                )
+              : undefined
+            return ts ? formatTimestampMs(ts, tsFormat) : ''
+          })()
+        : '',
+    })
+  }
+  lines.value = rendered
+  bgColor.value = t.options.theme?.background || '#1e1e1e'
+  fontCss.value = {
+    fontSize: `${t.options.fontSize ?? 13}px`,
+    fontFamily: typeof t.options.fontFamily === 'string' ? t.options.fontFamily : 'monospace',
+  }
+  const maxDigits = String(lineOffset + Math.max(total - 1, 0) + 1).length
+  // Column widths in px from the terminal's measured character width — the
+  // CSS `ch` unit measures the '0' glyph and drifts from the real cell size.
+  const cw = charWidth(t)
+  numColWidth.value = withNumbers ? `${maxDigits * cw}px` : ''
+  timeColWidth.value = withTimestamps ? `${(tsFormat.length + 1) * cw}px` : ''
+  // The number/timestamp columns live INSIDE the popup, so the popup must be
+  // wider than the terminal by exactly those columns — otherwise the content
+  // area shrinks and the right-hand side of each line gets clipped. The left
+  // gutter area of the terminal provides this extra room.
+  const colsExtra =
+    (withNumbers ? maxDigits * cw : 0) +
+    (withTimestamps ? (tsFormat.length + 1) * cw : 0)
+
+  const lh = cellHeight(t)
+  cellHeightPx.value = `${lh}px`
+  // Anchor measurements to the terminal's own container — never to the popup
+  // itself: while the popup is hidden (v-show display:none) its offsetParent
+  // is null, which used to misplace the very first appearance to (0,0).
+  const base = (host?.closest('.base-terminal') as HTMLElement | null)?.getBoundingClientRect()
+  if (!base) return
+  const termRect = t.element?.getBoundingClientRect()
+  if (!termRect) return
+
+  // box-sizing: content-box — `width` IS the content area, so text lines up
+  // with the terminal regardless of padding. CHROME (padding 4px ×2 + border
+  // 1px ×2) only matters for the outer footprint when positioning/clamping.
+  const POPUP_H_CHROME = 10
+  // Base the content width on the actual rendered text area (.xterm-screen),
+  // NOT the `.xterm` root: the root's width also spans the scrollbar strip,
+  // which left a blank margin at the right edge of every preview line.
+  const screenEl = t.element?.querySelector('.xterm-screen') as HTMLElement | null
+  const contentWidth = screenEl?.getBoundingClientRect().width ?? t.cols * cw
+  // Overlay the terminal window exactly: flush with its left edge and ending
+  // at the scrollbar. (The previous right-anchored layout left a visible gap
+  // on the left whenever the popup's content was narrower than the window.)
+  // Text is left-aligned, so lines start exactly where the terminal's do;
+  // the columns make the previewed text line up with the real columns.
+  const areaRect = (host?.closest('.terminal-area') as HTMLElement | null)?.getBoundingClientRect()
+  const width = areaRect
+    ? Math.max(contentWidth + colsExtra, sbRect.left - areaRect.left - POPUP_H_CHROME)
+    : contentWidth + colsExtra
+  const left = areaRect
+    ? Math.max(0, areaRect.left - base.left)
+    : Math.max(4, sbRect.left - width - POPUP_H_CHROME - 6 - base.left)
+  const height = PREVIEW_ROWS * lh
+  size.value = { width, height }
+  pos.value = {
+    left,
+    top: Math.min(
+      Math.max(4, lastClientY - lh * 2 - base.top),
+      Math.max(4, base.height - height - 8),
+    ),
+  }
+  visible.value = true
+}
+
+function onMouseLeave() {
+  clearTimers()
+  // Grace period so moving onto the popup itself doesn't close it.
+  hideTimer = window.setTimeout(() => {
+    hideTimer = undefined
+    hide()
+  }, HIDE_DELAY)
+}
+
+function onPopupEnter() {
+  if (hideTimer !== undefined) {
+    clearTimeout(hideTimer)
+    hideTimer = undefined
+  }
+}
+
+function hide() {
+  clearTimers()
+  visible.value = false
+}
+
+function onJump() {
+  const t = getTerminal()
+  if (t) t.scrollToLine(startRow.value)
+  hide()
+}
+
+watch(
+  () => props.sessionId,
+  () => nextTick(bind),
+  { immediate: false },
+)
+
+watch(
+  () => props.enabled,
+  (on) => {
+    if (!on) hide()
+  },
+)
+
+onMounted(() => nextTick(bind))
+onBeforeUnmount(unbind)
+</script>
+
+<style scoped>
+.terminal-screen-preview {
+  position: absolute;
+  z-index: 30;
+  overflow: hidden;
+  border: 1px solid var(--el-border-color, rgba(255, 255, 255, 0.2));
+  border-radius: 6px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.35);
+  padding: 2px 4px;
+  box-sizing: content-box;
+  pointer-events: auto;
+  cursor: pointer;
+}
+
+.preview-line {
+  display: flex;
+  white-space: pre;
+  overflow: hidden;
+}
+
+.preview-col-time {
+  flex: none;
+  opacity: 0.75;
+}
+
+.preview-col-num {
+  flex: none;
+  text-align: right;
+  opacity: 0.55;
+}
+
+.preview-content {
+  flex: 1 1 auto;
+  overflow: hidden;
+}
+
+.preview-blank {
+  display: inline-block;
+}
+</style>

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -356,6 +356,8 @@
   "settings.rightClickMenu": "Kontextmenü anzeigen",
   "settings.rightClickPaste": "Zwischenablage einfugen",
   "settings.maxHistory": "Max. Verlaufszeilen",
+  "settings.screenPreview": "Bildschirm-Vorschau",
+  "settings.screenPreviewDesc": "Zeigt beim Überfahren der Bildlaufleiste eine Vorschau des Verlaufs an; Klick springt zur Position",
   "settings.themeDesc": "Oberflächendesign auswählen",
   "settings.languageDesc": "Anzeigesprache wechseln",
   "settings.colorSchemeDesc": "Farbschema des Terminals",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -356,6 +356,8 @@
   "settings.rightClickMenu": "Show context menu",
   "settings.rightClickPaste": "Paste clipboard content",
   "settings.maxHistory": "Max History Lines",
+  "settings.screenPreview": "Screen Preview",
+  "settings.screenPreviewDesc": "Show a preview of history content when hovering over the terminal scrollbar",
   "settings.themeDesc": "Choose the interface theme",
   "settings.languageDesc": "Switch the display language",
   "settings.colorSchemeDesc": "Terminal color scheme",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -356,6 +356,8 @@
   "settings.rightClickMenu": "Mostrar menú contextual",
   "settings.rightClickPaste": "Pegar portapapeles",
   "settings.maxHistory": "Máximo de Líneas de Historial",
+  "settings.screenPreview": "Vista previa de pantalla",
+  "settings.screenPreviewDesc": "Muestra una vista previa del historial al pasar el ratón sobre la barra de desplazamiento; haga clic para saltar",
   "settings.themeDesc": "Elija el tema de la interfaz",
   "settings.languageDesc": "Cambiar el idioma de la interfaz",
   "settings.colorSchemeDesc": "Esquema de colores de la terminal",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -356,6 +356,8 @@
   "settings.rightClickMenu": "Afficher le menu contextuel",
   "settings.rightClickPaste": "Coller le presse-papiers",
   "settings.maxHistory": "Lignes d'historique max",
+  "settings.screenPreview": "Aperçu de l'écran",
+  "settings.screenPreviewDesc": "Affiche un aperçu de l'historique au survol de la barre de défilement ; cliquez pour y accéder",
   "settings.themeDesc": "Choisir le thème de l'interface",
   "settings.languageDesc": "Changer la langue d'affichage",
   "settings.colorSchemeDesc": "Palette de couleurs du terminal",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -356,6 +356,8 @@
   "settings.rightClickMenu": "コンテキストメニューを表示",
   "settings.rightClickPaste": "クリップボードを貼り付け",
   "settings.maxHistory": "履歴行数の上限",
+  "settings.screenPreview": "スクリーンプレビュー",
+  "settings.screenPreviewDesc": "スクロールバーにホバーするとその位置の履歴内容をプレビュー表示し、クリックでジャンプできます",
   "settings.themeDesc": "インターフェースのテーマを選択",
   "settings.languageDesc": "表示言語を切り替え",
   "settings.colorSchemeDesc": "ターミナルのカラースキーム",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -356,6 +356,8 @@
   "settings.rightClickMenu": "컨텍스트 메뉴 표시",
   "settings.rightClickPaste": "클립보드 붙여넣기",
   "settings.maxHistory": "최대 기록 줄 수",
+  "settings.screenPreview": "화면 미리보기",
+  "settings.screenPreviewDesc": "스크롤바에 마우스를 올리면 해당 위치의 기록 내용을 미리 보여주며, 클릭하면 이동합니다",
   "settings.themeDesc": "인터페이스 테마를 선택하세요",
   "settings.languageDesc": "표시 언어를 전환하세요",
   "settings.colorSchemeDesc": "터미널 색상 구성",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -356,6 +356,8 @@
   "settings.rightClickMenu": "Показать контекстное меню",
   "settings.rightClickPaste": "Вставить из буфера обмена",
   "settings.maxHistory": "Макс. строк истории",
+  "settings.screenPreview": "Просмотр экрана",
+  "settings.screenPreviewDesc": "Показывает предпросмотр истории при наведении на полосу прокрутки; клик выполняет переход",
   "settings.themeDesc": "Выберите тему интерфейса",
   "settings.languageDesc": "Переключить язык интерфейса",
   "settings.colorSchemeDesc": "Цветовая схема терминала",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -356,6 +356,8 @@
   "settings.rightClickMenu": "弹出右键菜单",
   "settings.rightClickPaste": "粘贴剪贴板中内容",
   "settings.maxHistory": "最大历史行数",
+  "settings.screenPreview": "屏幕回看",
+  "settings.screenPreviewDesc": "鼠标悬停终端滚动条时，弹出该位置的历史内容预览，点击可跳转",
   "settings.themeDesc": "选择界面主题风格",
   "settings.languageDesc": "切换界面显示语言",
   "settings.colorSchemeDesc": "终端窗口的配色方案",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -356,6 +356,8 @@
   "settings.rightClickMenu": "彈出右鍵選單",
   "settings.rightClickPaste": "貼上剪貼簿內容",
   "settings.maxHistory": "最大歷史行數",
+  "settings.screenPreview": "螢幕回看",
+  "settings.screenPreviewDesc": "滑鼠懸停終端機捲軸時，彈出該位置的歷史內容預覽，點擊可跳轉",
   "settings.themeDesc": "選擇介面主題風格",
   "settings.languageDesc": "切換介面顯示語言",
   "settings.colorSchemeDesc": "終端機視窗的配色方案",

--- a/frontend/src/services/screenPreview.test.ts
+++ b/frontend/src/services/screenPreview.test.ts
@@ -1,0 +1,278 @@
+// Issue #729 — screen preview (屏幕回看): pure logic for rendering xterm.js
+// buffer lines into styled runs for the hover preview popup, and for mapping
+// a scrollbar hover position to a buffer row.
+//
+// These functions are structurally typed against xterm.js's IBufferLine /
+// IBufferCell APIs so tests can exercise them with plain fakes, and the real
+// xterm objects satisfy the same shape at runtime.
+import { describe, it, expect } from 'vitest'
+import {
+  buildPalette,
+  colorToCss,
+  lineToRuns,
+  computePreviewStart,
+  pickVerticalTrackIndex,
+  type PreviewPalette,
+  type PreviewBufferCell,
+} from './screenPreview'
+
+const palette: PreviewPalette = {
+  defaultFg: '#cccccc',
+  defaultBg: '#1e1e1e',
+  ansi16: [
+    '#000000', // 0 black
+    '#cd3131', // 1 red
+    '#0dbc79', // 2 green
+    '#e5e510', // 3 yellow
+    '#2472c8', // 4 blue
+    '#bc3fbc', // 5 magenta
+    '#11a8cd', // 6 cyan
+    '#e5e5e5', // 7 white
+    '#666666', // 8 brightBlack
+    '#f14c4c', // 9 brightRed
+    '#23d18b', // 10 brightGreen
+    '#f5f543', // 11 brightYellow
+    '#3b8eea', // 12 brightBlue
+    '#d670d6', // 13 brightMagenta
+    '#29b8db', // 14 brightCyan
+    '#ffffff', // 15 brightWhite
+  ],
+}
+
+function makeLine(cells: Array<Partial<PreviewBufferCell>>) {
+  return {
+    isWrapped: false,
+    getCell(x: number): PreviewBufferCell | undefined {
+      return cells[x]
+    },
+    translateToString(): string {
+      return ''
+    },
+  }
+}
+
+describe('buildPalette', () => {
+  it('maps the 16 ANSI colors from an xterm theme', () => {
+    const p = buildPalette({
+      foreground: '#f0f0f0',
+      background: '#101010',
+      black: '#010101',
+      red: '#020202',
+      green: '#030303',
+      yellow: '#040404',
+      blue: '#050505',
+      magenta: '#060606',
+      cyan: '#070707',
+      white: '#080808',
+      brightBlack: '#090909',
+      brightRed: '#0a0a0a',
+      brightGreen: '#0b0b0b',
+      brightYellow: '#0c0c0c',
+      brightBlue: '#0d0d0d',
+      brightMagenta: '#0e0e0e',
+      brightCyan: '#0f0f0f',
+      brightWhite: '#101010',
+    })
+    expect(p.defaultFg).toBe('#f0f0f0')
+    expect(p.defaultBg).toBe('#101010')
+    expect(p.ansi16[0]).toBe('#010101')
+    expect(p.ansi16[9]).toBe('#0a0a0a')
+    expect(p.ansi16[15]).toBe('#101010')
+  })
+
+  it('falls back to sane defaults for missing theme entries', () => {
+    const p = buildPalette(undefined)
+    expect(p.defaultFg).toBeTruthy()
+    expect(p.defaultBg).toBeTruthy()
+    expect(p.ansi16).toHaveLength(16)
+    expect(p.ansi16.every((c) => typeof c === 'string' && c.length > 0)).toBe(true)
+  })
+})
+
+describe('colorToCss', () => {
+  it('returns undefined for the default color mode (0)', () => {
+    expect(colorToCss(0, 0, palette)).toBeUndefined()
+  })
+
+  // xterm.js v6 color modes: 0 = default, 1 = palette (index 0-255,
+  // covering both the 16 base colors and the 256-color set), 2 = RGB.
+  it('resolves palette 0-15 colors through ansi16', () => {
+    expect(colorToCss(1, 4, palette)).toBe('#2472c8')
+    expect(colorToCss(1, 9, palette)).toBe('#f14c4c')
+  })
+
+  it('resolves palette 256-color cube indices 16-231', () => {
+    // 196 = cube (5,0,0) → rgb(255, 0, 0)
+    expect(colorToCss(1, 196, palette)).toBe('rgb(255, 0, 0)')
+    // 17 = cube (0,0,1) → rgb(0, 0, 95)
+    expect(colorToCss(1, 17, palette)).toBe('rgb(0, 0, 95)')
+    // 231 = cube (5,5,5) → rgb(255, 255, 255)
+    expect(colorToCss(1, 231, palette)).toBe('rgb(255, 255, 255)')
+  })
+
+  it('resolves palette grayscale indices 232-255', () => {
+    expect(colorToCss(1, 232, palette)).toBe('rgb(8, 8, 8)')
+    expect(colorToCss(1, 255, palette)).toBe('rgb(238, 238, 238)')
+  })
+
+  it('resolves direct RGB mode (2)', () => {
+    expect(colorToCss(2, 0xff0000, palette)).toBe('rgb(255, 0, 0)')
+    expect(colorToCss(2, 0x102030, palette)).toBe('rgb(16, 32, 48)')
+  })
+
+  it('returns undefined for out-of-range indices', () => {
+    expect(colorToCss(1, 999, palette)).toBeUndefined()
+  })
+})
+
+describe('lineToRuns', () => {
+  function cell(over: Partial<PreviewBufferCell>): PreviewBufferCell {
+    return {
+      getWidth: () => 1,
+      getChars: () => 'a',
+      getFgColor: () => 0,
+      getBgColor: () => 0,
+      isFgRGB: () => false,
+      isFgPalette: () => false,
+      isBgRGB: () => false,
+      isBgPalette: () => false,
+      isBold: () => false,
+      isDim: () => false,
+      isItalic: () => false,
+      isUnderline: () => false,
+      isInverse: () => false,
+      ...over,
+    }
+  }
+
+  it('joins consecutive same-style cells into a single run', () => {
+    const line = makeLine([cell({ getChars: () => 'a' }), cell({ getChars: () => 'b' }), cell({ getChars: () => 'c' })])
+    expect(lineToRuns(line, 3, palette)).toEqual([{ text: 'abc' }])
+  })
+
+  it('splits runs when the style changes', () => {
+    const line = makeLine([
+      cell({ getChars: () => 'a' }),
+      cell({ getChars: () => 'b', isBold: () => true }),
+      cell({ getChars: () => 'c', isBold: () => true }),
+    ])
+    expect(lineToRuns(line, 3, palette)).toEqual([
+      { text: 'a' },
+      { text: 'bc', bold: true },
+    ])
+  })
+
+  it('resolves foreground and background colors', () => {
+    const line = makeLine([
+      cell({ getChars: () => 'x', isFgPalette: () => true, getFgColor: () => 1 }),
+      cell({ getChars: () => 'y', isBgRGB: () => true, getBgColor: () => 0x00ff00 }),
+    ])
+    expect(lineToRuns(line, 2, palette)).toEqual([
+      { text: 'x', fg: '#cd3131' },
+      { text: 'y', bg: 'rgb(0, 255, 0)' },
+    ])
+  })
+
+  it('resolves colors via predicate APIs even when getFgColorMode returns v6 flag masks', () => {
+    // Regression: xterm v6's getFgColorMode() returns masked flag bits
+    // (palette = 16777216/33554432, RGB = 50331648), NOT 0/1/2. Cells must be
+    // classified through isFgRGB()/isFgPalette() predicates instead.
+    const line = makeLine([
+      cell({ getChars: () => 'p', isFgPalette: () => true, getFgColorMode: () => 16777216, getFgColor: () => 4 }),
+      cell({ getChars: () => 'r', isFgRGB: () => true, getFgColorMode: () => 50331648, getFgColor: () => 0xff8000 }),
+    ])
+    expect(lineToRuns(line, 2, palette)).toEqual([
+      { text: 'p', fg: '#2472c8' },
+      { text: 'r', fg: 'rgb(255, 128, 0)' },
+    ])
+  })
+
+  it('swaps colors for inverse video', () => {
+    const line = makeLine([
+      cell({ getChars: () => 'i', isInverse: () => true, isFgPalette: () => true, getFgColor: () => 1 }),
+    ])
+    // inverse: fg becomes the default background, bg becomes the cell fg
+    expect(lineToRuns(line, 1, palette)).toEqual([
+      { text: 'i', fg: '#1e1e1e', bg: '#cd3131', inverse: true },
+    ])
+  })
+
+  it('skips zero-width continuation cells (CJK wide chars)', () => {
+    const line = makeLine([
+      cell({ getChars: () => '中', getWidth: () => 2 }),
+      cell({ getChars: () => '', getWidth: () => 0 }), // trailing half of the wide char
+      cell({ getChars: () => 'b' }),
+    ])
+    expect(lineToRuns(line, 3, palette)).toEqual([{ text: '中b' }])
+  })
+
+  it('trims trailing blank cells', () => {
+    const line = makeLine([
+      cell({ getChars: () => 'a' }),
+      cell({ getChars: () => '' }),
+      cell({ getChars: () => '' }),
+    ])
+    expect(lineToRuns(line, 3, palette)).toEqual([{ text: 'a' }])
+  })
+
+  it('returns an empty array for an empty line', () => {
+    expect(lineToRuns(makeLine([]), 5, palette)).toEqual([])
+  })
+})
+
+describe('computePreviewStart', () => {
+  const rows = 30
+  const previewRows = 10
+
+  it('maps ratio 0 to the top of the buffer', () => {
+    expect(computePreviewStart(0, 100, rows, previewRows)).toBe(0)
+  })
+
+  it('maps ratio 1 to the last scrollable position', () => {
+    // 100 lines, 30 viewport rows → max scroll top is 70
+    expect(computePreviewStart(1, 100, rows, previewRows)).toBe(70)
+  })
+
+  it('is monotonic between 0 and 1', () => {
+    const prev = computePreviewStart(0.25, 100, rows, previewRows)
+    const mid = computePreviewStart(0.5, 100, rows, previewRows)
+    const next = computePreviewStart(0.75, 100, rows, previewRows)
+    expect(prev).toBeLessThan(mid)
+    expect(mid).toBeLessThan(next)
+  })
+
+  it('clamps out-of-range ratios', () => {
+    expect(computePreviewStart(-0.5, 100, rows, previewRows)).toBe(0)
+    expect(computePreviewStart(1.5, 100, rows, previewRows)).toBe(70)
+  })
+
+  it('keeps the preview window inside the buffer', () => {
+    // 12 total lines, 30 rows, 10 preview rows: ratio 1 → start 0
+    // (max scroll is negative → no scrolling, start clamped to 0)
+    expect(computePreviewStart(1, 12, rows, previewRows)).toBe(0)
+  })
+
+  it('returns 0 for buffers with no scroll room', () => {
+    expect(computePreviewStart(0.5, 10, rows, previewRows)).toBe(0)
+  })
+})
+
+describe('pickVerticalTrackIndex', () => {
+  it('picks the vertical track when the degenerate 0x0 horizontal track comes first', () => {
+    // Real-world shape seen in diagnostics: horizontal 0x0, vertical 14x699.
+    expect(pickVerticalTrackIndex([
+      { width: 0, height: 0 },
+      { width: 14, height: 699 },
+    ])).toBe(1)
+  })
+
+  it('picks the only track when just the vertical one exists', () => {
+    expect(pickVerticalTrackIndex([{ width: 14, height: 699 }])).toBe(0)
+  })
+
+  it('returns -1 when no candidate is a plausible vertical track', () => {
+    expect(pickVerticalTrackIndex([{ width: 0, height: 0 }])).toBe(-1)
+    expect(pickVerticalTrackIndex([{ width: 699, height: 14 }])).toBe(-1)
+    expect(pickVerticalTrackIndex([])).toBe(-1)
+  })
+})

--- a/frontend/src/services/screenPreview.ts
+++ b/frontend/src/services/screenPreview.ts
@@ -1,0 +1,194 @@
+// Issue #729 — screen preview (屏幕回看): pure helpers behind the scrollbar
+// hover preview popup (WindTerm/Termora-style). The popup renders ~10 lines of
+// scrollback next to the scrollbar while the mouse hovers over it.
+//
+// Everything here is pure and structurally typed against xterm.js v6's
+// IBufferLine / IBufferCell so it can be tested with plain fakes; the real
+// xterm objects satisfy the same shape at runtime.
+import type { ITheme } from '@xterm/xterm'
+
+export interface PreviewPalette {
+  defaultFg: string
+  defaultBg: string
+  /** The 16 base ANSI colors, index 0 (black) … 15 (brightWhite). */
+  ansi16: string[]
+}
+
+export interface PreviewStyleRun {
+  text: string
+  fg?: string
+  bg?: string
+  bold?: boolean
+  dim?: boolean
+  italic?: boolean
+  underline?: boolean
+  inverse?: boolean
+}
+
+/**
+ * Structural subset of xterm.js v6 `IBufferCell`. Color modes must be
+ * classified through the predicate APIs — `getFgColorMode()` returns masked
+ * flag bits in v6 (palette = 16777216/33554432, RGB = 50331648), not 0/1/2.
+ */
+export interface PreviewBufferCell {
+  getWidth(): number
+  getChars(): string
+  getFgColor(): number
+  getBgColor(): number
+  isFgRGB(): boolean
+  isFgPalette(): boolean
+  isBgRGB(): boolean
+  isBgPalette(): boolean
+  isBold(): boolean | number
+  isDim(): boolean | number
+  isItalic(): boolean | number
+  isUnderline(): boolean | number
+  isInverse(): boolean | number
+}
+
+/** Structural subset of xterm.js v6 `IBufferLine`. */
+export interface PreviewBufferLine {
+  getCell(x: number): PreviewBufferCell | undefined
+  isWrapped: boolean
+}
+
+const FALLBACK_ANSI16 = [
+  '#2e3436', '#cc0000', '#4e9a06', '#c4a000',
+  '#3465a4', '#75507b', '#06989a', '#d3d7cf',
+  '#555753', '#ef2929', '#8ae234', '#fce94f',
+  '#729fcf', '#ad7fa8', '#34e2e2', '#eeeeec',
+]
+
+const CUBE_STEPS = [0, 95, 135, 175, 215, 255]
+
+export function buildPalette(theme?: Partial<ITheme>): PreviewPalette {
+  const ansi16 = [
+    'black', 'red', 'green', 'yellow',
+    'blue', 'magenta', 'cyan', 'white',
+    'brightBlack', 'brightRed', 'brightGreen', 'brightYellow',
+    'brightBlue', 'brightMagenta', 'brightCyan', 'brightWhite',
+  ].map((key) => theme?.[key] || FALLBACK_ANSI16.shift() || '#888888') as string[]
+  return {
+    defaultFg: theme?.foreground || '#ffffff',
+    defaultBg: theme?.background || '#000000',
+    ansi16,
+  }
+}
+
+/** Resolve an xterm cell color (mode + value) to a CSS color string. */
+export function colorToCss(
+  mode: number,
+  color: number,
+  palette: PreviewPalette,
+): string | undefined {
+  if (mode === 0) return undefined
+  if (mode === 1) {
+    if (color < 0 || color > 255) return undefined
+    if (color < 16) return palette.ansi16[color]
+    if (color < 232) {
+      const n = color - 16
+      const r = CUBE_STEPS[Math.floor(n / 36)]
+      const g = CUBE_STEPS[Math.floor(n / 6) % 6]
+      const b = CUBE_STEPS[n % 6]
+      return `rgb(${r}, ${g}, ${b})`
+    }
+    const v = 8 + (color - 232) * 10
+    return `rgb(${v}, ${v}, ${v})`
+  }
+  if (mode === 2) {
+    const r = (color >> 16) & 0xff
+    const g = (color >> 8) & 0xff
+    const b = color & 0xff
+    return `rgb(${r}, ${g}, ${b})`
+  }
+  return undefined
+}
+
+/**
+ * Convert one buffer line into styled text runs (consecutive cells with the
+ * same style merged). Zero-width cells (the trailing half of CJK wide chars)
+ * are skipped and trailing blanks are trimmed.
+ */
+export function lineToRuns(
+  line: PreviewBufferLine,
+  cols: number,
+  palette: PreviewPalette,
+): PreviewStyleRun[] {
+  const runs: PreviewStyleRun[] = []
+  for (let x = 0; x < cols; x++) {
+    const cell = line.getCell(x)
+    if (!cell || cell.getWidth() === 0) continue
+    const ch = cell.getChars() || ' '
+
+    // xterm v6: classify color modes via the documented predicates —
+    // getFgColorMode()'s numeric value is a flag mask, not 0/1/2.
+    const fgMode = cell.isFgRGB() ? 2 : cell.isFgPalette() ? 1 : 0
+    const bgMode = cell.isBgRGB() ? 2 : cell.isBgPalette() ? 1 : 0
+    const fgRaw = colorToCss(fgMode, cell.getFgColor(), palette)
+    const bgRaw = colorToCss(bgMode, cell.getBgColor(), palette)
+    const inverse = cell.isInverse()
+    const fg = inverse ? (bgRaw ?? palette.defaultBg) : fgRaw
+    const bg = inverse ? (fgRaw ?? palette.defaultFg) : bgRaw
+
+    const style: PreviewStyleRun = { text: ch }
+    if (fg) style.fg = fg
+    if (bg) style.bg = bg
+    if (cell.isBold()) style.bold = true
+    if (cell.isDim()) style.dim = true
+    if (cell.isItalic()) style.italic = true
+    if (cell.isUnderline()) style.underline = true
+    if (inverse) style.inverse = true
+
+    const prev = runs[runs.length - 1]
+    if (prev && sameStyle(prev, style)) {
+      prev.text += ch
+    } else {
+      runs.push(style)
+    }
+  }
+  // Trim trailing blank cells (drop runs that are pure spaces, then trim
+  // trailing spaces off the last remaining run).
+  while (runs.length > 0 && runs[runs.length - 1].text.trim() === '') runs.pop()
+  const tail = runs[runs.length - 1]
+  if (tail) tail.text = tail.text.replace(/ +$/, '')
+  return runs
+}
+
+function sameStyle(a: PreviewStyleRun, b: PreviewStyleRun): boolean {
+  return (
+    a.fg === b.fg && a.bg === b.bg && !!a.bold === !!b.bold && !!a.dim === !!b.dim &&
+    !!a.italic === !!b.italic && !!a.underline === !!b.underline && !!a.inverse === !!b.inverse
+  )
+}
+
+/**
+ * Map a scrollbar hover ratio (0 = top, 1 = bottom) to the first buffer row
+ * the preview window should show. The window is clamped so that
+ * `start + previewRows` never exceeds `totalLines`.
+ */
+export function computePreviewStart(
+  ratio: number,
+  totalLines: number,
+  rows: number,
+  previewRows: number,
+): number {
+  const r = Math.min(1, Math.max(0, ratio))
+  const maxScroll = Math.max(0, totalLines - rows)
+  const maxStart = Math.max(0, totalLines - previewRows)
+  return Math.min(Math.round(r * maxScroll), maxStart)
+}
+
+/**
+ * Pick the vertical scrollbar track from candidate track rects. xterm v6 has
+ * both a horizontal and a vertical track; the horizontal one can be
+ * degenerate (0x0), so require a strictly taller-than-wide, non-empty rect.
+ * Returns the index into `rects`, or -1 when none qualifies.
+ */
+export function pickVerticalTrackIndex(
+  rects: Array<{ width: number; height: number }>,
+): number {
+  for (let i = 0; i < rects.length; i++) {
+    if (rects[i].height > 0 && rects[i].height > rects[i].width) return i
+  }
+  return -1
+}

--- a/frontend/src/types/settings.ts
+++ b/frontend/src/types/settings.ts
@@ -68,6 +68,9 @@ export interface TerminalSettings {
   // #671) for scroll-sensitive mice; defaults to enabled.
   ctrlWheelZoom?: boolean
   maxHistoryLines: number
+  // Issue #729: WindTerm/Termora-style screen preview — hovering the terminal
+  // scrollbar pops up a read-only preview of the scrollback at that position.
+  screenPreview?: boolean
   smartCompletion: boolean
   aiTranscription: boolean
   highlightEnabled: boolean
@@ -230,6 +233,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
     rightClickAction: 'menu',
     middleClickAction: 'paste',
     maxHistoryLines: 2500,
+    screenPreview: true,
     smartCompletion: true,
     aiTranscription: true,
     highlightEnabled: true,


### PR DESCRIPTION
Closes #729

## Summary

Add a WindTerm/Termora-style **screen preview** (屏幕回看): hovering the terminal scrollbar for 250ms pops up a small read-only preview of the scrollback at that position. Moving along the scrollbar scrolls the preview; clicking it jumps the terminal to that position.

- Hover detection is geometry-based against xterm v6's custom scrollbar track (); the thumb (slider) area is excluded since it marks the content already on screen. Alt-screen apps (vim/htop) and non-scrollable buffers never trigger it.
- Preview content is rendered from the xterm buffer cell by cell with full color support (16-color, 256-color, true color, inverse video, bold/italic/underline/dim).
- Optional line-number and timestamp columns reuse the existing gutter data (), mirroring its wrapped-line semantics; the popup overlays the terminal window flush on both edges.
- New setting `terminal.screenPreview` (default on) under Settings → Terminal; i18n for all 9 locales.
- Pure frontend change — no backend/PTY modifications, TUI apps are unaffected.

New unit tests cover the pure logic (row mapping, v6 color-mode resolution via predicate APIs, style-run splitting, vertical track selection): 28 tests, suite 258/258 green.

---

## 摘要

新增 WindTerm/Termora 风格的**屏幕回看**功能（#729）：鼠标悬停终端滚动条 250ms 后，弹出该位置回滚内容的只读预览小窗。沿滚动条移动可滚动预览，点击预览可跳转到对应位置。

- 悬停检测基于几何命中测试，针对 xterm v6 的自绘滚动条轨道（`.xterm-scrollable-element > .scrollbar`）；拖动块（slider）区域不触发——它对应的就是当前屏幕内容。alt-screen 程序（vim/htop）和无滚动内容时不触发。
- 预览内容从 xterm buffer 逐单元格渲染，完整支持颜色（16 色、256 色、真彩色、反色、粗体/斜体/下划线/暗淡）。
- 可选行号/时间戳列复用现有 gutter 的 `lineTimestamps` 数据，换行行语义与 gutter 一致；弹窗左右边缘与终端窗口紧贴对齐。
- 新增设置项 `terminal.screenPreview`（默认开启），位于 设置 → 终端；已添加全部 9 种语言的 i18n。
- 纯前端改动，不涉及后端/PTY，不影响 TUI 程序。

新增单元测试覆盖纯逻辑部分（行号换算、v6 颜色模式谓词解析、样式 run 切分、竖向轨道选择）：28 个测试，全量 258/258 通过。