### PR TITLE
feat(editor): unify code/YAML editors on shared CodeMirror component

### DIFF
--- a/frontend/src/components/ConnectionForm.vue
+++ b/frontend/src/components/ConnectionForm.vue
@@ -272,7 +272,12 @@
               </el-form-item>
 
               <el-form-item v-else :label="t('conn.k8sConfigInline')">
-                <el-input v-model="form.k8sConfigInline" type="textarea" :rows="6" placeholder="apiVersion: v1..." />
+                <SyntaxEditor
+                  :model-value="form.k8sConfigInline ?? ''"
+                  lang="yaml"
+                  class="kubeconfig-editor"
+                  @update:model-value="form.k8sConfigInline = $event"
+                />
               </el-form-item>
 
               <el-form-item :label="t('conn.k8sContext')">
@@ -637,6 +642,7 @@ import { ElInput } from 'element-plus'
 import { msg } from '../services/message'
 import { Plus, Trash2, ChevronDown, ChevronRight, FolderOpen, Eye, EyeOff, RefreshCw, Terminal, Monitor, Database, DatabaseZap, Layers, DatabaseSearch, SquareTerminal, Zap, Laptop, Cable, FolderUp, HardDrive, Cloud, Globe, MonitorCloud, MonitorSmartphone, Boxes, ShipWheel, AppWindow, ArrowLeftRight, CircleCheck, CircleX } from '@lucide/vue'
 import { listContexts } from '../services/k8sClient'
+import SyntaxEditor from './SyntaxEditor.vue'
 import type { K8sContextInfo } from '../types/k8s'
 import IdentityEditDialog from './IdentityEditDialog.vue'
 import ProxyEditDialog from './ProxyEditDialog.vue'
@@ -1583,6 +1589,11 @@ function onConnect() {
 </script>
 
 <style scoped>
+/* Inline kubeconfig YAML editor (replaces the former plain textarea). */
+.kubeconfig-editor {
+  height: 140px;
+  width: 100%;
+}
 /* Color the connection-test status icon (rendered via el-button's `icon` prop,
    so spacing matches the native loading spinner) by result. */
 .test-status-btn.test-success :deep(.el-icon) {

--- a/frontend/src/components/ElasticsearchTabContent.vue
+++ b/frontend/src/components/ElasticsearchTabContent.vue
@@ -92,11 +92,11 @@
               />
             </div>
             <div v-else class="query-editor-wrap">
-              <textarea
+              <SyntaxEditor
                 v-model="dslBody"
-                class="query-textarea"
-                :placeholder='`{\n  "query": { "match_all": {} }\n}`'
-                @keydown="onDslKeydown"
+                lang="json"
+                compact
+                @execute="runSearch"
               />
             </div>
             <div class="docs-actions">
@@ -125,7 +125,7 @@
                   border
                   size="small"
                   style="width:100%"
-                  highlight-current-row
+                  class="db-result-table"
                   :empty-text="t('db.noData')"
                   @row-click="onRowClick"
                   @row-dblclick="onRowDblClick"
@@ -139,7 +139,10 @@
                     show-overflow-tooltip
                   >
                     <template #default="{ row }">
-                      <span class="cell-value">{{ formatCellValue(row[col]) }}</span>
+                      <span
+                        class="cell-value"
+                        :class="{ 'cell-null': row[col] === null || row[col] === undefined }"
+                      >{{ formatCellValue(row[col]) }}</span>
                     </template>
                   </el-table-column>
                   <el-table-column width="80" fixed="right">
@@ -194,11 +197,11 @@
             <input v-model="restPath" class="rest-path" placeholder="/_cluster/health" @keydown.enter="runRest" />
             <button class="btn btn-primary btn-sm" @click="runRest" :disabled="restLoading">{{ t('es.send') }}</button>
           </div>
-          <textarea
+          <SyntaxEditor
             v-model="restBody"
+            lang="json"
             class="rest-body"
-            :placeholder="t('es.restBodyPlaceholder')"
-            :disabled="restMethod === 'GET' || restMethod === 'DELETE'"
+            :readonly="restMethod === 'GET' || restMethod === 'DELETE'"
           />
           <div class="rest-result">
             <div class="rest-status" v-if="restResult">HTTP {{ restResult.status }}</div>
@@ -232,7 +235,7 @@
           <el-input v-model="docEditId" :placeholder="t('es.documentIdAuto')" />
         </el-form-item>
       </el-form>
-      <textarea v-model="docEditText" class="doc-editor" spellcheck="false" />
+      <SyntaxEditor v-model="docEditText" lang="json" class="doc-editor" />
       <template #footer>
         <button class="btn btn-default" @click="docDialogVisible = false">{{ t('settings.cancel') }}</button>
         <button class="btn btn-primary" @click="saveDocument" :disabled="docSaving">{{ t('redis.save') }}</button>
@@ -246,7 +249,7 @@
           <el-input v-model="newIndexName" />
         </el-form-item>
         <el-form-item :label="t('es.indexBody')">
-          <textarea v-model="newIndexBody" class="doc-editor" style="min-height:160px" :placeholder='`{\n  "settings": { "number_of_shards": 1 }\n}`' />
+          <SyntaxEditor v-model="newIndexBody" lang="json" class="doc-editor index-body" />
         </el-form-item>
       </el-form>
       <template #footer>
@@ -263,6 +266,7 @@ import { useI18n } from '../i18n'
 import { msg } from '../services/message'
 import { ElMessageBox } from 'element-plus'
 import Menu from './Menu.vue'
+import SyntaxEditor from './SyntaxEditor.vue'
 import MenuItem from './MenuItem.vue'
 import MenuDivider from './MenuDivider.vue'
 import {
@@ -458,13 +462,6 @@ function onPageSizeChange(size: number) {
   pageSize.value = size
   pageFrom.value = 0
   runSearch()
-}
-
-function onDslKeydown(e: KeyboardEvent) {
-  if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
-    e.preventDefault()
-    runSearch()
-  }
 }
 
 function formatCellValue(v: unknown): string {
@@ -910,20 +907,6 @@ function onTopResizeStart(e: MouseEvent) {
 .query-mode-row { display: flex; }
 .simple-query { flex: 1; }
 .query-editor-wrap { flex: 1; min-height: 0; display: flex; }
-.query-textarea {
-  width: 100%;
-  height: 100%;
-  min-height: 60px;
-  font-family: var(--font-mono);
-  font-size: 12px;
-  padding: 8px;
-  border: 1px solid var(--border-subtle);
-  border-radius: var(--radius-sm);
-  background: var(--bg-base);
-  color: var(--text-primary);
-  resize: none;
-  outline: none;
-}
 .docs-actions {
   display: flex;
   align-items: center;
@@ -960,9 +943,24 @@ function onTopResizeStart(e: MouseEvent) {
   min-height: 0;
   overflow: auto;
 }
+/* 结果表格主题变量与 DBResultGrid 保持一致 */
+.db-result-table {
+  --el-table-header-bg-color: var(--bg-elevated, var(--bg-surface));
+  --el-table-tr-bg-color: var(--bg-surface);
+  --el-table-row-hover-bg-color: var(--bg-hover);
+  --el-table-border-color: var(--border-subtle);
+  --el-table-header-text-color: var(--text-secondary);
+  --el-table-text-color: var(--text-primary);
+  --el-table-bg-color: var(--bg-surface);
+  font-size: 12px;
+}
 .cell-value {
   font-family: var(--font-mono);
   font-size: 12px;
+}
+.cell-null {
+  color: var(--text-muted);
+  font-style: italic;
 }
 .pagination {
   padding-top: 8px;
@@ -1047,15 +1045,6 @@ function onTopResizeStart(e: MouseEvent) {
 }
 .rest-body {
   height: 140px;
-  font-family: var(--font-mono);
-  font-size: 12px;
-  padding: 8px;
-  border: 1px solid var(--border-subtle);
-  border-radius: var(--radius-sm);
-  background: var(--bg-base);
-  color: var(--text-primary);
-  resize: vertical;
-  outline: none;
   flex-shrink: 0;
 }
 .rest-result {
@@ -1076,16 +1065,10 @@ function onTopResizeStart(e: MouseEvent) {
 
 .doc-editor {
   width: 100%;
-  min-height: 280px;
-  font-family: var(--font-mono);
-  font-size: 13px;
-  padding: 10px;
-  border: 1px solid var(--border-subtle);
-  border-radius: var(--radius-sm);
-  background: var(--bg-base);
-  color: var(--text-primary);
-  resize: vertical;
-  outline: none;
+  height: 320px;
+}
+.doc-editor.index-body {
+  height: 180px;
 }
 
 </style>

--- a/frontend/src/components/K8sCreateDialog.vue
+++ b/frontend/src/components/K8sCreateDialog.vue
@@ -7,17 +7,7 @@
     :close-on-click-modal="false"
     destroy-on-close
   >
-    <div class="editor-container">
-      <div ref="lineNumbers" class="editor-line-numbers">{{ lineNumbersText }}</div>
-      <textarea
-        ref="textarea"
-        v-model="content"
-        class="editor-textarea"
-        spellcheck="false"
-        wrap="off"
-        @scroll="onScroll"
-      ></textarea>
-    </div>
+    <SyntaxEditor v-model="content" lang="yaml" />
     <div v-if="error" class="yaml-error">{{ error }}</div>
     <template #footer>
       <el-button @click="visible = false">{{ t('common.cancel') || '取消' }}</el-button>
@@ -30,6 +20,7 @@
 import { computed, ref, watch } from 'vue'
 import { ElDialog, ElButton } from 'element-plus'
 import { useI18n } from '../i18n'
+import SyntaxEditor from './SyntaxEditor.vue'
 
 const props = defineProps<{ modelValue: boolean; title: string; template: string; saving?: boolean; error?: string }>()
 const emit = defineEmits<{
@@ -44,21 +35,8 @@ const visible = computed({
   set: (v) => emit('update:modelValue', v),
 })
 const content = ref(props.template)
-const textarea = ref<HTMLTextAreaElement | null>(null)
-const lineNumbers = ref<HTMLDivElement | null>(null)
 
 watch(() => props.modelValue, (v) => { if (v) content.value = props.template })
-
-const lineNumbersText = computed(() => {
-  const count = (content.value.match(/\n/g) || []).length + 1
-  const lines: string[] = []
-  for (let i = 1; i <= count; i++) lines.push(String(i))
-  return lines.join('\n')
-})
-
-function onScroll() {
-  if (lineNumbers.value && textarea.value) lineNumbers.value.scrollTop = textarea.value.scrollTop
-}
 
 function onConfirm() {
   emit('confirm', content.value)
@@ -66,45 +44,5 @@ function onConfirm() {
 </script>
 
 <style scoped>
-.editor-container {
-  display: flex;
-  height: 55vh;
-  border: 1px solid var(--el-border-color);
-  border-radius: 4px;
-  overflow: hidden;
-}
-.editor-container:focus-within {
-  border-color: var(--el-color-primary);
-}
-.editor-line-numbers {
-  flex-shrink: 0;
-  min-width: 36px;
-  padding: 12px 8px 12px 12px;
-  font-family: 'Cascadia Code', 'Fira Code', 'JetBrains Mono', 'Consolas', 'Courier New', monospace;
-  font-size: 14px;
-  line-height: 24px;
-  color: var(--text-disabled);
-  background: var(--el-fill-color-light);
-  text-align: right;
-  overflow: hidden;
-  user-select: none;
-  white-space: pre;
-}
-.editor-textarea {
-  flex: 1;
-  font-family: 'Cascadia Code', 'Fira Code', 'JetBrains Mono', 'Consolas', 'Courier New', monospace;
-  font-size: 14px;
-  line-height: 24px;
-  background: var(--el-fill-color-blank);
-  color: var(--el-text-color-primary);
-  border: none;
-  padding: 12px;
-  white-space: pre;
-  overflow-x: auto;
-  resize: none;
-  outline: none;
-  overflow-y: auto;
-  tab-size: 2;
-}
 .yaml-error { color: var(--el-color-danger, #f56); padding: 8px 2px 0; font-size: 12px; }
 </style>

--- a/frontend/src/components/K8sDetailDrawer.vue
+++ b/frontend/src/components/K8sDetailDrawer.vue
@@ -45,7 +45,7 @@
           </template>
         </div>
         <pre v-if="!editing" class="k8s-yaml-drawer-body" @contextmenu="copyMenu.onContextMenu">{{ yamlText }}</pre>
-        <textarea v-else v-model="draft" class="k8s-yaml-drawer-body yaml-edit" spellcheck="false"></textarea>
+        <SyntaxEditor v-else v-model="draft" lang="yaml" compact />
         <div v-if="saveError" class="yaml-error">{{ saveError }}</div>
       </div>
     </template>
@@ -91,6 +91,7 @@ import { getResource, genericDetailSections, type DetailSection } from '../servi
 import { requestJSON, startLogStream, type LogHandle } from '../services/k8sClient'
 import { useI18n } from '../i18n'
 import Menu from './Menu.vue'
+import SyntaxEditor from './SyntaxEditor.vue'
 import { Clipboard } from '@wailsio/runtime'
 import MenuItem from './MenuItem.vue'
 
@@ -451,7 +452,6 @@ onBeforeUnmount(stopLogs)
 .detail-section-title { font-weight: 600; color: var(--text-secondary); margin: 8px 0 4px; }
 .yaml-pane { flex: 1; display: flex; flex-direction: column; overflow: hidden; }
 .yaml-actions { display: flex; gap: 8px; padding: 8px 12px; border-bottom: 1px solid var(--border-subtle); }
-.yaml-edit { width: 100%; box-sizing: border-box; resize: none; background: transparent; color: var(--text-primary); border: none; outline: none; }
 .yaml-error { color: var(--el-color-danger, #f56); padding: 8px 12px; font-size: 12px; }
 
 .detail-drawer.wide { width: 640px; }

--- a/frontend/src/components/MongoDBCollectionView.vue
+++ b/frontend/src/components/MongoDBCollectionView.vue
@@ -30,12 +30,11 @@
           </div>
           <div class="query-panel">
             <div class="query-editor-wrap">
-              <textarea
-                ref="queryTextareaRef"
+              <SyntaxEditor
                 v-model="filterText"
-                class="query-textarea"
-                :placeholder="t('mongodb.filter')"
-                @keydown="onQueryKeydown"
+                lang="json"
+                compact
+                @execute="executeQuery"
               />
               <div class="exec-btn-wrapper">
                 <button class="btn btn-primary exec-btn-overlay" @click="executeQuery">
@@ -73,8 +72,9 @@
               border
               size="small"
               style="width:100%"
+              class="db-result-table"
               :empty-text="t('db.noData')"
-              @row-dblclick="onRowDblClick"
+              @row-click="onRowClick"
             >
               <el-table-column
                 v-for="col in columns"
@@ -85,15 +85,18 @@
                 show-overflow-tooltip
               >
                 <template #default="{ row }">
-                  <span class="cell-value">{{ formatCellValue(row[col]) }}</span>
+                  <span
+                    class="cell-value"
+                    :class="{ 'cell-null': row[col] === null || row[col] === undefined }"
+                  >{{ formatCellValue(row[col]) }}</span>
                 </template>
               </el-table-column>
               <el-table-column width="80" fixed="right">
                 <template #default="{ row }">
-                  <button class="btn btn-ghost btn-icon btn-sm" style="color:var(--text-secondary)" @click="onRowDblClick(row)">
+                  <button class="btn btn-ghost btn-icon btn-sm" style="color:var(--text-secondary)" @click.stop="onRowClick(row)">
                     <Pencil :size="14" />
                   </button>
-                  <button class="btn btn-ghost btn-icon btn-sm" style="color:var(--error)" @click="deleteDocument(row)">
+                  <button class="btn btn-ghost btn-icon btn-sm" style="color:var(--error)" @click.stop="deleteDocument(row)">
                     <Trash2 :size="14" />
                   </button>
                 </template>
@@ -184,11 +187,10 @@
       :title="docDialogMode === 'insert' ? t('mongodb.newDocument') : t('mongodb.editDocument')"
       width="600px"
     >
-      <textarea
+      <SyntaxEditor
         v-model="docEditorText"
-        class="doc-editor-textarea"
-        placeholder="{}"
-        rows="14"
+        lang="json"
+        class="doc-editor"
       />
       <div v-if="docEditorError" class="error-msg" style="margin-top:8px">{{ docEditorError }}</div>
       <template #footer>
@@ -218,6 +220,7 @@ import {
   MongoDropIndex,
 } from '../../bindings/github.com/ys-ll/uniterm/app'
 import type { MongoIndexInfo, MongoQueryResult } from '../types/mongodb'
+import SyntaxEditor from './SyntaxEditor.vue'
 
 defineOptions({ name: 'MongoDBCollectionView' })
 
@@ -264,7 +267,6 @@ const queryLoading = ref(false)
 const queryError = ref('')
 const queryResult = ref<MongoQueryResult | null>(null)
 const currentSkip = ref(0)
-const queryTextareaRef = ref<HTMLTextAreaElement | null>(null)
 
 const totalDocs = computed(() => queryResult.value?.total || 0)
 
@@ -309,13 +311,6 @@ const docSaving = ref(false)
 const editingRow = ref<any>(null)
 
 // ── Query methods ──
-function onQueryKeydown(e: KeyboardEvent) {
-  if (e.ctrlKey && e.key === 'Enter') {
-    e.preventDefault()
-    executeQuery()
-  }
-}
-
 function onNLKeydown(e: KeyboardEvent) {
   if (e.ctrlKey && e.key === 'Enter') {
     e.preventDefault()
@@ -405,7 +400,7 @@ function openNewDocument() {
   docDialogVisible.value = true
 }
 
-function onRowDblClick(row: any) {
+function onRowClick(row: any) {
   docDialogMode.value = 'edit'
   docEditorText.value = JSON.stringify(row, null, 2)
   docEditorError.value = ''
@@ -645,23 +640,9 @@ watch(() => [props.dbName, props.collectionName], () => {
   flex: 1;
   display: flex;
 }
-.query-textarea {
-  flex: 1;
-  width: 100%;
-  font-family: var(--font-mono);
-  font-size: 13px;
-  line-height: 1.5;
-  background: var(--bg-base);
-  color: var(--text-primary);
-  border: 1px solid var(--border-subtle);
-  border-radius: var(--radius-sm);
-  padding: 8px 80px 36px 8px;
-  resize: none;
-  transition: border-color 0.15s ease;
-}
-.query-textarea:focus {
-  border-color: var(--accent);
-  outline: none;
+/* Keep query text clear of the overlaying execute button */
+.query-editor-wrap :deep(.cm-content) {
+  padding-bottom: 44px;
 }
 .exec-btn-wrapper {
   position: absolute;
@@ -761,10 +742,26 @@ watch(() => [props.dbName, props.collectionName], () => {
   overflow: auto;
   min-height: 0;
 }
+/* 结果表格主题变量与 DBResultGrid 保持一致 */
+.db-result-table {
+  --el-table-header-bg-color: var(--bg-elevated, var(--bg-surface));
+  --el-table-tr-bg-color: var(--bg-surface);
+  --el-table-row-hover-bg-color: var(--bg-hover);
+  --el-table-border-color: var(--border-subtle);
+  --el-table-header-text-color: var(--text-secondary);
+  --el-table-text-color: var(--text-primary);
+  --el-table-bg-color: var(--bg-surface);
+  font-size: 12px;
+}
 .cell-value {
+  font-family: var(--font-mono, monospace);
   font-size: 12px;
   word-break: break-all;
   cursor: default;
+}
+.cell-null {
+  color: var(--text-muted);
+  font-style: italic;
 }
 .pagination {
   display: flex;
@@ -804,20 +801,7 @@ watch(() => [props.dbName, props.collectionName], () => {
   font-size: 14px;
 }
 
-.doc-editor-textarea {
-  width: 100%;
-  font-family: var(--font-mono);
-  font-size: 13px;
-  line-height: 1.5;
-  background: var(--bg-base);
-  color: var(--text-primary);
-  border: 1px solid var(--border-subtle);
-  border-radius: var(--radius-sm);
-  padding: 8px;
-  resize: vertical;
-}
-.doc-editor-textarea:focus {
-  border-color: var(--accent);
-  outline: none;
+.doc-editor {
+  height: 320px;
 }
 </style>

--- a/frontend/src/components/SyntaxEditor.vue
+++ b/frontend/src/components/SyntaxEditor.vue
@@ -1,9 +1,9 @@
 <template>
-  <div ref="hostRef" class="syntax-editor" :class="{ compact }" />
+  <div ref="hostRef" class="syntax-editor" :class="{ compact, 'theme-dark': isDark }" />
 </template>
 
 <script setup lang="ts">
-import { ref, watch, onMounted, onBeforeUnmount, nextTick } from 'vue'
+import { ref, computed, watch, onMounted, onBeforeUnmount, nextTick } from 'vue'
 import { EditorState } from '@codemirror/state'
 import { EditorView, keymap, lineNumbers, highlightActiveLine, highlightActiveLineGutter, drawSelection } from '@codemirror/view'
 import { defaultKeymap, history, historyKeymap, indentWithTab } from '@codemirror/commands'
@@ -27,6 +27,7 @@ import { clike } from '@codemirror/legacy-modes/mode/clike'
 import { go } from '@codemirror/legacy-modes/mode/go'
 import { rust } from '@codemirror/legacy-modes/mode/rust'
 import { ruby } from '@codemirror/legacy-modes/mode/ruby'
+import { useSettingsStore } from '../stores/settingsStore'
 
 const props = defineProps<{
   modelValue: string
@@ -34,6 +35,7 @@ const props = defineProps<{
   compact?: boolean
   lang?: string
   wrap?: boolean
+  readonly?: boolean
 }>()
 
 const emit = defineEmits<{
@@ -45,6 +47,10 @@ const hostRef = ref<HTMLElement | null>(null)
 let view: EditorView | null = null
 let applyingExternal = false
 let resizeObserver: ResizeObserver | null = null
+
+// Follow the app theme (dark/deep-blue → dark, light/system → resolved).
+const settingsStore = useSettingsStore()
+const isDark = computed(() => settingsStore.resolvedAppTheme === 'dark')
 
 function extOf(path: string): string {
   const base = path.replace(/\\/g, '/').split('/').pop() || ''
@@ -163,8 +169,12 @@ function buildExtensions(path: string) {
     history(),
     foldGutter(),
     bracketMatching(),
+    // Dark: One Dark tokens; light: defaultHighlightStyle (light-tuned) takes
+    // over as the active highlighter via the fallback chain.
     syntaxHighlighting(defaultHighlightStyle, { fallback: true }),
-    oneDark,
+    ...(isDark.value ? [oneDark] : []),
+    EditorState.readOnly.of(!!props.readonly),
+    EditorView.editable.of(!props.readonly),
     props.lang ? languageFor(props.lang) : languageExtension(path),
     keymap.of([
       {
@@ -252,7 +262,16 @@ watch(() => props.modelValue, (v) => {
   setDoc(v ?? '')
 })
 
-watch(() => [props.filePath, props.lang, props.wrap], async () => {
+watch(() => [props.filePath, props.lang, props.wrap, props.readonly], async () => {
+  const text = view?.state.doc.toString() ?? props.modelValue
+  await nextTick()
+  createEditor()
+  if (text !== props.modelValue) setDoc(text)
+})
+
+// Theme swap needs a full rebuild: oneDark vs defaultHighlightStyle are
+// different extension sets, and EditorState extensions are immutable.
+watch(isDark, async () => {
   const text = view?.state.doc.toString() ?? props.modelValue
   await nextTick()
   createEditor()
@@ -295,8 +314,14 @@ defineExpose({
   border: 1px solid var(--border-subtle);
   border-radius: 4px;
   overflow: hidden;
-  background: #282c34;
+  background: var(--bg-base);
+  color: var(--text-primary);
   box-sizing: border-box;
+}
+/* Keep the container background in sync with the active CodeMirror theme. */
+.syntax-editor.theme-dark {
+  background: #282c34;
+  color: #abb2bf;
 }
 .syntax-editor.compact {
   height: 100%;


### PR DESCRIPTION
## Summary

- Replace the remaining code/YAML textareas with the shared SyntaxEditor (CodeMirror) component — the same one used by the SFTP built-in file editor:
  - MongoDB query editor and document dialogs
  - Elasticsearch DSL query, REST body, document dialog, new-index dialog
  - K8s create-resource dialog and YAML detail drawer (edit mode)
  - Connection form inline kubeconfig
- SyntaxEditor now follows the app theme (dark/light) instead of a fixed dark palette; the editor is rebuilt on theme switch to swap the CodeMirror highlight theme
- Add `readonly` prop support (used by ES REST body for GET/DELETE)
- MongoDB result list: open the document editor on single row click, matching the DB tab behavior
- Mongo/ES result tables: align cell/table styling with DBResultGrid (theme CSS variables, monospace cells, italic muted nulls); removed the ES row highlight to stay consistent

## Test

- `npm run build` passes
- Verified Mongo flows against a local Docker MongoDB (query, single-click edit, doc dialogs)
- Visual check of dark/light theme switching across DB / Mongo / ES / K8s editors

## 说明（中文）

- 将剩余的代码/YAML 输入框统一替换为 SFTP 内置文件编辑器使用的 CodeMirror 组件（SyntaxEditor）：Mongo 查询与文档弹窗、ES DSL/REST/文档/新建索引弹窗、K8s 新建资源弹窗与 YAML 详情抽屉、连接表单内联 kubeconfig
- SyntaxEditor 跟随应用主题（深色/浅色）切换，切换时重建编辑器以更换高亮主题
- 新增 readonly 属性（ES REST 的 GET/DELETE 请求体只读）
- Mongo 结果列表改为单击行打开编辑窗口，与数据库 tab 一致
- Mongo/ES 数据表格样式与数据库 tab 的 DBResultGrid 对齐（主题变量、等宽字体、null 斜体弱化），并去掉 ES 的行选中高亮