### PR TITLE
feat(sidebar): restore tunnels tab with per-tab visibility

### DIFF
--- a/backend/store/settings_store.go
+++ b/backend/store/settings_store.go
@@ -125,6 +125,13 @@ type AppSettings struct {
 	CustomTerminalThemes []CustomTerminalTheme `json:"customTerminalThemes"`
 	DefaultLocalShell    string                `json:"defaultLocalShell"`
 	TabCloseButton       string                `json:"tabCloseButton"`
+	// SidebarTabs toggles which connection-sidebar tab icons are visible,
+	// keyed by view id (connections/files/monitor/tunnels/quickCommands/
+	// history/personalization). "connections" is always shown in the UI and
+	// never hidden. Pointer + omitempty so settings.json written by older
+	// builds (which lack this field) still load; a nil map means "use the
+	// frontend defaults" (everything visible except tunnels — issue #736).
+	SidebarTabs map[string]bool `json:"sidebarTabs,omitempty"`
 }
 
 type SFTPBookmarks struct {

--- a/frontend/src/components/SettingsTab.vue
+++ b/frontend/src/components/SettingsTab.vue
@@ -156,6 +156,31 @@
             </div>
           </div>
 
+          <div class="setting-card">
+            <div class="setting-info">
+              <div class="setting-title">{{ t('settings.sidebarTabs') }}</div>
+              <div class="setting-desc">{{ t('settings.sidebarTabsDesc') }}</div>
+            </div>
+            <div class="setting-control">
+              <el-select
+                v-model="visibleSidebarTabs"
+                multiple
+                collapse-tags
+                :collapse-tags-limit="3"
+                @change="onSidebarTabsChange"
+              >
+                <!-- "connections" is fixed and never rendered as an option;
+                     the computed keeps it force-selected. -->
+                <el-option
+                  v-for="tab in SIDEBAR_TAB_ORDER.filter(tab => tab.key !== 'connections')"
+                  :key="tab.key"
+                  :label="t(tab.labelKey)"
+                  :value="tab.key"
+                />
+              </el-select>
+            </div>
+          </div>
+
           </div>
 
         <h2 class="section-title" style="margin-top: 28px">{{ t('settings.interaction') }}</h2>
@@ -1074,7 +1099,7 @@ import { useLocalStateStore } from '../stores/localStateStore'
 import { useUpdateCheck } from '../composables/useUpdateCheck'
 import { useI18n, locale } from '../i18n'
 import { ElMessage, ElMessageBox } from 'element-plus'
-import { FONT_OPTIONS, FONT_WEIGHT_OPTIONS, LANGUAGE_OPTIONS, DEFAULT_KEYBOARD, SHORTCUT_LABELS, USER_AGENT_PRESETS, FOLLOW_APP_THEME, CURSOR_STYLES, TIMESTAMP_FORMATS } from '../types/settings'
+import { FONT_OPTIONS, FONT_WEIGHT_OPTIONS, LANGUAGE_OPTIONS, DEFAULT_KEYBOARD, SHORTCUT_LABELS, USER_AGENT_PRESETS, FOLLOW_APP_THEME, CURSOR_STYLES, TIMESTAMP_FORMATS, SIDEBAR_TAB_ORDER, SIDEBAR_TAB_DEFAULTS } from '../types/settings'
 import { formatFontFamily, normalizeFontFamilyValue } from '../utils/formatFontFamily'
 import SkillsManager from './SkillsManager.vue'
 import CommandsManager from './CommandsManager.vue'
@@ -1533,6 +1558,25 @@ const tunnelStore = useTunnelStore()
 const tunnelDialogVisible = ref(false)
 const editingTunnelId = ref<string | undefined>(undefined)
 const togglingTunnelId = ref<string | undefined>(undefined)
+
+// ── Sidebar tab visibility (issue #736) ──
+// Writable computed over AppSettings.sidebarTabs. "connections" never appears
+// in the select (no option, no tag) — it is forced on at the data level.
+const visibleSidebarTabs = computed<string[]>({
+  get: () => SIDEBAR_TAB_ORDER
+    .map(tab => tab.key)
+    .filter(key => key !== 'connections')
+    .filter(key => settingsStore.settings.sidebarTabs?.[key] ?? SIDEBAR_TAB_DEFAULTS[key] ?? true),
+  set: (keys: string[]) => {
+    const tabs = settingsStore.settings.sidebarTabs
+    for (const tab of SIDEBAR_TAB_ORDER) {
+      tabs[tab.key] = tab.key === 'connections' || keys.includes(tab.key)
+    }
+  },
+})
+function onSidebarTabsChange() {
+  settingsStore.save()
+}
 function openTunnelDialog(t?: Tunnel) {
   editingTunnelId.value = t?.id
   tunnelDialogVisible.value = true
@@ -1540,7 +1584,7 @@ function openTunnelDialog(t?: Tunnel) {
 async function removeTunnel(row: Tunnel) {
   await tunnelStore.deleteTunnel(row.id)
 }
-const modeName = (m: TunnelMode) => m.charAt(0).toUpperCase() + m.slice(1)
+const modeName = (m: TunnelMode) => t(`tunnels.mode.${m}`)
 const effPort = (t: Tunnel) => tunnelStore.states[t.id]?.localPort || t.listenPort
 const statusOf = (id: string) => tunnelStore.statusOf(id)
 async function toggleRun(row: Tunnel) {

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -6,13 +6,14 @@
     :style="{ width: sidebarWidth + 'px' }"
   >
     <div class="resize-handle" @mousedown="onResizeStart" />
-    <div class="sidebar-header">
+    <div class="sidebar-header" @contextmenu.prevent="onTabStripContextMenu">
       <button class="sidebar-tab" :class="{ active: activeView === 'connections' }" @click="activeView = 'connections'" :title="t('header.connections')"><el-icon><Network :size="14" /></el-icon></button>
-      <button class="sidebar-tab" :class="{ active: activeView === 'files' }" @click="onFilesTabClick" :title="t('header.files')"><el-icon><FolderTree :size="14" /></el-icon></button>
-      <button class="sidebar-tab" :class="{ active: activeView === 'monitor' }" @click="onMonitorTabClick" :title="t('header.monitor')"><el-icon><Activity :size="14" /></el-icon></button>
-      <button class="sidebar-tab" :class="{ active: activeView === 'quickCommands' }" @click="activeView = 'quickCommands'" :title="t('quickCommands.quickCommandsTab')"><el-icon><Zap :size="14" /></el-icon></button>
-      <button class="sidebar-tab" :class="{ active: activeView === 'history' }" @click="activeView = 'history'" :title="t('quickCommands.historyTab')"><el-icon><Clock :size="14" /></el-icon></button>
-      <button class="sidebar-tab" :class="{ active: activeView === 'personalization' }" @click="activeView = 'personalization'" :title="t('sidebar.personalization')"><el-icon><Palette :size="14" /></el-icon></button>
+      <button v-if="tabVisible('files')" class="sidebar-tab" :class="{ active: activeView === 'files' }" @click="onFilesTabClick" :title="t('header.files')"><el-icon><FolderTree :size="14" /></el-icon></button>
+      <button v-if="tabVisible('monitor')" class="sidebar-tab" :class="{ active: activeView === 'monitor' }" @click="onMonitorTabClick" :title="t('header.monitor')"><el-icon><Activity :size="14" /></el-icon></button>
+      <button v-if="tabVisible('tunnels')" class="sidebar-tab" :class="{ active: activeView === 'tunnels' }" @click="activeView = 'tunnels'" :title="t('tunnels.tunnelsTab')"><el-icon><ArrowRightLeft :size="14" /></el-icon></button>
+      <button v-if="tabVisible('quickCommands')" class="sidebar-tab" :class="{ active: activeView === 'quickCommands' }" @click="activeView = 'quickCommands'" :title="t('quickCommands.quickCommandsTab')"><el-icon><Zap :size="14" /></el-icon></button>
+      <button v-if="tabVisible('history')" class="sidebar-tab" :class="{ active: activeView === 'history' }" @click="activeView = 'history'" :title="t('quickCommands.historyTab')"><el-icon><Clock :size="14" /></el-icon></button>
+      <button v-if="tabVisible('personalization')" class="sidebar-tab" :class="{ active: activeView === 'personalization' }" @click="activeView = 'personalization'" :title="t('sidebar.personalization')"><el-icon><Palette :size="14" /></el-icon></button>
       <button class="icon-btn" @click="emit('toggle')" :title="t('sidebar.collapse')"><el-icon><X :size="14" /></el-icon></button>
     </div>
 
@@ -173,6 +174,8 @@
 
     <QuickCommandsPanel v-if="activeView === 'quickCommands'" />
 
+    <TunnelsPanel v-if="activeView === 'tunnels'" />
+
     
     <HistoryPanel v-if="activeView === 'history'" />
 
@@ -289,6 +292,19 @@
     <ExportDialog v-model:visible="showExportDialog" />
     <ImportDialog v-model:visible="showImportDialog" />
     <CustomThemeEditor v-model="themeEditorVisible" :source-theme-id="themeEditorSourceId" />
+
+    <!-- Tab-strip context menu: toggle which sidebar tabs are shown.
+         Reuses the same AppSettings.sidebarTabs as the Settings page card.
+         "connections" is fixed, so it is not listed. -->
+    <Menu ref="tabStripMenuRef" v-model:visible="tabStripMenuVisible">
+      <MenuItem
+        v-for="tab in SIDEBAR_TAB_ORDER.filter(tab => tab.key !== 'connections')"
+        :key="tab.key"
+        iconic
+        :icon="tabVisible(tab.key) ? Check : undefined"
+        @click="onTabVisibilityClick(tab.key)"
+      >{{ t(tab.labelKey) }}</MenuItem>
+    </Menu>
 
     <!-- Connection context menu -->
     <Menu ref="menuRef" v-model:visible="menuVisible" @contextmenu.stop>
@@ -448,7 +464,7 @@
 
 <script setup lang="ts">
 import { ref, onMounted, onUnmounted, computed, watch, nextTick, provide } from 'vue'
-import { X, ChevronRight, ChevronDown, Filter, Check, Network, Zap, Clock, Plus, Palette, SquareTerminal, Terminal, FolderUp, HardDrive, Cloud, Globe, Monitor, MonitorCloud, MonitorSmartphone, Database, DatabaseZap, Layers, DatabaseSearch, Activity, Laptop, Cable, Pencil, MoreHorizontal, FolderTree, ShipWheel, Boxes, AppWindow, ArrowLeftRight } from '@lucide/vue'
+import { X, ChevronRight, ChevronDown, Filter, Check, Network, Zap, Clock, Plus, Palette, SquareTerminal, Terminal, FolderUp, HardDrive, Cloud, Globe, Monitor, MonitorCloud, MonitorSmartphone, Database, DatabaseZap, Layers, DatabaseSearch, Activity, Laptop, Cable, Pencil, MoreHorizontal, FolderTree, ShipWheel, Boxes, AppWindow, ArrowLeftRight, ArrowRightLeft } from '@lucide/vue'
 import { ElMessageBox } from 'element-plus'
 import { msg } from '../services/message'
 import { useConnectionStore } from '../stores/connectionStore'
@@ -461,6 +477,7 @@ import ConnectionForm from './ConnectionForm.vue'
 import ExportDialog from './ExportDialog.vue'
 import ImportDialog from './ImportDialog.vue'
 import QuickCommandsPanel from './QuickCommandsPanel.vue'
+import TunnelsPanel from './TunnelsPanel.vue'
 import HistoryPanel from './HistoryPanel.vue'
 import FileSidebar from './FileSidebar.vue'
 import MonitorOverviewSidebar from './MonitorOverviewSidebar.vue'
@@ -473,7 +490,7 @@ import MenuSubmenu from './MenuSubmenu.vue'
 import MenuDivider from './MenuDivider.vue'
 import type { ConnectionConfig, ConnectionGroup } from '../types/session'
 import { parseQuickConnect, formatConnSubtitle, getConnectionTypeKey, getTypeCategory, formatTypeFilterLabel, getTypeFilterCatalog, isWindows } from '../utils/quickConnect'
-import { FONT_OPTIONS, FONT_WEIGHT_OPTIONS, LANGUAGE_OPTIONS, FOLLOW_APP_THEME } from '../types/settings'
+import { FONT_OPTIONS, FONT_WEIGHT_OPTIONS, LANGUAGE_OPTIONS, FOLLOW_APP_THEME, SIDEBAR_TAB_DEFAULTS, SIDEBAR_TAB_ORDER } from '../types/settings'
 import { formatFontFamily, normalizeFontFamilyValue } from '../utils/formatFontFamily'
 import { useTerminalThemeOptions } from '../composables/useTerminalThemeOptions'
 import { GetAllFonts } from '../../bindings/github.com/ys-ll/uniterm/app'
@@ -503,7 +520,7 @@ const showForm = ref(false)
 const showExportDialog = ref(false)
 const showImportDialog = ref(false)
 const editConfig = ref<ConnectionConfig | undefined>(undefined)
-const activeView = ref<'connections' | 'quickCommands' | 'history' | 'personalization' | 'files' | 'monitor'>('connections')
+const activeView = ref<'connections' | 'quickCommands' | 'history' | 'personalization' | 'files' | 'monitor' | 'tunnels'>('connections')
 
 // ── SSH companion: files / monitor folded into this sidebar ──
 function onFilesTabClick() {
@@ -530,6 +547,31 @@ watch(
     if (!monitorVisible && activeView.value === 'monitor') activeView.value = 'connections'
   },
 )
+
+// ── Sidebar tab visibility (issue #736) ──
+// Single source of truth is AppSettings.sidebarTabs (editable in Settings →
+// basic); right-clicking the tab strip opens the same toggles as a shortcut.
+// "connections" is the primary view and can never be hidden.
+
+function tabVisible(key: string): boolean {
+  return settingsStore.settings.sidebarTabs?.[key] ?? SIDEBAR_TAB_DEFAULTS[key] ?? true
+}
+
+const tabStripMenuRef = ref<InstanceType<typeof Menu> | null>(null)
+const tabStripMenuVisible = ref(false)
+
+function onTabStripContextMenu(e: MouseEvent) {
+  tabStripMenuRef.value?.openAt(e.clientX, e.clientY)
+}
+
+function onTabVisibilityClick(key: string) {
+  if (key === 'connections') return // always visible
+  const tabs = settingsStore.settings.sidebarTabs
+  tabs[key] = !tabVisible(key)
+  settingsStore.save()
+  // Hiding the view that's currently active falls back to connections.
+  if (!tabs[key] && activeView.value === key) activeView.value = 'connections'
+}
 
 // ── Personalization panel ──
 // Single source: GetAllFonts returns every installed family with its mono

--- a/frontend/src/components/TunnelsPanel.vue
+++ b/frontend/src/components/TunnelsPanel.vue
@@ -1,0 +1,169 @@
+<template>
+  <div class="tunnels-panel">
+    <!-- Toolbar -->
+    <div class="tn-toolbar">
+      <el-input
+        v-model="searchQuery"
+        :placeholder="t('tunnels.searchPlaceholder')"
+        clearable
+        class="tn-search-input"
+      />
+      <button class="tn-icon-btn" :title="t('tunnels.addTunnel')" @click="addTunnel">
+        <Plus :size="15" />
+      </button>
+    </div>
+
+    <!-- Flat list (grouping lives in the Settings page's data model only;
+         the sidebar shows every tunnel in sortOrder, issue #736) -->
+    <div class="tn-list">
+      <div
+        v-for="tn in visibleTunnels"
+        :key="tn.id"
+        class="tn-item"
+        :class="{ running: statusOf(tn) === 'running', errored: statusOf(tn) === 'error' }"
+        @dblclick="toggleRun(tn)"
+        @contextmenu.prevent="onTunnelContextMenu($event, tn)"
+      >
+        <span class="tn-status" :title="statusTitle(tn)"></span>
+        <div class="tn-item-content">
+          <div class="tn-item-name">{{ tn.name }}</div>
+          <div class="tn-item-meta">
+            <span class="tn-badge" :class="tn.mode">{{ t(`tunnels.mode.${tn.mode}`) }}</span>
+            <span class="tn-port">:{{ effPort(tn) }}</span>
+          </div>
+        </div>
+        <button
+          class="tn-run-btn"
+          :title="statusOf(tn) === 'running' ? t('tunnels.stop') : t('tunnels.start')"
+          @click.stop="toggleRun(tn)"
+        >
+          <Square v-if="statusOf(tn) === 'running'" :size="13" />
+          <Play v-else :size="13" />
+        </button>
+      </div>
+
+      <div v-if="store.tunnels.length === 0" class="tn-empty">{{ t('tunnels.empty') }}</div>
+    </div>
+
+    <!-- Row context menu -->
+    <Menu ref="rowMenuRef" v-model:visible="rowMenuVisible">
+      <template v-if="selectedTunnel">
+        <MenuItem @click="toggleRun(selectedTunnel); rowMenuVisible = false">
+          {{ statusOf(selectedTunnel) === 'running' ? t('tunnels.stop') : t('tunnels.start') }}
+        </MenuItem>
+        <MenuDivider />
+        <MenuItem @click="editTunnel(selectedTunnel.id)">{{ t('tunnels.editTunnel') }}</MenuItem>
+        <MenuItem class="danger" @click="doDeleteTunnel(selectedTunnel)">{{ t('tunnels.deleteTunnel') }}</MenuItem>
+      </template>
+    </Menu>
+
+    <TunnelEditDialog v-model="editDialogVisible" :editing-id="editingTunnelId" />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue'
+import { Plus, Play, Square } from '@lucide/vue'
+import { useTunnelStore, type Tunnel } from '../stores/tunnelStore'
+import { useConnectionStore } from '../stores/connectionStore'
+import { useI18n } from '../i18n'
+import { msg } from '../services/message'
+import TunnelEditDialog from './TunnelEditDialog.vue'
+import Menu from './Menu.vue'
+import MenuItem from './MenuItem.vue'
+import MenuDivider from './MenuDivider.vue'
+
+const { t } = useI18n()
+const store = useTunnelStore()
+const connectionStore = useConnectionStore()
+
+const searchQuery = ref('')
+
+const rowMenuRef = ref<InstanceType<typeof Menu> | null>(null)
+const rowMenuVisible = ref(false)
+const selectedTunnel = ref<Tunnel | null>(null)
+
+const editDialogVisible = ref(false)
+const editingTunnelId = ref<string | undefined>(undefined)
+
+const visibleTunnels = computed(() =>
+  [...store.tunnels]
+    .sort((a, b) => (a.sortOrder || 0) - (b.sortOrder || 0))
+    .filter(matchesSearch)
+)
+
+onMounted(async () => {
+  await store.load()
+  await connectionStore.load()
+})
+
+function matchesSearch(tn: Tunnel): boolean {
+  if (!searchQuery.value.trim()) return true
+  return tn.name.toLowerCase().includes(searchQuery.value.toLowerCase())
+}
+
+const statusOf = (tn: Tunnel) => store.statusOf(tn.id)
+const effPort = (tn: Tunnel) => store.states[tn.id]?.localPort || tn.listenPort
+const statusTitle = (tn: Tunnel) => {
+  const status = statusOf(tn)
+  if (status === 'error') return store.states[tn.id]?.error || t('tunnels.statusError')
+  return status === 'running' ? t('tunnels.statusRunning') : t('tunnels.statusStopped')
+}
+
+async function toggleRun(tn: Tunnel) {
+  if (statusOf(tn) === 'running') {
+    await store.stop(tn.id)
+  } else {
+    const st = await store.start(tn.id)
+    if (st.status === 'error') msg.error(st.error || t('tunnels.startFailed'))
+  }
+}
+
+function onTunnelContextMenu(e: MouseEvent, tn: Tunnel) {
+  selectedTunnel.value = tn
+  rowMenuRef.value?.openAt(e.clientX, e.clientY)
+}
+
+function editTunnel(id: string) {
+  rowMenuVisible.value = false
+  editingTunnelId.value = id
+  editDialogVisible.value = true
+}
+
+function addTunnel() {
+  editingTunnelId.value = undefined
+  editDialogVisible.value = true
+}
+
+function doDeleteTunnel(tn: Tunnel) {
+  rowMenuVisible.value = false
+  store.deleteTunnel(tn.id)
+}
+</script>
+
+<style scoped>
+.tunnels-panel { display: flex; flex-direction: column; height: 100%; overflow: hidden; }
+.tn-toolbar { display: flex; align-items: center; gap: 4px; padding: 0 10px 6px; flex-shrink: 0; }
+.tn-search-input { flex: 1; min-width: 0; }
+.tn-icon-btn { width: 26px; height: 26px; display: flex; align-items: center; justify-content: center; border: none; border-radius: 4px; background: transparent; color: var(--text-muted); cursor: pointer; flex-shrink: 0; }
+.tn-icon-btn:hover { color: var(--text-primary); background: var(--bg-hover); }
+.tn-list { flex: 1; overflow-y: auto; padding: 0 8px 8px; }
+.tn-item { display: flex; align-items: center; gap: 10px; padding: 7px 10px; min-height: 40px; border-radius: var(--radius-sm); cursor: pointer; margin: 1px 0; user-select: none; }
+.tn-item:hover { background: var(--bg-hover); }
+.tn-status { width: 8px; height: 8px; border-radius: 50%; background: var(--text-disabled); flex-shrink: 0; }
+.tn-item.running .tn-status { background: var(--success, #24c08a); box-shadow: 0 0 0 3px color-mix(in srgb, var(--success, #24c08a) 20%, transparent); }
+.tn-item.errored .tn-status { background: var(--error, #e5604d); }
+.tn-item-content { flex: 1; min-width: 0; }
+.tn-item-name { font-size: 12px; color: var(--text-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.tn-item-meta { display: flex; align-items: center; gap: 8px; margin-top: 2px; }
+.tn-badge { font-size: 10px; font-weight: 600; padding: 0 5px; border-radius: 4px; background: var(--bg-active, rgba(255,255,255,.06)); color: var(--text-muted); }
+.tn-badge.local { color: #8fb6ff; }
+.tn-badge.remote { color: #e0a54b; }
+.tn-badge.dynamic { color: #24c08a; }
+.tn-port { font-size: 11px; color: var(--text-muted); font-family: var(--font-mono, monospace); }
+.tn-run-btn { width: 24px; height: 24px; display: inline-flex; align-items: center; justify-content: center; border: none; border-radius: 5px; background: transparent; color: var(--text-muted); cursor: pointer; flex-shrink: 0; }
+.tn-item.running .tn-run-btn { color: var(--error, #e5604d); }
+.tn-item:not(.running) .tn-run-btn { color: var(--success, #24c08a); }
+.tn-run-btn:hover { background: var(--bg-active, rgba(255,255,255,.08)); }
+.tn-empty { padding: 24px 12px; text-align: center; color: var(--text-muted); font-size: 12px; }
+</style>

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -335,6 +335,8 @@
   "settings.themeSystem": "System",
   "settings.tabCloseButton": "Tab-Schließen-Schaltfläche",
   "settings.tabCloseButtonDesc": "Wählen Sie, ob die Schließen-Schaltfläche (×) des Tabs links oder rechts sitzt",
+  "settings.sidebarTabs": "Seitenleisten-Registerkarten",
+  "settings.sidebarTabsDesc": "Wählt die Registerkarten oben in der Seitenleiste (Umschalten per Rechtsklick auf die Leiste)",
   "settings.tabCloseButtonLeft": "Links",
   "settings.tabCloseButtonRight": "Rechts",
   "settings.language": "Sprache",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -335,6 +335,8 @@
   "settings.themeSystem": "System",
   "settings.tabCloseButton": "Tab Close Button",
   "settings.tabCloseButtonDesc": "Choose whether the tab close (×) button sits on the left or right side of the tab",
+  "settings.sidebarTabs": "Sidebar Tabs",
+  "settings.sidebarTabsDesc": "Choose which tabs show at the top of the sidebar (right-click the tab strip to toggle)",
   "settings.tabCloseButtonLeft": "Left",
   "settings.tabCloseButtonRight": "Right",
   "settings.language": "Language",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -335,6 +335,8 @@
   "settings.themeSystem": "Sistema",
   "settings.tabCloseButton": "Botón de cerrar pestaña",
   "settings.tabCloseButtonDesc": "Elija si el botón de cerrar (×) de la pestaña se muestra a la izquierda o a la derecha",
+  "settings.sidebarTabs": "Pestañas de la barra lateral",
+  "settings.sidebarTabsDesc": "Elige qué pestañas se muestran en la parte superior de la barra lateral (clic derecho en la barra para alternar)",
   "settings.tabCloseButtonLeft": "Izquierda",
   "settings.tabCloseButtonRight": "Derecha",
   "settings.language": "Idioma",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -335,6 +335,8 @@
   "settings.themeSystem": "Système",
   "settings.tabCloseButton": "Bouton de fermeture de l'onglet",
   "settings.tabCloseButtonDesc": "Choisissez si le bouton de fermeture (×) de l'onglet se trouve à gauche ou à droite",
+  "settings.sidebarTabs": "Onglets de la barre latérale",
+  "settings.sidebarTabsDesc": "Choisissez les onglets affichés en haut de la barre latérale (clic droit sur la barre pour basculer)",
   "settings.tabCloseButtonLeft": "Gauche",
   "settings.tabCloseButtonRight": "Droite",
   "settings.language": "Langue",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -335,6 +335,8 @@
   "settings.themeSystem": "システム",
   "settings.tabCloseButton": "タブの閉じるボタン",
   "settings.tabCloseButtonDesc": "タブの閉じるボタン（×）の表示位置（左または右）を選択します",
+  "settings.sidebarTabs": "サイドバータブ",
+  "settings.sidebarTabsDesc": "サイドバー上部に表示するタブを選択します（タブバー右クリックで切り替え可）",
   "settings.tabCloseButtonLeft": "左",
   "settings.tabCloseButtonRight": "右",
   "settings.language": "言語",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -335,6 +335,8 @@
   "settings.themeSystem": "시스템",
   "settings.tabCloseButton": "탭 닫기 버튼",
   "settings.tabCloseButtonDesc": "탭의 닫기 버튼(×)을 왼쪽 또는 오른쪽에 표시할지 선택합니다",
+  "settings.sidebarTabs": "사이드바 탭",
+  "settings.sidebarTabsDesc": "사이드바 상단에 표시할 탭을 선택합니다(탭 막대 우클릭으로 전환 가능)",
   "settings.tabCloseButtonLeft": "왼쪽",
   "settings.tabCloseButtonRight": "오른쪽",
   "settings.language": "언어",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -335,6 +335,8 @@
   "settings.themeSystem": "Системная",
   "settings.tabCloseButton": "Кнопка закрытия вкладки",
   "settings.tabCloseButtonDesc": "Выберите, где находится кнопка закрытия вкладки (×): слева или справа",
+  "settings.sidebarTabs": "Вкладки боковой панели",
+  "settings.sidebarTabsDesc": "Выберите вкладки вверху боковой панели (переключение правым кликом по панели вкладок)",
   "settings.tabCloseButtonLeft": "Слева",
   "settings.tabCloseButtonRight": "Справа",
   "settings.language": "Язык",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -335,6 +335,8 @@
   "settings.themeSystem": "跟随系统",
   "settings.tabCloseButton": "标签关闭按钮",
   "settings.tabCloseButtonDesc": "选择标签的关闭按钮（×）显示在左侧还是右侧",
+  "settings.sidebarTabs": "边栏标签",
+  "settings.sidebarTabsDesc": "选择在边栏顶部显示哪些标签页（可在标签栏右键切换）",
   "settings.tabCloseButtonLeft": "左边",
   "settings.tabCloseButtonRight": "右边",
   "settings.language": "语言",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -335,6 +335,8 @@
   "settings.themeSystem": "跟隨系統",
   "settings.tabCloseButton": "標籤關閉按鈕",
   "settings.tabCloseButtonDesc": "選擇標籤的關閉按鈕（×）顯示在左側還是右側",
+  "settings.sidebarTabs": "邊欄標籤",
+  "settings.sidebarTabsDesc": "選擇在邊欄頂部顯示哪些標籤頁（可在標籤列右鍵切換）",
   "settings.tabCloseButtonLeft": "左邊",
   "settings.tabCloseButtonRight": "右邊",
   "settings.language": "語言",

--- a/frontend/src/stores/settingsStore.ts
+++ b/frontend/src/stores/settingsStore.ts
@@ -285,6 +285,12 @@ function mergeSettings(loaded: AppSettings): AppSettings {
     },
     customTerminalThemes: loaded.customTerminalThemes || [],
     defaultLocalShell: loaded.defaultLocalShell ?? DEFAULT_SETTINGS.defaultLocalShell,
-    tabCloseButton: loaded.tabCloseButton || DEFAULT_SETTINGS.tabCloseButton
+    tabCloseButton: loaded.tabCloseButton || DEFAULT_SETTINGS.tabCloseButton,
+    // Per-key merge so a settings.json written before a view existed (or
+    // with a key dropped) still gets the default for that view.
+    sidebarTabs: {
+      ...DEFAULT_SETTINGS.sidebarTabs,
+      ...(loaded.sidebarTabs || {})
+    }
   }
 }

--- a/frontend/src/types/settings.ts
+++ b/frontend/src/types/settings.ts
@@ -218,7 +218,35 @@ export interface AppSettings {
   defaultLocalShell: string
   // Which side of the tab the close (X) button sits on.
   tabCloseButton: 'left' | 'right'
+  // Which connection-sidebar tab icons are visible, keyed by view id.
+  // Missing keys fall back to SIDEBAR_TAB_DEFAULTS (issue #736).
+  sidebarTabs: Record<string, boolean>
 }
+
+// Default visibility per sidebar view. "connections" is the primary view and
+// is always shown (never hidden by either the settings card or the tab-strip
+// context menu); tunnels ships hidden by default (issue #736).
+export const SIDEBAR_TAB_DEFAULTS: Record<string, boolean> = {
+  connections: true,
+  files: true,
+  monitor: true,
+  tunnels: false,
+  quickCommands: true,
+  history: true,
+  personalization: true,
+}
+
+// Canonical sidebar tab order shared by the tab-strip context menu and the
+// Settings card. `labelKey` is the existing i18n key for each tab's title.
+export const SIDEBAR_TAB_ORDER: { key: string; labelKey: string }[] = [
+  { key: 'connections', labelKey: 'header.connections' },
+  { key: 'files', labelKey: 'header.files' },
+  { key: 'monitor', labelKey: 'header.monitor' },
+  { key: 'tunnels', labelKey: 'tunnels.tunnelsTab' },
+  { key: 'quickCommands', labelKey: 'quickCommands.quickCommandsTab' },
+  { key: 'history', labelKey: 'quickCommands.historyTab' },
+  { key: 'personalization', labelKey: 'sidebar.personalization' },
+]
 
 export const DEFAULT_SETTINGS: AppSettings = {
   theme: 'dark',
@@ -271,7 +299,8 @@ export const DEFAULT_SETTINGS: AppSettings = {
   },
   customTerminalThemes: [],
   defaultLocalShell: '',
-  tabCloseButton: 'left'
+  tabCloseButton: 'left',
+  sidebarTabs: { ...SIDEBAR_TAB_DEFAULTS }
 }
 
 export interface TerminalThemeEntry { label: string; value: string; type: 'dark' | 'light' }


### PR DESCRIPTION
## Summary
Closes #736

- Restore the sidebar tunnels tab (removed in 1.9.1) as a **flat list — no groups** — with search, add, dblclick / context-menu start-stop-edit-delete, and live status indicators. Reuses the existing `tunnels.*` i18n keys.
- Add **per-tab sidebar visibility** stored in `AppSettings.sidebarTabs` (Go settings store + regenerated bindings). Tunnels ships **hidden by default**; all other tabs are visible. `connections` is fixed and never hideable.
- Right-clicking the sidebar tab strip opens a toggle menu for the six hideable tabs; hiding the active view falls back to the connections view.
- Settings → Basic gains a compact multi-select "Sidebar tabs" control bound to the same setting ("Connections" is not listed since it cannot be toggled).
- Localize tunnel mode labels (`tunnels.mode.*`) in the sidebar row badge and the settings table (previously hardcoded English).
- i18n: only two new keys (`settings.sidebarTabs` / `sidebarTabsDesc`) across all 9 locales.

## Verification
- `npm run build` and `wails3 build` pass; `vue-tsc` introduces no new type errors (325 → 324 baseline).
- Manual: tunnels tab hidden by default, re-enabled via tab-strip right-click or Settings; visibility persists across restart; tunnel start/stop/edit/delete from the sidebar.

---

## 摘要
Closes #736

- 恢复侧边栏隧道标签页（1.9.1 移除），以**扁平列表（无分组）**呈现：搜索、新增、双击/右键菜单启停、编辑、删除、实时状态指示，翻译全部复用现有 `tunnels.*` keys。
- 新增**边栏标签显隐配置**，持久化到 `AppSettings.sidebarTabs`（Go settings store + 重新生成绑定）。隧道默认隐藏，其余默认显示；「连接」固定显示、不可隐藏。
- 右键侧边栏标签条可弹出勾选菜单切换 6 个可隐藏标签；隐藏当前激活视图时自动回落到「连接」。
- 设置 → 基本设置 新增紧凑的「边栏标签」多选下拉，与右键菜单写同一份数据（「连接」不可切换，故不列出）。
- 隧道模式徽标与设置页表格的模式列改为本地化（`tunnels.mode.*`，原先硬编码英文）。
- i18n：仅新增 `settings.sidebarTabs` / `sidebarTabsDesc` 两条 × 9 个语言。

## 验证
- `npm run build`、`wails3 build` 通过；`vue-tsc` 无新增类型错误（基线 325 → 324）。
- 手动验证：隧道 tab 默认隐藏、可经标签条右键或设置页恢复；显隐配置重启后保持；边栏内可正常启停/编辑/删除隧道。
