### PR TITLE
fix(db): route connection tests and tab actions by dbType for redis/mongodb/elasticsearch

### DIFF
--- a/backend/session/test_connection.go
+++ b/backend/session/test_connection.go
@@ -15,6 +15,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -55,6 +56,17 @@ func ProbeConnection(config ConnectionConfig) (string, error) {
 	case "mongodb":
 		return probeMongo(config)
 	case "database":
+		// redis/mongodb/elasticsearch are stored as type "database" with a
+		// dbType discriminator (mirroring the SQL family). Route them to their
+		// dedicated probes; the rest go through the SQL provider registry.
+		switch config.DBType {
+		case "redis":
+			return probeRedis(config)
+		case "mongodb":
+			return probeMongo(config)
+		case "elasticsearch":
+			return probeElasticsearch(config)
+		}
 		return probeDatabase(config)
 	default:
 		return "", fmt.Errorf("connection type %q does not support connection testing", config.Type)
@@ -250,6 +262,64 @@ func probeMongo(config ConnectionConfig) (string, error) {
 		return "", fmt.Errorf("mongodb ping: %w", err)
 	}
 	return fmt.Sprintf("mongodb: connected to %s:%d", config.Host, config.Port), nil
+}
+
+// probeElasticsearch probes the cluster with GET / using the same URL, TLS and
+// auth construction as ElasticsearchSession.Connect (basic and ApiKey auth).
+func probeElasticsearch(config ConnectionConfig) (string, error) {
+	host := config.Host
+	if host == "" {
+		host = "127.0.0.1"
+	}
+	port := config.Port
+	if port == 0 {
+		port = 9200
+	}
+	scheme := "http"
+	if config.EsUseSSL {
+		scheme = "https"
+	}
+	prefix := strings.TrimSuffix(config.EsPathPrefix, "/")
+	if prefix != "" && !strings.HasPrefix(prefix, "/") {
+		prefix = "/" + prefix
+	}
+
+	transport := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   10 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		TLSHandshakeTimeout: 10 * time.Second,
+	}
+	if config.EsUseSSL {
+		transport.TLSClientConfig = &tls.Config{
+			InsecureSkipVerify: config.EsSkipVerify, //nolint:gosec // intentional user opt-in
+		}
+	}
+	client := &http.Client{
+		Timeout:   15 * time.Second,
+		Transport: transport,
+	}
+
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s://%s:%d%s", scheme, host, port, prefix), nil)
+	if err != nil {
+		return "", fmt.Errorf("elasticsearch connect: %w", err)
+	}
+	if auth := buildEsAuthHeader(config); auth != "" {
+		req.Header.Set("Authorization", auth)
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("elasticsearch connect: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		return "", fmt.Errorf("elasticsearch connect: HTTP %s", resp.Status)
+	}
+	return fmt.Sprintf("elasticsearch: connected to %s:%d", host, port), nil
 }
 
 func probeDatabase(config ConnectionConfig) (string, error) {

--- a/backend/session/test_connection_test.go
+++ b/backend/session/test_connection_test.go
@@ -1,0 +1,46 @@
+package session
+
+// Regression tests for the "database" connection test dispatch. redis /
+// mongodb / elasticsearch are stored as type "database" with a dbType field,
+// so ProbeConnection must route them to their dedicated probes instead of
+// falling through to the SQL provider registry (which would fail with
+// "unsupported database type: ...").
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestProbeConnectionDatabaseDispatchesByDBType(t *testing.T) {
+	// 127.0.0.1:1 is a closed port, so each probe fails fast with a dial
+	// error. The assertion is about WHICH probe ran, not connectivity.
+	cases := []struct {
+		name   string
+		dbType string
+		port   int
+	}{
+		{"redis", "redis", 6379},
+		{"mongodb", "mongodb", 27017},
+		{"elasticsearch", "elasticsearch", 9200},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			config := ConnectionConfig{
+				Type:   "database",
+				DBType: tc.dbType,
+				Host:   "127.0.0.1",
+				Port:   1,
+			}
+			_, err := ProbeConnection(config)
+			if err == nil {
+				t.Fatalf("expected error probing closed port")
+			}
+			if strings.Contains(err.Error(), "unsupported database type") {
+				t.Fatalf("dbType %q was not dispatched to its dedicated probe: %v", tc.dbType, err)
+			}
+			if !strings.Contains(err.Error(), tc.dbType) {
+				t.Fatalf("error should mention the probed database type %q, got: %v", tc.dbType, err)
+			}
+		})
+	}
+}

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1824,6 +1824,7 @@ async function reconnectDatabasePanel(panel: { id: string; sessionId: string | n
   let sessionType = 'database'
   if (cfg.dbType === 'redis') sessionType = 'redis'
   else if (cfg.dbType === 'mongodb') sessionType = 'mongodb'
+  else if (cfg.dbType === 'elasticsearch') sessionType = 'elasticsearch'
   try {
     const info = await CreateSession(sessionType, cfg)
     panelStore.bindSession(panel.id, info.id)

--- a/frontend/src/components/TabItem.vue
+++ b/frontend/src/components/TabItem.vue
@@ -185,7 +185,7 @@ const tabIcon = computed(() => {
   if (t.type === 'vnc') return MonitorSmartphone
   if (t.type === 'spice') return MonitorCloud
   if (t.type === 'x11-desktop') return AppWindow
-  if (t.type === 'database' || t.type === 'mongodb' || t.type === 'elasticsearch') {
+  if (t.type === 'database' || t.type === 'redis' || t.type === 'mongodb' || t.type === 'elasticsearch') {
     const panel = panelStore.getPanel(t.panelId)
     if (panel?.config?.dbType === 'redis') return DatabaseZap
     if (panel?.config?.dbType === 'mongodb') return Layers
@@ -276,7 +276,7 @@ const TTY_RECONNECT_TYPES: readonly string[] = ['ssh', 'telnet', 'serial', 'mosh
 const canReconnect = computed(() => {
   const type = props.tab.type
   if (type === 'rdp' || type === 'vnc' || type === 'spice' || type === 'x11-desktop') return true
-  if (type === 'database' || type === 'mongodb' || type === 'redis' || type === 'sftp' || type === 'monitor') {
+  if (type === 'database' || type === 'redis' || type === 'mongodb' || type === 'elasticsearch' || type === 'sftp' || type === 'monitor') {
     return 'panelId' in props.tab && !!panelStore.getPanel(props.tab.panelId)
   }
   if (type === 'k8s' || type === 'container') {


### PR DESCRIPTION
## Summary

Fixes three issues with redis / mongodb / elasticsearch connections:

1. **Redis tab missing its icon.** `onConnectDB` rewrites the tab type to `redis`, but the `tabIcon` computed in `TabItem.vue` did not include `redis` in its type list, so the icon resolved to null. Added `redis` to the list.
2. **Test connection fails for redis / mongodb / elasticsearch** with `unsupported database type: redis`. These database types are stored as `type: "database"` with a `dbType` discriminator, but `ProbeConnection` dispatched on `config.Type` only, falling through to the SQL provider registry which has no providers for them (the dead `case "redis"` / `case "mongodb"` entries never matched). `ProbeConnection` now dispatches by `dbType` inside the `"database"` case, and a new `probeElasticsearch` (reusing the session's URL/TLS/auth construction: SSL, skip-verify, ApiKey / Basic auth) was added — no ES probe existed before.
3. **Elasticsearch tab missing the reconnect context-menu item.** `canReconnect` in `TabItem.vue` did not include `elasticsearch`, so the menu item was not rendered. Also, the reconnect handler in `App.vue` did not map the `elasticsearch` dbType to its session type, so a reconnect would have gone through `DatabaseSession` and failed the same way; both are fixed.

No new user-facing strings, no i18n or binding changes.

## Test plan

- New regression test `TestProbeConnectionDatabaseDispatchesByDBType`: verified it reproduces the original error before the fix (RED) and passes after (GREEN); probes run against a closed local port and assert the dedicated probe (not the provider registry) was reached.
- `go build ./...` and `go test ./backend/session/` pass.
- `npm run build` passes.
- Full `go test ./...`: only `TestStartPprofIfDev_ProductionSkip` fails, confirmed pre-existing on a clean tree (environment-related, unrelated to this change).
- Manual: `wails3 dev` and verify the redis tab icon, test-connection for redis/mongodb/elasticsearch, and the elasticsearch tab right-click reconnect.

---

## 摘要

修复 redis / mongodb / elasticsearch 连接相关的三个问题：

1. **Redis 标签页没有图标。** `onConnectDB` 会把 redis 标签的 type 改写为 `redis`，但 `TabItem.vue` 的 `tabIcon` 类型列表没有包含 `redis`，图标解析为 null。已把 `redis` 加入列表。
2. **redis / mongodb / elasticsearch 的测试连接失败**，提示 `unsupported database type: redis`。这三种数据库以 `type: "database"` + `dbType` 区分字段存储，但 `ProbeConnection` 只按 `config.Type` 分发，落入 SQL provider 注册表（其中没有它们，原有的 `case "redis"` / `case "mongodb"` 分支早已失效）。现在 `"database"` 分支内按 `dbType` 分发到专属探测，并新增 `probeElasticsearch`（此前不存在，复用会话层的 URL/TLS/auth 构造：SSL、跳过证书验证、ApiKey / Basic 认证）。
3. **Elasticsearch 标签右键缺少重新连接菜单项。** `TabItem.vue` 的 `canReconnect` 没有包含 `elasticsearch`，菜单项不渲染；同时 `App.vue` 的重连处理也没有把 `elasticsearch` 的 dbType 映射到对应会话类型（否则重连会误走 `DatabaseSession` 以同样方式失败），两处均已修复。

无新增界面文案，不需要改动 i18n 和绑定。

## 测试计划

- 新增回归测试 `TestProbeConnectionDatabaseDispatchesByDBType`：修复前确认复现原错误（RED），修复后通过（GREEN）；探测目标是本地关闭的端口，断言走到了专属探测而非 provider 注册表。
- `go build ./...` 与 `go test ./backend/session/` 通过。
- `npm run build` 通过。
- 全量 `go test ./...`：仅 `TestStartPprofIfDev_ProductionSkip` 失败，已在干净工作树上确认为修复前就存在的环境相关问题，与本次改动无关。
- 手动验证：`wails3 dev` 后检查 redis 标签图标、三种库的测试连接、elasticsearch 标签右键重连。
