### PR TITLE
feat(import): import connections from DBeaver workspace and Navicat .ncx

### DIFF
--- a/backend/importer/dbeaver.go
+++ b/backend/importer/dbeaver.go
@@ -1,0 +1,253 @@
+package importer
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+
+	"github.com/ys-ll/uniterm/backend/session"
+)
+
+// FormatDBeaver imports DBeaver connections straight from a workspace's
+// General/.dbeaver folder (data-sources.json + credentials-config.json).
+const FormatDBeaver = "dbeaver"
+
+// dbeaverAesKey is DBeaver's built-in local-encryption key (zero IV, first
+// decrypted block discarded — the file's real IV is recovered that way).
+var dbeaverAesKey, _ = hex.DecodeString("babb4a9f774ab853c96c2d653dfe544a")
+
+// dbeaverDBType maps DBeaver providers onto uniterm dbType keys.
+var dbeaverDBType = map[string]string{
+	"mysql":         "mysql",
+	"mariadb":       "mysql",
+	"postgresql":    "postgres",
+	"postgres":      "postgres",
+	"mssql":         "sqlserver",
+	"sqlserver":     "sqlserver",
+	"oracle":        "oracle",
+	"redis":         "redis",
+	"mongodb":       "mongodb",
+	"elasticsearch": "elasticsearch",
+}
+
+// dbeaverDefaultPort per uniterm dbType, used when the source omits port.
+var dbeaverDefaultPort = map[string]int{
+	"mysql": 3306, "postgres": 5432, "sqlserver": 1433, "oracle": 1521,
+	"mongodb": 27017, "redis": 6379, "elasticsearch": 9200,
+}
+
+// dbeaverSource is one entry of data-sources.json's connections map.
+type dbeaverSource struct {
+	Name          string `json:"name"`
+	Provider      string `json:"provider"`
+	Folder        string `json:"folder"`
+	Configuration struct {
+		Host       string          `json:"host"`
+		Port       json.RawMessage `json:"port"`
+		Database   string          `json:"database"`
+		User       string          `json:"user"`
+		ServerType string          `json:"serverType"`
+	} `json:"configuration"`
+}
+
+// dbeaverCredentials is the decrypted credentials-config.json payload keyed by
+// connection id; #connection holds the main user/password pair.
+type dbeaverCredentials struct {
+	Conn struct {
+		User     string `json:"user"`
+		Password string `json:"password"`
+	} `json:"#connection"`
+}
+
+// parseDBeaver imports connections from a DBeaver workspace. srcPath may be:
+// empty (auto-detect the platform default), a .dbeaver dir, or a
+// data-sources.json file. Passwords come from credentials-config.json; when it
+// cannot be decrypted (e.g. DBeaver master password set) they are left empty
+// with a warning.
+func parseDBeaver(srcPath string, opts ParseOptions) (*ImportResult, error) {
+	dir, err := dbeaverConfigDir(srcPath)
+	if err != nil {
+		return nil, err
+	}
+
+	raw, err := os.ReadFile(filepath.Join(dir, "data-sources.json"))
+	if err != nil {
+		return nil, fmt.Errorf("read data-sources.json: %w", err)
+	}
+	var doc struct {
+		Connections map[string]dbeaverSource `json:"connections"`
+		Folders     map[string]struct {
+			Connections []string `json:"connections"`
+		} `json:"folders"`
+	}
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		return nil, fmt.Errorf("parse data-sources.json: %w", err)
+	}
+
+	creds, credWarn := dbeaverLoadCredentials(dir)
+
+	res := &ImportResult{}
+	pathMap := map[string]string{}
+	newGroup := func() string { return newGroupID() }
+	newConn := newConnectionID
+
+	for id, src := range doc.Connections {
+		dbType, ok := dbeaverDBType[strings.ToLower(strings.TrimSpace(src.Provider))]
+		if !ok {
+			res.Warnings = append(res.Warnings, fmt.Sprintf("%s: unsupported provider %q, skipped", src.Name, src.Provider))
+			continue
+		}
+		conn := session.ConnectionConfig{
+			ID:       newConn(),
+			Name:     firstNonEmpty(src.Name, id),
+			Type:     "database",
+			Host:     src.Configuration.Host,
+			DBType:   dbType,
+			DBName:   src.Configuration.Database,
+			User:     src.Configuration.User,
+			AuthType: "password",
+		}
+		conn.Port = dbeaverPortOf(src.Configuration.Port, dbType)
+		if creds != nil {
+			if c, ok := creds[id]; ok {
+				if conn.User == "" {
+					conn.User = c.Conn.User
+				}
+				conn.Password = c.Conn.Password
+			}
+		}
+		if src.Folder != "" {
+			conn.GroupId = ensureGroupPath([]string{src.Folder}, pathMap, &res.Groups, newGroup)
+		}
+		res.Connections = append(res.Connections, conn)
+	}
+	if credWarn != "" {
+		res.Warnings = append(res.Warnings, credWarn)
+	}
+	return res, nil
+}
+
+// dbeaverConfigDir resolves the .dbeaver config folder from srcPath or the
+// platform default workspace location.
+func dbeaverConfigDir(srcPath string) (string, error) {
+	if srcPath != "" {
+		info, err := os.Stat(srcPath)
+		if err != nil {
+			return "", err
+		}
+		dir := srcPath
+		if !info.IsDir() {
+			dir = filepath.Dir(srcPath)
+		}
+		if filepath.Base(dir) == ".dbeaver" {
+			return dir, nil
+		}
+		// A workspace root: look for the standard General/.dbeaver below it.
+		candidate := filepath.Join(dir, "General", ".dbeaver")
+		if st, err := os.Stat(candidate); err == nil && st.IsDir() {
+			return candidate, nil
+		}
+		return dir, nil
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	var candidates []string
+	switch runtime.GOOS {
+	case "darwin":
+		candidates = []string{filepath.Join(home, "Library", "DBeaverData", "workspace6", "General", ".dbeaver")}
+	case "windows":
+		appdata := os.Getenv("APPDATA")
+		if appdata == "" {
+			appdata = filepath.Join(home, "AppData", "Roaming")
+		}
+		candidates = []string{filepath.Join(appdata, "DBeaverData", "workspace6", "General", ".dbeaver")}
+	default:
+		data := os.Getenv("XDG_DATA_HOME")
+		if data == "" {
+			data = filepath.Join(home, ".local", "share")
+		}
+		candidates = []string{
+			filepath.Join(data, "DBeaverData", "workspace6", "General", ".dbeaver"),
+			filepath.Join(home, ".local", "share", "DBeaverData", "workspace6", "General", ".dbeaver"),
+		}
+	}
+	for _, c := range candidates {
+		if st, err := os.Stat(c); err == nil && st.IsDir() {
+			return c, nil
+		}
+	}
+	return "", errors.New("DBeaver workspace not found; select data-sources.json manually")
+}
+
+// dbeaverLoadCredentials decrypts credentials-config.json (AES-128-CBC with
+// DBeaver's built-in key; the first plaintext block is the file IV, skipped).
+// Returns nil + a warning when the file is missing or undecryptable.
+func dbeaverLoadCredentials(dir string) (map[string]dbeaverCredentials, string) {
+	raw, err := os.ReadFile(filepath.Join(dir, "credentials-config.json"))
+	if err != nil {
+		return nil, "" // no credentials file: passwords simply absent
+	}
+	plain, err := dbeaverDecrypt(raw)
+	if err != nil {
+		return nil, "DBeaver credentials could not be decrypted (custom master password?); passwords left empty"
+	}
+	var creds map[string]dbeaverCredentials
+	if err := json.Unmarshal(plain, &creds); err != nil {
+		return nil, "DBeaver credentials file has unexpected format; passwords left empty"
+	}
+	return creds, ""
+}
+
+// dbeaverDecrypt reverses DBeaver's local credential encryption:
+// AES-128-CBC, zero IV, where the first 16-byte plaintext block is the file's
+// own random IV and the remainder is the PKCS#7-padded JSON payload.
+func dbeaverDecrypt(data []byte) ([]byte, error) {
+	block, err := aes.NewCipher(dbeaverAesKey)
+	if err != nil {
+		return nil, err
+	}
+	if len(data) < 2*block.BlockSize() || len(data)%block.BlockSize() != 0 {
+		return nil, errors.New("unexpected credentials-config.json length")
+	}
+	plain := make([]byte, len(data))
+	cipher.NewCBCDecrypter(block, make([]byte, block.BlockSize())).CryptBlocks(plain, data)
+	return pkcs7Unpad(plain[block.BlockSize():], block.BlockSize())
+}
+
+// dbeaverPortOf parses DBeaver's port (string or number) with a per-dbType
+// default fallback.
+func dbeaverPortOf(raw json.RawMessage, dbType string) int {
+	var n int
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &n); err == nil && n > 0 {
+			return n
+		}
+		var s string
+		if err := json.Unmarshal(raw, &s); err == nil {
+			if v, err := strconv.Atoi(strings.TrimSpace(s)); err == nil && v > 0 {
+				return v
+			}
+		}
+	}
+	return dbeaverDefaultPort[dbType]
+}
+
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/backend/importer/dbimport_test.go
+++ b/backend/importer/dbimport_test.go
@@ -1,0 +1,232 @@
+package importer
+
+import (
+	"bytes"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/sha1"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"golang.org/x/crypto/blowfish"
+)
+
+// dbeaverEncryptFile mirrors DBeaver's local credential encryption so tests can
+// build a real credentials-config.json: AES-128-CBC with the built-in key and a
+// zero IV, where the first plaintext block is the file's random IV.
+func dbeaverEncryptFile(t *testing.T, payload []byte) []byte {
+	t.Helper()
+	block, err := aes.NewCipher(dbeaverAesKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fileIV := bytes.Repeat([]byte{0xAB}, block.BlockSize())
+	plain := append(append([]byte{}, fileIV...), payload...)
+	pad := block.BlockSize() - len(plain)%block.BlockSize()
+	plain = append(plain, bytes.Repeat([]byte{byte(pad)}, pad)...)
+	out := make([]byte, len(plain))
+	cipher.NewCBCEncrypter(block, make([]byte, block.BlockSize())).CryptBlocks(out, plain)
+	return out
+}
+
+// dbeaverEncryptV11 mirrors Navicat v11's Blowfish password scheme for tests.
+func dbeaverEncryptV11(t *testing.T, plaintext string) string {
+	t.Helper()
+	sum := sha1.Sum([]byte("3DC5CA39"))
+	bf, err := blowfish.NewCipher(sum[:])
+	if err != nil {
+		t.Fatal(err)
+	}
+	iv := bytes.Repeat([]byte{0xFF}, blowfish.BlockSize)
+	cv := make([]byte, blowfish.BlockSize)
+	bf.Encrypt(cv, iv)
+
+	src := []byte(plaintext)
+	var out []byte
+	full := len(src) / blowfish.BlockSize * blowfish.BlockSize
+	for off := 0; off < full; off += blowfish.BlockSize {
+		block := make([]byte, blowfish.BlockSize)
+		for i := range block {
+			block[i] = src[off+i] ^ cv[i]
+		}
+		ct := make([]byte, blowfish.BlockSize)
+		bf.Encrypt(ct, block)
+		out = append(out, ct...)
+		next := make([]byte, blowfish.BlockSize)
+		copy(next, ct)
+		for i := range next {
+			next[i] ^= cv[i]
+		}
+		bf.Encrypt(cv, next)
+	}
+	if rem := len(src) % blowfish.BlockSize; rem != 0 {
+		cv2 := make([]byte, blowfish.BlockSize)
+		bf.Encrypt(cv2, cv)
+		for i := 0; i < rem; i++ {
+			out = append(out, src[full+i]^cv2[i])
+		}
+	}
+	return strings.ToUpper(hex.EncodeToString(out))
+}
+
+// dbeaverEncryptV12 mirrors Navicat v12+ NCX password encryption for tests.
+func dbeaverEncryptV12(t *testing.T, plaintext string) string {
+	t.Helper()
+	block, err := aes.NewCipher(navicatNcxKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := []byte(plaintext)
+	pad := block.BlockSize() - len(src)%block.BlockSize()
+	src = append(src, bytes.Repeat([]byte{byte(pad)}, pad)...)
+	out := make([]byte, len(src))
+	cipher.NewCBCEncrypter(block, navicatNcxIV).CryptBlocks(out, src)
+	return strings.ToUpper(hex.EncodeToString(out))
+}
+
+func TestParseDBeaver(t *testing.T) {
+	dir := t.TempDir()
+	sources := map[string]any{
+		"connections": map[string]any{
+			"mysql-prod": map[string]any{
+				"name":     "MySQL Prod",
+				"provider": "mysql",
+				"folder":   "Company/Prod",
+				"configuration": map[string]any{
+					"host": "10.0.0.10", "port": "3307", "database": "app", "user": "admin",
+				},
+			},
+			"pg-dev": map[string]any{
+				"name":     "PG Dev",
+				"provider": "postgresql",
+				"configuration": map[string]any{
+					"host": "10.0.0.20", "port": 5433, "database": "devdb",
+				},
+			},
+			"sqlite-x": map[string]any{
+				"name":         "Unsupported",
+				"provider":     "sqlite",
+				"configuration": map[string]any{"host": "", "database": "/tmp/x.db"},
+			},
+		},
+	}
+	sourcesJSON, _ := json.Marshal(sources)
+	creds := map[string]dbeaverCredentials{
+		"mysql-prod": func() dbeaverCredentials {
+			var c dbeaverCredentials
+			c.Conn.User = "admin"
+			c.Conn.Password = "p@ss-mysql"
+			return c
+		}(),
+		"pg-dev": func() dbeaverCredentials {
+			var c dbeaverCredentials
+			c.Conn.User = "pguser"
+			c.Conn.Password = "secret-pg"
+			return c
+		}(),
+	}
+	credsJSON, _ := json.Marshal(creds)
+
+	if err := os.WriteFile(filepath.Join(dir, "data-sources.json"), sourcesJSON, 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "credentials-config.json"), dbeaverEncryptFile(t, credsJSON), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := parseDBeaver(dir, ParseOptions{})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(res.Connections) != 2 {
+		t.Fatalf("expected 2 connections, got %d", len(res.Connections))
+	}
+	byName := map[string]int{}
+	for i, c := range res.Connections {
+		byName[c.Name] = i
+	}
+	mp := res.Connections[byName["MySQL Prod"]]
+	if mp.Type != "database" || mp.DBType != "mysql" || mp.Host != "10.0.0.10" || mp.Port != 3307 ||
+		mp.DBName != "app" || mp.User != "admin" || mp.Password != "p@ss-mysql" {
+		t.Fatalf("mysql-prod mapping wrong: %+v", mp)
+	}
+	if mp.GroupId == nil || groupPathFor(res.Groups, *mp.GroupId) != "Company/Prod" {
+		t.Fatalf("mysql-prod group wrong: %+v", mp.GroupId)
+	}
+	pg := res.Connections[byName["PG Dev"]]
+	if pg.DBType != "postgres" || pg.Port != 5433 || pg.User != "pguser" || pg.Password != "secret-pg" {
+		t.Fatalf("pg-dev mapping wrong: %+v", pg)
+	}
+}
+
+func TestParseDBeaverUndecryptableCredentials(t *testing.T) {
+	dir := t.TempDir()
+	sources := `{"connections":{"c1":{"name":"C1","provider":"mysql","configuration":{"host":"h","port":"3306"}}}}`
+	if err := os.WriteFile(filepath.Join(dir, "data-sources.json"), []byte(sources), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "credentials-config.json"), []byte("garbage-garbage-garbage-garbage"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	res, err := parseDBeaver(dir, ParseOptions{})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(res.Connections) != 1 || res.Connections[0].Password != "" {
+		t.Fatalf("expected connection with empty password, got %+v", res.Connections)
+	}
+	if len(res.Warnings) == 0 {
+		t.Fatalf("expected a warning about undecryptable credentials")
+	}
+}
+
+func TestNavicatPasswordV12(t *testing.T) {
+	enc := dbeaverEncryptV12(t, "s3cret")
+	got, err := navicatDecryptPassword(enc)
+	if err != nil || got != "s3cret" {
+		t.Fatalf("v12 roundtrip: got %q err %v", got, err)
+	}
+}
+
+func TestNavicatPasswordV11(t *testing.T) {
+	enc := dbeaverEncryptV11(t, "old-pass")
+	got, err := navicatDecryptPassword(enc)
+	if err != nil || got != "old-pass" {
+		t.Fatalf("v11 roundtrip: got %q err %v", got, err)
+	}
+}
+
+func TestParseNavicat(t *testing.T) {
+	ncx := `<Root>
+<Connection ConnectionName="Local MySQL" ConnType="MYSQL" Host="127.0.0.1" Port="3306" Database="shop" UserName="root" Password="` + dbeaverEncryptV12(t, "root-pw") + `"/>
+<Connection ConnectionName="Team PG" ConnType="POSTGRESQL" Host="db.corp" Port="5432" Database="analytics" UserName="analyst" Password="` + dbeaverEncryptV11(t, "pg-pw") + `" Folder="Corp"/>
+<Connection ConnectionName="Bad Type" ConnType="SQLITE" Host="x" Port="0"/>
+</Root>`
+	path := filepath.Join(t.TempDir(), "connections.ncx")
+	if err := os.WriteFile(path, []byte(ncx), 0600); err != nil {
+		t.Fatal(err)
+	}
+	res, err := parseNavicat(path, ParseOptions{})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(res.Connections) != 2 {
+		t.Fatalf("expected 2 connections, got %d", len(res.Connections))
+	}
+	my := res.Connections[0]
+	if my.DBType != "mysql" || my.Host != "127.0.0.1" || my.Port != 3306 || my.DBName != "shop" ||
+		my.User != "root" || my.Password != "root-pw" {
+		t.Fatalf("mysql mapping wrong: %+v", my)
+	}
+	pg := res.Connections[1]
+	if pg.DBType != "postgres" || pg.User != "analyst" || pg.Password != "pg-pw" {
+		t.Fatalf("pg mapping wrong: %+v", pg)
+	}
+	if pg.GroupId == nil || groupPathFor(res.Groups, *pg.GroupId) != "Corp" {
+		t.Fatalf("pg group wrong: %+v", pg.GroupId)
+	}
+}

--- a/backend/importer/importer.go
+++ b/backend/importer/importer.go
@@ -8,10 +8,16 @@ import (
 
 // Parse reads the source file and dispatches to the matching provider. Providers
 // return groups/connections with freshly generated ids and restored group paths.
-// OpenSSH uses the default ~/.ssh/config when no path is given.
+// OpenSSH uses the default ~/.ssh/config when no path is given; DBeaver
+// auto-detects its default workspace when no path is given.
 func Parse(format, srcPath string, opts ParseOptions) (*ImportResult, error) {
 	if format == FormatOpenSSH && srcPath == "" {
 		srcPath = defaultSSHConfigPath()
+	}
+	if format == FormatDBeaver && srcPath == "" {
+		// parseDBeaver resolves the platform-default workspace itself; pass a
+		// sentinel so the generic ReadFile below is skipped.
+		return parseDBeaver("", opts)
 	}
 	data, err := os.ReadFile(srcPath)
 	if err != nil {
@@ -30,6 +36,10 @@ func Parse(format, srcPath string, opts ParseOptions) (*ImportResult, error) {
 		return parseSecureCRT(data)
 	case FormatOpenSSH:
 		return parseOpenSSH(data)
+	case FormatDBeaver:
+		return parseDBeaver(srcPath, opts)
+	case FormatNavicat:
+		return parseNavicat(srcPath, ParseOptions{})
 	default:
 		return nil, fmt.Errorf("unknown import format %q", format)
 	}

--- a/backend/importer/navicat.go
+++ b/backend/importer/navicat.go
@@ -1,0 +1,253 @@
+package importer
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/sha1"
+	"encoding/hex"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/ys-ll/uniterm/backend/session"
+	"golang.org/x/crypto/blowfish"
+)
+
+// FormatNavicat imports Navicat connections from a .ncx export file
+// (File → Export Connections with "Export password" checked).
+const FormatNavicat = "navicat"
+
+// navicatNcxKey / navicatNcxIV are Navicat v12+'s fixed export-file key pair.
+var (
+	navicatNcxKey = []byte("libcckeylibcckey")
+	navicatNcxIV  = []byte("libcciv libcciv ")
+)
+
+// navicatConnType maps NCX ConnType values onto uniterm dbType keys.
+var navicatConnType = map[string]string{
+	"MYSQL":  "mysql",
+	"MARIADB": "mysql",
+	"POSTGRESQL": "postgres",
+	"MSSQL":      "sqlserver",
+	"ORACLE":     "oracle",
+	"MONGODB":    "mongodb",
+	"REDIS":      "redis",
+}
+
+// navicatDefaultPort per uniterm dbType for entries missing Port.
+var navicatDefaultPort = map[string]int{
+	"mysql": 3306, "postgres": 5432, "sqlserver": 1433, "oracle": 1521,
+	"mongodb": 27017, "redis": 6379,
+}
+
+// navicatConn is one <Connection .../> element of an .ncx export. The format
+// keeps every field as XML attributes.
+type navicatConn struct {
+	ConnectionName string `xml:"ConnectionName,attr"`
+	ConnType       string `xml:"ConnType,attr"`
+	Host           string `xml:"Host,attr"`
+	Port           string `xml:"Port,attr"`
+	Database       string `xml:"Database,attr"`
+	UserName       string `xml:"UserName,attr"`
+	Password       string `xml:"Password,attr"`
+	Folder         string `xml:"Folder,attr"`
+}
+
+// parseNavicat imports connections from a Navicat .ncx export file. Passwords
+// are decrypted with the v12+ AES scheme, falling back to the v11 Blowfish
+// variant for older exports.
+func parseNavicat(srcPath string, _ ParseOptions) (*ImportResult, error) {
+	raw, err := os.ReadFile(srcPath)
+	if err != nil {
+		return nil, err
+	}
+
+	// .ncx files may be UTF-16 encoded; convert to UTF-8 before XML decode.
+	raw = normalizeNavicatEncoding(raw)
+
+	var root struct {
+		Conns []navicatConn `xml:"Connection"`
+	}
+	if err := xml.Unmarshal(raw, &root); err != nil {
+		return nil, fmt.Errorf("parse .ncx: %w", err)
+	}
+	if len(root.Conns) == 0 {
+		return nil, errors.New("no <Connection> entries found; is this an exported .ncx file?")
+	}
+
+	res := &ImportResult{}
+	pathMap := map[string]string{}
+	newGroup := func() string { return newGroupID() }
+
+	for _, c := range root.Conns {
+		dbType, ok := navicatConnType[strings.ToUpper(strings.TrimSpace(c.ConnType))]
+		if !ok {
+			if c.ConnType != "" {
+				res.Warnings = append(res.Warnings, fmt.Sprintf("%s: unsupported connection type %q, skipped", c.ConnectionName, c.ConnType))
+			}
+			continue
+		}
+		conn := session.ConnectionConfig{
+			ID:       newConnectionID(),
+			Name:     firstNonEmpty(c.ConnectionName, c.Host),
+			Type:     "database",
+			Host:     c.Host,
+			DBType:   dbType,
+			DBName:   c.Database,
+			User:     c.UserName,
+			AuthType: "password",
+		}
+		if p, err := strconv.Atoi(strings.TrimSpace(c.Port)); err == nil && p > 0 {
+			conn.Port = p
+		} else {
+			conn.Port = navicatDefaultPort[dbType]
+		}
+		if c.Password != "" {
+			pwd, err := navicatDecryptPassword(c.Password)
+			if err != nil {
+				res.Warnings = append(res.Warnings, fmt.Sprintf("%s: password could not be decrypted, left empty", c.ConnectionName))
+			} else {
+				conn.Password = pwd
+			}
+		}
+		if c.Folder != "" {
+			conn.GroupId = ensureGroupPath([]string{c.Folder}, pathMap, &res.Groups, newGroup)
+		}
+		res.Connections = append(res.Connections, conn)
+	}
+	return res, nil
+}
+
+// utf16BOM is the U+FEFF byte-order mark appearing at the start of a decoded
+// UTF-16 string.
+const utf16BOM = "\ufeff"
+
+// normalizeNavicatEncoding converts UTF-16 (LE or BE, with BOM) .ncx content to
+// UTF-8; anything else is returned unchanged.
+func normalizeNavicatEncoding(raw []byte) []byte {
+	if len(raw) >= 2 {
+		if raw[0] == 0xFF && raw[1] == 0xFE {
+			return []byte(strings.TrimPrefix(runesFromUTF16LE(raw[2:]), utf16BOM))
+		}
+		if raw[0] == 0xFE && raw[1] == 0xFF {
+			return []byte(strings.TrimPrefix(runesFromUTF16BE(raw[2:]), utf16BOM))
+		}
+	}
+	return raw
+}
+
+func runesFromUTF16LE(b []byte) string {
+	var sb strings.Builder
+	for i := 0; i+1 < len(b); i += 2 {
+		sb.WriteRune(rune(uint16(b[i]) | uint16(b[i+1])<<8))
+	}
+	return sb.String()
+}
+
+func runesFromUTF16BE(b []byte) string {
+	var sb strings.Builder
+	for i := 0; i+1 < len(b); i += 2 {
+		sb.WriteRune(rune(uint16(b[i])<<8 | uint16(b[i+1])))
+	}
+	return sb.String()
+}
+
+// navicatDecryptPassword tries the v12+ AES-128-CBC scheme first (uppercase hex
+// ciphertext), then the v11 Blowfish-based variant used by older exports.
+func navicatDecryptPassword(cipherHex string) (string, error) {
+	s := strings.TrimSpace(cipherHex)
+	if v12, err := navicatDecryptV12(s); err == nil {
+		return v12, nil
+	}
+	return navicatDecryptV11(s)
+}
+
+// navicatDecryptV12 decrypts Navicat v12+ passwords: AES-128-CBC with the fixed
+// libcckey/libcciv pair over PKCS#7-padded plaintext, uppercase hex encoded.
+func navicatDecryptV12(s string) (string, error) {
+	data, err := hex.DecodeString(strings.ToLower(s))
+	if err != nil {
+		return "", err
+	}
+	block, err := aes.NewCipher(navicatNcxKey)
+	if err != nil {
+		return "", err
+	}
+	if len(data) == 0 || len(data)%block.BlockSize() != 0 {
+		return "", errors.New("invalid ciphertext length")
+	}
+	plain := make([]byte, len(data))
+	cipher.NewCBCDecrypter(block, navicatNcxIV).CryptBlocks(plain, data)
+	plain, err = pkcs7Unpad(plain, block.BlockSize())
+	if err != nil {
+		return "", err
+	}
+	return string(plain), nil
+}
+
+// navicatDecryptV11 decrypts Navicat v11 passwords: Blowfish-ECB with the
+// SHA-1 of "3DC5CA39" as key, in a CBC-like XOR feedback mode whose IV is the
+// encryption of 0xFFFFFFFFFFFFFFFF.
+func navicatDecryptV11(s string) (string, error) {
+	data, err := hex.DecodeString(strings.ToLower(s))
+	if err != nil {
+		return "", err
+	}
+	sum := sha1.Sum([]byte("3DC5CA39"))
+	bf, err := blowfish.NewCipher(sum[:])
+	if err != nil {
+		return "", err
+	}
+	iv := make([]byte, blowfish.BlockSize)
+	for i := range iv {
+		iv[i] = 0xFF
+	}
+	cv := make([]byte, blowfish.BlockSize)
+	bf.Encrypt(cv, iv)
+
+	plain := make([]byte, 0, len(data))
+	for off := 0; off+blowfish.BlockSize <= len(data); off += blowfish.BlockSize {
+		block := make([]byte, blowfish.BlockSize)
+		bf.Decrypt(block, data[off:off+blowfish.BlockSize])
+		for i := range block {
+			block[i] ^= cv[i]
+		}
+		plain = append(plain, block...)
+		next := make([]byte, blowfish.BlockSize)
+		copy(next, data[off:off+blowfish.BlockSize])
+		for i := range next {
+			next[i] ^= cv[i]
+		}
+		bf.Encrypt(cv, next)
+	}
+	if rem := len(data) % blowfish.BlockSize; rem != 0 {
+		cv2 := make([]byte, blowfish.BlockSize)
+		bf.Encrypt(cv2, cv)
+		tail := make([]byte, rem)
+		for i := 0; i < rem; i++ {
+			tail[i] = data[len(data)-rem+i] ^ cv2[i]
+		}
+		plain = append(plain, tail...)
+	}
+	return strings.TrimRight(string(plain), "\x00"), nil
+}
+
+// pkcs7Unpad strips PKCS#7 padding, mirroring the windterm importer.
+func pkcs7Unpad(data []byte, blockSize int) ([]byte, error) {
+	if len(data) == 0 || len(data)%blockSize != 0 {
+		return nil, errors.New("invalid padded data length")
+	}
+	n := data[len(data)-1]
+	if n == 0 || int(n) > blockSize || int(n) > len(data) {
+		return nil, errors.New("invalid padding")
+	}
+	for _, b := range data[len(data)-int(n):] {
+		if b != n {
+			return nil, errors.New("invalid padding bytes")
+		}
+	}
+	return data[:len(data)-int(n)], nil
+}

--- a/frontend/src/components/ImportDialog.vue
+++ b/frontend/src/components/ImportDialog.vue
@@ -14,12 +14,20 @@
           <el-option label="SecureCRT (.xml)" value="securecrt" />
           <el-option label="WindTerm (.sessions)" value="windterm" />
           <el-option label="Xshell (.xts)" value="xshell" />
+          <el-option label="DBeaver (workspace)" value="dbeaver" />
+          <el-option label="Navicat (.ncx)" value="navicat" />
         </el-select>
       </el-form-item>
-      <el-form-item v-if="format !== 'openssh'" :label="t('importExport.file')">
+      <el-form-item v-if="format !== 'openssh' && format !== 'dbeaver'" :label="t('importExport.file')">
         <div style="display:flex;gap:8px;width:100%">
           <el-input v-model="srcPath" readonly :placeholder="t('importExport.chooseFile')" style="flex:1" />
           <el-button @click="pickFile">{{ t('importExport.chooseFile') }}</el-button>
+        </div>
+      </el-form-item>
+      <el-form-item v-if="format === 'dbeaver'" :label="t('importExport.file')">
+        <div style="display:flex;gap:8px;width:100%">
+          <el-input v-model="srcPath" readonly :placeholder="t('importExport.dbeaverPathHint')" style="flex:1" />
+          <el-button @click="pickDBeaverDir">{{ t('importExport.chooseFile') }}</el-button>
         </div>
       </el-form-item>
       <el-form-item v-if="format === 'uniterm' || format === 'windterm'" :label="t('importExport.importPassword')">
@@ -28,7 +36,7 @@
     </el-form>
     <template #footer>
       <el-button @click="onCancel">{{ t('common.cancel') }}</el-button>
-      <el-button type="primary" :loading="importing" :disabled="!srcPath && format !== 'openssh'" @click="onImport">{{ t('importExport.import') }}</el-button>
+      <el-button type="primary" :loading="importing" :disabled="!srcPath && format !== 'openssh' && format !== 'dbeaver'" @click="onImport">{{ t('importExport.import') }}</el-button>
     </template>
   </el-dialog>
 </template>
@@ -37,7 +45,7 @@
 import { ref, watch } from 'vue'
 import { useI18n } from '../i18n'
 import { msg } from '../services/message'
-import { ParseImportFile, ApplyImport, OpenFileDialogFiltered } from '../../bindings/github.com/ys-ll/uniterm/app'
+import { ParseImportFile, ApplyImport, OpenFileDialogFiltered, OpenDirectoryDialog } from '../../bindings/github.com/ys-ll/uniterm/app'
 
 const props = defineProps<{ visible: boolean }>()
 const emit = defineEmits<{ (e: 'update:visible', v: boolean): void; (e: 'done', count: number): void }>()
@@ -54,6 +62,7 @@ const FILTERS: Record<string, { display: string; pattern: string }> = {
   mobaxterm: { display: 'MobaXterm (*.mxtsessions)', pattern: '*.mxtsessions' },
   windterm: { display: 'WindTerm (*.sessions)', pattern: '*.sessions' },
   securecrt: { display: 'SecureCRT (*.xml)', pattern: '*.xml' },
+  navicat: { display: 'Navicat (*.ncx)', pattern: '*.ncx' },
 }
 
 watch(() => props.visible, (v) => {
@@ -69,10 +78,17 @@ async function pickFile() {
   if (p) srcPath.value = p
 }
 
+async function pickDBeaverDir() {
+  const p = await OpenDirectoryDialog()
+  if (p) srcPath.value = p
+}
+
 async function onImport() {
   importing.value = true
   try {
-    const result = await ParseImportFile(format.value, srcPath.value,
+    // DBeaver with an empty path means "auto-detect the default workspace".
+    const path = (format.value === 'dbeaver' && !srcPath.value) ? '' : srcPath.value
+    const result = await ParseImportFile(format.value, path,
       (format.value === 'uniterm' || format.value === 'windterm') ? password.value : '')
     await ApplyImport({ groups: result.groups || [], connections: result.connections || [] } as any)
     const count = (result.connections || []).length

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -464,6 +464,7 @@
   "importExport.file": "Datei",
   "importExport.importPassword": "Importpasswort",
   "importExport.chooseFile": "Datei auswählen...",
+  "importExport.dbeaverPathHint": "Leer lassen, um den DBeaver-Workspace automatisch zu finden, oder data-sources.json / Ordner wählen",
   "importExport.importedCount": "{count} Verbindungen importiert",
   "importExport.exported": "Erfolgreich exportiert",
   "settings.sync": "Cloud-Sync",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -464,6 +464,7 @@
   "importExport.file": "File",
   "importExport.importPassword": "Import password",
   "importExport.chooseFile": "Choose file...",
+  "importExport.dbeaverPathHint": "Leave empty to auto-detect the DBeaver workspace, or pick data-sources.json / its folder",
   "importExport.importedCount": "Imported {count} connections",
   "importExport.exported": "Exported successfully",
   "settings.sync": "Cloud Sync",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -464,6 +464,7 @@
   "importExport.file": "Archivo",
   "importExport.importPassword": "Contraseña de importación",
   "importExport.chooseFile": "Elegir archivo...",
+  "importExport.dbeaverPathHint": "Deje vacío para detectar el workspace de DBeaver o elija data-sources.json / carpeta",
   "importExport.importedCount": "Se importaron {count} conexiones",
   "importExport.exported": "Exportado correctamente",
   "settings.sync": "Sincronización en la nube",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -464,6 +464,7 @@
   "importExport.file": "ファイル",
   "importExport.importPassword": "インポートパスワード",
   "importExport.chooseFile": "ファイルを選択...",
+  "importExport.dbeaverPathHint": "空欄でDBeaverワークスペースを自動検出、または data-sources.json / フォルダを選択",
   "importExport.importedCount": "{count} 件の接続をインポートしました",
   "importExport.exported": "正常にエクスポートしました",
   "settings.sync": "クラウド同期",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -464,6 +464,7 @@
   "importExport.file": "파일",
   "importExport.importPassword": "가져오기 비밀번호",
   "importExport.chooseFile": "파일 선택...",
+  "importExport.dbeaverPathHint": "비우면 DBeaver 워크스페이스를 자동 감지하거나 data-sources.json / 폴더를 선택하세요",
   "importExport.importedCount": "{count}개 연결을 가져왔습니다",
   "importExport.exported": "내보내기 완료",
   "settings.sync": "클라우드 동기화",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -464,6 +464,7 @@
   "importExport.file": "Файл",
   "importExport.importPassword": "Пароль импорта",
   "importExport.chooseFile": "Выбрать файл...",
+  "importExport.dbeaverPathHint": "Оставьте пустым для автоопределения workspace DBeaver или выберите data-sources.json / папку",
   "importExport.importedCount": "Импортировано подключений: {count}",
   "importExport.exported": "Успешно экспортировано",
   "settings.sync": "Облачная синхронизация",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -464,6 +464,7 @@
   "importExport.file": "文件",
   "importExport.importPassword": "导入密码",
   "importExport.chooseFile": "选择文件...",
+  "importExport.dbeaverPathHint": "留空自动检测 DBeaver 工作区，或选择 data-sources.json / 文件夹",
   "importExport.importedCount": "导入 {count} 个连接",
   "importExport.exported": "导出成功",
   "settings.sync": "云同步",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -464,6 +464,7 @@
   "importExport.file": "檔案",
   "importExport.importPassword": "匯入密碼",
   "importExport.chooseFile": "選擇檔案...",
+  "importExport.dbeaverPathHint": "留空自動偵測 DBeaver 工作區，或選擇 data-sources.json / 資料夾",
   "importExport.importedCount": "已匯入 {count} 個連線",
   "importExport.exported": "匯出成功",
   "settings.sync": "雲端同步",


### PR DESCRIPTION
## Summary

Add database-client connection import to the existing import dialog, requested in #544 comments:

- **DBeaver**: reads `data-sources.json` + `credentials-config.json` straight from a workspace's `General/.dbeaver` folder — no export needed. An empty path auto-detects the platform-default workspace (`~/Library/DBeaverData` on macOS, `%APPDATA%\DBeaverData` on Windows, XDG data dir on Linux); a folder or `data-sources.json` can also be picked manually.
- **Navicat**: parses a `.ncx` connection export file (File → Export Connections), UTF-8 or UTF-16 with BOM.

Passwords are recovered where the tools' own (documented, public) local encryption allows, following the same conventions as the existing SSH importers (WindTerm/SecureCRT): undecryptable passwords are left empty with a non-fatal warning.

## Changes

- `backend/importer/dbeaver.go`: workspace auto-detection, `data-sources.json` parsing (string and numeric ports), `credentials-config.json` decryption (DBeaver's built-in AES-128-CBC key; first plaintext block is the file IV, PKCS#7 padding), provider → dbType mapping (mysql/mariadb, postgresql, mssql, oracle, mongodb, redis, elasticsearch), folder → group restore. Unsupported providers are skipped with a warning; a DBeaver master password re-encrypts credentials, in which case passwords are left empty with a warning.
- `backend/importer/navicat.go`: `.ncx` XML parsing, v12+ AES-128-CBC (`libcckey`) password decryption with v11 Blowfish fallback, ConnType → dbType mapping, Folder attribute → group.
- `importer.go` / `types.go`: new formats `dbeaver` (path optional) and `navicat`.
- `ImportDialog.vue`: two new dropdown entries — DBeaver picks a directory (`OpenDirectoryDialog`), Navicat filters `*.ncx`; plus `importExport.dbeaverPathHint` in all 8 locales.
- Tests (`dbimport_test.go`) round-trip real encrypted samples: credentials file encryption, v11/v12 password schemes, folder mapping, unsupported provider/type warnings.

Part of #544

## Validation

- `go test ./backend/importer/` (5 new tests, full package green)
- `go build ./...`
- `npm --prefix frontend run build`

---

## 摘要

在现有导入对话框中新增数据库客户端连接导入（#544 评论区需求）：

- **DBeaver**：直接读取工作区 `General/.dbeaver` 目录下的 `data-sources.json` + `credentials-config.json`，无需导出。路径留空时自动探测平台默认工作区（macOS `~/Library/DBeaverData`、Windows `%APPDATA%\DBeaverData`、Linux XDG 数据目录），也可手动选择文件夹或 `data-sources.json`。
- **Navicat**：解析 `.ncx` 连接导出文件（文件 → 导出连接），支持 UTF-8 与带 BOM 的 UTF-16。

密码解密遵循现有 SSH 导入器（WindTerm/SecureCRT）的约定：无法解密时密码留空并给出非致命警告。

## 验证

- `go test ./backend/importer/`（新增 5 个测试，整包通过）
- `go build ./...`
- `npm --prefix frontend run build`