### PR TITLE
fix(ui): make all tooltips pass-through so they never block interactions

### DIFF
--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -880,6 +880,13 @@ body::before {
   display: none !important;
 }
 
+/* Tooltips are visual-only: let mouse events pass through to underlying
+   elements. Dark effect = tooltips; light poppers stay interactive. */
+.el-popper.is-dark {
+  pointer-events: none;
+  user-select: none;
+}
+
 /* Tab transitions */
 .tab-fade-enter-active,
 .tab-fade-leave-active {


### PR DESCRIPTION
## Summary
- Makes all tooltips (dark-effect poppers: `el-tooltip` and table `show-overflow-tooltip`) purely visual via `pointer-events: none; user-select: none` in the global stylesheet.
- Fixes #759: table tooltips no longer intercept mouse events, so hovering/clicking the row above works immediately and the tooltip disappears as soon as the cursor leaves the cell.
- Light poppers (select/dropdown/filter panels) keep their default interactivity.
- Affects all table tooltips uniformly: SFTP file list, database object/structure/result tables, MongoDB, Elasticsearch, containers, K8s.

## Test plan
- `wails3 dev`, hover a truncated filename in the SFTP sidebar, move the cursor up — tooltip disappears instantly and the row above receives hover/click.
- Verify dropdowns, date pickers and table filter panels still open and are clickable.

---

## 概要
- 全局样式将所有 tooltip（dark effect popper，包括 `el-tooltip` 与表格 `show-overflow-tooltip`）设为 `pointer-events: none; user-select: none`，tooltip 仅做视觉展示。
- 修复 #759：表格 tooltip 不再拦截鼠标事件，鼠标上移时立即消失，可正常悬停/点击上一行内容。
- 下拉框、日期选择器、表格筛选面板等 light popper 保持可交互。
- 统一生效于所有表格 tooltip：SFTP 文件列表、数据库对象/结构/结果表格、MongoDB、Elasticsearch、容器、K8s。

## 测试计划
- `wails3 dev` 后在 SFTP 边栏悬停被截断的文件名，向上移动鼠标，tooltip 立即消失且上一行可正常点击。
- 验证下拉框、日期选择器、表格筛选面板仍可正常打开并点击。