### PR TITLE
feat(db): add data-only table export option

### DIFF
--- a/frontend/src/components/DBTreePanel.vue
+++ b/frontend/src/components/DBTreePanel.vue
@@ -70,6 +70,7 @@
         <MenuItem @click="onCtxCopyName">{{ t('db.copyName') }}</MenuItem>
         <MenuDivider />
         <MenuItem @click="onCtxExportStructure">{{ t('db.exportStructure') }}</MenuItem>
+        <MenuItem v-if="current.tableType !== 'view'" @click="onCtxExportData">{{ t('db.exportData') }}</MenuItem>
         <MenuItem v-if="current.tableType !== 'view'" @click="onCtxExportStructureData">{{ t('db.exportStructureData') }}</MenuItem>
         <MenuDivider />
         <template v-if="current.tableType === 'view'">
@@ -438,6 +439,10 @@ async function exportTable(withStructure: boolean, withData: boolean) {
 
 function onCtxExportStructure() {
   exportTable(true, false)
+}
+
+function onCtxExportData() {
+  exportTable(false, true)
 }
 
 function onCtxExportStructureData() {

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -1257,6 +1257,7 @@
   "db.affectedRowsTotal": "Betroffene Zeilen gesamt",
   "db.exportSQL": "SQL exportieren",
   "db.exportStructure": "Nur Struktur exportieren",
+  "db.exportData": "Nur Daten exportieren",
   "db.exportStructureData": "Struktur und Daten exportieren",
   "db.exportDone": "{name} exportiert",
   "config.changeDir": "Verzeichnis ändern",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1257,6 +1257,7 @@
   "db.affectedRowsTotal": "Total affected rows",
   "db.exportSQL": "Export SQL",
   "db.exportStructure": "Export structure only",
+  "db.exportData": "Export data only",
   "db.exportStructureData": "Export structure and data",
   "db.exportDone": "{name} exported",
   "dataDir.title": "Choose data location",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -1257,6 +1257,7 @@
   "db.affectedRowsTotal": "Total filas afectadas",
   "db.exportSQL": "Exportar SQL",
   "db.exportStructure": "Exportar solo estructura",
+  "db.exportData": "Exportar solo datos",
   "db.exportStructureData": "Exportar estructura y datos",
   "db.exportDone": "{name} exportado",
   "config.changeDir": "Cambiar directorio",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -1257,6 +1257,7 @@
   "db.affectedRowsTotal": "影響行数（合計）",
   "db.exportSQL": "SQLエクスポート",
   "db.exportStructure": "構造のみエクスポート",
+  "db.exportData": "データのみエクスポート",
   "db.exportStructureData": "構造とデータをエクスポート",
   "db.exportDone": "{name} をエクスポートしました",
   "config.changeDir": "ディレクトリを変更",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -1257,6 +1257,7 @@
   "db.affectedRowsTotal": "영향 받은 행(합계)",
   "db.exportSQL": "SQL 내보내기",
   "db.exportStructure": "구조만 내보내기",
+  "db.exportData": "데이터만 내보내기",
   "db.exportStructureData": "구조와 데이터 내보내기",
   "db.exportDone": "{name} 내보냄",
   "config.changeDir": "디렉터리 변경",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -1257,6 +1257,7 @@
   "db.affectedRowsTotal": "Всего затронуто строк",
   "db.exportSQL": "Экспорт SQL",
   "db.exportStructure": "Экспорт только структуру",
+  "db.exportData": "Экспорт только данные",
   "db.exportStructureData": "Экспорт структуру и данные",
   "db.exportDone": "{name} экспортировано",
   "config.changeDir": "Изменить каталог",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -1257,6 +1257,7 @@
   "db.affectedRowsTotal": "累计影响行数",
   "db.exportSQL": "导出 SQL",
   "db.exportStructure": "导出（仅结构）",
+  "db.exportData": "导出（仅数据）",
   "db.exportStructureData": "导出（结构+数据）",
   "db.exportDone": "已导出 {name}",
   "dataDir.title": "选择配置存储位置",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -1257,6 +1257,7 @@
   "db.affectedRowsTotal": "累計影響行數",
   "db.exportSQL": "匯出 SQL",
   "db.exportStructure": "匯出（僅結構）",
+  "db.exportData": "匯出（僅資料）",
   "db.exportStructureData": "匯出（結構+資料）",
   "db.exportDone": "已匯出 {name}",
   "config.changeDir": "更改目錄",


### PR DESCRIPTION
## Summary

Add a third export entry to the table context menu: **data only** (`INSERT` statements without the `CREATE` statement), alongside the existing "structure only" and "structure + data" options. The backend `DumpOptions{Structure, Data}` already supported this combination — this PR only wires it up in the UI.

Data-bearing entries stay hidden for views, consistent with the existing "structure + data" behavior.

## Changes

- Add 「导出（仅数据）」 menu item to the table context menu, calling `DumpTable(false, true)`
- Add the `db.exportData` i18n key to all 8 locales

Part of #544 (仅数据导出)

## Validation

- `npm --prefix frontend run build`

---

## 摘要

在表右键菜单中新增第三个导出入口：**仅数据**（只导出 `INSERT` 语句，不含 `CREATE`），与现有「仅结构」「结构+数据」并列。后端 `DumpOptions{Structure, Data}` 本就支持该组合，本 PR 仅接通 UI。

对视图仍隐藏数据类导出项，与现有「结构+数据」行为保持一致。

## 验证

- `npm --prefix frontend run build`