### PR TITLE
fix(db): support named-instance hosts (server\instance) for SQL Server

### DIFF
--- a/backend/database/provider_sqlserver.go
+++ b/backend/database/provider_sqlserver.go
@@ -18,13 +18,24 @@ func init() {
 }
 
 func (p *sqlserverProvider) DSN(host string, port int, user, password, dbName string, extraParams map[string]string) string {
-	if port <= 0 {
+	// A named instance ("server\instance") must not go into url.URL.Host:
+	// url.URL.String() escapes the backslash to %5C and the driver's
+	// url.Parse then rejects the DSN. The driver instead expects the
+	// instance as the URL path (sqlserver://host/instance). With an
+	// instance and no explicit port, omit the port so the driver resolves
+	// the instance's dynamic port via SQL Browser (a forced 1433 would
+	// bypass the Browser and almost always fail).
+	u := &url.URL{Scheme: "sqlserver", User: url.UserPassword(user, password)}
+	if server, instance, found := strings.Cut(host, `\`); found {
+		u.Path = "/" + instance
+		host = server
+	} else if port <= 0 {
 		port = 1433
 	}
-	u := &url.URL{
-		Scheme: "sqlserver",
-		User:   url.UserPassword(user, password),
-		Host:   fmt.Sprintf("%s:%d", host, port),
+	if port > 0 {
+		u.Host = fmt.Sprintf("%s:%d", host, port)
+	} else {
+		u.Host = host
 	}
 	q := u.Query()
 	if dbName != "" {

--- a/backend/database/provider_sqlserver_test.go
+++ b/backend/database/provider_sqlserver_test.go
@@ -1,0 +1,86 @@
+package database
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// TestSqlserverDSN covers DSN building for plain hosts and named instances
+// (issue: host containing "\" must not end up in url.URL.Host, where
+// url.URL.String() escapes it to %5C and the driver's url.Parse rejects it
+// as an invalid URL escape).
+func TestSqlserverDSN(t *testing.T) {
+	cases := []struct {
+		name         string
+		host         string
+		port         int
+		wantHost     string // expected u.Host in the parsed DSN
+		wantInstance string // expected u.Path ("/instance") or ""
+		wantRawQuery string // substring that must appear in RawQuery
+		noPort       bool   // DSN must not carry an explicit port
+	}{
+		{
+			name:         "plain host with default port",
+			host:         "localhost",
+			port:         0,
+			wantHost:     "localhost:1433",
+			wantInstance: "",
+			wantRawQuery: "database=mydb",
+		},
+		{
+			name:         "plain host with explicit port",
+			host:         "db.example.com",
+			port:         11433,
+			wantHost:     "db.example.com:11433",
+			wantInstance: "",
+			wantRawQuery: "database=mydb",
+		},
+		{
+			name:         "named instance without port omits port for SQL Browser",
+			host:         `localhost\SQLEXPRESS`,
+			port:         0,
+			wantHost:     "localhost",
+			wantInstance: "/SQLEXPRESS",
+			wantRawQuery: "database=mydb",
+			noPort:       true,
+		},
+		{
+			name:         "named instance with explicit port keeps port",
+			host:         `192.168.1.5\SQL2019`,
+			port:         21433,
+			wantHost:     "192.168.1.5:21433",
+			wantInstance: "/SQL2019",
+			wantRawQuery: "database=mydb",
+		},
+	}
+
+	p := &sqlserverProvider{}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dsn := p.DSN(tc.host, tc.port, "sa", "secret", "mydb", nil)
+			u, err := url.Parse(dsn)
+			if err != nil {
+				t.Fatalf("driver-side url.Parse failed on DSN %q: %v", dsn, err)
+			}
+			if u.Scheme != "sqlserver" {
+				t.Errorf("scheme = %q, want sqlserver", u.Scheme)
+			}
+			if u.Host != tc.wantHost {
+				t.Errorf("host = %q, want %q", u.Host, tc.wantHost)
+			}
+			if u.Path != tc.wantInstance {
+				t.Errorf("path = %q, want %q", u.Path, tc.wantInstance)
+			}
+			if !strings.Contains(u.RawQuery, tc.wantRawQuery) {
+				t.Errorf("raw query %q does not contain %q", u.RawQuery, tc.wantRawQuery)
+			}
+			if tc.noPort && strings.Contains(u.Host, ":") {
+				t.Errorf("DSN %q must omit port for browser resolution", dsn)
+			}
+			if got, ok := u.User.Password(); !ok || got != "secret" {
+				t.Errorf("password not preserved")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

A SQL Server host containing a backslash (e.g. `localhost\SQLEXPRESS`, i.e. a named instance) failed to connect with an "invalid URL format" error.

Root cause: `DSN()` put the raw host into `url.URL.Host`. `url.URL.String()` escapes the backslash to `%5C`, and the go-mssqldb driver's `url.Parse` rejects `%5C` in the host portion of the DSN.

Fix in `provider_sqlserver.DSN()`:

- Split the host on the first `\`: the server part goes into `u.Host`, the instance name goes into the URL path (`sqlserver://host/instance`), which is the form the driver expects.
- When a named instance is present and no explicit port is configured, the port is omitted from the DSN so the driver resolves the instance's dynamic port via SQL Browser. Forcing the default 1433 would bypass the Browser and almost always fail.
- When an explicit port is given, it is kept as-is (fixed-port instances).
- Plain hosts behave exactly as before (default 1433).

No new fields or UI changes — users type `server\instance` in the existing host input, which is also the standard notation in SSMS and ADO connection strings, and imported connections from DBeaver/Navicat with `host\instance` now work transparently.

## Testing

- Added `TestSqlserverDSN` covering: plain host with default port, plain host with explicit port, named instance without port (port omitted for Browser resolution), named instance with explicit port.
- Before the fix, the new test reproduced the exact driver error (`invalid URL escape "%5C"`); after the fix all cases pass.
- Verified end-to-end with the driver's own `msdsn.Parse` that the generated DSNs split into the expected host/instance/port.
- `go build ./...`, `go vet` and the full `backend/database` test suite pass.

Fixes #754

---

## 描述

SQL Server 主机名包含反斜杠（如 `localhost\SQLEXPRESS`，即命名实例）时，连接报 "invalid URL format" 错误。

根因：`DSN()` 直接把 host 塞进 `url.URL.Host`，`url.URL.String()` 会把反斜杠转义成 `%5C`，而 go-mssqldb 驱动用 `url.Parse` 解析 DSN 时拒绝 host 中的 `%5C`。

`provider_sqlserver.DSN()` 中的修复：

- host 按第一个 `\` 拆分：server 部分放 `u.Host`，实例名放 URL 路径（`sqlserver://host/instance`），这是驱动支持的形式。
- 有命名实例且未显式配置端口时，DSN 不带端口，由驱动通过 SQL Browser 解析实例的动态端口。强塞默认 1433 会绕过 Browser，基本必然失败。
- 用户显式填了端口则保留（固定端口实例）。
- 普通主机行为完全不变（默认 1433）。

不新增字段、不改 UI——用户直接在现有主机输入框填 `server\instance` 即可（这也是 SSMS 和 ADO 连接字符串的标准写法），从 DBeaver/Navicat 导入的 `host\instance` 连接也能透明生效。

## 测试

- 新增 `TestSqlserverDSN`：普通主机默认端口、普通主机显式端口、命名实例不带端口（省略端口走 Browser）、命名实例带固定端口。
- 修复前新测试能复现驱动报错（`invalid URL escape "%5C"`）；修复后全部通过。
- 用驱动自身的 `msdsn.Parse` 端到端验证生成的 DSN 能正确拆出 host/instance/port。
- `go build ./...`、`go vet` 及 `backend/database` 全量测试通过。

Fixes #754