### PR TITLE
feat(terminal): fixed logical-line numbers/timestamps in gutter; layout and persistence fixes

### DIFF
--- a/backend/store/settings_store.go
+++ b/backend/store/settings_store.go
@@ -44,6 +44,29 @@ type TerminalSettings struct {
 	// separators. Empty means the frontend falls back to its built-in
 	// default. Mirrors the `wordSeparator` Terminal option.
 	WordSeparator string `json:"wordSeparator,omitempty"`
+	// FallbackFont is the secondary font family for glyphs the primary font
+	// lacks (most useful for CJK). Empty means no explicit fallback.
+	FallbackFont string `json:"fallbackFont,omitempty"`
+	// FontWeight is the CSS weight of regular terminal text. Pointer +
+	// omitempty so older settings.json files still load; the frontend
+	// defaults to 400 when nil.
+	FontWeight *int `json:"fontWeight,omitempty"`
+	// CursorStyle is the focused-terminal cursor shape (block/underline/bar).
+	// Empty means the frontend falls back to `block`.
+	CursorStyle string `json:"cursorStyle,omitempty"`
+	// MinimumContrast is xterm's text/background contrast boost (1 = off).
+	// Pointer + omitempty so older settings.json files still load; the
+	// frontend defaults to 4.5 when nil.
+	MinimumContrast *float64 `json:"minimumContrast,omitempty"`
+	// ShowLineNumbers / ShowTimestamps toggle the gutter columns in front of
+	// the terminal. Pointer + omitempty so settings.json written by older
+	// builds (which lack these fields) still loads; the frontend defaults
+	// to false when nil.
+	ShowLineNumbers *bool `json:"showLineNumbers,omitempty"`
+	ShowTimestamps  *bool `json:"showTimestamps,omitempty"`
+	// TimestampFormat renders the gutter time column (e.g. "HH:mm:ss").
+	// Empty means the frontend falls back to its built-in default.
+	TimestampFormat string `json:"timestampFormat,omitempty"`
 }
 
 // TerminalThemeColors mirrors xterm.js's ITheme shape: the 4 base colors
@@ -96,6 +119,9 @@ type AIModelConfig struct {
 	BaseURL  string `json:"baseURL"`
 	Model    string `json:"model"`
 	Protocol string `json:"protocol"`
+	// UserAgent overrides the HTTP User-Agent for this model's API calls.
+	// Empty means the frontend/protocol default.
+	UserAgent string `json:"userAgent,omitempty"`
 }
 
 type AISettings struct {

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -338,6 +338,13 @@ async function checkCredentials() {
   credStore.watchEvents()
   await credStore.loadDataDir()
   await credStore.loadStatus()
+  // Backend unreachable (wails3 dev browser preview): every binding call
+  // rejects and the placeholder status would wrongly pop the encryption
+  // dialog. Skip the whole credential flow so the UI renders for debugging.
+  if (!credStore.backendAvailable) {
+    console.warn('[uniTerm] Backend unreachable — browser debug mode: credential flow skipped')
+    return
+  }
   if (credStore.firstRun || credStore.dataDirInfo.firstRun) {
     dataDirVisible.value = true
     return

--- a/frontend/src/components/BaseTerminal.vue
+++ b/frontend/src/components/BaseTerminal.vue
@@ -10,6 +10,7 @@
   >
     <div class="terminal-area" @contextmenu="onTerminalContextMenu">
       <TerminalGutter
+        ref="gutterRef"
         :session-id="props.sessionId"
         :show-line-numbers="showLineNumbers"
         :show-timestamps="showTimestamps"
@@ -87,6 +88,16 @@
       <MenuItem v-if="isSsh" @click="openMonitor">{{ t('sidebar.connectMonitor') }}</MenuItem>
     </Menu>
 
+    <!-- Gutter context menu — right-click on the line-number/time columns -->
+    <Menu ref="gutterMenuRef" v-model:visible="gutterMenuVisible" root-class="right-shortcuts">
+      <MenuItem :shortcut="menuShortcut('toggleLineNumbers')" @click="toggleLineNumbers">
+        {{ showLineNumbers ? t('settings.hideLineNumbers') : t('settings.showLineNumbers') }}
+      </MenuItem>
+      <MenuItem :shortcut="menuShortcut('toggleTimestamps')" @click="toggleTimestamps">
+        {{ showTimestamps ? t('settings.hideTimestamps') : t('settings.showTimestamps') }}
+      </MenuItem>
+    </Menu>
+
     <!-- Terminal suggestions popup -->
     <TerminalSuggestion
       :visible="suggestions.state.value.visible"
@@ -153,7 +164,7 @@ import { useSuggestions, quickCommandCache } from '../composables/useSuggestions
 import TerminalSuggestion from './TerminalSuggestion.vue'
 import TerminalGutter from './TerminalGutter.vue'
 import { startZmodemService } from '../services/zmodemService'
-import { stampWrittenLines, stampCommandLine, currentAbsoluteLine } from '../services/terminalTimestamps'
+import { recordWrite, stampCommandLine, currentAbsoluteLine } from '../services/terminalTimestamps'
 import { useZmodemStore } from '../stores/zmodemStore'
 import ZmodemTransfer from './ZmodemTransfer.vue'
 import TerminalScreenPreview from './TerminalScreenPreview.vue'
@@ -207,9 +218,11 @@ const showLineNumbers = computed(() => settingsStore.settings.terminal.showLineN
 // Whether the timestamp column is enabled (from the persistent setting).
 const showTimestamps = computed(() => settingsStore.settings.terminal.showTimestamps ?? false)
 
-// Write terminal data and stamp the rows it writes with their arrival time for
-// the timestamp column. Capture the cursor line before the write and stamp up
-// to where it ends after xterm finishes parsing (no-op when timestamps are off).
+// Write terminal data and fold it into the logical-line registry for the
+// gutter's number/time columns: lines that just received characters get the
+// next sequential number and the arrival time; lines the cursor moved past
+// get their timestamp fixed to the completion time. `before` is an absolute
+// row index, so a trim inside the write doesn't skew the band.
 function writeStamped(data: string) {
   const t = terminal
   const sid = props.sessionId
@@ -217,7 +230,7 @@ function writeStamped(data: string) {
   const ts = Date.now()
   const before = currentAbsoluteLine(sid)
   t.write(data, () => {
-    stampWrittenLines(sid, before, currentAbsoluteLine(sid), ts)
+    recordWrite(sid, before, ts)
   })
 }
 
@@ -229,11 +242,13 @@ function getTerminalHost(): HTMLElement | null {
 
 function toggleLineNumbers() {
   menu.closeMenu()
+  gutterMenuVisible.value = false
   settingsStore.updateTerminal({ showLineNumbers: !showLineNumbers.value })
 }
 
 function toggleTimestamps() {
   menu.closeMenu()
+  gutterMenuVisible.value = false
   settingsStore.updateTerminal({ showTimestamps: !showTimestamps.value })
 }
 
@@ -273,6 +288,10 @@ let onTerminalCopy: ((e: Event) => void) | null = null
 let onTerminalPaste: ((e: Event) => void) | null = null
 
 let resizeTimer: ReturnType<typeof setTimeout> | null = null
+// Trailing resize for size changes observed while a resize gate (window
+// resize debounce / split drag / suppress window) was active. Separate from
+// resizeTimer so it never cancels another handler's pending resize.
+let deferredResizeTimer: ReturnType<typeof setTimeout> | null = null
 let unsubNativeResizeEnd: (() => void) | null = null
 let isResizing = false
 let splitResizing = false
@@ -531,6 +550,13 @@ function resize() {
     // Skip resize when the component is hidden (e.g. during tab switching
     // with KeepAlive). A zero-size resize would corrupt xterm.js buffers.
     if (rect.width === 0 || rect.height === 0) return
+
+    // Heal any stale scroll offset on the host: a focus()-driven auto-scroll
+    // during a resize transition can leave it scrolled (content displaced
+    // upward, blank space below). The host is never scrolled deliberately.
+    if (el.scrollTop !== 0) {
+      el.scrollTop = 0
+    }
 
     // Always fit first to update CSS dimensions on the .xterm element.
     // Without this, stale inline pixel dimensions from a previous fit()
@@ -1440,7 +1466,21 @@ onMounted(() => {
   bindListeners()
 
   resizeObserver = new ResizeObserver(() => {
-    if (isResizing || splitResizing || Date.now() < suppressResizeUntil) return
+    // A size change landing inside a resize gate must not be dropped: if it
+    // were the last event (e.g. maximize/restore right after a split-drag),
+    // the terminal would keep its old pixel size — blank space below — with
+    // no further trigger. Park a trailing resize that runs once the gate
+    // clears; harmless if another handler (window debounce, native resize
+    // end) already fits at the settled size.
+    if (isResizing || splitResizing || Date.now() < suppressResizeUntil) {
+      if (deferredResizeTimer) clearTimeout(deferredResizeTimer)
+      deferredResizeTimer = setTimeout(() => {
+        deferredResizeTimer = null
+        if (isResizing || splitResizing || Date.now() < suppressResizeUntil) return
+        resize()
+      }, Math.max(0, suppressResizeUntil - Date.now()) + 150)
+      return
+    }
     const el = terminalRef.value
     if (!el) return
     if (resizeTimer) clearTimeout(resizeTimer)
@@ -1729,6 +1769,10 @@ onUnmounted(() => {
   nativeDrop.unbind()
   resizeObserver?.disconnect()
   intersectionObserver?.disconnect()
+  if (deferredResizeTimer) {
+    clearTimeout(deferredResizeTimer)
+    deferredResizeTimer = null
+  }
 
   // Dispose per-component listeners BEFORE releasing terminal.
   // The terminal instance may outlive this component if another
@@ -1859,6 +1903,19 @@ async function refreshOutputLogState() {
 }
 
 function onTerminalContextMenu(e: MouseEvent) {
+  // Right-click on the gutter (line-number/time columns) opens the gutter
+  // toggle menu instead of the terminal menu. The gutter itself is
+  // pointer-events: none, so the event surfaces on .terminal-area and is
+  // routed here by hit-testing the click position against the gutter rect.
+  if (showLineNumbers.value || showTimestamps.value) {
+    const g = gutterRef.value?.$el as HTMLElement | null
+    const r = g?.getBoundingClientRect()
+    if (r && e.clientX >= r.left && e.clientX <= r.right && e.clientY >= r.top && e.clientY <= r.bottom) {
+      e.preventDefault()
+      gutterMenuRef.value?.openAt(e.clientX, e.clientY)
+      return
+    }
+  }
   if (supportsOutputLog.value) {
     refreshOutputLogState()
   }
@@ -1930,6 +1987,11 @@ function openMonitor() {
 }
 
 const terminalMenuRef = ref<InstanceType<typeof Menu> | null>(null)
+// Gutter context menu (right-click on the line-number/time columns) and the
+// gutter component ref, for hit-testing where a right-click landed.
+const gutterMenuRef = ref<InstanceType<typeof Menu> | null>(null)
+const gutterMenuVisible = ref(false)
+const gutterRef = ref<{ $el: HTMLElement } | null>(null)
 const menu = useTerminalMenu({
   getSelection,
   openAt: (x, y) => terminalMenuRef.value?.openAt(x, y),
@@ -1986,7 +2048,12 @@ defineExpose({
   flex: 1;
   min-width: 0;
   min-height: 0;
-  overflow: hidden;
+  /* `clip` (not `hidden`): a hidden box is still programmatically scrollable,
+   * so a focus()-driven auto-scroll during a resize transition could leave a
+   * stale scrollTop here and shove the whole .xterm up, leaving blank space
+   * below (it is never scrolled deliberately — xterm scrolls its own layers).
+   * `clip` makes the box a non-scroll-container, so the offset cannot exist. */
+  overflow: clip;
   position: relative;
 }
 

--- a/frontend/src/components/TerminalGutter.vue
+++ b/frontend/src/components/TerminalGutter.vue
@@ -163,18 +163,13 @@ function compute() {
     : 0
 
   const viewport = Math.max(0, Math.min(buf.baseY, currentViewportY))
-  const lineOffset = buf.type === 'alternate' ? 0 : (managed?.lineOffset ?? 0)
+  const alternate = buf.type === 'alternate'
+  const lineOffset = alternate ? 0 : (managed?.lineOffset ?? 0)
   const theme = t.options.theme ?? {}
   const fg = theme?.foreground
 
-  const maxDigits = String(Math.max(lineOffset + buf.baseY + 1, 1)).length
   const tsFormat = settingsStore.settings.terminal.timestampFormat || 'HH:mm:ss'
-  const timeWidth = props.showTimestamps
-    ? Math.ceil(cellWidth * formatTimestampMs(TIMESTAMP_WIDTH_SAMPLE_MS, tsFormat).length) + 2
-    : 0
-  const numWidth = props.showLineNumbers
-    ? Math.max(Math.ceil(cellWidth * maxDigits) + 8, 24)
-    : 0
+  const registry = managed?.lineRegistry
 
   const result = buildGutterLines({
     rows: t.rows,
@@ -183,9 +178,23 @@ function compute() {
     showTimestamps: props.showTimestamps,
     cursorAbsoluteY: buf.baseY + buf.cursorY,
     getLine: (n) => buf.getLine(n),
-    getTimestamp: (abs) => (managed && buf.type !== 'alternate' ? managed.lineTimestamps.get(abs) : undefined),
+    getMeta: (abs) => {
+      // Alternate screen lines are transient — fall back to per-screen
+      // positional numbers, no timestamps.
+      if (alternate) return { number: abs + 1 }
+      return registry?.entries.get(abs)
+    },
+    maxNumberHint: registry && !alternate ? registry.nextNumber - 1 : 0,
     formatTimestamp: (ms) => formatTimestampMs(ms, tsFormat),
   })
+
+  const maxDigits = String(Math.max(result.maxLineNumber, 1)).length
+  const timeWidth = props.showTimestamps
+    ? Math.ceil(cellWidth * formatTimestampMs(TIMESTAMP_WIDTH_SAMPLE_MS, tsFormat).length) + 2
+    : 0
+  const numWidth = props.showLineNumbers
+    ? Math.max(Math.ceil(cellWidth * maxDigits) + 8, 24)
+    : 0
 
   layout.value = {
     lines: result.lines,

--- a/frontend/src/components/TerminalScreenPreview.vue
+++ b/frontend/src/components/TerminalScreenPreview.vue
@@ -13,12 +13,12 @@
       <span
         v-if="showTimestamps"
         class="preview-col-time"
-        :style="{ width: timeColWidth }"
+        :style="{ width: timeColWidth, color: timeColor, borderRight: dividerOnTime ? dividerCss : undefined }"
       >{{ row.timestamp }}&nbsp;</span>
       <span
         v-if="showLineNumbers"
         class="preview-col-num"
-        :style="{ width: numColWidth }"
+        :style="{ width: numColWidth, color: numColor, marginRight: numColGap, borderRight: dividerOnNum ? dividerCss : undefined }"
       >{{ row.lineNumber }}</span>
       <span class="preview-content">
         <template v-if="row.runs.length">
@@ -44,7 +44,7 @@ import { ref, computed, watch, nextTick, onMounted, onBeforeUnmount } from 'vue'
 import type { Terminal } from '@xterm/xterm'
 import { getManagedTerminal } from '../services/terminalManager'
 import { useSettingsStore } from '../stores/settingsStore'
-import { formatTimestampMs, resolveRowTimestamp } from '../utils/terminalGutter'
+import { formatTimestampMs, resolveRowMeta } from '../utils/terminalGutter'
 import {
   buildPalette,
   lineToRuns,
@@ -80,6 +80,18 @@ const fgColor = ref('#cccccc')
 const fontCss = ref({ fontSize: '13px', fontFamily: 'monospace' })
 const numColWidth = ref('')
 const timeColWidth = ref('')
+// Gutter-mirroring colors: same alphas the main gutter uses (time 0.85,
+// number 0.6, divider 0.16 of the terminal foreground) so the preview's
+// columns read exactly like the terminal's.
+const timeColor = ref('')
+const numColor = ref('')
+const dividerColor = ref('')
+const numColGap = ref('')
+const dividerCss = computed(() => `1px solid ${dividerColor.value}`)
+// The divider sits after the LAST gutter column (number, when numbers are
+// shown; otherwise the time column).
+const dividerOnNum = computed(() => showLineNumbers.value)
+const dividerOnTime = computed(() => showTimestamps.value && !showLineNumbers.value)
 
 const popupStyle = computed(() => ({
   left: `${pos.value.left}px`,
@@ -308,6 +320,10 @@ function show(t: Terminal, sbRect: DOMRect) {
   const withNumbers = showLineNumbers.value
   const withTimestamps = showTimestamps.value && managed
   const tsFormat = settingsStore.settings.terminal.timestampFormat || 'HH:mm:ss'
+  const alternate = buf.type === 'alternate'
+  const registry = managed?.lineRegistry
+  const getMeta = (abs: number) =>
+    alternate ? { number: abs + 1 } : registry?.entries.get(abs)
 
   const rendered: Array<{ runs: PreviewStyleRun[]; lineNumber: string; timestamp: string }> = []
   for (let i = 0; i < PREVIEW_ROWS; i++) {
@@ -315,49 +331,54 @@ function show(t: Terminal, sbRect: DOMRect) {
     const line = buf.getLine(bufferLine)
     const isWrapped = line?.isWrapped ?? false
     const runs = line ? lineToRuns(line, t.cols, palette) : []
-    // Mirror the gutter's semantics: wrapped continuation rows belong to the
-    // line above, so they carry no number/timestamp of their own.
+    // Mirror the gutter's semantics: numbers/timestamps come from the logical
+    // line registry; wrapped continuation rows belong to the line above, so
+    // they carry no number/timestamp of their own.
     const numbered = withNumbers && !isWrapped
     const stamped = withTimestamps && !isWrapped
+    const meta = (numbered || stamped) && managed
+      ? resolveRowMeta(bufferLine, lineOffset, (y) => buf.getLine(y), getMeta)
+      : undefined
     rendered.push({
       runs,
-      lineNumber: numbered ? String(lineOffset + bufferLine + 1) : '',
-      timestamp: stamped
-        ? (() => {
-            const ts = managed
-              ? resolveRowTimestamp(
-                  bufferLine,
-                  lineOffset,
-                  (y) => buf.getLine(y),
-                  (abs) => managed.lineTimestamps.get(abs),
-                )
-              : undefined
-            return ts ? formatTimestampMs(ts, tsFormat) : ''
-          })()
-        : '',
+      lineNumber: numbered && meta ? String(meta.number) : '',
+      timestamp: stamped && meta?.ts ? formatTimestampMs(meta.ts, tsFormat) : '',
     })
   }
   lines.value = rendered
   // Resolved (not raw-option) colors — same source the cells were styled from.
   bgColor.value = palette.defaultBg
   fgColor.value = palette.defaultFg
+  // Mirror the gutter's column palette (TerminalGutter.vue): same alphas of
+  // the terminal foreground for time, number and the divider line.
+  timeColor.value = withAlpha(palette.defaultFg, 0.85)
+  numColor.value = withAlpha(palette.defaultFg, 0.6)
+  dividerColor.value = withAlpha(palette.defaultFg, 0.16)
   fontCss.value = {
     fontSize: `${t.options.fontSize ?? 13}px`,
     fontFamily: typeof t.options.fontFamily === 'string' ? t.options.fontFamily : 'monospace',
   }
-  const maxDigits = String(lineOffset + Math.max(total - 1, 0) + 1).length
-  // Column widths in px from the terminal's measured character width — the
-  // CSS `ch` unit measures the '0' glyph and drifts from the real cell size.
+  // Column width from the largest line number handed out (registry counter);
+  // falls back to the buffer extent when there is no registry data (alt screen).
+  const maxNumberHint = registry && !alternate ? registry.nextNumber - 1 : total
+  const maxDigits = String(Math.max(maxNumberHint, 1)).length
+  // Column widths mirror the gutter's formulas (TerminalGutter.vue): time =
+  // ceil(cellWidth × format length) + 2px padding; number = max(ceil(cellWidth
+  // × digits) + 8px padding, 24); 12px gap between the two columns; the
+  // character width comes from the terminal's measured cell — the CSS `ch`
+  // unit measures the '0' glyph and drifts from the real cell size.
   const cw = charWidth(t)
-  numColWidth.value = withNumbers ? `${maxDigits * cw}px` : ''
-  timeColWidth.value = withTimestamps ? `${(tsFormat.length + 1) * cw}px` : ''
+  const timeW = withTimestamps ? Math.ceil(cw * tsFormat.length) + 2 : 0
+  const numW = withNumbers ? Math.max(Math.ceil(cw * maxDigits) + 8, 24) : 0
+  const gap = withTimestamps && withNumbers ? 12 : 0
+  timeColWidth.value = withTimestamps ? `${timeW}px` : ''
+  numColWidth.value = withNumbers ? `${numW}px` : ''
+  numColGap.value = gap ? `${gap}px` : ''
   // The number/timestamp columns live INSIDE the popup, so the popup must be
-  // wider than the terminal by exactly those columns — otherwise the content
-  // area shrinks and the right-hand side of each line gets clipped. The left
-  // gutter area of the terminal provides this extra room.
-  const colsExtra =
-    (withNumbers ? maxDigits * cw : 0) +
-    (withTimestamps ? (tsFormat.length + 1) * cw : 0)
+  // wider than the terminal by exactly those columns (+1px divider) —
+  // otherwise the content area shrinks and the right-hand side of each line
+  // gets clipped. The left gutter area of the terminal provides this room.
+  const colsExtra = timeW + gap + numW + 1
 
   const lh = cellHeight(t)
   cellHeightPx.value = `${lh}px`
@@ -490,17 +511,20 @@ onBeforeUnmount(unbind)
   display: flex;
   white-space: pre;
   overflow: hidden;
+  /* Same tabular figures as the gutter so digits line up column-wide. */
+  font-variant-numeric: tabular-nums;
 }
 
 .preview-col-time {
   flex: none;
-  opacity: 0.75;
+  text-align: right;
+  padding-right: 2px;
 }
 
 .preview-col-num {
   flex: none;
   text-align: right;
-  opacity: 0.55;
+  padding-right: 8px;
 }
 
 .preview-content {

--- a/frontend/src/services/terminalManager.ts
+++ b/frontend/src/services/terminalManager.ts
@@ -8,6 +8,12 @@ import { useSettingsStore } from '../stores/settingsStore'
 import { useLocalStateStore } from '../stores/localStateStore'
 import type { CustomTerminalTheme } from '../types/settings'
 import { formatFontFamily } from '../utils/formatFontFamily'
+import {
+  bufferRowSource,
+  createLineRegistry,
+  realignRegistry,
+  type LineRegistryState,
+} from './terminalTimestamps'
 
 export interface TerminalOptions {
   fontSize?: number
@@ -37,16 +43,20 @@ export interface ManagedTerminal {
    * double input when multiple KeepAlive-cached components share the same
    * terminal instance. */
   onDataGeneration: number
-  /** Birth time (Date.now()) of buffer rows, keyed by absolute row index
-   * (lineOffset-compensated), used by the timestamp gutter column. Kept on
-   * the shared terminal so it survives KeepAlive and drag-across-panes. */
-  lineTimestamps: Map<number, number>
+  /** Logical-line registry (sequential number + birth/completion time per
+   * shell line), keyed by absolute row index (lineOffset-compensated). Backs
+   * the gutter's line-number and time columns. Kept on the shared terminal so
+   * it survives KeepAlive and drag-across-panes. */
+  lineRegistry: LineRegistryState
   /** Absolute-row offset accumulated from scrollback trimming, so both the
    * line-number and timestamp columns stay continuous as old lines drop off
    * the top of the buffer. */
   lineOffset: number
   /** Subscription to the normal-buffer line-collection onTrim event. */
   trimDispose: { dispose(): void } | null
+  /** Subscription to terminal.onResize — reflows the buffer, so the registry
+   * must be re-keyed to the rows lines now start at. */
+  resizeDispose: { dispose(): void } | null
 }
 
 const terminals = new Map<string, ManagedTerminal>()
@@ -167,9 +177,10 @@ export function acquireTerminal(
       disposeTimer: null,
       isNew: true,
       onDataGeneration: 0,
-      lineTimestamps: new Map(),
+      lineRegistry: createLineRegistry(),
       lineOffset: 0,
       trimDispose: null,
+      resizeDispose: null,
     }
 
     // Track scrollback trimming so line-numbers / timestamps stay continuous
@@ -182,10 +193,30 @@ export function acquireTerminal(
       const lines = core?._bufferService?.buffers?.normal?.lines
       if (typeof lines?.onTrim === 'function') {
         m.trimDispose = lines.onTrim((amount: number) => {
+          // NOTE: deliberately no entry pruning here. "key < lineOffset ⇒
+          // off-buffer" only holds for append+trim growth; a resize reflow
+          // also fires trims while INSERTING physical rows for wrapped lines,
+          // so surviving content's absolute coordinates shift and live
+          // entries would be deleted (tail lines lose their number/time).
+          // Off-buffer entries are bounded by the size cap in the registry
+          // and dropped wholesale by realignRegistry on the next resize.
           m.lineOffset += amount
         })
       }
     } catch { /* noop */ }
+
+    // A resize reflows the (normal) buffer: physical rows move but logical
+    // lines keep their identity. Re-key the registry so each entry points at
+    // the row its line now starts at. Uses the normal buffer explicitly so a
+    // resize while an alternate-screen app is up still realigns.
+    m.resizeDispose = terminal.onResize(() => {
+      const buf = terminal.buffer.normal
+      realignRegistry(m.lineRegistry, {
+        lineOffset: m.lineOffset,
+        cursorAbs: m.lineOffset + buf.baseY + buf.cursorY,
+        source: bufferRowSource(buf),
+      })
+    })
 
     terminals.set(sessionId, m)
   }
@@ -206,6 +237,8 @@ export function releaseTerminal(sessionId: string, ref: string): void {
     managed.disposeTimer = setTimeout(() => {
       managed.trimDispose?.dispose()
       managed.trimDispose = null
+      managed.resizeDispose?.dispose()
+      managed.resizeDispose = null
       managed.terminal.dispose()
       terminals.delete(sessionId)
     }, 500)
@@ -220,6 +253,8 @@ export function disposeTerminal(sessionId: string): void {
   }
   managed.trimDispose?.dispose()
   managed.trimDispose = null
+  managed.resizeDispose?.dispose()
+  managed.resizeDispose = null
   managed.terminal.dispose()
   terminals.delete(sessionId)
 }

--- a/frontend/src/services/terminalTimestamps.test.ts
+++ b/frontend/src/services/terminalTimestamps.test.ts
@@ -1,0 +1,231 @@
+import { describe, it, expect, vi } from 'vitest'
+
+// The merged module pulls in the terminal manager and the settings store;
+// mock both so these registry tests stay hermetic (no xterm / pinia needed).
+vi.mock('./terminalManager', () => ({
+  getManagedTerminal: () => undefined,
+}))
+vi.mock('../stores/settingsStore', () => ({
+  useSettingsStore: () => ({ settings: { terminal: { showTimestamps: false } } }),
+}))
+
+import {
+  bufferRowSource,
+  createLineRegistry,
+  recordWrittenLines,
+  realignRegistry,
+  type LineRegistryRowSource,
+  type RegistryBufferLike,
+} from './terminalTimestamps'
+
+/** Fake buffer: wrapped flags + per-row text ('' = blank). */
+function fakeBuffer(wrapped: boolean[], text: string[]) {
+  return {
+    getLine(y: number) {
+      if (y < 0 || y >= wrapped.length) return undefined
+      return {
+        isWrapped: wrapped[y],
+        translateToString: () => text[y] ?? '',
+      }
+    },
+  }
+}
+
+function source(wrapped: boolean[], text: string[]): LineRegistryRowSource {
+  return bufferRowSource(fakeBuffer(wrapped, text) as unknown as RegistryBufferLike)
+}
+
+/** Run one write from cursor `before` (buffer row) to `after`. */
+function write(
+  state: ReturnType<typeof createLineRegistry>,
+  src: LineRegistryRowSource,
+  before: number,
+  after: number,
+  ts: number,
+  lineOffset = 0,
+) {
+  recordWrittenLines(state, {
+    lineOffset,
+    beforeAbs: lineOffset + before,
+    afterAbs: lineOffset + after,
+    source: src,
+    now: ts,
+  })
+}
+
+function numbers(state: ReturnType<typeof createLineRegistry>): Array<[number, number]> {
+  return [...state.entries.entries()]
+    .map(([k, v]) => [k, v.number] as [number, number])
+    .sort((a, b) => a[0] - b[0])
+}
+
+function times(state: ReturnType<typeof createLineRegistry>): Array<[number, number]> {
+  return [...state.entries.entries()]
+    .map(([k, v]) => [k, v.ts] as [number, number])
+    .sort((a, b) => a[0] - b[0])
+}
+
+describe('recordWrittenLines()', () => {
+  it('registers content rows with sequential numbers', () => {
+    const state = createLineRegistry()
+    const src = source([false, false, false], ['a', 'b', 'c'])
+    write(state, src, 0, 2, 1000)
+    expect(numbers(state)).toEqual([[0, 1], [1, 2], [2, 3]])
+    expect(state.nextNumber).toBe(4)
+  })
+
+  it('does not register the empty row the cursor lands on after a newline', () => {
+    const state = createLineRegistry()
+    const src = source([false, false, false], ['a', '', ''])
+    write(state, src, 0, 2, 1000)
+    expect(numbers(state)).toEqual([[0, 1]])
+  })
+
+  it('registers a line only once (first write wins for the number and start ts)', () => {
+    const state = createLineRegistry()
+    const src = source([false], ['hello'])
+    write(state, src, 0, 0, 1000)
+    write(state, src, 0, 0, 2000)
+    expect(numbers(state)).toEqual([[0, 1]])
+    expect(times(state)).toEqual([[0, 1000]])
+  })
+
+  it('overwrites ts with the completion time once the cursor moves past', () => {
+    const state = createLineRegistry()
+    const src = source([false, false], ['hello', ''])
+    write(state, src, 0, 0, 1000) // "hel" typed
+    write(state, src, 0, 1, 2000) // newline: line 0 complete
+    expect(times(state)).toEqual([[0, 2000]])
+  })
+
+  it('keeps the start ts while a progress bar redraws in place with \\r', () => {
+    const state = createLineRegistry()
+    const src = source([false], ['30%'])
+    write(state, src, 0, 0, 1000)
+    // \r redraw: cursor stays on the row, line not complete.
+    write(state, src, 0, 0, 2000)
+    expect(times(state)).toEqual([[0, 1000]])
+    // The final newline completes it.
+    write(state, src, 0, 1, 3000)
+    expect(times(state)).toEqual([[0, 3000]])
+  })
+
+  it('handles a wrapped group: continuation rows get no number, completion stamps the start', () => {
+    const state = createLineRegistry()
+    // Rows 0-1 belong to one logical line; row 2 is the next line.
+    const src = source([false, true, false], ['aaa', 'bbb', 'next'])
+    write(state, src, 0, 2, 1000)
+    expect(numbers(state)).toEqual([[0, 1], [2, 2]])
+    // Newline moves cursor to row 3: the second line completes; the first
+    // group already completed in the first write, so its ts is untouched.
+    write(state, src, 2, 3, 2000)
+    expect(times(state)).toEqual([[0, 1000], [2, 2000]])
+  })
+
+  it('registers lines arriving in the same write as one band, all with that write ts', () => {
+    const state = createLineRegistry()
+    const src = source([false, false, false, false], ['l1', 'l2', 'l3', ''])
+    write(state, src, 0, 3, 1000)
+    expect(numbers(state)).toEqual([[0, 1], [1, 2], [2, 3]])
+    expect(times(state)).toEqual([[0, 1000], [1, 1000], [2, 1000]])
+  })
+
+  it('also registers content rows written above the band (cursor-addressed redraws)', () => {
+    const state = createLineRegistry()
+    // Rows 0-4 already registered; rows 5-8 blank. Cursor sits at row 9 while
+    // a redraw paints content on row 7 without the cursor moving there.
+    const wrapped = new Array(10).fill(false)
+    const text = new Array(10).fill('x').map((c, i) => (i === 9 || i < 5 ? c : ''))
+    let src = source(wrapped, text)
+    write(state, src, 0, 9, 1000)
+    // Now the redraw: row 7 gains content, cursor stays at row 9.
+    text[7] = 'progress'
+    src = source(wrapped, text)
+    write(state, src, 9, 9, 2000)
+    // Row 7 joins late, so it takes the next number after row 9's — late
+    // registration, but registered.
+    expect(numbers(state)).toEqual([[0, 1], [1, 2], [2, 3], [3, 4], [4, 5], [7, 7], [9, 6]])
+    expect(times(state)).toEqual([[0, 1000], [1, 1000], [2, 1000], [3, 1000], [4, 1000], [7, 2000], [9, 1000]])
+  })
+
+  it('caps the map size by dropping the oldest numbers', () => {
+    const state = createLineRegistry()
+    for (let i = 0; i < 5001; i += 1) {
+      state.entries.set(i, { number: i + 1, ts: 1000 })
+    }
+    state.nextNumber = 5002
+    const src = source(new Array(5002).fill(false), new Array(5001).fill('x').concat(['new']))
+    write(state, src, 5001, 5001, 2000)
+    expect(state.entries.size).toBe(3000)
+    // Oldest numbers dropped, the brand-new line survives.
+    expect(state.entries.get(5001)?.number).toBe(5002)
+    expect(state.entries.get(0)).toBeUndefined()
+  })
+})
+
+describe('realignRegistry()', () => {
+  it('re-keys entries to the rows lines start at after a reflow, preserving values', () => {
+    const state = createLineRegistry()
+    // Before: three logical lines at rows 0,1,2.
+    let wrapped = [false, false, false]
+    let text = ['a', 'b', 'c']
+    let src = source(wrapped, text)
+    write(state, src, 0, 3, 1000)
+
+    // Reflow: shrinking cols wraps each line onto two rows → starts at 0,2,4.
+    wrapped = [false, true, false, true, false]
+    text = ['a', 'b', 'b', 'c', 'c', '']
+    src = source(wrapped, text)
+    realignRegistry(state, { lineOffset: 0, cursorAbs: 4, source: src })
+
+    expect(numbers(state)).toEqual([[0, 1], [2, 2], [4, 3]])
+    expect(times(state)).toEqual([[0, 1000], [2, 1000], [4, 1000]])
+  })
+
+  it('drops entries whose lines no longer exist in the buffer', () => {
+    const state = createLineRegistry()
+    const src = source([false, false, false], ['a', 'b', 'c'])
+    write(state, src, 0, 3, 1000)
+    // After the reflow only the last two lines remain (e.g. older content
+    // scrolled off): starts at rows 0 and 1.
+    const after = source([false, false], ['b', 'c'])
+    realignRegistry(state, { lineOffset: 0, cursorAbs: 1, source: after })
+    expect(numbers(state)).toEqual([[0, 2], [1, 3]])
+  })
+
+  it('offsets keys by lineOffset (trim-compensated absolute rows)', () => {
+    const state = createLineRegistry()
+    const src = source([false, false], ['a', 'b'])
+    write(state, src, 0, 2, 1000, 5)
+    const after = source([false, false], ['a', 'b'])
+    realignRegistry(state, { lineOffset: 5, cursorAbs: 5 + 1, source: after })
+    expect(numbers(state)).toEqual([[5, 1], [6, 2]])
+  })
+
+  it('anchors matching at the bottom: when entries run short, the OLDEST lines go without', () => {
+    const state = createLineRegistry()
+    // Only two entries survived (numbers 4,5 — the newest lines), but the
+    // buffer holds four content lines after the reflow.
+    state.entries.set(0, { number: 4, ts: 1000 })
+    state.entries.set(1, { number: 5, ts: 1000 })
+    state.nextNumber = 6
+    const after = source([false, false, false, false], ['a', 'b', 'c', 'd'])
+    realignRegistry(state, { lineOffset: 0, cursorAbs: 3, source: after })
+    // Bottom lines keep the newest numbers; the top of the buffer goes blank.
+    expect(numbers(state)).toEqual([[2, 4], [3, 5]])
+  })
+})
+
+describe('bufferRowSource()', () => {
+  it('treats whitespace-only rows as empty', () => {
+    const src = source([false, false], ['   ', 'x'])
+    expect(src.hasContent(0)).toBe(false)
+    expect(src.hasContent(1)).toBe(true)
+  })
+
+  it('is tolerant of rows past the end of the buffer', () => {
+    const src = source([false], ['a'])
+    expect(src.isWrapped(99)).toBe(false)
+    expect(src.hasContent(99)).toBe(false)
+  })
+})

--- a/frontend/src/services/terminalTimestamps.ts
+++ b/frontend/src/services/terminalTimestamps.ts
@@ -2,28 +2,209 @@ import { getManagedTerminal } from './terminalManager'
 import { useSettingsStore } from '../stores/settingsStore'
 
 /**
- * Per-line birth timestamps for the terminal gutter's time column.
+ * Logical-line registry + recording for the terminal gutter's number/time
+ * columns. One module owns the whole feature:
  *
- * xterm has no notion of "when a line was written", so we record it ourselves:
- * - Write path: capture the absolute line index before and after each
- *   `terminal.write()` and stamp any rows that appeared in between with the
- *   arrival time (first write wins).
- * - Command submit: when Enter is pressed, stamp the current command line (its
- *   wrapped group) with that moment so the prompt line carries "when the
- *   command was executed".
+ * 1. Pure registry below (LineRegistryState / recordWrittenLines /
+ *    realignRegistry / bufferRowSource) — no xterm/DOM so it is unit-testable.
+ * 2. Service functions (recordWrite / stampCommandLine / currentAbsoluteLine)
+ *    that adapt the live terminal to the registry.
  *
- * Rows are keyed by absolute row index inside the managed terminal's shared
- * Map, so the data survives KeepAlive and drag-across-panes. Only the first
- * stamp of a row is kept, symbolising when that terminal line appeared.
+ * xterm has no notion of "when a line was written" or "which number a line
+ * is", so we maintain a registry ourselves. A "logical line" is one
+ * shell/output line: a non-wrapped buffer row plus any wrapped continuation
+ * rows below it. xterm only exposes physical rows, and reflow (resize)
+ * redistributes them, so line numbers and timestamps must NOT be derived from
+ * buffer positions — they are assigned once, when the line is born, and stay
+ * fixed for the line's lifetime:
  *
- * Recording is UNCONDITIONAL: we stamp every line regardless of the
- * showTimestamps setting, so enabling the column mid-session still shows
- * timestamps for lines that already appeared. The display setting only decides
- * whether the gutter paints the time column (and whether we bother to poke the
- * gutter to refresh immediately).
+ * - `number` — sequential, assigned at registration; wrapped continuation
+ *   rows never get one, and resize never renumbers existing lines.
+ * - `ts` — arrival time of the write that first put characters on the line;
+ *   overwritten with the completion time once the cursor moves past the line
+ *   (progress bars redrawn in place keep their start time until the newline
+ *   completes them).
+ *
+ * Entries are keyed by the line's absolute start row (lineOffset-compensated
+ * buffer row). Scrollback trimming keeps absolute indexes stable by
+ * construction (lineOffset grows in lockstep), and realignRegistry re-keys
+ * the whole map after a resize reflow, so a key always points at the row the
+ * line currently starts at. The registry lives on the managed terminal, so
+ * the data survives KeepAlive and drag-across-panes.
+ *
+ * Recording is UNCONDITIONAL: we register every line regardless of the
+ * showTimestamps/showLineNumbers settings, so enabling a column mid-session
+ * still shows data for lines that already appeared. The display settings only
+ * decide whether the gutter paints the columns (and whether we bother to poke
+ * the gutter to refresh immediately).
+ *
+ * Display-side computation (resolving a visible row to its number/time)
+ * lives in utils/terminalGutter.ts — it is shared by TerminalGutter.vue and
+ * TerminalScreenPreview.vue.
  */
 
-// Ask the gutter to re-read the (now updated) timestamp Map.
+// ─── Pure registry (no xterm/DOM) ───────────────────────────────────────────
+
+export interface LineMetaEntry {
+  /** Sequential logical line number, fixed at registration time. */
+  number: number
+  /** Birth time (ms); overwritten with the completion time when done. */
+  ts: number
+}
+
+export interface LineRegistryState {
+  /** Next sequential line number to hand out. */
+  nextNumber: number
+  /** Absolute start row → meta. Reassigned wholesale by realignRegistry —
+   * always reach it through the state object, never cache the Map. */
+  entries: Map<number, LineMetaEntry>
+}
+
+export function createLineRegistry(): LineRegistryState {
+  return { nextNumber: 1, entries: new Map() }
+}
+
+/** Minimal row probe the registry needs from the live buffer. */
+export interface LineRegistryRowSource {
+  isWrapped: (bufferRow: number) => boolean
+  /** Whether the row holds any visible (non-whitespace) cell content. */
+  hasContent: (bufferRow: number) => boolean
+}
+
+/** Duck-typed shape of an xterm buffer, for the adapter below. */
+export interface RegistryBufferLike {
+  getLine(y: number): {
+    isWrapped: boolean
+    translateToString?(trimRight: boolean): string
+  } | undefined | null
+}
+
+/** Adapter from an xterm buffer to the registry's row probe. */
+export function bufferRowSource(buf: RegistryBufferLike): LineRegistryRowSource {
+  return {
+    isWrapped: (y) => buf.getLine(y)?.isWrapped ?? false,
+    hasContent: (y) => {
+      const line = buf.getLine(y)
+      if (!line?.translateToString) return false
+      return line.translateToString(true).trim().length > 0
+    },
+  }
+}
+
+export interface RecordWriteOptions {
+  /** Current lineOffset (trim accumulator) — keys are offset-compensated. */
+  lineOffset: number
+  /** Absolute cursor row captured before and after the write. If a trim
+   * happened inside the write, absolute indexes survive it unchanged. */
+  beforeAbs: number
+  afterAbs: number
+  source: LineRegistryRowSource
+  /** Arrival time of this write (ms). */
+  now: number
+}
+
+/** Rows above the cursor band also scanned for unregistered content —
+ * catches in-place redraws (TUI progress lines, prompt repaints) that write
+ * above the cursor without the cursor ever travelling there. */
+const LOOK_ABOVE_ROWS = 200
+
+/** Entry-count bounds: drop the oldest entries past the cap. The buffer can
+ * hold at most scrollback+rows logical lines (~2.5k here), so anything below
+ * the kept watermark is guaranteed to be off-buffer already. */
+const MAX_ENTRIES = 5000
+const KEEP_ENTRIES = 3000
+
+/**
+ * Fold one applied write into the registry: register logical lines that just
+ * received their first characters, and stamp completion times for lines the
+ * cursor has moved past. The main scan walks the band the cursor travelled
+ * (exactly the band shell output touches); a look-above window also picks up
+ * content painted out-of-band by cursor-addressed redraws.
+ */
+export function recordWrittenLines(state: LineRegistryState, opts: RecordWriteOptions): void {
+  const { lineOffset, beforeAbs, afterAbs, source, now } = opts
+  const from = Math.min(beforeAbs, afterAbs) - lineOffset
+  const to = Math.max(beforeAbs, afterAbs) - lineOffset
+  const cursorRow = afterAbs - lineOffset
+  const scanFrom = Math.max(0, from - LOOK_ABOVE_ROWS)
+
+  // 1. Registration: every non-wrapped row in the scanned range that now
+  //    holds visible content and has no entry yet becomes a new logical line.
+  for (let y = scanFrom; y <= to; y += 1) {
+    if (source.isWrapped(y)) continue
+    const abs = lineOffset + y
+    if (state.entries.has(abs)) continue
+    // A newline parks the cursor on an empty row below the output — that row
+    // only joins the registry once something actually writes characters on it.
+    if (!source.hasContent(y)) continue
+    state.entries.set(abs, { number: state.nextNumber++, ts: now })
+  }
+
+  // 2. Completion: for rows in the band belonging to lines that now end above
+  //    the cursor, the output has finished — fix their timestamp.
+  for (let y = from; y <= to; y += 1) {
+    let start = y
+    while (start > 0 && source.isWrapped(start)) start -= 1
+    let end = start
+    while (source.isWrapped(end + 1)) end += 1
+    if (end >= cursorRow) continue
+    const entry = state.entries.get(lineOffset + start)
+    if (entry && entry.ts !== now) entry.ts = now
+  }
+
+  // 3. Bound memory: off-buffer entries are only ever looked up by rows
+  //    currently on screen, so dropping the OLDEST numbers is safe.
+  if (state.entries.size > MAX_ENTRIES) {
+    const byNumber = [...state.entries.values()].sort((a, b) => a.number - b.number)
+    const keep = new Set(byNumber.slice(byNumber.length - KEEP_ENTRIES).map((m) => m.number))
+    for (const [key, meta] of state.entries) {
+      if (!keep.has(meta.number)) state.entries.delete(key)
+    }
+  }
+}
+
+export interface RealignOptions {
+  lineOffset: number
+  /** Absolute cursor row after the reflow; rows below it are unwritten. */
+  cursorAbs: number
+  source: LineRegistryRowSource
+}
+
+/**
+ * Re-key the registry after a resize reflow. Reflow redistributes physical
+ * rows but never merges or reorders logical lines, so the logical line starts
+ * currently in the buffer (non-wrapped content rows, top of buffer down to
+ * the cursor) correspond, IN ORDER, to a suffix of the registered lines.
+ *
+ * Matching is anchored at the BOTTOM: the last start pairs with the newest
+ * entry, the second-to-last with the second-newest, and so on. A few
+ * unregistered lines (out-of-band repaints) can only shift lines ABOVE them —
+ * the visible bottom of the screen always keeps its number/time.
+ */
+export function realignRegistry(state: LineRegistryState, opts: RealignOptions): void {
+  const { lineOffset, cursorAbs, source } = opts
+  const cursorRow = Math.max(0, cursorAbs - lineOffset)
+
+  const starts: number[] = []
+  for (let y = 0; y <= cursorRow; y += 1) {
+    if (source.isWrapped(y)) continue
+    if (state.entries.has(lineOffset + y) || source.hasContent(y)) starts.push(y)
+  }
+
+  const byNumber = [...state.entries.values()].sort((a, b) => a.number - b.number)
+
+  const next = new Map<number, LineMetaEntry>()
+  for (let i = 0; i < starts.length; i += 1) {
+    // i counts from the BOTTOM of the buffer.
+    const meta = byNumber[byNumber.length - 1 - i]
+    if (meta) next.set(lineOffset + starts[starts.length - 1 - i], meta)
+  }
+  state.entries = next
+}
+
+// ─── Service functions (live terminal adaptation) ───────────────────────────
+
+// Ask the gutter to re-read the (now updated) registry.
 function notifyGutter() {
   window.dispatchEvent(new CustomEvent('terminal:refresh-gutter'))
 }
@@ -42,56 +223,59 @@ function absoluteCursorLine(sessionId: string, lineOffset: number): number {
 }
 
 /**
- * Stamp every row written between `fromLine` and `toLine` (inclusive, any
- * order) that hasn't been stamped yet. Call this around a terminal.write(),
- * with `fromLine` captured before the write and `toLine` after it completes.
+ * Fold one applied write into the registry. Call this from the write's
+ * completion callback, with `beforeAbs` captured before the write started.
+ * No-op while an alternate-screen app owns the buffer — lines there are
+ * transient and never join the registry.
  */
-export function stampWrittenLines(sessionId: string, fromLine: number, toLine: number, ts: number): void {
+export function recordWrite(sessionId: string, beforeAbs: number, ts: number): void {
   const managed = getManagedTerminal(sessionId)
   if (!managed) return
-  if (managed.terminal.buffer.active.type === 'alternate') return
+  const t = managed.terminal
+  const buf = t.buffer.active
+  if (buf.type === 'alternate') return
 
-  const map = managed.lineTimestamps
-  const start = Math.min(fromLine, toLine)
-  const end = Math.max(fromLine, toLine)
-  for (let y = start; y <= end; y += 1) {
-    if (!map.has(y)) map.set(y, ts)
-  }
-
-  // Bound memory: keep the rolled-in map no larger than the recent window.
-  const keepFrom = Math.max(0, start - 3000)
-  for (const key of Array.from(map.keys())) {
-    if (key < keepFrom) map.delete(key)
-  }
-
-  if (timestampsEnabled()) notifyGutter()
+  recordWrittenLines(managed.lineRegistry, {
+    lineOffset: managed.lineOffset,
+    beforeAbs,
+    afterAbs: managed.lineOffset + buf.baseY + buf.cursorY,
+    source: bufferRowSource(buf),
+    now: ts,
+  })
+  notifyGutter()
 }
 
 /**
- * Stamp the current command line with `ts` — called when the user submits a
- * command (Enter), so the prompt line records when it was executed. Walks back
- * through the wrapped group so a wrapped command shares one timestamp.
+ * Overwrite the current command line's timestamp with `ts` — called when the
+ * user submits a command (Enter), so the prompt line records when it was
+ * executed. Walks back through the wrapped group so a wrapped command shares
+ * one timestamp.
  */
 export function stampCommandLine(sessionId: string, ts: number): void {
   const managed = getManagedTerminal(sessionId)
   if (!managed) return
-  if (managed.terminal.buffer.active.type === 'alternate') return
-
   const t = managed.terminal
   const buf = t.buffer.active
-  const map = managed.lineTimestamps
+  if (buf.type === 'alternate') return
+
+  const registry = managed.lineRegistry
   const offset = managed.lineOffset
-  const cursorLine = buf.baseY + buf.cursorY
+  const cursorRow = buf.baseY + buf.cursorY
 
-  let startLine = cursorLine
-  while (startLine > 0) {
-    const line = buf.getLine(startLine)
-    if (line && !line.isWrapped) break
-    startLine -= 1
-  }
+  let startRow = cursorRow
+  while (startRow > 0 && buf.getLine(startRow)?.isWrapped) startRow -= 1
 
-  for (let y = startLine; y <= cursorLine; y += 1) {
-    map.set(offset + y, ts)
+  const abs = offset + startRow
+  const entry = registry.entries.get(abs)
+  if (entry) {
+    entry.ts = ts
+  } else {
+    // Normally the prompt line registered itself when the shell drew it; only
+    // materialize it here if that somehow didn't happen and it has content.
+    const line = buf.getLine(startRow)
+    if (line?.translateToString?.(true)?.trim()) {
+      registry.entries.set(abs, { number: registry.nextNumber++, ts } satisfies LineMetaEntry)
+    }
   }
   if (timestampsEnabled()) notifyGutter()
 }

--- a/frontend/src/stores/credentialStore.ts
+++ b/frontend/src/stores/credentialStore.ts
@@ -13,12 +13,23 @@ export const useCredentialStore = defineStore('credential', () => {
   const dataDirInfo = ref<DataDirInfo>({ dataDir: '', type: 'default', firstRun: false })
   const status = ref<CredentialStatus>({ mode: '', unlocked: false, needsSetup: true, keychainLost: false, existingSecrets: 0 })
   const firstRun = ref(false)
+  // False when backend calls reject — i.e. the frontend is served to a plain
+  // browser (wails3 dev browser preview). The status placeholder above must
+  // NOT be trusted in that case (needsSetup:true would pop the encryption
+  // dialog), so the startup flow checks this before resolving dialogs.
+  const backendAvailable = ref(true)
 
   async function loadDataDir() {
-    try { dataDirInfo.value = (await GetDataDirInfo()) as DataDirInfo } catch { /* ignore */ }
+    try {
+      dataDirInfo.value = (await GetDataDirInfo()) as DataDirInfo
+      backendAvailable.value = true
+    } catch { backendAvailable.value = false }
   }
   async function loadStatus() {
-    try { status.value = (await GetCredentialStatus()) as CredentialStatus } catch { /* ignore */ }
+    try {
+      status.value = (await GetCredentialStatus()) as CredentialStatus
+      backendAvailable.value = true
+    } catch { backendAvailable.value = false }
   }
   async function selectDataDir(kind: string, customDir: string, migrate: boolean) {
     await SetDataDir(kind, customDir, migrate)
@@ -56,7 +67,7 @@ export const useCredentialStore = defineStore('credential', () => {
   }
 
   return {
-    dataDirInfo, status, firstRun,
+    dataDirInfo, status, firstRun, backendAvailable,
     loadDataDir, loadStatus, selectDataDir, setup, unlock, switchMode, changeMasterPassword, reset,
     watchEvents, dispose,
   }

--- a/frontend/src/types/settings.ts
+++ b/frontend/src/types/settings.ts
@@ -47,6 +47,13 @@ export interface CustomTerminalTheme {
   colors: TerminalThemeColors
 }
 
+// ⚠️ PERSISTENCE CONTRACT — every field added to this interface (and to
+// AppSettings / AISettings / AIModelConfig below) MUST get a matching field
+// in `backend/store/settings_store.go` (TerminalSettings / AppSettings / ...),
+// otherwise the value silently fails to persist: settings round-trip through
+// the Go struct on Save/Load, and Go drops unknown JSON keys. Add it with a
+// pointer + omitempty for optional fields so older settings.json files still
+// load, then run `wails3 generate bindings`.
 export interface TerminalSettings {
   theme: TerminalTheme | string
   fontFamily: string
@@ -108,6 +115,8 @@ export interface AIModelConfig {
   baseURL: string
   model: string
   protocol: 'anthropic' | 'openai' | 'responses'
+  // See the persistence-contract note on TerminalSettings: this field MUST
+  // also exist in the Go AIModelConfig (backend/store/settings_store.go).
   userAgent?: string
 }
 

--- a/frontend/src/utils/terminalGutter.test.ts
+++ b/frontend/src/utils/terminalGutter.test.ts
@@ -1,10 +1,17 @@
 import { describe, it, expect } from 'vitest'
-import { buildGutterLines, formatTimestampMs, resolveRowTimestamp, type BuildGutterLinesOptions } from './terminalGutter'
+import {
+  buildGutterLines,
+  formatTimestampMs,
+  resolveRowMeta,
+  type BuildGutterLinesOptions,
+  type GutterMeta,
+} from './terminalGutter'
 
-/** Build options from a compact list of isWrapped flags indexed by buffer row. */
+/** Build options from wrapped flags + a meta map keyed by absolute row. */
 function mk(
   wrapped: boolean[],
-  over?: Partial<Omit<BuildGutterLinesOptions, 'getLine' | 'record'>>
+  entries: Map<number, GutterMeta> = new Map(),
+  over?: Partial<Omit<BuildGutterLinesOptions, 'getLine' | 'getMeta'>>
 ): BuildGutterLinesOptions {
   return {
     rows: wrapped.length,
@@ -12,45 +19,99 @@ function mk(
     lineOffset: 0,
     cursorAbsoluteY: wrapped.length - 1,
     getLine: (n) => ({ isWrapped: wrapped[n] ?? false }),
+    getMeta: (abs) => entries.get(abs),
     ...over,
   }
 }
 
 describe('buildGutterLines()', () => {
-  it('numbers every non-wrapped row from 1', () => {
-    const { lines } = buildGutterLines(mk([false, false, false]))
+  it('numbers non-wrapped rows from their registry meta', () => {
+    const entries = new Map<number, GutterMeta>([
+      [0, { number: 1 }],
+      [1, { number: 2 }],
+      [2, { number: 3 }],
+    ])
+    const { lines } = buildGutterLines(mk([false, false, false], entries))
     expect(lines.map((l) => l.lineNumber)).toEqual(['1', '2', '3'])
   })
 
   it('leaves wrapped continuation rows blank so a wrapped line reads as one', () => {
-    // A long command wraps onto rows 0,1,2; row 3 begins the real next line.
-    const { lines } = buildGutterLines(mk([false, true, true, false, false, false]))
-    expect(lines.map((l) => l.lineNumber)).toEqual(['1', '', '', '4', '5', '6'])
+    // A long command wraps onto rows 0,1,2; row 3 is the next logical line.
+    // Numbers are per logical line: no gap where the wrapped rows sit.
+    const entries = new Map<number, GutterMeta>([
+      [0, { number: 1 }],
+      [3, { number: 2 }],
+      [4, { number: 3 }],
+      [5, { number: 4 }],
+    ])
+    const { lines } = buildGutterLines(mk([false, true, true, false, false, false], entries))
+    expect(lines.map((l) => l.lineNumber)).toEqual(['1', '', '', '2', '3', '4'])
   })
 
   it('leaves rows below the cursor blank (screen not fully written yet)', () => {
     // cursor is at buffer row 3 (0-based); the 5th row is unwritten.
-    const { lines } = buildGutterLines(mk([false, false, false, false], { rows: 5, cursorAbsoluteY: 3 }))
+    const entries = new Map<number, GutterMeta>([
+      [0, { number: 1 }],
+      [1, { number: 2 }],
+      [2, { number: 3 }],
+      [3, { number: 4 }],
+    ])
+    const { lines } = buildGutterLines(mk([false, false, false, false], entries, { rows: 5, cursorAbsoluteY: 3 }))
     expect(lines.map((l) => l.lineNumber)).toEqual(['1', '2', '3', '4', ''])
   })
 
-  it('applies the trim offset so numbers stay continuous after scrollback trimming', () => {
-    const { lines } = buildGutterLines(mk([false, false, false], { lineOffset: 97 }))
-    expect(lines.map((l) => l.lineNumber)).toEqual(['98', '99', '100'])
+  it('leaves rows without registry data blank', () => {
+    // The empty row under the cursor was never registered (no content yet).
+    const entries = new Map<number, GutterMeta>([[0, { number: 1 }]])
+    const { lines } = buildGutterLines(mk([false, false], entries))
+    expect(lines.map((l) => l.lineNumber)).toEqual(['1', ''])
   })
 
-  it('reflects a scrolled viewport (buffer row offset from viewportY)', () => {
-    const { lines } = buildGutterLines(mk([false, false, false, false, false], {
+  it('keeps numbers stable when the viewport scrolls (no positional drift)', () => {
+    // Same three logical lines, viewed from buffer row 2: numbers unchanged.
+    const entries = new Map<number, GutterMeta>([
+      [2, { number: 7 }],
+      [3, { number: 8 }],
+      [4, { number: 9 }],
+    ])
+    const { lines } = buildGutterLines(mk([false, false, false, false, false], entries, {
       viewportY: 2,
       rows: 3,
       cursorAbsoluteY: 4,
     }))
-    expect(lines.map((l) => l.lineNumber)).toEqual(['3', '4', '5'])
+    expect(lines.map((l) => l.lineNumber)).toEqual(['7', '8', '9'])
   })
 
-  it('reports the largest visible number for column sizing', () => {
-    const { maxLineNumber } = buildGutterLines(mk([false, true, false, false], { lineOffset: 1000 }))
-    expect(maxLineNumber).toBe(1004)
+  it('reports the largest visible/hint number for column sizing', () => {
+    const entries = new Map<number, GutterMeta>([
+      [0, { number: 1 }],
+      [1, { number: 2 }],
+    ])
+    const { maxLineNumber } = buildGutterLines(mk([false, false], entries, { maxNumberHint: 1000 }))
+    expect(maxLineNumber).toBe(1000)
+    const { maxLineNumber: visible } = buildGutterLines(mk([false, false], entries))
+    expect(visible).toBe(2)
+  })
+})
+
+describe('buildGutterLines() with timestamps', () => {
+  it('shows the group timestamp only on non-wrapped rendered rows', () => {
+    // row 0 stamped; rows 1,2 wrapped (inherit group time); row 3 own stamp.
+    // Local Date construction keeps the assertion timezone-independent.
+    const stamp = new Date(2026, 7, 18, 12, 34, 56).getTime()
+    const stamp2 = new Date(2026, 7, 18, 13, 0, 1).getTime()
+    const entries = new Map<number, GutterMeta>([
+      [0, { number: 1, ts: stamp }],
+      [3, { number: 2, ts: stamp2 }],
+    ])
+    const { lines } = buildGutterLines(mk([false, true, true, false], entries, { showTimestamps: true }))
+    expect(lines.map((l) => l.timestamp)).toEqual(['12:34:56', '', '', '13:00:01'])
+  })
+
+  it('shows nothing when showTimestamps is off', () => {
+    const entries = new Map<number, GutterMeta>([[0, { number: 1, ts: 5000 }]])
+    const { lines } = buildGutterLines(mk([false, false], entries))
+    expect(lines.map((l) => l.timestamp)).toEqual(['', ''])
   })
 })
 
@@ -71,44 +132,23 @@ describe('formatTimestampMs', () => {
   })
 })
 
-describe('resolveRowTimestamp', () => {
+describe('resolveRowMeta', () => {
   const wrapped = [false, true, true, false] // rows 1,2 are continuation of row 0
   const getLine = (n: number) => ({ isWrapped: wrapped[n] ?? false })
 
-  it('finds the timestamp from the wrapped group start', () => {
-    // rows 1 and 2 belong to group started at row 0 (timestamp 111).
-    const ts = resolveRowTimestamp(2, 0, getLine, (i) => (i === 0 ? 111 : undefined))
-    expect(ts).toBe(111)
+  it('finds the meta from the wrapped group start', () => {
+    // rows 1 and 2 belong to the group started at row 0 (line 1).
+    const m = resolveRowMeta(2, 0, getLine, (i) => (i === 0 ? { number: 1, ts: 111 } : undefined))
+    expect(m).toEqual({ number: 1, ts: 111 })
   })
 
-  it('uses the row itself when it carries the timestamp', () => {
-    const ts = resolveRowTimestamp(3, 0, getLine, (i) => (i === 3 ? 999 : undefined))
-    expect(ts).toBe(999)
+  it('uses the row itself when it carries the meta', () => {
+    const m = resolveRowMeta(3, 0, getLine, (i) => (i === 3 ? { number: 2 } : undefined))
+    expect(m).toEqual({ number: 2 })
   })
 
-  it('returns undefined when no row in the group was stamped', () => {
-    const ts = resolveRowTimestamp(1, 0, getLine, () => undefined)
-    expect(ts).toBeUndefined()
-  })
-})
-
-describe('buildGutterLines() with timestamps', () => {
-  it('shows the group timestamp only on non-wrapped rendered rows', () => {
-    // row 0 stamped; rows 1,2 wrapped (inherit group time); row 3 own stamp.
-    // Local Date construction keeps the assertion timezone-independent.
-    const stamp = new Map<number, number>([
-      [0, new Date(2026, 7, 18, 12, 34, 56).getTime()],
-      [3, new Date(2026, 7, 18, 13, 0, 1).getTime()],
-    ])
-    const { lines } = buildGutterLines(mk([false, true, true, false], {
-      showTimestamps: true,
-      getTimestamp: (i) => stamp.get(i),
-    }))
-    expect(lines.map((l) => l.timestamp)).toEqual(['12:34:56', '', '', '13:00:01'])
-  })
-
-  it('shows nothing when showTimestamps is off', () => {
-    const { lines } = buildGutterLines(mk([false, false], { getTimestamp: () => 5000 }))
-    expect(lines.map((l) => l.timestamp)).toEqual(['', ''])
+  it('returns undefined when no row in the group is registered', () => {
+    const m = resolveRowMeta(1, 0, getLine, () => undefined)
+    expect(m).toBeUndefined()
   })
 })

--- a/frontend/src/utils/terminalGutter.ts
+++ b/frontend/src/utils/terminalGutter.ts
@@ -1,8 +1,14 @@
 /**
- * Pure line-number computation for the terminal gutter.
+ * Pure line-number/timestamp computation for the terminal gutter.
  *
  * Kept free of DOM/xterm so the numbering rules can be unit-tested without a
  * terminal instance. The gutter component adapts xterm's buffer to this model.
+ *
+ * Numbers and timestamps are NOT derived from buffer positions — they come
+ * from the logical-line registry (services/terminalTimestamps), where each
+ * line got a fixed sequential number and birth time when it first received
+ * characters. Wrapped continuation rows carry neither; resize reflows never
+ * renumber anything.
  */
 
 /** Default timestamp format, e.g. "12:34:56". */
@@ -21,23 +27,32 @@ export interface GutterLineSource {
   isWrapped: boolean
 }
 
+/** Per-logical-line data the gutter reads from the registry. */
+export interface GutterMeta {
+  number: number
+  ts?: number
+}
+
 export interface BuildGutterLinesOptions {
   /** Number of visible rows on the terminal screen (terminal.rows). */
   rows: number
   /** Index of the top visible buffer row (terminal.buffer.active.viewportY). */
   viewportY: number
   /** Absolute-row offset accumulated from scrollback trimming
-   * (0 in the alternate screen, where numbering restarts from 1). */
+   * (0 in the alternate screen). */
   lineOffset: number
   /** Absolute index of the cursor row (baseY + cursorY); rows below it
    * have not been rendered yet and carry no number. */
   cursorAbsoluteY: number
   /** Fetch the wrapping flag for a given absolute buffer row. */
   getLine: (bufferLine: number) => GutterLineSource | null | undefined
-  /** When true and a getTimestamp is provided, populate the time column. */
+  /** Look up a logical line's meta by its absolute start row. */
+  getMeta?: (absoluteStartIndex: number) => GutterMeta | undefined
+  /** When true and a getTimestamp-style meta is present, populate the column. */
   showTimestamps?: boolean
-  /** Birth timestamp (ms) of a logical line by its absolute start index. */
-  getTimestamp?: (absoluteStartIndex: number) => number | undefined
+  /** Largest line number handed out so far — keeps the column width stable
+   * even when the viewport shows only low numbers. */
+  maxNumberHint?: number
   /** Convert a birth timestamp to display text. Defaults to [HH:mm:ss]. */
   formatTimestamp?: (ms: number) => string
 }
@@ -72,30 +87,29 @@ export function formatTimestampMs(ms: number, format: string = DEFAULT_TIMESTAMP
 export const TIMESTAMP_WIDTH_SAMPLE_MS = new Date(2099, 11, 28, 23, 59, 59).getTime()
 
 /**
- * Resolve the birth timestamp of a visible row's logical line. Walks back
- * through the wrapped group: the timestamp lives on the first (non-wrapped)
- * row, so wrapped continuation rows inherit the group's start.
+ * Resolve the meta of a visible row's logical line. Walks back through the
+ * wrapped group: the meta lives on the first (non-wrapped) row, so wrapped
+ * continuation rows inherit their group's number and timestamp.
  */
-export function resolveRowTimestamp(
+export function resolveRowMeta(
   bufferLine: number,
   lineOffset: number,
   getLine: (bufferLine: number) => GutterLineSource | null | undefined,
-  getTimestamp: (absoluteStartIndex: number) => number | undefined,
-): number | undefined {
+  getMeta: (absoluteStartIndex: number) => GutterMeta | undefined,
+): GutterMeta | undefined {
   let y = bufferLine
   for (;;) {
-    const ts = getTimestamp(lineOffset + y)
-    if (ts) return ts
+    const meta = getMeta(lineOffset + y)
+    if (meta) return meta
     const line = getLine(y)
-    if (!line?.isWrapped) break
+    if (!line?.isWrapped) return undefined
     y -= 1
   }
-  return undefined
 }
 
 export function buildGutterLines(opts: BuildGutterLinesOptions): GutterBuildResult {
   const lines: GutterRow[] = []
-  let maxLineNumber = 1
+  let maxLineNumber = Math.max(opts.maxNumberHint ?? 0, 1)
   const fmt = opts.formatTimestamp ?? formatTimestampMs
 
   for (let i = 0; i < opts.rows; i += 1) {
@@ -104,24 +118,23 @@ export function buildGutterLines(opts: BuildGutterLinesOptions): GutterBuildResu
     const isRendered = bufferLine <= opts.cursorAbsoluteY
 
     // Wrapped continuation rows and rows the cursor hasn't reached yet get no
-    // number — the former would otherwise look like fresh lines, the latter
-    // would show a phantom number below the last written row.
+    // number — the former belong to the line above, the latter haven't been
+    // written (nor registered) yet.
     const showNumber = isRendered && !isWrapped
     const key = opts.lineOffset + bufferLine
 
+    let lineNumber = ''
     let timestamp = ''
-    if (opts.showTimestamps && showNumber && opts.getTimestamp) {
-      const ts = resolveRowTimestamp(bufferLine, opts.lineOffset, opts.getLine, opts.getTimestamp)
-      if (ts) timestamp = fmt(ts)
+    if (showNumber && opts.getMeta) {
+      const meta = resolveRowMeta(bufferLine, opts.lineOffset, opts.getLine, opts.getMeta)
+      if (meta) {
+        lineNumber = String(meta.number)
+        maxLineNumber = Math.max(maxLineNumber, meta.number)
+        if (opts.showTimestamps && meta.ts) timestamp = fmt(meta.ts)
+      }
     }
 
-    if (showNumber) {
-      const number = opts.lineOffset + bufferLine + 1
-      maxLineNumber = Math.max(maxLineNumber, number)
-      lines.push({ key, lineNumber: String(number), timestamp })
-    } else {
-      lines.push({ key, lineNumber: '', timestamp })
-    }
+    lines.push({ key, lineNumber, timestamp })
   }
 
   return { lines, maxLineNumber }

--- a/main.go
+++ b/main.go
@@ -180,6 +180,15 @@ func main() {
 			Red: 27, Green: 38, Blue: 54, Alpha: 1,
 		},
 		EnableFileDrop: true,
+		// Open the WebView2 inspector when the window is first shown. Wails
+		// disables browser accelerator keys on Windows (F12 / Ctrl+Shift+I
+		// never reach us), and the app's custom context menus hide the
+		// default "Inspect" entry — without this there is NO way to open
+		// DevTools, even in dev builds. Inert in production: the wails
+		// runtime only honors it when built without the `production` tag.
+		// (Deliberately NOT a window KeyBinding for F12: that would be
+		// window-global and could swallow F12 from TUI apps.)
+		OpenInspectorOnStartup: true,
 		Mac: application.MacWindow{
 			TitleBar: macTitleBar,
 		},


### PR DESCRIPTION
## Summary

This PR reworks the terminal gutter's line-number and timestamp columns onto a per-terminal **logical-line registry**, fixes a blank-area layout bug after maximize/restore/drag, and closes several settings-persistence gaps.

### Gutter: fixed logical line numbers & timestamps
- Line numbers are now assigned **once per logical line** when it first receives characters (sequential registry counter) instead of being derived from buffer positions: wrapped rows no longer consume numbers, and resizing the window never renumbers existing lines.
- Each line records its **start time** when it first receives characters and the timestamp is **overwritten with the completion time** once the cursor moves past it (progress bars redrawn in place keep their start time until the newline completes them).
- Resize reflow is healed by re-keying the registry (bottom-anchored matching), so numbers/times survive maximize/restore; out-of-band repaints (TUI progress lines) are picked up by a look-above scan; registry memory is bounded.
- Right-click on the gutter opens a menu to toggle line numbers / timestamps (persisted).

### Screen preview
- The popup now mirrors the gutter columns exactly: same width formulas, colors (fg alpha 0.85/0.6/0.16), 12px column gap, divider line, and tabular figures.

### Blank area below the terminal (maximize/restore/drag)
- Root cause: a focus-driven auto-scroll left a stale `scrollTop` on `.terminal-host`, shoving the whole `.xterm` up. Fixed with `overflow: clip` (the host is never scrolled deliberately) plus a defensive reset in `resize()`.
- Size changes landing inside a resize gate (window-resize debounce / split drag) are no longer dropped; a trailing resize runs once the gate clears.

### Settings persistence
- Several settings were silently dropped on save because the Go `AppSettings` struct lacked matching fields: `fallbackFont`, `fontWeight`, `cursorStyle`, `minimumContrast`, `showLineNumbers`, `showTimestamps`, `timestampFormat`, and model `userAgent`. All added (pointer + omitempty, backwards compatible with existing settings.json).
- Persistence-contract comment added to `types/settings.ts` so future fields don't miss the Go struct.

### Misc
- Dev builds auto-open the WebView2 inspector (wails gates it to non-production builds; no F12 binding to avoid swallowing F12 in TUI apps).
- Browser preview (`wails3 dev` served to a plain browser): the credential dialog no longer pops up when backend calls fail; the main UI renders for debugging.

## Testing
- Frontend: `vitest` — 304 tests pass (registry unit tests cover registration, completion overwrite, wrapped groups, reflow re-keying, look-above scan, entry cap; gutter display tests updated for the meta model).
- `go build ./...`, `wails3 generate bindings`, and the frontend production build all pass.
- Manually verified: wrap/resize renumbering, scrollback trim continuity, maximize/restore/drag blank area, preview alignment, settings persistence across restarts.

---

## 摘要

本 PR 将终端行号/时间列重构为基于**逻辑行注册表**的实现，修复最大化/还原/拖动后终端下方的空白问题，并补齐多处设置持久化缺口。

### 行号/时间：按逻辑行固定
- 行号在逻辑行**首次收到字符时一次性分配**（注册表顺序计数器），不再从缓冲区位置推导：折行不再占号，缩放窗口不会重排行号。
- 每行在首次收到字符时记录**开始时间**，光标移过后**覆盖为结束时间**（`\r` 原地重绘的进度条保持开始时间，直到换行完成）。
- resize reflow 后按"底部锚定"重对齐注册表，行号/时间在最大化/还原后保持不变；带外重绘（TUI 进度条）通过向上扫描窗口补登记；注册表内存有上限。
- 右键行号/时间栏可弹出菜单切换显示/隐藏（配置持久化）。

### 屏幕预览
- 预览弹窗的时间/行号列与终端 gutter 完全一致：相同的宽度公式、配色（前景色 0.85/0.6/0.16 透明度）、12px 列间距、分割线与等宽数字。

### 终端下方空白（最大化/还原/拖动）
- 根因：focus 触发的自动滚动在 `.terminal-host` 上留下了过期的 `scrollTop`，把整个 `.xterm` 顶了上去。用 `overflow: clip`（宿主从不主动滚动）+ `resize()` 中的防御性清零修复。
- 落在 resize 抑制窗口内（窗口 resize 防抖 / 分栏拖动）的尺寸变化不再被丢弃，抑制期结束后补做一次 resize。

### 设置持久化
- 多个设置因 Go `AppSettings` 结构体缺少对应字段而在保存时被静默丢弃：`fallbackFont`、`fontWeight`、`cursorStyle`、`minimumContrast`、`showLineNumbers`、`showTimestamps`、`timestampFormat`、模型 `userAgent`。已全部补齐（指针 + omitempty，兼容旧 settings.json）。
- `types/settings.ts` 增加"持久化契约"注释，避免以后新增字段漏掉 Go 结构体。

### 其他
- dev 构建自动打开 WebView2 Inspector（由 wails 限定仅非生产构建生效；不加 F12 绑定，避免吞掉 TUI 程序的 F12）。
- 浏览器预览（`wails3 dev` 用普通浏览器打开）时后端调用失败不再误弹加密方式对话框，主界面正常渲染便于调试。

## 测试
- 前端 `vitest` 304 个测试全部通过（注册表单测覆盖登记、完成覆盖、折行组、reflow 重对齐、带外扫描、容量上限；gutter 显示测试同步更新为 meta 模型）。
- `go build ./...`、`wails3 generate bindings`、前端生产构建均通过。
- 手动验证：折行/缩放不再跳号、滚动裁剪连续性、最大化/还原/拖动空白、预览对齐、设置重启后保留。