### PR TITLE
feat(terminal): align text highlighting with MobaXterm simplified scheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Tunnel management moved into the Settings page.
 - Monitor: collapsible per-core / per-NIC / per-disk detail lists and a process kill button in the monitor tab; disk and network statistics are now more accurate (works on hosts without `ip` / `lsblk -j`, e.g. CentOS 7).
 - Terminal: configurable middle-click action, Ctrl/Cmd+right-click always opens the context menu, and font zoom via shortcuts or Ctrl/Cmd+wheel.
+- Terminal: text highlighting now follows MobaXterm's simplified scheme (issue #725) — IP addresses are magenta (the classic MobaXterm "pink IP", first octet 1–254), and error / success / warning / info keywords use MobaXterm's curated word lists with red / green / yellow / cyan colors; URLs are underlined. Arbitrary numbers are no longer highlighted; paths, timestamps, quoted strings and braces remain highlighted. Colors still follow the terminal theme palette.
 - Quick commands: remark field and a larger edit dialog.
 - Connection: "Connect Only" opens a session without saving it; new-connection forms prefill from the search box.
 - SSH: new "keyText" inline private-key auth mode — paste or import the PEM private-key text directly (beside password and key-file), encrypted at rest and portable across machines.

--- a/frontend/src/composables/useHighlight.test.ts
+++ b/frontend/src/composables/useHighlight.test.ts
@@ -4,27 +4,119 @@ import { highlight } from './useHighlight'
 // SGR sequences inserted by highlight() — we only assert presence/absence,
 // not exact bytes (the colour palette is intentionally allowed to evolve).
 
-describe('highlight()', () => {
-  it('highlights a path containing the + special char (issue #651)', () => {
+describe('highlight() — keyword rules', () => {
+  it('highlights IP addresses in magenta', () => {
+    const out = highlight('ping 10.1.0.13\n')
+    expect(out).toContain('\x1b[35m10.1.0.13\x1b[24;39m')
+  })
+
+  it('restricts the IP first octet to 1-254', () => {
+    expect(highlight('src 0.1.2.3\n')).not.toContain('\x1b[35m')
+    expect(highlight('src 255.1.2.3\n')).not.toContain('\x1b[35m')
+    expect(highlight('src 254.1.2.3\n')).toContain('\x1b[35m254.1.2.3')
+  })
+
+  it('colors localhost, null and none magenta like IPs', () => {
+    expect(highlight('connecting to localhost\n')).toContain('\x1b[35mlocalhost\x1b[24;39m')
+    expect(highlight('status: null\n')).toContain('\x1b[35mnull\x1b[24;39m')
+    expect(highlight('mode: none\n')).toContain('\x1b[35mnone\x1b[24;39m')
+  })
+
+  it('colors IPv6 addresses magenta (full and :: compressed forms)', () => {
+    expect(highlight('addr 2001:db8:0:0:0:0:2:1 end\n')).toContain('\x1b[35m2001:db8:0:0:0:0:2:1\x1b[24;39m')
+    expect(highlight('inet6 fe80::1/64\n')).toContain('\x1b[35mfe80::1\x1b[24;39m')
+    expect(highlight('listening on ::1\n')).toContain('\x1b[35m::1\x1b[24;39m')
+    expect(highlight('http://[::1]:8080/\n')).toContain('\x1b[35m::1\x1b[24;39m')
+    expect(highlight('route 2001:db8::/32 via gw\n')).toContain('\x1b[35m2001:db8::\x1b[24;39m')
+  })
+
+  it('does not highlight MAC addresses or :: scope tokens as IPv6', () => {
+    expect(highlight('mac aa:bb:cc:dd:ee:ff\n')).not.toContain('\x1b[35m')
+    expect(highlight('std::vector<int>\n')).not.toContain('\x1b[35m')
+    expect(highlight('at 12:34:56 sharp\n')).not.toContain('\x1b[35m')
+  })
+
+  it('colors error words red', () => {
+    expect(highlight('connect: connection refused\n')).toContain('\x1b[31mconnection refused\x1b[24;39m')
+    expect(highlight('ERROR: bad address\n')).toContain('\x1b[31mERROR\x1b[24;39m')
+    expect(highlight('ERROR: bad address\n')).toContain('\x1b[31mbad address\x1b[24;39m')
+    expect(highlight('kernel panic: segmentation fault\n')).toContain('\x1b[31msegmentation fault\x1b[24;39m')
+  })
+
+  it('colors falsy output values (false/no/ko) red when punctuation-guarded', () => {
+    expect(highlight('Result: no\n')).toContain('\x1b[31mno\x1b[24;39m')
+    expect(highlight('=> false\n')).toContain('\x1b[31mfalse\x1b[24;39m')
+    // prose must stay untouched
+    expect(highlight('nothing here\n')).toBe('nothing here\n')
+  })
+
+  it('colors success words green', () => {
+    expect(highlight('session connected\n')).toContain('\x1b[32mconnected\x1b[24;39m')
+    expect(highlight('request accepted\n')).toContain('\x1b[32maccepted\x1b[24;39m')
+    expect(highlight('deployed successfully\n')).toContain('\x1b[32msuccessfully\x1b[24;39m')
+  })
+
+  it('colors warning words yellow', () => {
+    expect(highlight('WARNING: low disk\n')).toContain('\x1b[33mWARNING\x1b[24;39m')
+    expect(highlight('file not found\n')).toContain('\x1b[33mfile not found\x1b[24;39m')
+    expect(highlight('cannot open device\n')).toContain('\x1b[33mcannot\x1b[24;39m')
+  })
+
+  it('colors info verbs cyan', () => {
+    expect(highlight('starting service…\n')).toContain('\x1b[36mstarting\x1b[24;39m')
+    expect(highlight('(ii) loading module\n')).toContain('\x1b[36m(ii)\x1b[24;39m')
+  })
+
+  it('underlines URLs in blue', () => {
+    const out = highlight('see https://example.com/a?b=1 now\n')
+    expect(out).toContain('\x1b[4;34mhttps://example.com/a?b=1\x1b[24;39m')
+  })
+
+  it('no longer highlights arbitrary numbers', () => {
+    expect(highlight('port 8080 and 42\n')).toBe('port 8080 and 42\n')
+  })
+
+  it('does not match keywords inside words', () => {
+    expect(highlight('terror attack\n')).toBe('terror attack\n')
+    expect(highlight('warninglabel\n')).toBe('warninglabel\n')
+    expect(highlight('noteworthy\n')).toBe('noteworthy\n')
+  })
+
+  it('is case-insensitive', () => {
+    expect(highlight('Connection Refused\n')).toContain('\x1b[31mConnection Refused\x1b[24;39m')
+    expect(highlight('PING 10.0.0.1\n')).toContain('\x1b[35m10.0.0.1')
+  })
+})
+
+describe('highlight() — retained rules', () => {
+  it('highlights a path containing the + special char', () => {
     const input = 'compiler /usr/local/gcc-11.5.0/bin/g++ -std=c++17\n'
     const out = highlight(input)
-    // The path anchor consumes the preceding whitespace (`(?:^|\s)`), so the
-    // coloured span starts with a space.
-    expect(out).toContain('\x1b[35m /usr/local/gcc-11.5.0/bin/g++\x1b[24;39m')
+    // The path anchor consumes the preceding whitespace (`(^|\s)` guard
+    // group), so the space itself is NOT part of the coloured span.
+    expect(out).toContain('\x1b[35m/usr/local/gcc-11.5.0/bin/g++\x1b[24;39m')
   })
 
-  it('highlights a path containing @ and ~ (issue #651)', () => {
+  it('highlights a path containing @ and ~', () => {
     const input = 'load /tmp/cache@1.tgz and ~/proj-2/app.exe now\n'
     const out = highlight(input)
-    expect(out).toContain('\x1b[35m /tmp/cache@1.tgz\x1b[24;39m')
-    expect(out).toContain('\x1b[35m ~/proj-2/app.exe\x1b[24;39m')
+    expect(out).toContain('\x1b[35m/tmp/cache@1.tgz\x1b[24;39m')
+    expect(out).toContain('\x1b[35m~/proj-2/app.exe\x1b[24;39m')
   })
 
-  it('does not treat a bare an+b expression as a path (issue #651)', () => {
+  it('does not treat a bare an+b expression as a path', () => {
     const input = 'compute an+b + c then d+e\n'
     const out = highlight(input)
     // Not starting with `/` or `~/` — must not match the path pattern.
     expect(out).not.toContain('\x1b[35m')
+  })
+
+  it('highlights timestamps in bright blue', () => {
+    expect(highlight('at 12:34:56 done\n')).toContain('\x1b[94m12:34:56\x1b[24;39m')
+  })
+
+  it('highlights quoted strings in yellow', () => {
+    expect(highlight('msg "hello world" end\n')).toContain('\x1b[33m"hello world"\x1b[24;39m')
   })
 
   it('highlights braces in plain prose', () => {
@@ -32,7 +124,9 @@ describe('highlight()', () => {
     expect(out).toContain('\x1b[95m') // brace colour from palette
     expect(out).not.toBe('hello {world}')
   })
+})
 
+describe('highlight() — safety guards', () => {
   it('skips content INSIDE a fenced code block', () => {
     const input = '```js\nconst x = {a: 1}\necho "hello {world}"\n```\n'
     const out = highlight(input)
@@ -58,24 +152,20 @@ describe('highlight()', () => {
     expect(out).toBe(input)
   })
 
-  it('skips indented code lines (4+ leading spaces)', () => {
-    // 4-space indented lines are treated as code: braces stay uncoloured
-    // (their SGR resets confuse TUI apps), but other tokens are highlighted.
-    const input = '    let {a} = obj\n    const b = {c: 1}\n'
+  it('skips indented code lines (4+ leading spaces): braces stay plain, keywords still colored', () => {
+    const input = '    log error {details}\n'
     const out = highlight(input)
-    // No brace (bright magenta) colour injected anywhere on the indented lines.
+    // No brace (bright magenta) colour injected on the indented line.
     expect(out).not.toContain('\x1b[95m')
-    // Non-brace tokens still get highlighted (the `1` becomes bright cyan).
-    expect(out).toContain('\x1b[96m1\x1b[24;39m')
+    // Non-brace tokens still get highlighted (the error word becomes red).
+    expect(out).toContain('\x1b[31merror\x1b[24;39m')
   })
 
-  it('highlights the IP in 4-space-indented `ip a` output (issue #644)', () => {
-    // ip a prints `inet …` lines indented by 4 spaces; those used to be
-    // skipped entirely, so the masked IP got no colour.
+  it('highlights the IP in 4-space-indented `ip a` output', () => {
     const input = '    inet 10.1.0.13/24 brd 10.1.0.255 scope global dynamic eth0\n'
     const out = highlight(input)
-    expect(out).toContain('\x1b[32m10.1.0.13\x1b[24;39m')
-    expect(out).toContain('\x1b[32m10.1.0.255\x1b[24;39m')
+    expect(out).toContain('\x1b[35m10.1.0.13\x1b[24;39m')
+    expect(out).toContain('\x1b[35m10.1.0.255\x1b[24;39m')
   })
 
   it('still highlights prose after a fence closes', () => {
@@ -97,8 +187,8 @@ describe('highlight()', () => {
     expect(highlight(input)).toBe(input)
   })
 
-  it('skips already-colored spans (issue #587) instead of fragmenting them', () => {
-    // `ls` colors a directory blue; the app must NOT re-color its digits.
+  it('skips already-colored spans instead of fragmenting them', () => {
+    // `ls` colors a directory blue; the app must NOT re-color its content.
     const input = '\x1b[01;34mchatGLM2-6B\x1b[0m\n'
     expect(highlight(input)).toBe(input)
   })
@@ -109,10 +199,10 @@ describe('highlight()', () => {
   })
 
   it('still highlights default-colored text after and around a colored span', () => {
-    // The digit "6" sits outside the colored span, so it must still be styled.
-    const input = '\x1b[32mOK\x1b[0m 6\n'
+    // "error" sits outside the colored span, so it must still be styled.
+    const input = '\x1b[32mOK\x1b[0m error\n'
     const out = highlight(input)
-    expect(out).toContain('\x1b[96m6')
+    expect(out).toContain('\x1b[31merror')
     expect(out).toContain('\x1b[32mOK\x1b[0m ')
   })
 

--- a/frontend/src/composables/useHighlight.ts
+++ b/frontend/src/composables/useHighlight.ts
@@ -31,38 +31,54 @@ function segmentText(text: string): { text: string; isCSI: boolean }[] {
 }
 
 // ── Color palette ──
-// Use ANSI standard SGR codes (30-37 / 90-97) instead of 256-color palette
-// indices so that highlight colors follow the terminal theme's ANSI color
-// definitions and always match the background.
-//
-// Standard: 30=black 31=red 32=green 33=yellow 34=blue 35=magenta 36=cyan 37=white
-// Bright:   90=brightBlack 91=brightRed 92=brightGreen 93=brightYellow
-//           94=brightBlue 95=brightMagenta 96=brightCyan 97=brightWhite
+// ANSI SGR codes (30-37 / 90-97) so highlight colors follow the terminal
+// theme's palette.
 const C = {
-  url:       '\x1b[4;34m',   // blue + underline
-  ip:        '\x1b[32m',     // green
-  path:      '\x1b[35m',     // magenta
-  datetime:  '\x1b[94m',     // bright blue
-  string:    '\x1b[33m',     // yellow
-  error:     '\x1b[31m',     // red
-  warning:   '\x1b[93m',     // bright yellow
-  info:      '\x1b[36m',     // cyan
-  brace:     '\x1b[95m',     // bright magenta
-  number:    '\x1b[96m',     // bright cyan
+  url:      '\x1b[4;34m',
+  host:     '\x1b[35m',
+  path:     '\x1b[35m',
+  datetime: '\x1b[94m',
+  string:   '\x1b[33m',
+  success:  '\x1b[32m',
+  error:    '\x1b[31m',
+  warning:  '\x1b[33m',
+  info:     '\x1b[36m',
+  brace:    '\x1b[95m',
 } as const
 
-// Patterns grouped by color type, ordered longest-first
+// Group 1, when present, is a consumed left word guard that is NOT part of
+// the highlighted span (highlightPlainSegment trims m[1]). Right guards are
+// zero-width lookaheads. No lookbehind anywhere — unsupported by the
+// JavaScriptCore in macOS ≤12.3 WebView, where this module fails to parse.
 const PATTERNS: { sgr: string; regexes: RegExp[] }[] = [
-  { sgr: C.url,     regexes: [/https?:\/\/[^\s\x1b]+/gi] },
-  { sgr: C.ip,      regexes: [/\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}(:\d+)?\b/g] },
-  // NOTE: path/`~/` must not use a lookbehind ((?<=…)) — it is a parse-time
-  // feature unsupported by the JavaScriptCore in macOS ≤12.3 (Safari 15.4
-  // WebView), where the whole module fails to parse and the terminal shows
-  // a black screen. Anchor the start with a consuming (^|\s) group instead.
+  { sgr: C.url,     regexes: [
+    /https?:\/\/[A-Za-z0-9_.&?=%~#{}()@+-]+(?::?[A-Za-z0-9_./&?=%~#{}()@+-]+)?/gi,
+  ]},
+  { sgr: C.host,    regexes: [
+    // IPv4 (first octet 1-254) and IPv6 (full and ::-compressed forms)
+    /(^|[^0-9a-z_&-])(localhost|(?:1[0-9][0-9]|2[0-4][0-9]|25[0-4]|[1-9][0-9]|[1-9])\.\d+\.\d+\.\d+|null|none)(?![0-9a-z_-])/gi,
+    /(^|[^0-9a-z_&-])((?:[a-f0-9]{1,4}:){7}[a-f0-9]{1,4}|(?:[a-f0-9]{1,4}:){1,7}:|(?:[a-f0-9]{1,4}:){1,6}:[a-f0-9]{1,4}|(?:[a-f0-9]{1,4}:){1,5}(?::[a-f0-9]{1,4}){1,2}|(?:[a-f0-9]{1,4}:){1,4}(?::[a-f0-9]{1,4}){1,3}|(?:[a-f0-9]{1,4}:){1,3}(?::[a-f0-9]{1,4}){1,4}|(?:[a-f0-9]{1,4}:){1,2}(?::[a-f0-9]{1,4}){1,5}|[a-f0-9]{1,4}:(?::[a-f0-9]{1,4}){1,6}|:(?::[a-f0-9]{1,4}){1,7})(?![0-9a-f:])/gi,
+  ]},
+  { sgr: C.error,   regexes: [
+    // "<adjective> <noun>" phrases: bad address, invalid argument, …
+    /(^|[^a-z_&-])((?:bad|wrong|incorrect|improper|invalid|unsupported)(?: file| memory)? (?:descriptor|alloc(?:ation)?|addr(?:ess)?|owner(?:ship)?|arg(?:ument)?|param(?:eter)?|setting|length|filename))(?![a-z_-])/gi,
+    // denied, failed, segfault, no X found, …
+    /(^|[^a-z_&-])((?:operation |connection |authentication |access |permission )?(?:denied|disallowed|not allowed|refused|problem|failed|failure|not permitted)|not properly|improperly|no [a-z]+(?: [a-z]+)? found|invalid|unsupported|not supported|seg(?:mentation )?fault|corrupt(?:ion|ed)?|overflow|underrun|not ok|unimplemented|unsuccessfull?|not implemented|permerrors?|errors?|crash(?:ed)?|core dump|\(ee\)|\(ni\))(?![a-z_-])/gi,
+    // falsy output values ("=> no", "status: false")
+    /([=>"':.,;({\[] *)(?:false|no|ko)(?=[\]=>"':.,;)} ]|$)/gi,
+  ]},
+  { sgr: C.success, regexes: [
+    /(^|[^a-z_&-])(accepted|allowed|enabled|connected|successfully|successful|succeeded|success)(?![a-z_-])/gi,
+  ]},
+  { sgr: C.warning, regexes: [
+    /(^|[^a-z_&-])(\[-w[a-z-]+\]|caught signal [0-9]+|cannot|not responding|(?:connection (?:to (?:remote host|[a-z0-9.]+) )?)?(?:closed|terminated|stopped)|exited|no more [a-z]+ available|unexpected|(?:command |binary |file )?not found|o{2,}ps|out of (?:space|memory)|low (?:memory|disk)|unknown|disabled|disconnect(?:ed|ion)?|deprecated|refused|warnings?|\(ww\)|\(\?\?\)|could not|unable to)(?![a-z_-])/gi,
+  ]},
+  { sgr: C.info,    regexes: [
+    /(^|[^a-z_&-])(last (?:failed )?login:|launching|checking|loading|creating|building|important|booting|starting|informational|informations?|info|notice|note|\(ii\)|\(\!\!\))(?![a-z_-])/gi,
+  ]},
   // Character class includes `+`, `~`, `@` so paths like
-  // `/usr/local/gcc-11.5.0/bin/g++` or `/tmp/cache@1.tgz` are recognised
-  // whole (issue #651), not truncated at the first special symbol.
-  { sgr: C.path,    regexes: [/(?:^|\s)(?:\/|~\/)[\w.+~@/-]+(?=[\s:;"')\]}]|$)/g] },
+  // `/usr/local/gcc-11.5.0/bin/g++` are recognised whole.
+  { sgr: C.path,    regexes: [/(^|\s)(?:\/|~\/)[\w.+~@/-]+(?=[\s:;"')\]}]|$)/g] },
   { sgr: C.datetime, regexes: [
     /\b\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}(?::\d{2})?(?:[.,]\d+)?Z?\b/g,
     /\b(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun)\s+(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s+\d{1,2}\s+\d{2}:\d{2}:\d{2}\s+\d{4}\b/g,
@@ -70,11 +86,7 @@ const PATTERNS: { sgr: string; regexes: RegExp[] }[] = [
     /\b\d{2}:\d{2}:\d{2}\b/g,
   ]},
   { sgr: C.string,  regexes: [/"(?:[^"\\]|\\.){2,}"|'(?:[^'\\]|\\.){2,}'/g] },
-  { sgr: C.error,   regexes: [/\b(?:ERROR|FAIL(?:ED|URE)?|CRITICAL|FATAL)\b/g] },
-  { sgr: C.warning, regexes: [/\bWARN(?:ING)?\b/g] },
-  { sgr: C.info,    regexes: [/\b(?:INFO|SUCCESS|OK)\b/g] },
   { sgr: C.brace,   regexes: [/[{}()\[\]|*=<>]/g] },
-  { sgr: C.number,  regexes: [/\d+/g] },
 ]
 
 // Report how an SGR sequence affects the foreground color:
@@ -118,7 +130,8 @@ function highlightPlainSegment(text: string, opts: HighlightSegmentOpts = {}): s
       regex.lastIndex = 0
       let m: RegExpExecArray | null
       while ((m = regex.exec(text)) !== null) {
-        allMatches.push({ start: m.index, end: m.index + m[0].length, sgr })
+        const lead = m[1] ? m[1].length : 0  // skip the consumed left guard
+        allMatches.push({ start: m.index + lead, end: m.index + m[0].length, sgr })
         if (allMatches.length > 200) break
       }
       if (allMatches.length > 200) break
@@ -148,10 +161,8 @@ function highlightPlainText(text: string, opts: HighlightSegmentOpts = {}): stri
   const segments = segmentText(text)
   let result = ''
   // Track whether the upstream application already set a non-default
-  // foreground color (e.g. `ls` coloring a directory name blue). Our keyword
-  // highlighting must skip such spans — re-coloring digits/braces inside an
-  // already-colored token would fragment the app's own color (issue #587).
-  // Only text still in the default foreground gets styled by us.
+  // foreground color (e.g. `ls` coloring a directory name blue); such spans
+  // must not be re-colored. Only default-foreground text gets styled by us.
   let colored = false
   for (const seg of segments) {
     if (seg.isCSI) {
@@ -205,11 +216,9 @@ export function highlight(text: string): string {
           fenceChar = m[1][0] as '`' | '~'
           result += line
         } else if (INDENTED_CODE_LINE.test(line)) {
-          // Indented lines used to pass through entirely, which left 4-space
-          // indented command output (e.g. `ip a`) with no highlighting at all
-          // (issue #644). Brace/bracket colour still injects SGR noise that
-          // some TUI apps misinterpret, so keep skipping it here — but colour
-          // the remaining tokens (IP, number, path, …) normally.
+          // Brace/bracket colour injects SGR noise that some TUI apps
+          // misinterpret, so keep skipping it here — but colour the
+          // remaining tokens normally.
           result += highlightPlainText(line, { skipBrace: true })
         } else {
           result += highlightPlainText(line)

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -406,7 +406,7 @@
   "settings.testSuccess": "Verbindung erfolgreich",
   "settings.testFailed": "Verbindung fehlgeschlagen",
   "settings.highlight": "Texthervorhebung",
-  "settings.highlightDesc": "Zeitstempel, IPs, Schlüsselwörter, Strings usw. hervorheben",
+  "settings.highlightDesc": "IPs, Fehler, Warnungen und Schlüsselwörter in der Terminalausgabe hervorheben (MobaXterm-Stil)",
   "settings.showLineNumbers": "Zeilennummern anzeigen",
   "settings.showLineNumbersDesc": "Zeigt eine Zeilennummern-Spalte am linken Rand des Terminals an. Umbruch-Zeilen bleiben leer.",
   "settings.showTimestamps": "Zeitstempel anzeigen",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -406,7 +406,7 @@
   "settings.testSuccess": "Connection successful",
   "settings.testFailed": "Connection failed",
   "settings.highlight": "Text Highlight",
-  "settings.highlightDesc": "Highlight timestamps, IPs, keywords, strings, etc.",
+  "settings.highlightDesc": "Highlight IPs, errors, warnings and keywords in terminal output (MobaXterm-style)",
   "settings.showLineNumbers": "Show Line Numbers",
   "settings.showLineNumbersDesc": "Show a line-number column on the left edge of the terminal. Wrapped continuation lines stay blank.",
   "settings.showTimestamps": "Show Timestamps",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -406,7 +406,7 @@
   "settings.testSuccess": "Conexión exitosa",
   "settings.testFailed": "Conexión fallida",
   "settings.highlight": "Resaltado de Texto",
-  "settings.highlightDesc": "Resaltar marcas de tiempo, IPs, palabras clave, cadenas, etc.",
+  "settings.highlightDesc": "Resaltar IPs, errores, advertencias y palabras clave en la salida del terminal (estilo MobaXterm)",
   "settings.showLineNumbers": "Mostrar números de línea",
   "settings.showLineNumbersDesc": "Muestra una columna con números de línea en el borde izquierdo del terminal. Las líneas envueltas quedan en blanco.",
   "settings.showTimestamps": "Mostrar marcas de tiempo",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -406,7 +406,7 @@
   "settings.testSuccess": "Connexion réussie",
   "settings.testFailed": "Échec de la connexion",
   "settings.highlight": "Surlignage du texte",
-  "settings.highlightDesc": "Surligner les horodatages, IP, mots-clés, chaînes, etc.",
+  "settings.highlightDesc": "Surligner les IP, erreurs, avertissements et mots-clés dans la sortie du terminal (style MobaXterm)",
   "settings.showLineNumbers": "Afficher les numéros de ligne",
   "settings.showLineNumbersDesc": "Affiche une colonne de numéros de ligne sur le bord gauche du terminal. Les lignes repliées restent vides.",
   "settings.showTimestamps": "Afficher les horodatages",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -406,7 +406,7 @@
   "settings.testSuccess": "接続成功",
   "settings.testFailed": "接続失敗",
   "settings.highlight": "テキストハイライト",
-  "settings.highlightDesc": "タイムスタンプ、IP、キーワード、文字列などをハイライト",
+  "settings.highlightDesc": "ターミナル出力の IP、エラー、警告、キーワードなどをハイライト（MobaXterm スタイル）",
   "settings.showLineNumbers": "行番号を表示",
   "settings.showLineNumbersDesc": "ターミナルの左端に行番号欄を表示します。折り返しの続き行は空欄になります。",
   "settings.showTimestamps": "時間を表示",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -406,7 +406,7 @@
   "settings.testSuccess": "연결 성공",
   "settings.testFailed": "연결 실패",
   "settings.highlight": "텍스트 강조",
-  "settings.highlightDesc": "타임스탬프, IP, 키워드, 문자열 등을 강조 표시",
+  "settings.highlightDesc": "터미널 출력의 IP, 오류, 경고, 키워드 등을 강조 표시 (MobaXterm 스타일)",
   "settings.showLineNumbers": "줄 번호 표시",
   "settings.showLineNumbersDesc": "터미널 왼쪽 가장자리에 줄 번호 칸을 표시합니다. 자동 줄바꿈된 연속 줄은 비워 둡니다.",
   "settings.showTimestamps": "시간 표시",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -406,7 +406,7 @@
   "settings.testSuccess": "Соединение успешно",
   "settings.testFailed": "Соединение не удалось",
   "settings.highlight": "Подсветка текста",
-  "settings.highlightDesc": "Выделять метки времени, IP, ключевые слова, строки и т.д.",
+  "settings.highlightDesc": "Выделять IP, ошибки, предупреждения и ключевые слова в выводе терминала (в стиле MobaXterm)",
   "settings.showLineNumbers": "Показывать номера строк",
   "settings.showLineNumbersDesc": "Показывает столбец с номерами строк по левому краю терминала. Продолжения перенесённых строк остаются пустыми.",
   "settings.showTimestamps": "Показывать время",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -406,7 +406,7 @@
   "settings.testSuccess": "连接成功",
   "settings.testFailed": "连接失败",
   "settings.highlight": "文本高亮",
-  "settings.highlightDesc": "自动高亮时间、IP、关键词、字符串等模式",
+  "settings.highlightDesc": "自动高亮 IP、错误、警告、成功等关键词（MobaXterm 风格）",
   "settings.showLineNumbers": "显示行号",
   "settings.showLineNumbersDesc": "在终端左侧显示行号栏，自动折行的续行留空。",
   "settings.showTimestamps": "显示时间",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -406,7 +406,7 @@
   "settings.testSuccess": "連線成功",
   "settings.testFailed": "連線失敗",
   "settings.highlight": "文字高亮",
-  "settings.highlightDesc": "自動高亮時間、IP、關鍵詞、字串等模式",
+  "settings.highlightDesc": "自動高亮 IP、錯誤、警告、成功等關鍵詞（MobaXterm 風格）",
   "settings.showLineNumbers": "顯示行號",
   "settings.showLineNumbersDesc": "在終端左側顯示行號欄，自動換行的續行留空。",
   "settings.showTimestamps": "顯示時間",


### PR DESCRIPTION
## Summary

Replace the terminal keyword-highlighting rule set with MobaXterm's simplified syntax-highlighting scheme (issue #725). Highlights are still ANSI SGR codes and follow the terminal theme palette, so switching to a MobaXterm color scheme reproduces the classic MobaXterm look.

- IP addresses are now magenta (the signature MobaXterm pink IP), with the first octet restricted to 1-254; localhost/null/none share the same group
- New IPv6 support: full 8-group form and all `::` compressed forms (an extension beyond MobaXterm, which does not recognize IPv6); MAC addresses and `::` scope tokens are not matched
- Curated keyword groups: errors red (denied / refused / failed / segfault / core dump / `no X found` / `(ee)` ...), success green (accepted / connected / successfully ...), warnings yellow (cannot / not found / unable to / could not / `(ww)` ...), info verbs cyan (launching / checking / loading / `(ii)` ...); falsy output values (`false` / `no` / `ko`) highlighted red when punctuation-guarded
- URLs keep blue + underline; the path / timestamp / quoted-string / brace rules are retained; the arbitrary-number rule is removed
- Keyword matching is case-insensitive with word guards (consumed capture groups, no lookbehind for WKWebView compatibility)
- Updated the highlight setting description in all 9 locales and the CHANGELOG

## Testing

- `useHighlight.test.ts` rewritten/extended: 34 cases covering the new keyword groups, IPv4/IPv6 matching and non-matching guards, plus all existing safety-guard cases (fences, indented code, already-colored spans)
- Full frontend suite: 278/278 passed; `npm run build` and `wails3 build` both succeed

---
## 摘要

将终端关键词高亮规则集替换为 MobaXterm 的简化语法高亮方案（issue #725）。高亮仍使用 ANSI SGR 码并跟随终端主题调色板，切换到 MobaXterm 配色即可还原经典观感。

- IP 地址改为品红色（MobaXterm 标志性的"粉色 IP"），首段限定 1–254；localhost/null/none 同组
- 新增 IPv6 支持：完整 8 组形式及所有 `::` 压缩形式（MobaXterm 原生不识别 IPv6，属于增强）；MAC 地址与 `::` 作用域符号不误染
- 关键词分组：错误红色（denied / refused / failed / segfault / core dump / `no X found` / `(ee)` 等）、成功绿色（accepted / connected / successfully 等）、警告黄色（cannot / not found / unable to / could not / `(ww)` 等）、提示动词青色（launching / checking / loading / `(ii)` 等）；输出值 `false` / `no` / `ko` 在标点护栏内染红
- URL 保留蓝色+下划线；保留路径 / 时间戳 / 引号字符串 / 括号规则，删除任意数字规则
- 关键词大小写不敏感，带词边界护栏（消耗式捕获组实现，不使用 lookbehind 以兼容 WKWebView）
- 更新 9 个语言文件的高亮设置描述及 CHANGELOG

## 测试

- 重写/扩展 `useHighlight.test.ts`：34 个用例覆盖新关键词分组、IPv4/IPv6 匹配与防误染护栏，以及全部既有安全防护用例（代码围栏、缩进行、已着色跳过等）
- 前端全量测试 278/278 通过；`npm run build` 与 `wails3 build` 均成功