### PR TITLE
feat(ui): add import/export entries to the header main menu

### DIFF
--- a/frontend/src/components/AppHeader.vue
+++ b/frontend/src/components/AppHeader.vue
@@ -70,11 +70,20 @@
 
         <MenuDivider />
 
+        <!-- 导入 / 导出连接 -->
+        <MenuItem @click="openImport">{{ t('importExport.import') }}</MenuItem>
+        <MenuItem @click="openExport">{{ t('importExport.export') }}</MenuItem>
+
+        <MenuDivider />
+
         <!-- 设置 / 关于 / 检查更新 -->
         <MenuItem @click="openCategory('basic')">{{ t('settings.title') }}</MenuItem>
         <MenuItem @click="openCategory('about')">{{ t('settings.about') }}</MenuItem>
         <MenuItem @click="checkUpdate">{{ t('settings.checkUpdate') }}</MenuItem>
       </Menu>
+
+      <ImportDialog v-model:visible="showImportDialog" />
+      <ExportDialog v-model:visible="showExportDialog" />
     </div>
 
     <!-- Windows/Linux: window controls right (hidden when using system title bar) -->
@@ -104,6 +113,8 @@ import { LANGUAGE_OPTIONS } from '../types/settings'
 import type { AppSettings } from '../types/settings'
 import WindowControls from './WindowControls.vue'
 import TabsList from './TabsList.vue'
+import ImportDialog from './ImportDialog.vue'
+import ExportDialog from './ExportDialog.vue'
 import Menu from './Menu.vue'
 import MenuItem from './MenuItem.vue'
 import MenuSubmenu from './MenuSubmenu.vue'
@@ -137,6 +148,20 @@ function toggleSettingsMenu() {
 
 function closeSettingsMenu() {
   showSettingsMenu.value = false
+}
+
+// ── 导入 / 导出（对话框自包含，菜单关闭后由对话框接管） ──
+const showImportDialog = ref(false)
+const showExportDialog = ref(false)
+
+function openImport() {
+  closeSettingsMenu()
+  showImportDialog.value = true
+}
+
+function openExport() {
+  closeSettingsMenu()
+  showExportDialog.value = true
 }
 
 function applyTheme(value: AppSettings['theme']) {


### PR DESCRIPTION
Closes #743

## Summary / 摘要

把连接的导入/导出入口加到右上角主菜单（齿轮下拉菜单）中，提升可发现性。

Move the connection import/export entries into the header dropdown main menu for discoverability.

## Changes / 改动

- 主菜单在「AI模型 / 密钥库 / 代理 / 隧道」与「设置」分组之间新增「导入 / 导出」两项
- 复用现有的 ImportDialog / ExportDialog（自包含、append-to-body），无新逻辑、无 i18n 新增
- 侧边栏「+」菜单中的原入口保留
- Add "Import / Export" items to the header dropdown menu, between the AI/identities/proxies/tunnels group and the settings group
- Reuse the existing self-contained ImportDialog / ExportDialog (append-to-body); no new logic, no new i18n keys
- Keep the existing sidebar '+' menu entry unchanged

## Validation / 验证

- [x] `npm run build` 通过
- [x] `wails dev` 启动应用，主菜单可见「导入 / 导出」，点击分别弹出导入/导出对话框
- [x] `npm run build` passes
- [x] App launched via `wails dev`; both entries visible in the header menu and each opens its dialog