### PR TITLE
fix(preview): align screen preview with scrollbar clicks, theme-aware colors

### DIFF
--- a/frontend/src/components/BaseTerminal.vue
+++ b/frontend/src/components/BaseTerminal.vue
@@ -103,10 +103,7 @@
     <ZmodemTransfer :session-id="props.sessionId || ''" @cancel="onZmodemCancel" />
 
     <!-- Screen preview on scrollbar hover (issue #729) -->
-    <TerminalScreenPreview
-      :session-id="props.sessionId || ''"
-      :enabled="settingsStore.settings.terminal.screenPreview ?? true"
-    />
+    <TerminalScreenPreview :session-id="props.sessionId || ''" />
   </div>
 </template>
 

--- a/frontend/src/components/SettingsTab.vue
+++ b/frontend/src/components/SettingsTab.vue
@@ -602,16 +602,6 @@
 
           <div class="setting-card">
             <div class="setting-info">
-              <div class="setting-title">{{ t('settings.screenPreview') }}</div>
-              <div class="setting-desc">{{ t('settings.screenPreviewDesc') }}</div>
-            </div>
-            <div class="setting-control">
-              <el-switch :model-value="settingsStore.settings.terminal.screenPreview ?? true" @update:model-value="(v: boolean) => { settingsStore.settings.terminal.screenPreview = v; settingsStore.save() }" />
-            </div>
-          </div>
-
-          <div class="setting-card">
-            <div class="setting-info">
               <div class="setting-title">{{ t('settings.sessionLogDir') }}</div>
               <div class="setting-desc">{{ t('settings.sessionLogDirDesc', { path: defaultLogDir }) }}</div>
             </div>

--- a/frontend/src/components/TerminalScreenPreview.vue
+++ b/frontend/src/components/TerminalScreenPreview.vue
@@ -3,9 +3,6 @@
     v-show="visible"
     class="terminal-screen-preview"
     :style="popupStyle"
-    @mouseenter="onPopupEnter"
-    @mouseleave="hide"
-    @click="onJump"
   >
     <div
       v-for="(row, i) in lines"
@@ -52,15 +49,18 @@ import {
   buildPalette,
   lineToRuns,
   computePreviewStart,
+  computePreviewWindowStart,
+  computeTrackClickRatio,
+  computeSliderHeight,
   pickVerticalTrackIndex,
+  type PreviewPalette,
   type PreviewStyleRun,
 } from '../services/screenPreview'
 
-const props = defineProps<{ sessionId: string; enabled?: boolean }>()
+const props = defineProps<{ sessionId: string }>()
 
 const PREVIEW_ROWS = 10
 const HOVER_DELAY = 250
-const HIDE_DELAY = 150
 
 const settingsStore = useSettingsStore()
 const showLineNumbers = computed(() => settingsStore.settings.terminal.showLineNumbers ?? false)
@@ -73,6 +73,10 @@ const pos = ref({ left: 0, top: 0 })
 const size = ref({ width: 0, height: 0 })
 const cellHeightPx = ref('1.5em')
 const bgColor = ref('#1e1e1e')
+// Terminal's resolved default foreground. Cells without an explicit color
+// have no inline style — the popup container must carry the terminal's
+// foreground, or they inherit the app UI's text color instead.
+const fgColor = ref('#cccccc')
 const fontCss = ref({ fontSize: '13px', fontFamily: 'monospace' })
 const numColWidth = ref('')
 const timeColWidth = ref('')
@@ -82,7 +86,10 @@ const popupStyle = computed(() => ({
   top: `${pos.value.top}px`,
   width: `${size.value.width}px`,
   height: `${size.value.height}px`,
-  background: bgColor.value,
+  // Translucent background + CSS backdrop blur (see .terminal-screen-preview)
+  // gives a frosted-glass popup that lets the content beneath show through.
+  background: withAlpha(bgColor.value, 0.7),
+  color: fgColor.value,
   fontSize: fontCss.value.fontSize,
   fontFamily: fontCss.value.fontFamily,
 }))
@@ -103,6 +110,39 @@ function getTerminal(): Terminal | null {
 }
 
 /**
+ * Palette for the preview popup. xterm resolves `options.theme` against its
+ * built-in defaults — a theme may override only a few keys, so the popup must
+ * read the RESOLVED colors from the theme service (what the terminal actually
+ * paints), not the raw option; reading the raw option left the preview stuck
+ * on fixed fallback colors after switching terminal themes.
+ */
+function buildLivePalette(t: Terminal): PreviewPalette {
+  try {
+    const colors = (t as any)._core?._themeService?.colors
+    if (Array.isArray(colors?.ansi) && colors.ansi.length >= 16) {
+      return {
+        defaultFg: colors.foreground?.css ?? '#ffffff',
+        defaultBg: colors.background?.css ?? '#000000',
+        ansi16: colors.ansi.slice(0, 16).map((c: { css: string }) => c.css),
+      }
+    }
+  } catch { /* internal API — fall through */ }
+  return buildPalette(t.options.theme)
+}
+
+/** Add alpha to a hex color (e.g. popup background); non-hex passes through. */
+function withAlpha(color: string, alpha: number): string {
+  const m = /^#([0-9a-f]{3}|[0-9a-f]{6})$/i.exec(color.trim())
+  if (!m) return color
+  let hex = m[1]
+  if (hex.length === 3) {
+    hex = hex.split('').map((ch) => ch + ch).join('')
+  }
+  const n = parseInt(hex, 16)
+  return `rgba(${(n >> 16) & 0xff}, ${(n >> 8) & 0xff}, ${n & 0xff}, ${alpha})`
+}
+
+/**
  * Locate xterm's scrollbar element. xterm v6 renders a VS Code-style overlay
  * scrollbar (`.xterm-scrollable-element > .scrollbar`) that is a *sibling* of
  * `.xterm-viewport` — hovering it never produces events on the viewport, so
@@ -119,18 +159,20 @@ function findScrollbar(t: Terminal): HTMLElement | null {
 
 let host: HTMLElement | null = null
 let hoverTimer: number | undefined
-let hideTimer: number | undefined
+/** Click-equivalent scroll fraction (slider-centered mapping). */
 let lastRatio = 0
+/** The pointer's own vertical fraction within the track ≙ viewport row. */
+let lastPointerFraction = 0
+/** Viewport top line the track click will land on. */
+let jumpTopLine = 0
 let lastClientY = 0
+/** True between pointerdown and pointerup on the track (preview visible). */
+let trackDragging = false
 
 function clearTimers() {
   if (hoverTimer !== undefined) {
     clearTimeout(hoverTimer)
     hoverTimer = undefined
-  }
-  if (hideTimer !== undefined) {
-    clearTimeout(hideTimer)
-    hideTimer = undefined
   }
 }
 
@@ -142,11 +184,13 @@ function bind() {
   host = el
   el.addEventListener('mousemove', onMouseMove)
   el.addEventListener('mouseleave', onMouseLeave)
+  el.addEventListener('pointerdown', onPointerDownCapture, true)
 }
 
 function unbind() {
   host?.removeEventListener('mousemove', onMouseMove)
   host?.removeEventListener('mouseleave', onMouseLeave)
+  host?.removeEventListener('pointerdown', onPointerDownCapture, true)
   host = null
   clearTimers()
   visible.value = false
@@ -176,8 +220,17 @@ function charWidth(t: Terminal): number {
  * A small tolerance on the left edge makes the narrow (14px) strip easier to
  * hit. Hovering the thumb (slider) returns null — the thumb marks the content
  * that is already on screen, so there is nothing to preview there.
+ *
+ * Returns the track rect plus the slider's real height: the preview maps the
+ * hover point to buffer rows with the same slider-centered formula xterm uses
+ * for track clicks (see computeTrackClickRatio), so the slider height is part
+ * of the math. Falls back to ScrollbarState's own max(20, …) formula when the
+ * slider element can't be measured.
  */
-function scrollbarRect(t: Terminal, e: MouseEvent): DOMRect | null {
+function scrollbarRect(
+  t: Terminal,
+  e: MouseEvent,
+): { track: DOMRect; sliderHeight: number } | null {
   const sb = findScrollbar(t)
   if (!sb) return null
   const r = sb.getBoundingClientRect()
@@ -190,32 +243,42 @@ function scrollbarRect(t: Terminal, e: MouseEvent): DOMRect | null {
   ) {
     return null
   }
-  const slider = sb.querySelector('.slider')
+  const slider = sb.querySelector('.slider') as HTMLElement | null
   if (slider) {
     const s = slider.getBoundingClientRect()
     const PAD = 4
     if (e.clientY >= s.top - PAD && e.clientY <= s.bottom + PAD) return null
+    return { track: r, sliderHeight: s.height }
   }
-  return r
+  const total = t.buffer.active.length
+  return {
+    track: r,
+    sliderHeight: computeSliderHeight(r.height, r.height, total * cellHeight(t)),
+  }
 }
 
 function onMouseMove(e: MouseEvent) {
-  if (!props.enabled) return hide()
   const t = getTerminal()
   if (!t || !host) return hide()
 
-  const rect = scrollbarRect(t, e)
-  if (!rect) return hide()
+  const hit = scrollbarRect(t, e)
+  if (!hit) return hide()
+  const rect = hit.track
   // Alt-screen apps (vim, htop) have no scrollback to preview.
   if (t.buffer.active.type === 'alternate') return hide()
   const total = t.buffer.active.length
   if (total <= t.rows) return hide()
 
-  lastRatio = Math.min(1, Math.max(0, (e.clientY - rect.top) / rect.height))
+  // Same mapping xterm applies to a track click at this point, so the
+  // previewed lines are exactly what the user would see after clicking.
+  lastRatio = computeTrackClickRatio(e.clientY - rect.top, rect.height, hit.sliderHeight)
+  lastPointerFraction = Math.min(1, Math.max(0, (e.clientY - rect.top) / rect.height))
   lastClientY = e.clientY
   clearTimers()
   if (visible.value) {
     show(t, rect)
+    // Pointer held down on the track: keep jumping while it drags.
+    if (trackDragging) scrollToPreviewTop(t)
   } else {
     hoverTimer = window.setTimeout(() => {
       hoverTimer = undefined
@@ -227,13 +290,21 @@ function onMouseMove(e: MouseEvent) {
 
 function show(t: Terminal, sbRect: DOMRect) {
   const total = t.buffer.active.length
-  const start = computePreviewStart(lastRatio, total, t.rows, PREVIEW_ROWS)
+  // Model the outcome of clicking the track at the hover point. The popup
+  // hangs above the pointer and previews the block that reappears below it:
+  // after the click, the line under the pointer is the viewport's top line
+  // plus the pointer's row within the viewport (the pointer stays put on
+  // screen while content scrolls underneath it).
+  const clickTop = computePreviewStart(lastRatio, total, t.rows, PREVIEW_ROWS)
+  const start = computePreviewWindowStart(clickTop, t.rows, lastPointerFraction, total, PREVIEW_ROWS)
   startRow.value = start
+  jumpTopLine = clickTop
 
-  const palette = buildPalette(t.options.theme)
+  const palette = buildLivePalette(t)
   const buf = t.buffer.active
   const managed = getManagedTerminal(props.sessionId)
   const lineOffset = managed?.lineOffset ?? 0
+
   const withNumbers = showLineNumbers.value
   const withTimestamps = showTimestamps.value && managed
   const tsFormat = settingsStore.settings.terminal.timestampFormat || 'HH:mm:ss'
@@ -267,7 +338,9 @@ function show(t: Terminal, sbRect: DOMRect) {
     })
   }
   lines.value = rendered
-  bgColor.value = t.options.theme?.background || '#1e1e1e'
+  // Resolved (not raw-option) colors — same source the cells were styled from.
+  bgColor.value = palette.defaultBg
+  fgColor.value = palette.defaultFg
   fontCss.value = {
     fontSize: `${t.options.fontSize ?? 13}px`,
     fontFamily: typeof t.options.fontFamily === 'string' ? t.options.fontFamily : 'monospace',
@@ -319,10 +392,13 @@ function show(t: Terminal, sbRect: DOMRect) {
     : Math.max(4, sbRect.left - width - POPUP_H_CHROME - 6 - base.left)
   const height = PREVIEW_ROWS * lh
   size.value = { width, height }
+  // Center the popup vertically on the pointer, to the LEFT of the scrollbar:
+  // its middle row is the line that lands under the pointer after the click
+  // (see computePreviewWindowStart).
   pos.value = {
     left,
     top: Math.min(
-      Math.max(4, lastClientY - lh * 2 - base.top),
+      Math.max(4, lastClientY - height / 2 - base.top),
       Math.max(4, base.height - height - 8),
     ),
   }
@@ -331,18 +407,7 @@ function show(t: Terminal, sbRect: DOMRect) {
 
 function onMouseLeave() {
   clearTimers()
-  // Grace period so moving onto the popup itself doesn't close it.
-  hideTimer = window.setTimeout(() => {
-    hideTimer = undefined
-    hide()
-  }, HIDE_DELAY)
-}
-
-function onPopupEnter() {
-  if (hideTimer !== undefined) {
-    clearTimeout(hideTimer)
-    hideTimer = undefined
-  }
+  hide()
 }
 
 function hide() {
@@ -350,23 +415,52 @@ function hide() {
   visible.value = false
 }
 
-function onJump() {
+/**
+ * Take over track clicks while the preview popup is up: jump so the previewed
+ * content lands at the pointer, exactly as shown. xterm's own track handling
+ * (slider-centering on stale buffer indices) is suppressed for this click.
+ * Without the popup, native xterm behavior is untouched; dragging the thumb
+ * is unaffected (pointerdown on the slider never reaches here — the popup
+ * hides when the pointer moves onto the slider).
+ */
+function onPointerDownCapture(e: MouseEvent) {
+  trackDragging = false
+  if (!visible.value || e.button !== 0) return
   const t = getTerminal()
-  if (t) t.scrollToLine(startRow.value)
-  hide()
+  if (!t) return
+  const hit = scrollbarRect(t, e)
+  if (!hit) return
+  e.preventDefault()
+  e.stopPropagation()
+  trackDragging = true
+  window.addEventListener(
+    'pointerup',
+    () => {
+      trackDragging = false
+    },
+    { once: true },
+  )
+  lastRatio = computeTrackClickRatio(e.clientY - hit.track.top, hit.track.height, hit.sliderHeight)
+  lastPointerFraction = Math.min(1, Math.max(0, (e.clientY - hit.track.top) / hit.track.height))
+  lastClientY = e.clientY
+  show(t, hit.track)
+  scrollToPreviewTop(t)
+}
+
+/** Instant, animation-free jump to the previewed viewport top. */
+function scrollToPreviewTop(t: Terminal) {
+  const vp = (t as any)?._core?._viewport
+  if (typeof vp?.scrollToLine === 'function') {
+    vp.scrollToLine(jumpTopLine, true)
+  } else {
+    t.scrollToLine(jumpTopLine)
+  }
 }
 
 watch(
   () => props.sessionId,
   () => nextTick(bind),
   { immediate: false },
-)
-
-watch(
-  () => props.enabled,
-  (on) => {
-    if (!on) hide()
-  },
 )
 
 onMounted(() => nextTick(bind))
@@ -383,8 +477,13 @@ onBeforeUnmount(unbind)
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.35);
   padding: 2px 4px;
   box-sizing: content-box;
-  pointer-events: auto;
-  cursor: pointer;
+  /* Frosted glass: translucent background (inline, theme-tinted) + backdrop
+     blur so the content beneath the popup shows through, blurred. */
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  /* Display-only: never intercepts the mouse, so hovering/clicking near it
+     keeps working and the preview keeps refreshing underneath. */
+  pointer-events: none;
 }
 
 .preview-line {

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -359,8 +359,6 @@
   "settings.rightClickMenu": "Kontextmenü anzeigen",
   "settings.rightClickPaste": "Zwischenablage einfugen",
   "settings.maxHistory": "Max. Verlaufszeilen",
-  "settings.screenPreview": "Bildschirm-Vorschau",
-  "settings.screenPreviewDesc": "Zeigt beim Überfahren der Bildlaufleiste eine Vorschau des Verlaufs an; Klick springt zur Position",
   "settings.themeDesc": "Oberflächendesign auswählen",
   "settings.languageDesc": "Anzeigesprache wechseln",
   "settings.colorSchemeDesc": "Farbschema des Terminals",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -359,8 +359,6 @@
   "settings.rightClickMenu": "Show context menu",
   "settings.rightClickPaste": "Paste clipboard content",
   "settings.maxHistory": "Max History Lines",
-  "settings.screenPreview": "Screen Preview",
-  "settings.screenPreviewDesc": "Show a preview of history content when hovering over the terminal scrollbar",
   "settings.themeDesc": "Choose the interface theme",
   "settings.languageDesc": "Switch the display language",
   "settings.colorSchemeDesc": "Terminal color scheme",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -359,8 +359,6 @@
   "settings.rightClickMenu": "Mostrar menú contextual",
   "settings.rightClickPaste": "Pegar portapapeles",
   "settings.maxHistory": "Máximo de Líneas de Historial",
-  "settings.screenPreview": "Vista previa de pantalla",
-  "settings.screenPreviewDesc": "Muestra una vista previa del historial al pasar el ratón sobre la barra de desplazamiento; haga clic para saltar",
   "settings.themeDesc": "Elija el tema de la interfaz",
   "settings.languageDesc": "Cambiar el idioma de la interfaz",
   "settings.colorSchemeDesc": "Esquema de colores de la terminal",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -359,8 +359,6 @@
   "settings.rightClickMenu": "Afficher le menu contextuel",
   "settings.rightClickPaste": "Coller le presse-papiers",
   "settings.maxHistory": "Lignes d'historique max",
-  "settings.screenPreview": "Aperçu de l'écran",
-  "settings.screenPreviewDesc": "Affiche un aperçu de l'historique au survol de la barre de défilement ; cliquez pour y accéder",
   "settings.themeDesc": "Choisir le thème de l'interface",
   "settings.languageDesc": "Changer la langue d'affichage",
   "settings.colorSchemeDesc": "Palette de couleurs du terminal",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -359,8 +359,6 @@
   "settings.rightClickMenu": "コンテキストメニューを表示",
   "settings.rightClickPaste": "クリップボードを貼り付け",
   "settings.maxHistory": "履歴行数の上限",
-  "settings.screenPreview": "スクリーンプレビュー",
-  "settings.screenPreviewDesc": "スクロールバーにホバーするとその位置の履歴内容をプレビュー表示し、クリックでジャンプできます",
   "settings.themeDesc": "インターフェースのテーマを選択",
   "settings.languageDesc": "表示言語を切り替え",
   "settings.colorSchemeDesc": "ターミナルのカラースキーム",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -359,8 +359,6 @@
   "settings.rightClickMenu": "컨텍스트 메뉴 표시",
   "settings.rightClickPaste": "클립보드 붙여넣기",
   "settings.maxHistory": "최대 기록 줄 수",
-  "settings.screenPreview": "화면 미리보기",
-  "settings.screenPreviewDesc": "스크롤바에 마우스를 올리면 해당 위치의 기록 내용을 미리 보여주며, 클릭하면 이동합니다",
   "settings.themeDesc": "인터페이스 테마를 선택하세요",
   "settings.languageDesc": "표시 언어를 전환하세요",
   "settings.colorSchemeDesc": "터미널 색상 구성",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -359,8 +359,6 @@
   "settings.rightClickMenu": "Показать контекстное меню",
   "settings.rightClickPaste": "Вставить из буфера обмена",
   "settings.maxHistory": "Макс. строк истории",
-  "settings.screenPreview": "Просмотр экрана",
-  "settings.screenPreviewDesc": "Показывает предпросмотр истории при наведении на полосу прокрутки; клик выполняет переход",
   "settings.themeDesc": "Выберите тему интерфейса",
   "settings.languageDesc": "Переключить язык интерфейса",
   "settings.colorSchemeDesc": "Цветовая схема терминала",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -359,8 +359,6 @@
   "settings.rightClickMenu": "弹出右键菜单",
   "settings.rightClickPaste": "粘贴剪贴板中内容",
   "settings.maxHistory": "最大历史行数",
-  "settings.screenPreview": "屏幕回看",
-  "settings.screenPreviewDesc": "鼠标悬停终端滚动条时，弹出该位置的历史内容预览，点击可跳转",
   "settings.themeDesc": "选择界面主题风格",
   "settings.languageDesc": "切换界面显示语言",
   "settings.colorSchemeDesc": "终端窗口的配色方案",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -359,8 +359,6 @@
   "settings.rightClickMenu": "彈出右鍵選單",
   "settings.rightClickPaste": "貼上剪貼簿內容",
   "settings.maxHistory": "最大歷史行數",
-  "settings.screenPreview": "螢幕回看",
-  "settings.screenPreviewDesc": "滑鼠懸停終端機捲軸時，彈出該位置的歷史內容預覽，點擊可跳轉",
   "settings.themeDesc": "選擇介面主題風格",
   "settings.languageDesc": "切換介面顯示語言",
   "settings.colorSchemeDesc": "終端機視窗的配色方案",

--- a/frontend/src/services/screenPreview.test.ts
+++ b/frontend/src/services/screenPreview.test.ts
@@ -11,6 +11,9 @@ import {
   colorToCss,
   lineToRuns,
   computePreviewStart,
+  computePreviewWindowStart,
+  computeTrackClickRatio,
+  computeSliderHeight,
   pickVerticalTrackIndex,
   type PreviewPalette,
   type PreviewBufferCell,
@@ -254,6 +257,105 @@ describe('computePreviewStart', () => {
 
   it('returns 0 for buffers with no scroll room', () => {
     expect(computePreviewStart(0.5, 10, rows, previewRows)).toBe(0)
+  })
+})
+
+describe('computeTrackClickRatio', () => {
+  // Real-world geometry: 14px track, ~600px tall, VS Code's minimum slider
+  // size of 20px (long scrollback shrinks the slider to the floor).
+  const track = 600
+  const slider = 20
+
+  it('centers the slider on the click point, like ScrollbarState does', () => {
+    // offset 310 = slider top 300 + half slider: the slider's center lands on
+    // the click, so the fraction is exactly 300 / (600 - 20).
+    expect(computeTrackClickRatio(310, track, slider)).toBeCloseTo(300 / 580, 10)
+  })
+
+  it('does NOT use the naive full-track ratio (regression: preview vs click offset)', () => {
+    // Naive ratio at offset 150 would be 0.25; the slider-centered mapping
+    // gives (150 - 10) / 580 ≈ 0.2414. At 2500 lines of scrollback that
+    // difference is ~40 lines — more than a screen.
+    expect(computeTrackClickRatio(150, track, slider)).not.toBe(150 / track)
+    expect(computeTrackClickRatio(150, track, slider)).toBeCloseTo(140 / 580, 10)
+  })
+
+  it('clamps clicks that push the slider past its travel range', () => {
+    // 10px above the track top: slider top would be negative → clamp to 0.
+    expect(computeTrackClickRatio(5, track, slider)).toBe(0)
+    // 10px above the bottom: slider bottom would pass the track → clamp to 1.
+    expect(computeTrackClickRatio(595, track, slider)).toBe(1)
+  })
+
+  it('is monotonic across the track', () => {
+    const a = computeTrackClickRatio(100, track, slider)
+    const b = computeTrackClickRatio(300, track, slider)
+    const c = computeTrackClickRatio(500, track, slider)
+    expect(a).toBeLessThan(b)
+    expect(b).toBeLessThan(c)
+  })
+
+  it('returns 0 for degenerate geometry', () => {
+    expect(computeTrackClickRatio(300, 0, 20)).toBe(0)
+    expect(computeTrackClickRatio(300, 20, 20)).toBe(0) // no travel room
+    expect(computeTrackClickRatio(300, 600, 600)).toBe(0) // slider fills the track
+  })
+})
+
+describe('computeSliderHeight', () => {
+  it('replicates ScrollbarState: max(20, floor(viewport × track / scroll))', () => {
+    // 600px viewport+track, 50800px scroll (2540 lines × 20px cell) → 7 → min 20.
+    expect(computeSliderHeight(600, 600, 50800)).toBe(20)
+    // Short scrollback: 2000px viewport, 600px track, 2400px scroll → 500.
+    expect(computeSliderHeight(2000, 600, 2400)).toBe(500)
+  })
+
+  it('falls back to the 20px minimum for degenerate inputs', () => {
+    expect(computeSliderHeight(600, 600, 0)).toBe(20)
+    expect(computeSliderHeight(0, 0, 0)).toBe(20)
+  })
+})
+
+describe('preview ↔ scrollbar click consistency', () => {
+  // The contract: the popup is vertically centered on the pointer and its
+  // MIDDLE row previews the line that lands under the pointer after clicking
+  // the track at the same point — clickTop + the pointer's own viewport row
+  // (pointerFraction × rows), NOT always the screen's middle. Mirrors
+  // Viewport._handleScroll's round(scrollTop / cellHeight) on top of
+  // ScrollbarState's click mapping.
+  it('popup middle row equals the post-click line under the pointer', () => {
+    const total = 2540 // default 2500 scrollback + screen
+    const rows = 30
+    const previewRows = 10
+    const cellHeight = 20
+    const track = 600
+    const slider = 20
+
+    for (const offset of [0, 50, 150, 310, 450, 590, 600]) {
+      const pointerFraction = offset / track
+      const frac = computeTrackClickRatio(offset, track, slider)
+      const scrollTopPx = frac * (total - rows) * cellHeight
+      const clickTop = Math.round(scrollTopPx / cellHeight)
+      expect(computePreviewStart(frac, total, rows, previewRows)).toBe(clickTop)
+
+      const start = computePreviewWindowStart(clickTop, rows, pointerFraction, total, previewRows)
+      const unclamped =
+        clickTop + Math.round(pointerFraction * rows) - Math.floor(previewRows / 2)
+      expect(start).toBe(Math.min(Math.max(0, unclamped), total - previewRows))
+      expect(start + previewRows).toBeLessThanOrEqual(total)
+    }
+  })
+
+  it('keeps the preview window inside the buffer at the extremes', () => {
+    const total = 2540
+    const rows = 30
+    // Top of the track: anchor row would be negative → clamped to 0.
+    expect(computePreviewWindowStart(0, 30, 0, total, 10)).toBe(0)
+    // Bottom of the track with the pointer low: anchor overruns the buffer
+    // → clamped to the last previewRows lines.
+    expect(computePreviewWindowStart(total - rows, rows, 0.9, total, 10)).toBe(total - 10)
+    // A tiny buffer: pointerRow 6 → anchor 6-5=1, within the 5-row maxStart.
+    expect(computePreviewWindowStart(0, 12, 0.5, 15, 10)).toBe(1)
   })
 })
 

--- a/frontend/src/services/screenPreview.ts
+++ b/frontend/src/services/screenPreview.ts
@@ -67,7 +67,7 @@ export function buildPalette(theme?: Partial<ITheme>): PreviewPalette {
     'blue', 'magenta', 'cyan', 'white',
     'brightBlack', 'brightRed', 'brightGreen', 'brightYellow',
     'brightBlue', 'brightMagenta', 'brightCyan', 'brightWhite',
-  ].map((key) => theme?.[key] || FALLBACK_ANSI16.shift() || '#888888') as string[]
+  ].map((key, i) => theme?.[key] || FALLBACK_ANSI16[i] || '#888888') as string[]
   return {
     defaultFg: theme?.foreground || '#ffffff',
     defaultBg: theme?.background || '#000000',
@@ -162,9 +162,46 @@ function sameStyle(a: PreviewStyleRun, b: PreviewStyleRun): boolean {
 }
 
 /**
- * Map a scrollbar hover ratio (0 = top, 1 = bottom) to the first buffer row
- * the preview window should show. The window is clamped so that
- * `start + previewRows` never exceeds `totalLines`.
+ * Fraction (0..1) of the scrollable range that xterm v6's scrollbar actually
+ * produces when the track is clicked at `offset` px from the track's top.
+ *
+ * xterm v6 embeds VS Code's Scrollable widget, whose mapping is NOT the naive
+ * `offset / trackHeight` ratio over the full track: the slider travels only
+ * `trackHeight - sliderHeight` px and is *centered* on the click point
+ * (ScrollbarState.getDesiredScrollPositionFromOffset). Using the naive ratio
+ * made the hover preview disagree with the resulting scroll position by up to
+ * ~sliderHeight / (2 × track) of the whole scroll range — over a screen of
+ * content at default scrollback sizes.
+ */
+export function computeTrackClickRatio(
+  offset: number,
+  trackHeight: number,
+  sliderHeight: number,
+): number {
+  const travel = trackHeight - sliderHeight
+  if (travel <= 0) return 0
+  const r = (offset - sliderHeight / 2) / travel
+  return Math.min(1, Math.max(0, r))
+}
+
+/**
+ * Fallback slider height replicating ScrollbarState._computeValues: the
+ * slider is artificially enlarged to `max(20, viewport × track / scroll)` so
+ * it stays grabbable. Used only when the real `.slider` rect can't be read.
+ */
+export function computeSliderHeight(
+  viewportHeight: number,
+  trackHeight: number,
+  scrollHeight: number,
+): number {
+  if (scrollHeight <= 0) return 20
+  return Math.max(20, Math.floor((viewportHeight * trackHeight) / scrollHeight))
+}
+
+/**
+ * Map a scrollbar click-equivalent ratio (0 = top, 1 = bottom, as produced by
+ * `computeTrackClickRatio`) to the line that will sit at the viewport's TOP
+ * after the user clicks the track at that point.
  */
 export function computePreviewStart(
   ratio: number,
@@ -176,6 +213,28 @@ export function computePreviewStart(
   const maxScroll = Math.max(0, totalLines - rows)
   const maxStart = Math.max(0, totalLines - previewRows)
   return Math.min(Math.round(r * maxScroll), maxStart)
+}
+
+/**
+ * First buffer row the preview popup should show. The popup is vertically
+ * centered on the pointer, and its MIDDLE row previews the line that lands
+ * under the pointer after the click: that line is the viewport's top line
+ * plus the pointer's own row within the viewport (`pointerFraction × rows` —
+ * the pointer stays at its screen position while the content scrolls beneath
+ * it; it is NOT always the screen's middle row). Clamped so the window stays
+ * inside the buffer.
+ */
+export function computePreviewWindowStart(
+  clickTopLine: number,
+  rows: number,
+  pointerFraction: number,
+  totalLines: number,
+  previewRows: number,
+): number {
+  const pointerRow = Math.round(Math.min(1, Math.max(0, pointerFraction)) * rows)
+  const anchorRow = pointerRow - Math.floor(previewRows / 2)
+  const maxStart = Math.max(0, totalLines - previewRows)
+  return Math.min(Math.max(0, clickTopLine + anchorRow), maxStart)
 }
 
 /**

--- a/frontend/src/types/settings.ts
+++ b/frontend/src/types/settings.ts
@@ -68,9 +68,6 @@ export interface TerminalSettings {
   // #671) for scroll-sensitive mice; defaults to enabled.
   ctrlWheelZoom?: boolean
   maxHistoryLines: number
-  // Issue #729: WindTerm/Termora-style screen preview — hovering the terminal
-  // scrollbar pops up a read-only preview of the scrollback at that position.
-  screenPreview?: boolean
   smartCompletion: boolean
   aiTranscription: boolean
   highlightEnabled: boolean
@@ -261,7 +258,6 @@ export const DEFAULT_SETTINGS: AppSettings = {
     rightClickAction: 'menu',
     middleClickAction: 'paste',
     maxHistoryLines: 2500,
-    screenPreview: true,
     smartCompletion: true,
     aiTranscription: true,
     highlightEnabled: true,


### PR DESCRIPTION
## Summary

Fixes the terminal scrollbar hover preview (screen preview, issue #729): the previewed content did not match where a click landed, sometimes offset by more than a screen. Also reworks the preview interaction and visual styling.

### Root causes fixed

- **Wrong track mapping**: the preview mapped the hover offset linearly over the full scrollbar track (`offset / trackHeight`), but xterm v6 embeds VS Code's Scrollable widget, which centers the slider on the click point and travels only `trackHeight - sliderHeight`. The new `computeTrackClickRatio()` mirrors `ScrollbarState`'s formula exactly, so the preview shows exactly what a click at that point produces.
- **Wrong anchor semantics**: the line that lands under the pointer after a click is the viewport's top line plus the pointer's own viewport row (`pointerFraction x rows`) — not always the screen middle. `computePreviewWindowStart()` now anchors the popup's middle row to that line.

### Interaction rework

- The popup is display-only (`pointer-events: none`) and closes immediately when the pointer leaves the scrollbar area; the click-to-jump handling and the 150 ms hide grace period were removed.
- Clicking the scrollbar track while the popup is up is intercepted (capture phase, `preventDefault` + `stopPropagation`) and jumps instantly to the previewed position; holding and dragging keeps following the pointer. Without the popup, native xterm scrollbar behavior (including thumb dragging) is untouched.
- The preview is now always enabled: the `screenPreview` settings toggle, its settings card, and i18n strings (9 locales) were removed.

### Visual fixes

- Preview colors are read from xterm's resolved theme service colors instead of the raw `options.theme`, so highlights follow terminal theme switches; also fixed `FALLBACK_ANSI16` being destructively consumed via `shift()`.
- The popup container now carries the terminal's default foreground color, so default-colored cells no longer inherit the app UI's text color.
- Frosted-glass styling: translucent theme-tinted background (`rgba`, 0.7) with `backdrop-filter: blur(8px)`.

### Testing

- New unit tests in `screenPreview.test.ts`: slider-centering mapping vs naive ratio, `max(20, ...)` fallback slider size, and the popup/click consistency contract (first previewed line == post-click line under the pointer, clamping at buffer edges). Full suite: 289 passed.
- `vue-tsc` error set unchanged from baseline.

---

## 摘要

修复终端滚动条悬停预览（屏幕回看，issue #729）：预览内容与点击后落点不一致、有时偏移超过一屏的问题，并按反馈重做了交互与视觉样式。

### 修复的根因

- **轨道映射错误**：预览按整条轨道线性换算（`offset / trackHeight`），而 xterm v6 内嵌 VS Code Scrollable 组件，点击轨道时滑块中心对准点击点、行程只有 `trackHeight - sliderHeight`。新增 `computeTrackClickRatio()` 完全复刻 `ScrollbarState` 公式，预览内容与该点点击结果一致。
- **锚点语义错误**：点击后落在鼠标处的内容行 = 视口顶行 + 鼠标自身所在视口行（`pointerFraction x rows`），并非恒为屏幕中部。`computePreviewWindowStart()` 改为把弹窗中间行锚定到该行。

### 交互重做

- 预览框改为纯展示（`pointer-events: none`），鼠标离开滚动条区域立即关闭；移除点击预览框跳转逻辑与 150ms 关闭宽限。
- 预览可见时点击滚动条轨道会被捕获阶段拦截（`preventDefault` + `stopPropagation`），瞬时跳转到预览对应位置；按住拖动会连续跟随。预览不可见时 xterm 原生行为（含滑块拖动）不受影响。
- 预览功能常开：移除 `screenPreview` 配置项、设置界面卡片及 9 种语言的 i18n 文案。

### 视觉修复

- 配色改读 xterm theme service 解析后的实际渲染色（而非原始 `options.theme`），切换终端主题即时跟随；同时修复 `FALLBACK_ANSI16` 被 `shift()` 破坏性消耗的问题。
- 弹窗容器携带终端默认前景色，无显式颜色的文字不再继承应用 UI 文字色。
- 毛玻璃样式：主题色半透明背景（`rgba`，0.7）+ `backdrop-filter: blur(8px)`。

### 测试

- `screenPreview.test.ts` 新增单元测试：滑块居中映射与朴素比例的对比、`max(20, ...)` 兜底滑块高度、预览/点击一致性契约（预览首行 == 点击后鼠标处落点，含缓冲区边界钳制）。全量 289 通过。
- `vue-tsc` 错误集与基线保持一致。