### PR TITLE
fix(sidebar): show tunnels tab by default

### DIFF
--- a/backend/store/settings_store.go
+++ b/backend/store/settings_store.go
@@ -130,7 +130,7 @@ type AppSettings struct {
 	// history/personalization). "connections" is always shown in the UI and
 	// never hidden. Pointer + omitempty so settings.json written by older
 	// builds (which lack this field) still load; a nil map means "use the
-	// frontend defaults" (everything visible except tunnels — issue #736).
+	// frontend defaults" (everything visible).
 	SidebarTabs map[string]bool `json:"sidebarTabs,omitempty"`
 }
 

--- a/frontend/src/components/SettingsTab.vue
+++ b/frontend/src/components/SettingsTab.vue
@@ -1559,7 +1559,7 @@ const tunnelDialogVisible = ref(false)
 const editingTunnelId = ref<string | undefined>(undefined)
 const togglingTunnelId = ref<string | undefined>(undefined)
 
-// ── Sidebar tab visibility (issue #736) ──
+// ── Sidebar tab visibility ──
 // Writable computed over AppSettings.sidebarTabs. "connections" never appears
 // in the select (no option, no tag) — it is forced on at the data level.
 const visibleSidebarTabs = computed<string[]>({

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -548,7 +548,7 @@ watch(
   },
 )
 
-// ── Sidebar tab visibility (issue #736) ──
+// ── Sidebar tab visibility ──
 // Single source of truth is AppSettings.sidebarTabs (editable in Settings →
 // basic); right-clicking the tab strip opens the same toggles as a shortcut.
 // "connections" is the primary view and can never be hidden.

--- a/frontend/src/components/TunnelsPanel.vue
+++ b/frontend/src/components/TunnelsPanel.vue
@@ -14,7 +14,7 @@
     </div>
 
     <!-- Flat list (grouping lives in the Settings page's data model only;
-         the sidebar shows every tunnel in sortOrder, issue #736) -->
+         the sidebar shows every tunnel in sortOrder) -->
     <div class="tn-list">
       <div
         v-for="tn in visibleTunnels"

--- a/frontend/src/types/settings.ts
+++ b/frontend/src/types/settings.ts
@@ -219,18 +219,18 @@ export interface AppSettings {
   // Which side of the tab the close (X) button sits on.
   tabCloseButton: 'left' | 'right'
   // Which connection-sidebar tab icons are visible, keyed by view id.
-  // Missing keys fall back to SIDEBAR_TAB_DEFAULTS (issue #736).
+  // Missing keys fall back to SIDEBAR_TAB_DEFAULTS.
   sidebarTabs: Record<string, boolean>
 }
 
 // Default visibility per sidebar view. "connections" is the primary view and
 // is always shown (never hidden by either the settings card or the tab-strip
-// context menu); tunnels ships hidden by default (issue #736).
+// context menu); every tab ships visible by default.
 export const SIDEBAR_TAB_DEFAULTS: Record<string, boolean> = {
   connections: true,
   files: true,
   monitor: true,
-  tunnels: false,
+  tunnels: true,
   quickCommands: true,
   history: true,
   personalization: true,


### PR DESCRIPTION
## Summary
- The tunnels sidebar tab now ships **visible by default**: `SIDEBAR_TAB_DEFAULTS.tunnels` flips to `true`, so the nil-map / missing-key fallback (including settings.json written by older builds) resolves to visible.
- Users who explicitly hid the tunnels tab via the tab-strip context menu or Settings keep their stored `sidebarTabs.tunnels: false` — no behavior change for them.
- Clean up leftover `issue #736` references in comments (settings_store.go, settings.ts, SettingsTab.vue, Sidebar.vue, TunnelsPanel.vue).

## Changes
- `frontend/src/types/settings.ts`: `tunnels: false` → `tunnels: true` in `SIDEBAR_TAB_DEFAULTS`; comment cleanup.
- `backend/store/settings_store.go`: comment cleanup only.
- `frontend/src/components/{SettingsTab,Sidebar,TunnelsPanel}.vue`: comment cleanup only.

---

## 摘要
- 隧道边栏 tab 现在默认显示：`SIDEBAR_TAB_DEFAULTS.tunnels` 改为 `true`，nil map / 缺失 key 的回落逻辑（包括旧版本写入的 settings.json）都会解析为可见。
- 用户若已通过 tab 栏右键菜单或设置页手动隐藏隧道 tab，其存储的 `sidebarTabs.tunnels: false` 仍然生效，行为不变。
- 清理侧边栏设置相关代码中遗留的 `issue #736` 注释引用（settings_store.go、settings.ts、SettingsTab.vue、Sidebar.vue、TunnelsPanel.vue）。

## 改动
- `frontend/src/types/settings.ts`：`SIDEBAR_TAB_DEFAULTS` 中 `tunnels: false` → `tunnels: true`；注释清理。
- `backend/store/settings_store.go`：仅注释清理。
- `frontend/src/components/{SettingsTab,Sidebar,TunnelsPanel}.vue`：仅注释清理。