### PR TITLE
feat(db): export query results as CSV / TXT / JSON

### DIFF
--- a/frontend/src/components/DBQueryEditor.vue
+++ b/frontend/src/components/DBQueryEditor.vue
@@ -81,6 +81,23 @@
           :placeholder="t('db.filterResults')"
         />
         <div class="result-toolbar-right">
+          <button
+            ref="exportBtnRef"
+            class="btn btn-ghost btn-icon btn-sm"
+            :title="t('db.exportResults')"
+            @click.stop="exportMenuRef?.toggle($event.currentTarget)"
+          >
+            <Download :size="14" />
+          </button>
+          <Menu
+            ref="exportMenuRef"
+            v-model:visible="exportMenuVisible"
+            align="end"
+          >
+            <MenuItem @click="onExportResults('csv')">CSV</MenuItem>
+            <MenuItem @click="onExportResults('txt')">TXT</MenuItem>
+            <MenuItem @click="onExportResults('json')">JSON</MenuItem>
+          </Menu>
           <span class="result-count">
             {{ displayRows.length }}{{ resultFilter ? ` / ${queryResult.rows.length}` : '' }} {{ t('db.rows') }}
             <span v-if="lastDurationMs != null"> ? {{ lastDurationMs }}ms</span>
@@ -180,12 +197,14 @@
 
 <script setup lang="ts">
 import { ref, shallowRef, computed, watch, nextTick, onMounted } from 'vue'
-import { Sparkles, History, FolderOpen } from '@lucide/vue'
+import { Sparkles, History, FolderOpen, Download } from '@lucide/vue'
 import { ElMessageBox } from 'element-plus'
 import { useI18n } from '../i18n'
 import SyntaxEditor from './SyntaxEditor.vue'
 import DBResultGrid from './DBResultGrid.vue'
-import { ExecuteQuery, ExecuteStatement, GetTables, GetTableSchema, DBDefaultTableQuery, DBInsertRow, DBUpdateRow, DBDeleteRow, ExecuteSQLScript, OpenFileDialogFiltered, ReadFileBase64 } from '../../bindings/github.com/ys-ll/uniterm/app'
+import Menu from './Menu.vue'
+import MenuItem from './MenuItem.vue'
+import { ExecuteQuery, ExecuteStatement, GetTables, GetTableSchema, DBDefaultTableQuery, DBInsertRow, DBUpdateRow, DBDeleteRow, ExecuteSQLScript, OpenFileDialogFiltered, ReadFileBase64, SaveFileDialogFiltered, WriteFileBase64 } from '../../bindings/github.com/ys-ll/uniterm/app'
 import { chat } from '../services/llm'
 import { msg } from '../services/message'
 import { loadSqlHistory, pushSqlHistory } from '../composables/useDbSqlHistory'
@@ -276,6 +295,60 @@ const browsePageTotal = computed(() => {
   if (browseHasMore.value) return (page.value + 1) * pageSize.value + 1
   return page.value * pageSize.value + rows
 })
+
+// ── Export result rows as CSV / TXT / JSON ──
+
+const exportMenuRef = ref<InstanceType<typeof Menu> | null>(null)
+const exportMenuVisible = ref(false)
+
+function csvCell(v: unknown): string {
+  if (v == null) return ''
+  const s = String(v)
+  return /[",\n\r]/.test(s) ? '"' + s.replace(/"/g, '""') + '"' : s
+}
+
+function fmtCell(v: unknown): string {
+  if (v == null) return 'NULL'
+  if (typeof v === 'object') return JSON.stringify(v)
+  return String(v)
+}
+
+function buildExportText(format: 'csv' | 'txt' | 'json'): string {
+  const cols = queryResult.value?.columns.map(c => c.name) || []
+  const rows = displayRows.value
+  if (format === 'json') {
+    return JSON.stringify(rows.map(r => Object.fromEntries(cols.map(c => [c, r[c] ?? null]))), null, 2)
+  }
+  if (format === 'txt') {
+    // Tab-separated with a header line; matches what spreadsheet tools paste back.
+    return [cols.join('\t'), ...rows.map(r => cols.map(c => fmtCell(r[c])).join('\t'))].join('\n')
+  }
+  // BOM so Excel detects UTF-8; CRLF per RFC 4180.
+  return '﻿' + [cols.map(csvCell).join(','), ...rows.map(r => cols.map(c => csvCell(r[c])).join(','))].join('\r\n')
+}
+
+async function onExportResults(format: 'csv' | 'txt' | 'json') {
+  exportMenuVisible.value = false
+  if (!queryResult.value?.rows.length) return
+  try {
+    const ext = format === 'json' ? 'json' : format === 'txt' ? 'txt' : 'csv'
+    const label = format === 'json' ? 'JSON File' : format === 'txt' ? 'Text File' : 'CSV File'
+    const defaultName = `${props.tableName || 'query_result'}_${new Date().toISOString().slice(0, 10)}.${ext}`
+    const path = await SaveFileDialogFiltered(t('db.exportResults'), defaultName, label, `*.${ext}`)
+    if (!path) return
+    await WriteFileBase64(path, encodeBase64(buildExportText(format)))
+    msg.success(t('db.exportDone', { name: path.split('/').pop() || defaultName }))
+  } catch (e: any) {
+    msg.error(e?.message || String(e))
+  }
+}
+
+function encodeBase64(text: string): string {
+  const bytes = new TextEncoder().encode(text)
+  let bin = ''
+  for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i])
+  return btoa(bin)
+}
 
 function refreshHistory() {
   history.value = loadSqlHistory(props.sessionId)

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -1259,6 +1259,7 @@
   "db.exportStructure": "Nur Struktur exportieren",
   "db.exportStructureData": "Struktur und Daten exportieren",
   "db.exportDone": "{name} exportiert",
+  "db.exportResults": "Ergebnisse exportieren",
   "config.changeDir": "Verzeichnis ändern",
   "config.changeDone": "Master-Passwort geändert",
   "config.changePassword": "Master-Passwort ändern",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1259,6 +1259,7 @@
   "db.exportStructure": "Export structure only",
   "db.exportStructureData": "Export structure and data",
   "db.exportDone": "{name} exported",
+  "db.exportResults": "Export results",
   "dataDir.title": "Choose data location",
   "dataDir.default": "System default directory (recommended for installed version)",
   "dataDir.portable": "Program directory (portable, must be in a writable location)",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -1259,6 +1259,7 @@
   "db.exportStructure": "Exportar solo estructura",
   "db.exportStructureData": "Exportar estructura y datos",
   "db.exportDone": "{name} exportado",
+  "db.exportResults": "Exportar resultados",
   "config.changeDir": "Cambiar directorio",
   "config.changeDone": "Contraseña maestra cambiada",
   "config.changePassword": "Cambiar contraseña maestra",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -1259,6 +1259,7 @@
   "db.exportStructure": "構造のみエクスポート",
   "db.exportStructureData": "構造とデータをエクスポート",
   "db.exportDone": "{name} をエクスポートしました",
+  "db.exportResults": "結果をエクスポート",
   "config.changeDir": "ディレクトリを変更",
   "config.changeDone": "マスターパスワードを変更しました",
   "config.changePassword": "マスターパスワードを変更",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -1259,6 +1259,7 @@
   "db.exportStructure": "구조만 내보내기",
   "db.exportStructureData": "구조와 데이터 내보내기",
   "db.exportDone": "{name} 내보냄",
+  "db.exportResults": "결과 내보내기",
   "config.changeDir": "디렉터리 변경",
   "config.changeDone": "마스터 비밀번호 변경됨",
   "config.changePassword": "마스터 비밀번호 변경",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -1259,6 +1259,7 @@
   "db.exportStructure": "Экспорт только структуру",
   "db.exportStructureData": "Экспорт структуру и данные",
   "db.exportDone": "{name} экспортировано",
+  "db.exportResults": "Экспорт результатов",
   "config.changeDir": "Изменить каталог",
   "config.changeDone": "Мастер-пароль изменён",
   "config.changePassword": "Изменить мастер-пароль",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -1259,6 +1259,7 @@
   "db.exportStructure": "导出（仅结构）",
   "db.exportStructureData": "导出（结构+数据）",
   "db.exportDone": "已导出 {name}",
+  "db.exportResults": "导出结果",
   "dataDir.title": "选择配置存储位置",
   "dataDir.default": "系统默认目录（安装版建议选择该项）",
   "dataDir.portable": "程序目录（便携模式，需保证程序所在目录可写入）",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -1259,6 +1259,7 @@
   "db.exportStructure": "匯出（僅結構）",
   "db.exportStructureData": "匯出（結構+資料）",
   "db.exportDone": "已匯出 {name}",
+  "db.exportResults": "匯出結果",
   "config.changeDir": "更改目錄",
   "config.changeDone": "主密碼已修改",
   "config.changePassword": "修改主密碼",


### PR DESCRIPTION
## Summary

Add a download button to the query-result toolbar that exports the current result grid to **CSV**, **TXT** (tab-separated), or **JSON**.

- Exports the **filtered** rows currently displayed in the grid (the same rows the user sees)
- CSV: RFC 4180 quoting, CRLF line endings, and a UTF-8 BOM so Excel opens Chinese text correctly
- TXT: tab-separated with a header line, suitable for pasting into spreadsheets
- JSON: array of row objects keyed by column name
- Default filename `表名_日期.ext` (or `query_result_日期.ext` for ad-hoc queries), reuses the existing `SaveFileDialogFiltered` + `WriteFileBase64` save flow from the table .sql export

## Changes

- Add export dropdown (CSV / TXT / JSON) to `DBQueryEditor.vue` result toolbar using the shared `Menu` component
- Add the `db.exportResults` i18n key to all 8 locales

Part of #544 (查询结果导出)

## Validation

- `npm --prefix frontend run build`

---

## 摘要

在查询结果工具栏新增下载按钮，可将当前结果网格导出为 **CSV**、**TXT**（制表符分隔）或 **JSON**。

- 导出的是网格中**过滤后**的展示行（即用户实际看到的数据）
- CSV：RFC 4180 引号转义、CRLF 换行、UTF-8 BOM，Excel 直接打开中文不乱码
- TXT：制表符分隔，带表头行，便于粘贴进表格工具
- JSON：以列名为键的行对象数组
- 默认文件名 `表名_日期.ext`（临时查询为 `query_result_日期.ext`），复用表导出 .sql 已有的 `SaveFileDialogFiltered` + `WriteFileBase64` 流程

## 验证

- `npm --prefix frontend run build`