### PR TITLE
feat(quick-commands): remember collapsed groups across restarts

### DIFF
--- a/backend/store/local_state_store.go
+++ b/backend/store/local_state_store.go
@@ -12,11 +12,14 @@ type LocalState struct {
 	SidebarVisible    bool     `json:"sidebarVisible"`
 	AISidebarVisible  bool     `json:"aiSidebarVisible"`
 	CollapsedGroupIds []string `json:"collapsedGroupIds"`
-	WindowX           int      `json:"windowX"`
-	WindowY           int      `json:"windowY"`
-	WindowWidth       int      `json:"windowWidth"`
-	WindowHeight      int      `json:"windowHeight"`
-	WindowMaximised   bool     `json:"windowMaximised"`
+	// Collapsed quick-command group ids (plus "__ungrouped__"). Local-only
+	// UI state, never synced; groups absent from the list stay expanded.
+	CollapsedQuickCommandGroupIds []string `json:"collapsedQuickCommandGroupIds"`
+	WindowX                       int      `json:"windowX"`
+	WindowY                       int      `json:"windowY"`
+	WindowWidth                   int      `json:"windowWidth"`
+	WindowHeight                  int      `json:"windowHeight"`
+	WindowMaximised               bool     `json:"windowMaximised"`
 	// Background image — local-only appearance, never synced.
 	BackgroundEnabled bool   `json:"backgroundEnabled"`
 	BackgroundImage   string `json:"backgroundImage"`
@@ -53,11 +56,12 @@ func (s *LocalStateStore) Save(state LocalState) error {
 
 func defaultLocalState() LocalState {
 	return LocalState{
-		SidebarVisible:    true,
-		AISidebarVisible:  true,
-		BackgroundOpacity: 60,
-		BackgroundBlur:    3,
-		BackgroundFit:     "cover",
+		SidebarVisible:                true,
+		AISidebarVisible:              true,
+		CollapsedQuickCommandGroupIds: []string{},
+		BackgroundOpacity:             60,
+		BackgroundBlur:                3,
+		BackgroundFit:                 "cover",
 	}
 }
 

--- a/backend/store/local_state_store_test.go
+++ b/backend/store/local_state_store_test.go
@@ -1,0 +1,49 @@
+package store
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLocalStateRoundtrip(t *testing.T) {
+	s := NewLocalStateStore(t.TempDir())
+
+	loaded, err := s.Load()
+	if err != nil {
+		t.Fatalf("initial load: %v", err)
+	}
+	if loaded.CollapsedQuickCommandGroupIds == nil {
+		t.Fatalf("default LocalState should init CollapsedQuickCommandGroupIds, got nil")
+	}
+	if len(loaded.CollapsedQuickCommandGroupIds) != 0 {
+		t.Fatalf("default CollapsedQuickCommandGroupIds should be empty, got %v", loaded.CollapsedQuickCommandGroupIds)
+	}
+
+	loaded.CollapsedQuickCommandGroupIds = []string{"qcg-1", "__ungrouped__"}
+	if err := s.Save(loaded); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	again, err := s.Load()
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if len(again.CollapsedQuickCommandGroupIds) != 2 ||
+		again.CollapsedQuickCommandGroupIds[0] != "qcg-1" ||
+		again.CollapsedQuickCommandGroupIds[1] != "__ungrouped__" {
+		t.Fatalf("roundtrip mismatch: got %v", again.CollapsedQuickCommandGroupIds)
+	}
+
+	// Defaults must survive: older configs lack the new key entirely.
+	if err := os.WriteFile(filepath.Join(s.configDir, localStateFileName), []byte(`{"sidebarVisible":false}`), 0600); err != nil {
+		t.Fatalf("write legacy config: %v", err)
+	}
+	legacy, err := s.Load()
+	if err != nil {
+		t.Fatalf("load legacy: %v", err)
+	}
+	if legacy.CollapsedQuickCommandGroupIds == nil || len(legacy.CollapsedQuickCommandGroupIds) != 0 {
+		t.Fatalf("legacy config should yield empty CollapsedQuickCommandGroupIds, got %v", legacy.CollapsedQuickCommandGroupIds)
+	}
+}

--- a/frontend/src/components/QuickCommandsPanel.vue
+++ b/frontend/src/components/QuickCommandsPanel.vue
@@ -226,7 +226,11 @@ import {
   Plus, Play, Clipboard, Copy,
   ChevronDown, ChevronRight
 } from '@lucide/vue'
-import { useQuickCommandStore, type QuickCommand, type QuickCommandGroup } from '../stores/quickCommandStore'
+import {
+  useQuickCommandStore, type QuickCommand, type QuickCommandGroup,
+  expandedFromCollapsed, collapsedFromExpanded
+} from '../stores/quickCommandStore'
+import { useLocalStateStore } from '../stores/localStateStore'
 import { useTabStore } from '../stores/tabStore'
 import { usePanelStore } from '../stores/panelStore'
 import { SessionWrite } from '../../bindings/github.com/ys-ll/uniterm/app'
@@ -240,6 +244,7 @@ import MenuDivider from './MenuDivider.vue'
 
 const { t } = useI18n()
 const store = useQuickCommandStore()
+const localState = useLocalStateStore()
 const tabStore = useTabStore()
 const panelStore = usePanelStore()
 
@@ -251,6 +256,19 @@ const searchQuery = ref('')
 const expandedGroups = ref<Set<string>>(new Set())
 
 const dragOverGroupId = ref<string | null>(null)
+
+// All expandable ids: group ids plus the "__ungrouped__" sentinel.
+function allExpandableIds(): string[] {
+  return [...store.groups.map(g => g.id), '__ungrouped__']
+}
+
+// Persist only collapsed ids (like the connections sidebar) so new or
+// renamed groups stay expanded by default.
+function persistCollapsedGroups() {
+  localState.update({
+    collapsedQuickCommandGroupIds: collapsedFromExpanded(allExpandableIds(), expandedGroups.value)
+  })
+}
 
 const ctxMenuVisible = ref(false)
 const ctxMenuRef = ref<InstanceType<typeof Menu> | null>(null)
@@ -275,14 +293,18 @@ const editingCmdRemark = ref<string | undefined>(undefined)
 
 onMounted(async () => {
   await store.load()
-  store.groups.forEach(g => expandedGroups.value.add(g.id))
-  expandedGroups.value.add('__ungrouped__')
+  await localState.init()
+  expandedGroups.value = expandedFromCollapsed(
+    allExpandableIds(),
+    localState.state.collapsedQuickCommandGroupIds ?? []
+  )
 })
 
 
 function toggleGroup(id: string) {
   if (expandedGroups.value.has(id)) expandedGroups.value.delete(id)
   else expandedGroups.value.add(id)
+  persistCollapsedGroups()
 }
 
 function matchesSearch(cmd: QuickCommand): boolean {

--- a/frontend/src/stores/localStateStore.ts
+++ b/frontend/src/stores/localStateStore.ts
@@ -7,6 +7,7 @@ const DEFAULT: LocalState = {
   sidebarVisible: true,
   aiSidebarVisible: true,
   collapsedGroupIds: [],
+  collapsedQuickCommandGroupIds: [],
   windowX: 0,
   windowY: 0,
   windowWidth: 0,

--- a/frontend/src/stores/quickCommandStore.test.ts
+++ b/frontend/src/stores/quickCommandStore.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import { expandedFromCollapsed, collapsedFromExpanded } from './quickCommandStore'
+
+describe('expandedFromCollapsed', () => {
+  it('expands all ids by default when nothing is collapsed', () => {
+    const result = expandedFromCollapsed(['a', 'b', '__ungrouped__'], [])
+    expect(result).toEqual(new Set(['a', 'b', '__ungrouped__']))
+  })
+
+  it('keeps collapsed ids closed and others open', () => {
+    const result = expandedFromCollapsed(['a', 'b', 'c'], ['b'])
+    expect(result).toEqual(new Set(['a', 'c']))
+  })
+
+  it('ignores collapsed ids that no longer exist', () => {
+    const result = expandedFromCollapsed(['a'], ['a', 'deleted-group'])
+    expect(result).toEqual(new Set())
+  })
+})
+
+describe('collapsedFromExpanded', () => {
+  it('lists every known id that is not expanded', () => {
+    const result = collapsedFromExpanded(
+      ['a', 'b', 'c', '__ungrouped__'],
+      new Set(['a', '__ungrouped__'])
+    )
+    expect(result).toEqual(['b', 'c'])
+  })
+
+  it('collapses everything when nothing is expanded', () => {
+    expect(collapsedFromExpanded(['a', 'b'], new Set())).toEqual(['a', 'b'])
+  })
+
+  it('ignores expanded ids outside the known set', () => {
+    expect(collapsedFromExpanded(['a'], new Set(['a', 'ghost']))).toEqual([])
+  })
+})

--- a/frontend/src/stores/quickCommandStore.ts
+++ b/frontend/src/stores/quickCommandStore.ts
@@ -28,6 +28,18 @@ function genId(prefix: string): string {
   return `${prefix}-${Date.now()}-${++idCounter}`
 }
 
+// Expand/collapse bookkeeping for the quick-commands panel, kept pure so it
+// can be unit-tested. Mirrors the connections sidebar: only collapsed group
+// ids are persisted, so new/unknown groups default to expanded.
+export function expandedFromCollapsed(allIds: string[], collapsedIds: string[]): Set<string> {
+  const collapsed = new Set(collapsedIds)
+  return new Set(allIds.filter(id => !collapsed.has(id)))
+}
+
+export function collapsedFromExpanded(allIds: string[], expanded: Set<string>): string[] {
+  return allIds.filter(id => !expanded.has(id))
+}
+
 export const useQuickCommandStore = defineStore('quickCommands', () => {
   const groups = ref<QuickCommandGroup[]>([])
   const commands = ref<QuickCommand[]>([])


### PR DESCRIPTION
## Summary
- Persist collapsed quick-command group ids in `LocalState` (`local_state.json`), local-only and never synced, mirroring the existing connections-sidebar behavior.
- Groups remain expanded by default; only groups the user manually collapses are remembered, keyed by group id (plus the `__ungrouped__` sentinel), so renames/reordering and unknown/new groups are unaffected.
- Search force-expands all groups without touching the persisted state; toggling a group header writes the collapsed list back immediately.
- Added pure helpers `expandedFromCollapsed` / `collapsedFromExpanded` in `quickCommandStore.ts` with unit tests, plus a Go roundtrip test for the new `LocalState` field (defaults, save/load, legacy config without the key).

Closes #750

## Test plan
- [x] Frontend vitest: 310/310 pass (6 new cases for collapse bookkeeping)
- [x] Go: new `TestLocalStateRoundtrip` passes; full suite green except pre-existing `TestStartPprofIfDev_ProductionSkip` failure (reproduces on clean `main`, unrelated)
- [x] `npm run build` and `wails3 build` succeed; manual check: collapse groups → restart app → collapsed state retained

---

## 摘要
- 在 `LocalState`（`local_state.json`）中持久化快捷命令被折叠的分组 id，仅本地保存、不参与同步，与连接目录侧边栏的既有行为保持一致。
- 分组默认全部展开；仅记住用户手动折叠的分组，按分组 id（含 `__ungrouped__` 哨兵 id）记忆，因此改名、排序及新增分组均不受影响。
- 搜索时强制展开所有分组但不写入持久化状态；点击分组头部切换时立即写回折叠列表。
- 在 `quickCommandStore.ts` 中新增纯函数 `expandedFromCollapsed` / `collapsedFromExpanded` 并附单元测试；Go 侧为新的 `LocalState` 字段补充 roundtrip 测试（默认值、保存/加载、旧配置缺少该字段的场景）。

Closes #750

## 测试计划
- [x] 前端 vitest：310/310 通过（新增 6 个折叠状态换算用例）
- [x] Go：新增 `TestLocalStateRoundtrip` 通过；全量测试除既有的 `TestStartPprofIfDev_ProductionSkip`（干净 `main` 上同样失败，与本次无关）外全部通过
- [x] `npm run build` 与 `wails3 build` 成功；手动验证：折叠分组 → 重启应用 → 折叠状态保持