### PR TITLE
fix(sync): spurious config-conflict dialog on every open + unify synced file list

### DIFF
--- a/backend/sync/crypto.go
+++ b/backend/sync/crypto.go
@@ -45,52 +45,25 @@ func EncryptConfigFiles(srcDir, destDir string, key []byte, kc *Keychain, ps Pas
 		return err
 	}
 
-	if err := encryptConnectionsFile(
-		filepath.Join(srcDir, "connections.json"),
-		filepath.Join(destDir, "connections.json"),
-		key, kc, ps,
-	); err != nil {
-		return fmt.Errorf("encrypt connections: %w", err)
-	}
-
-	if err := encryptSettingsFile(
-		filepath.Join(srcDir, "settings.json"),
-		filepath.Join(destDir, "settings.json"),
-		key, kc, ps,
-	); err != nil {
-		return fmt.Errorf("encrypt settings: %w", err)
-	}
-
-	if err := encryptGenericFile(
-		filepath.Join(srcDir, "quickCommands.json"),
-		filepath.Join(destDir, "quickCommands.json"),
-		key,
-	); err != nil {
-		return fmt.Errorf("encrypt quick commands: %w", err)
-	}
-
-	if err := encryptGenericFile(
-		filepath.Join(srcDir, "tunnels.json"),
-		filepath.Join(destDir, "tunnels.json"),
-		key,
-	); err != nil {
-		return fmt.Errorf("encrypt tunnels: %w", err)
-	}
-
-	if err := encryptIdentitiesFile(
-		filepath.Join(srcDir, "identities.json"),
-		filepath.Join(destDir, "identities.json"),
-		key, ps,
-	); err != nil {
-		return fmt.Errorf("encrypt identities: %w", err)
-	}
-
-	if err := encryptProxiesFile(
-		filepath.Join(srcDir, "proxies.json"),
-		filepath.Join(destDir, "proxies.json"),
-		key, ps,
-	); err != nil {
-		return fmt.Errorf("encrypt proxies: %w", err)
+	for _, name := range syncedFiles {
+		src := filepath.Join(srcDir, name)
+		dest := filepath.Join(destDir, name)
+		var err error
+		switch name {
+		case "connections.json":
+			err = encryptConnectionsFile(src, dest, key, kc, ps)
+		case "settings.json":
+			err = encryptSettingsFile(src, dest, key, kc, ps)
+		case "identities.json":
+			err = encryptIdentitiesFile(src, dest, key, ps)
+		case "proxies.json":
+			err = encryptProxiesFile(src, dest, key, ps)
+		default:
+			err = encryptGenericFile(src, dest, key)
+		}
+		if err != nil {
+			return fmt.Errorf("encrypt %s: %w", name, err)
+		}
 	}
 
 	return nil
@@ -266,52 +239,25 @@ func DecryptConfigFiles(srcDir, destDir string, key []byte, ps PasswordStore) er
 		return err
 	}
 
-	if err := decryptConnectionsFile(
-		filepath.Join(srcDir, "connections.json"),
-		filepath.Join(destDir, "connections.json"),
-		key, ps,
-	); err != nil {
-		return fmt.Errorf("decrypt connections: %w", err)
-	}
-
-	if err := decryptSettingsFile(
-		filepath.Join(srcDir, "settings.json"),
-		filepath.Join(destDir, "settings.json"),
-		key, ps,
-	); err != nil {
-		return fmt.Errorf("decrypt settings: %w", err)
-	}
-
-	if err := decryptGenericFile(
-		filepath.Join(srcDir, "quickCommands.json"),
-		filepath.Join(destDir, "quickCommands.json"),
-		key,
-	); err != nil {
-		return fmt.Errorf("decrypt quick commands: %w", err)
-	}
-
-	if err := decryptGenericFile(
-		filepath.Join(srcDir, "tunnels.json"),
-		filepath.Join(destDir, "tunnels.json"),
-		key,
-	); err != nil {
-		return fmt.Errorf("decrypt tunnels: %w", err)
-	}
-
-	if err := decryptIdentitiesFile(
-		filepath.Join(srcDir, "identities.json"),
-		filepath.Join(destDir, "identities.json"),
-		key, ps,
-	); err != nil {
-		return fmt.Errorf("decrypt identities: %w", err)
-	}
-
-	if err := decryptProxiesFile(
-		filepath.Join(srcDir, "proxies.json"),
-		filepath.Join(destDir, "proxies.json"),
-		key, ps,
-	); err != nil {
-		return fmt.Errorf("decrypt proxies: %w", err)
+	for _, name := range syncedFiles {
+		src := filepath.Join(srcDir, name)
+		dest := filepath.Join(destDir, name)
+		var err error
+		switch name {
+		case "connections.json":
+			err = decryptConnectionsFile(src, dest, key, ps)
+		case "settings.json":
+			err = decryptSettingsFile(src, dest, key, ps)
+		case "identities.json":
+			err = decryptIdentitiesFile(src, dest, key, ps)
+		case "proxies.json":
+			err = decryptProxiesFile(src, dest, key, ps)
+		default:
+			err = decryptGenericFile(src, dest, key)
+		}
+		if err != nil {
+			return fmt.Errorf("decrypt %s: %w", name, err)
+		}
 	}
 
 	return nil

--- a/backend/sync/git.go
+++ b/backend/sync/git.go
@@ -98,14 +98,12 @@ func (g *GitRepo) StageAndCommit(msg string) (bool, error) {
 		return false, nil
 	}
 
-	// Whitelist only known config filenames so stray files dropped in
+	// Whitelist the synced config files (single source of truth in
+	// synced_files.go) plus repo metadata, so stray files dropped in
 	// the sync repo (e.g. an SSH key) are NOT committed plaintext
 	// (SYNC-P1-9).
-	for _, name := range []string{
-		"connections.json", "settings.json",
-		"ai-sessions.json", "skills.json",
-		"quickCommands.json", "identities.json", "proxies.json", ".sync-salt", "README.md",
-	} {
+	commitWhitelist := append(syncedFiles[:len(syncedFiles):len(syncedFiles)], ".sync-salt", "README.md")
+	for _, name := range commitWhitelist {
 		if _, err := os.Stat(filepath.Join(g.repoPath, name)); err != nil {
 			continue
 		}

--- a/backend/sync/git.go
+++ b/backend/sync/git.go
@@ -176,51 +176,107 @@ func (g *GitRepo) ReadRemoteFile(branch, filePath string) ([]byte, error) {
 	return []byte(content), nil
 }
 
-// CompareHeads returns sync direction after fetching.
-func (g *GitRepo) CompareHeads(branch string) (SyncDirection, *time.Time, *time.Time, error) {
+// BranchHeads is the resolved state of the sync branch after a fetch.
+// A nil Local means HEAD is still unborn (no commits yet); a nil Remote
+// means the remote branch does not exist (empty repository).
+type BranchHeads struct {
+	Local  *plumbing.Hash
+	Remote *plumbing.Hash
+}
+
+// ResolveBranchHeads returns the local HEAD hash and the origin/<branch>
+// hash without assuming either exists.
+func (g *GitRepo) ResolveBranchHeads(branch string) (BranchHeads, error) {
+	var heads BranchHeads
+
 	localRef, err := g.repo.Head()
 	if err != nil {
-		return SyncNone, nil, nil, fmt.Errorf("local head: %w", err)
+		if err != plumbing.ErrReferenceNotFound {
+			return heads, fmt.Errorf("local head: %w", err)
+		}
+		// Unborn HEAD — no local commits yet.
+	} else {
+		h := localRef.Hash()
+		heads.Local = &h
 	}
-	localHash := localRef.Hash()
 
 	remoteRef, err := g.repo.Reference(
 		plumbing.NewRemoteReferenceName("origin", branch), true,
 	)
 	if err != nil {
-		if err == plumbing.ErrReferenceNotFound {
-			return SyncPush, nil, nil, nil
+		if err != plumbing.ErrReferenceNotFound {
+			return heads, fmt.Errorf("remote ref: %w", err)
 		}
-		return SyncNone, nil, nil, fmt.Errorf("remote ref: %w", err)
-	}
-	remoteHash := remoteRef.Hash()
-
-	if localHash == remoteHash {
-		return SyncNone, nil, nil, nil
+	} else {
+		h := remoteRef.Hash()
+		heads.Remote = &h
 	}
 
-	localCommit, err := g.repo.CommitObject(localHash)
+	return heads, nil
+}
+
+// MergeBase returns the best common ancestor of the two commits, or nil
+// when they share no history.
+func (g *GitRepo) MergeBase(a, b plumbing.Hash) (*plumbing.Hash, error) {
+	ca, err := g.repo.CommitObject(a)
 	if err != nil {
-		return SyncNone, nil, nil, fmt.Errorf("local commit: %w", err)
+		return nil, fmt.Errorf("commit %s: %w", a, err)
 	}
-	remoteCommit, err := g.repo.CommitObject(remoteHash)
+	cb, err := g.repo.CommitObject(b)
 	if err != nil {
-		return SyncNone, nil, nil, fmt.Errorf("remote commit: %w", err)
+		return nil, fmt.Errorf("commit %s: %w", b, err)
 	}
-
-	localTime := localCommit.Committer.When
-	remoteTime := remoteCommit.Committer.When
-
-	localAncestor, _ := localCommit.IsAncestor(remoteCommit)
-	remoteAncestor, _ := remoteCommit.IsAncestor(localCommit)
-
-	if remoteAncestor {
-		return SyncPush, &localTime, &remoteTime, nil
+	bases, err := ca.MergeBase(cb)
+	if err != nil {
+		return nil, fmt.Errorf("merge base: %w", err)
 	}
-	if localAncestor {
-		return SyncPull, &localTime, &remoteTime, nil
+	if len(bases) == 0 {
+		return nil, nil
 	}
-	return SyncConflict, &localTime, &remoteTime, nil
+	h := bases[0].Hash
+	return &h, nil
+}
+
+// CommitTime returns the committer timestamp of the given commit.
+func (g *GitRepo) CommitTime(h plumbing.Hash) (time.Time, error) {
+	commit, err := g.repo.CommitObject(h)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("commit %s: %w", h, err)
+	}
+	return commit.Committer.When, nil
+}
+
+// ExtractCommitFiles writes the synced config files as committed at hash
+// into destDir. The extracted files are still encrypted — the caller
+// decrypts them. Files absent from that commit's tree are skipped.
+func (g *GitRepo) ExtractCommitFiles(hash plumbing.Hash, destDir string) error {
+	commit, err := g.repo.CommitObject(hash)
+	if err != nil {
+		return fmt.Errorf("commit %s: %w", hash, err)
+	}
+	tree, err := commit.Tree()
+	if err != nil {
+		return fmt.Errorf("tree: %w", err)
+	}
+	if err := os.MkdirAll(destDir, 0755); err != nil {
+		return err
+	}
+	for _, name := range syncedFiles {
+		file, err := tree.File(name)
+		if err != nil {
+			// Not present in this commit (e.g. the merge base predates
+			// the file) — nothing to extract.
+			continue
+		}
+		content, err := file.Contents()
+		if err != nil {
+			return fmt.Errorf("read %s: %w", name, err)
+		}
+		if err := os.WriteFile(filepath.Join(destDir, name), []byte(content), 0600); err != nil {
+			return fmt.Errorf("write %s: %w", name, err)
+		}
+	}
+	return nil
 }
 
 // PushToBranch pushes the current HEAD to the specified remote branch.
@@ -236,11 +292,6 @@ func (g *GitRepo) PushToBranch(branch, username, token string) error {
 		return nil
 	}
 	return err
-}
-
-// ForcePush pushes with force, overwriting remote.
-func (g *GitRepo) ForcePush(username, token string) error {
-	return g.repo.Push(&git.PushOptions{Auth: buildAuth(username, token), Force: true})
 }
 
 // ResetToRemote resets local HEAD to match remote branch.

--- a/backend/sync/security_test.go
+++ b/backend/sync/security_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
+	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/zalando/go-keyring"
 )
 
@@ -29,13 +30,26 @@ func initLocalRepoWithBareRemote(t *testing.T) (*SyncService, string) {
 		t.Fatalf("mkdir remote: %v", err)
 	}
 
-	if _, err := git.PlainInit(remotePath, true); err != nil {
+	bare, err := git.PlainInit(remotePath, true)
+	if err != nil {
 		t.Fatalf("init bare: %v", err)
+	}
+	// Align both HEADs with config.Branch ("main") — PlainInit defaults to
+	// master, which would desync every branch reference in the flow tests.
+	if err := bare.Storer.SetReference(
+		plumbing.NewSymbolicReference(plumbing.HEAD, plumbing.NewBranchReferenceName("main")),
+	); err != nil {
+		t.Fatalf("set bare HEAD: %v", err)
 	}
 
 	work, err := git.PlainInit(repoPath, false)
 	if err != nil {
 		t.Fatalf("init work: %v", err)
+	}
+	if err := work.Storer.SetReference(
+		plumbing.NewSymbolicReference(plumbing.HEAD, plumbing.NewBranchReferenceName("main")),
+	); err != nil {
+		t.Fatalf("set work HEAD: %v", err)
 	}
 	if _, err := work.CreateRemote(&config.RemoteConfig{
 		Name: "origin",
@@ -66,35 +80,14 @@ func initLocalRepoWithBareRemote(t *testing.T) (*SyncService, string) {
 	return s, repoPath
 }
 
-// TestCompareLocalWithRepo_WrongKeyReturnsError is the file-level half of the
-// SYNC-P1-11 guard: when Sync() hands compareLocalWithRepo an encKey that
-// cannot decrypt the remote ciphertext (wrong master password, corrupted
-// blob), the helper must surface the error rather than return false (which
-// would let Sync() push locally-derived ciphertext over the only good copy).
-func TestCompareLocalWithRepo_WrongKeyReturnsError(t *testing.T) {
-	s, repoPath := initLocalRepoWithBareRemote(t)
+// TestCompareLocalWithRepo_WrongKeyReturnsError was folded into
+// TestSync_WrongPasswordSetsPasswordMismatchStatus: the wrong-key abort is
+// now the verifyDecryption guard inside Sync() itself.
 
-	realKey := DeriveKey("correct-password", []byte("0123456789abcdef"))
-	wrongKey := DeriveKey("WRONG-password", []byte("0123456789abcdef"))
-
-	srcDir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(srcDir, "connections.json"),
-		[]byte(`{"connections":[]}`), 0600); err != nil {
-		t.Fatalf("write src connections: %v", err)
-	}
-	if err := EncryptConfigFiles(srcDir, repoPath, realKey, nil, nil); err != nil {
-		t.Fatalf("encrypt with realKey: %v", err)
-	}
-
-	_, err := s.compareLocalWithRepo(wrongKey)
-	if err == nil {
-		t.Fatal("compareLocalWithRepo with wrong key returned nil error — SYNC-P1-11 regression")
-	}
-}
-
-// TestSync_WrongPasswordSetsPasswordMismatchStatus drives Sync() to the
-// compareLocalWithRepo branch and asserts the on-disk status record reflects
-// the password_mismatch outcome (not a generic "failed").
+// TestSync_WrongPasswordSetsPasswordMismatchStatus drives Sync() with an
+// encKey that cannot open the existing ciphertext and asserts the on-disk
+// status record reflects the password_mismatch outcome (not a generic
+// "failed").
 func TestSync_WrongPasswordSetsPasswordMismatchStatus(t *testing.T) {
 	s, repoPath := initLocalRepoWithBareRemote(t)
 

--- a/backend/sync/sync_flow_test.go
+++ b/backend/sync/sync_flow_test.go
@@ -1,0 +1,258 @@
+package sync
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+)
+
+// newFlowService builds a SyncService wired to a bare remote with a data
+// dir and a known encryption key, ready to exercise full Sync() flows.
+func newFlowService(t *testing.T) (*SyncService, []byte) {
+	t.Helper()
+	s, _ := initLocalRepoWithBareRemote(t)
+	s.dataDir = t.TempDir()
+	key := DeriveKey("flow-pass", []byte("0123456789abcdef"))
+	if err := s.keychain.StoreEncryptionKey(key); err != nil {
+		t.Fatalf("store key: %v", err)
+	}
+	return s, key
+}
+
+func writeConnections(t *testing.T, dir, id string) {
+	t.Helper()
+	// Shape mirrors the production ConnectionStoreData wrapper — the
+	// upload normalizer re-marshals through a {groups, connections}
+	// struct, so the file must carry both keys to round-trip byte-stable.
+	if err := os.WriteFile(filepath.Join(dir, "connections.json"),
+		[]byte(`{"groups":[],"connections":[{"id":"`+id+`","name":"n"}]}`), 0600); err != nil {
+		t.Fatalf("write connections: %v", err)
+	}
+}
+
+func readConnectionsID(t *testing.T, dir string) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(dir, "connections.json"))
+	if err != nil {
+		t.Fatalf("read connections: %v", err)
+	}
+	var wrapper struct {
+		Connections []struct {
+			ID string `json:"id"`
+		} `json:"connections"`
+	}
+	if err := json.Unmarshal(data, &wrapper); err != nil {
+		t.Fatalf("parse connections: %v", err)
+	}
+	if len(wrapper.Connections) == 0 {
+		return ""
+	}
+	return wrapper.Connections[0].ID
+}
+
+// pushRemoteContent simulates ANOTHER machine: clones the remote, commits
+// the given content and pushes. Returns the pushed head hash.
+func pushRemoteContent(t *testing.T, s *SyncService, key []byte, id string) plumbing.Hash {
+	t.Helper()
+	remotePath := filepath.Join(s.configDir, "remote.git")
+	dirB := t.TempDir()
+	repoB, err := git.PlainClone(dirB, false, &git.CloneOptions{URL: remotePath})
+	if err != nil {
+		t.Fatalf("device-B clone: %v", err)
+	}
+	src := t.TempDir()
+	writeConnections(t, src, id)
+	if err := EncryptConfigFiles(src, dirB, key, nil, nil); err != nil {
+		t.Fatalf("device-B encrypt: %v", err)
+	}
+	gb := &GitRepo{repo: repoB, repoPath: dirB}
+	if _, err := gb.StageAndCommit("device B"); err != nil {
+		t.Fatalf("device-B commit: %v", err)
+	}
+	if err := repoB.Push(&git.PushOptions{}); err != nil {
+		t.Fatalf("device-B push: %v", err)
+	}
+	head, err := repoB.Head()
+	if err != nil {
+		t.Fatalf("device-B head: %v", err)
+	}
+	return head.Hash()
+}
+
+// commitLocalWithoutPush simulates a local commit that never reached the
+// remote (e.g. push failed on the previous sync).
+func commitLocalWithoutPush(t *testing.T, s *SyncService, key []byte) {
+	t.Helper()
+	if err := EncryptConfigFiles(s.dataDir, s.repoPath, key, nil, nil); err != nil {
+		t.Fatalf("local encrypt: %v", err)
+	}
+	repoO, err := git.PlainOpen(s.repoPath)
+	if err != nil {
+		t.Fatalf("open repo: %v", err)
+	}
+	g := &GitRepo{repo: repoO, repoPath: s.repoPath}
+	if _, err := g.StageAndCommit("local unpushed"); err != nil {
+		t.Fatalf("local commit: %v", err)
+	}
+}
+
+// TestSync_SilentPullWhenRemoteAdvanced is the issue-#745 regression: the
+// other machine pushed a change, this machine changed nothing. Sync must
+// silently pull — never surface the conflict dialog.
+func TestSync_SilentPullWhenRemoteAdvanced(t *testing.T) {
+	s, key := newFlowService(t)
+
+	writeConnections(t, s.dataDir, "c1")
+	res, err := s.Sync()
+	if err != nil {
+		t.Fatalf("initial sync: %v", err)
+	}
+	if res.Direction != SyncPush {
+		t.Fatalf("initial sync direction = %d, want SyncPush", res.Direction)
+	}
+
+	pushRemoteContent(t, s, key, "c2")
+
+	res, err = s.Sync()
+	if err != nil {
+		t.Fatalf("second sync: %v", err)
+	}
+	if res.Direction != SyncPull {
+		t.Fatalf("direction = %d, want SyncPull (silent) — conflict dialog on unchanged machine", res.Direction)
+	}
+	if got := readConnectionsID(t, s.dataDir); got != "c2" {
+		t.Fatalf("after pull connections id = %q, want c2", got)
+	}
+}
+
+// TestSync_ConflictOnlyWhenBothChanged: remote advanced AND local content
+// changed independently since the merge base — only then is the conflict
+// dialog legitimate.
+func TestSync_ConflictOnlyWhenBothChanged(t *testing.T) {
+	s, key := newFlowService(t)
+
+	writeConnections(t, s.dataDir, "c1")
+	if _, err := s.Sync(); err != nil {
+		t.Fatalf("initial sync: %v", err)
+	}
+
+	pushRemoteContent(t, s, key, "c2")
+	writeConnections(t, s.dataDir, "c3") // local diverges too
+
+	res, err := s.Sync()
+	if err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+	if res.Direction != SyncConflict {
+		t.Fatalf("direction = %d, want SyncConflict", res.Direction)
+	}
+}
+
+// TestResolveConflict_LocalKeepsHistoryFastForwardable is the anti-ping-pong
+// regression: resolving with the local side must land a normal commit on
+// top of the remote head (fast-forward), NOT a force push. Force-pushing
+// orphaned the other machine's head so it conflicted again on its next
+// open, forever.
+func TestResolveConflict_LocalKeepsHistoryFastForwardable(t *testing.T) {
+	s, key := newFlowService(t)
+
+	writeConnections(t, s.dataDir, "c1")
+	if _, err := s.Sync(); err != nil {
+		t.Fatalf("initial sync: %v", err)
+	}
+
+	remoteHead := pushRemoteContent(t, s, key, "c2")
+	writeConnections(t, s.dataDir, "c3")
+	if _, err := s.Sync(); err != nil {
+		t.Fatalf("sync (expect conflict): %v", err)
+	}
+
+	if _, err := s.ResolveConflict(true); err != nil {
+		t.Fatalf("resolve conflict (use local): %v", err)
+	}
+
+	// The new remote head must have the previous remote head as its parent —
+	// i.e. history was NOT rewritten.
+	bare, err := git.PlainOpen(filepath.Join(s.configDir, "remote.git"))
+	if err != nil {
+		t.Fatalf("open bare remote: %v", err)
+	}
+	ref, err := bare.Reference(plumbing.NewBranchReferenceName("main"), true)
+	if err != nil {
+		t.Fatalf("remote ref: %v", err)
+	}
+	commit, err := bare.CommitObject(ref.Hash())
+	if err != nil {
+		t.Fatalf("remote head commit: %v", err)
+	}
+	parents := commit.ParentHashes
+	if len(parents) != 1 || parents[0] != remoteHead {
+		t.Fatalf("remote history rewritten: head parents = %v, want parent == previous remote head %s — force-push ping-pong regression", parents, remoteHead)
+	}
+
+	// And the very next sync must be a quiet no-op, not another conflict.
+	writeConnections(t, s.dataDir, "c3")
+	res, err := s.Sync()
+	if err != nil {
+		t.Fatalf("sync after resolve: %v", err)
+	}
+	if res.Direction != SyncNone {
+		t.Fatalf("direction after resolve = %d, want SyncNone", res.Direction)
+	}
+}
+
+// TestSync_HealsDivergedHeadsWithSameContent: both heads moved but the
+// decrypted content is identical (e.g. re-encrypt noise) — Sync must heal
+// the history silently instead of showing the conflict dialog.
+func TestSync_HealsDivergedHeadsWithSameContent(t *testing.T) {
+	s, key := newFlowService(t)
+
+	writeConnections(t, s.dataDir, "c1")
+	if _, err := s.Sync(); err != nil {
+		t.Fatalf("initial sync: %v", err)
+	}
+
+	// Local side: commit a re-encryption of the SAME content (new IV,
+	// different ciphertext, identical plaintext).
+	commitLocalWithoutPush(t, s, key)
+	// Remote side: another machine re-encrypts the same content too.
+	pushRemoteContent(t, s, key, "c1")
+
+	res, err := s.Sync()
+	if err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+	if res.Direction != SyncNone {
+		t.Fatalf("direction = %d, want SyncNone (healed, no conflict)", res.Direction)
+	}
+}
+
+// TestSync_RecoversFromUnpushedLocalCommit: a local commit that failed to
+// push on a previous sync must not wedge the next sync — the changed
+// content is re-anchored on the remote head and pushed.
+func TestSync_RecoversFromUnpushedLocalCommit(t *testing.T) {
+	s, key := newFlowService(t)
+
+	writeConnections(t, s.dataDir, "c1")
+	if _, err := s.Sync(); err != nil {
+		t.Fatalf("initial sync: %v", err)
+	}
+
+	writeConnections(t, s.dataDir, "c2")
+	commitLocalWithoutPush(t, s, key)
+
+	res, err := s.Sync()
+	if err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+	if res.Direction != SyncPush {
+		t.Fatalf("direction = %d, want SyncPush", res.Direction)
+	}
+	if got := readConnectionsID(t, s.dataDir); got != "c2" {
+		t.Fatalf("local data corrupted by recovery: id = %q, want c2", got)
+	}
+}

--- a/backend/sync/sync_service.go
+++ b/backend/sync/sync_service.go
@@ -11,6 +11,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/go-git/go-git/v5/plumbing"
+	ggittransport "github.com/go-git/go-git/v5/plumbing/transport"
 	"github.com/ys-ll/uniterm/backend/utils"
 )
 
@@ -157,7 +159,16 @@ func (s *SyncService) getToken() string {
 	return token
 }
 
-// Sync runs a full sync cycle: clone/open → encrypt → commit → fetch → compare → push/pull → decrypt.
+// Sync runs a full sync cycle: clone/open → fetch → three-way content
+// analysis → commit/pull/push → decrypt.
+//
+// The remote state is fetched BEFORE anything is committed locally: the
+// old commit-then-fetch order turned "not pulled yet" into a local commit
+// on a stale head, so two machines used alternately diverged and hit the
+// conflict dialog on every open. Content is then analyzed three-way
+// (local data dir vs merge base vs remote head) so that "merely out of
+// date" is a silent pull and only a genuine both-sides edit surfaces the
+// conflict dialog.
 func (s *SyncService) Sync() (*SyncResult, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -182,76 +193,137 @@ func (s *SyncService) Sync() (*SyncResult, error) {
 	username := config.Username
 	token := s.getToken()
 
-	// 1. Clone or open repo
+	// 1. Clone or open repo.
 	repo, err := CloneOrOpen(s.repoPath, config.RepoURL, config.Branch, username, token)
 	if err != nil {
 		s.updateLastSyncResult("failed", fmt.Sprintf("open repo: %v", err))
 		return nil, fmt.Errorf("open repo: %w", err)
 	}
 
-	// 2. Encrypt and commit only if local config has actually changed.
-	// A decrypt error means the stored master password / key cannot
-	// open the remote ciphertext (wrong password or corrupted blob);
-	// refuse to push and surface the error to the user rather than
-	// overwriting the only good remote copy with locally-derived
-	// ciphertext (SYNC-P1-11).
-	committed := false
-	same, cmpErr := s.compareLocalWithRepo(encKey)
-	if cmpErr != nil {
-		s.updateLastSyncResult("password_mismatch", cmpErr.Error())
-		return nil, cmpErr
-	}
-	if !same {
-		if err := EncryptConfigFiles(s.dataDir, s.repoPath, encKey, s.keychain, s.passwordStore); err != nil {
-			s.updateLastSyncResult("failed", fmt.Sprintf("encrypt files: %v", err))
-			return nil, fmt.Errorf("encrypt files: %w", err)
-		}
-
-		committed, err = repo.StageAndCommit(commitMsg("uniTerm config sync"))
-		if err != nil {
-			s.updateLastSyncResult("failed", fmt.Sprintf("commit: %v", err))
-			return nil, fmt.Errorf("commit: %w", err)
+	// SYNC-P1-11: a key that cannot open the existing ciphertext (wrong
+	// master password, corrupted blob) must abort the sync before any
+	// locally-derived ciphertext can be pushed over the only good copy.
+	if repoHasFiles(s.repoPath) {
+		if err := verifyDecryption(s.repoPath, encKey); err != nil {
+			s.updateLastSyncResult("password_mismatch", err.Error())
+			return nil, err
 		}
 	}
 
-	// 4. Fetch
+	// 2. Fetch on a truly empty remote returns ErrEmptyRemoteRepository —
+	// treat as "remote has no branch yet", not as an error.
 	if err := repo.Fetch(username, token); err != nil {
-		if committed {
-			if pushErr := repo.Push(username, token); pushErr != nil {
-				s.updateLastSyncResult("failed", fmt.Sprintf("push: %v", pushErr))
-				return nil, fmt.Errorf("push to empty remote: %w", pushErr)
-			}
-			s.updateLastSyncResult("success", "")
-			return &SyncResult{Direction: SyncPush, Message: "配置已上传"}, nil
+		if !errors.Is(err, ggittransport.ErrEmptyRemoteRepository) {
+			s.updateLastSyncResult("failed", fmt.Sprintf("fetch: %v", err))
+			return nil, fmt.Errorf("fetch: %w", err)
 		}
-		s.updateLastSyncResult("success", "")
-		return &SyncResult{Message: "已是最新"}, nil
 	}
 
-	// 5. Compare heads
-	direction, localTime, remoteTime, err := repo.CompareHeads(config.Branch)
+	heads, err := repo.ResolveBranchHeads(config.Branch)
 	if err != nil {
-		s.updateLastSyncResult("failed", fmt.Sprintf("compare: %v", err))
-		return nil, fmt.Errorf("compare: %w", err)
+		s.updateLastSyncResult("failed", fmt.Sprintf("resolve heads: %v", err))
+		return nil, fmt.Errorf("resolve heads: %w", err)
 	}
 
-	switch direction {
-	case SyncNone:
+	// 3. Bootstrap cases.
+	if heads.Local == nil && heads.Remote == nil {
+		// Nothing anywhere: publish the local config as the initial commit.
+		return s.pushLocalConfig(repo, encKey, username, token)
+	}
+	if heads.Local == nil {
+		// Fresh local repo — adopt the remote silently.
+		if err := repo.ResetToRemote(config.Branch); err != nil {
+			s.updateLastSyncResult("failed", fmt.Sprintf("reset: %v", err))
+			return nil, fmt.Errorf("reset: %w", err)
+		}
+		if err := DecryptConfigFiles(s.repoPath, s.dataDir, encKey, s.passwordStore); err != nil {
+			s.updateLastSyncResult("failed", fmt.Sprintf("decrypt files: %v", err))
+			return nil, fmt.Errorf("decrypt files: %w", err)
+		}
+		s.updateLastSyncResult("success", "")
+		return &SyncResult{Direction: SyncPull, Message: "配置已下载"}, nil
+	}
+	if heads.Remote == nil {
+		// The remote branch does not exist (wiped or force-emptied) —
+		// re-publish the local config on top of it.
+		return s.pushLocalConfig(repo, encKey, username, token)
+	}
+
+	// 4. Heads in sync — only local data drift can require a push.
+	if *heads.Local == *heads.Remote {
+		same, err := s.dataMatchesCommit(repo, encKey, *heads.Local)
+		if err != nil {
+			s.updateLastSyncResult("failed", err.Error())
+			return nil, err
+		}
+		if same {
+			s.updateLastSyncResult("success", "")
+			return &SyncResult{Message: "已是最新"}, nil
+		}
+		return s.pushLocalConfig(repo, encKey, username, token)
+	}
+
+	// 5. Heads diverged or fast-forwardable — three-way content analysis
+	// against the merge base, so "only the remote moved" is a silent pull
+	// and only a genuine both-sides edit surfaces the conflict dialog.
+	base, err := repo.MergeBase(*heads.Local, *heads.Remote)
+	if err != nil {
+		s.updateLastSyncResult("failed", fmt.Sprintf("merge base: %v", err))
+		return nil, fmt.Errorf("merge base: %w", err)
+	}
+
+	baseDir, cleanupBase, err := s.decryptCommitToDir(repo, encKey, base)
+	if err != nil {
+		s.updateLastSyncResult("failed", err.Error())
+		return nil, err
+	}
+	defer cleanupBase()
+	remoteDir, cleanupRemote, err := s.decryptCommitToDir(repo, encKey, heads.Remote)
+	if err != nil {
+		s.updateLastSyncResult("failed", err.Error())
+		return nil, err
+	}
+	defer cleanupRemote()
+
+	localChanged, err := dirsDiffer(s.dataDir, baseDir, s.keychain, s.passwordStore)
+	if err != nil {
+		s.updateLastSyncResult("failed", err.Error())
+		return nil, err
+	}
+	remoteChanged, err := dirsDiffer(remoteDir, baseDir, nil, nil)
+	if err != nil {
+		s.updateLastSyncResult("failed", err.Error())
+		return nil, err
+	}
+
+	switch {
+	case !localChanged && !remoteChanged:
+		// Content identical on both sides, heads diverged anyway (e.g.
+		// re-encrypt noise from older builds) — heal the history
+		// silently; no data changes.
+		if err := repo.ResetToRemote(config.Branch); err != nil {
+			s.updateLastSyncResult("failed", fmt.Sprintf("reset: %v", err))
+			return nil, fmt.Errorf("reset: %w", err)
+		}
 		s.updateLastSyncResult("success", "")
 		return &SyncResult{Message: "已是最新"}, nil
 
-	case SyncPush:
-		if err := repo.Push(username, token); err != nil {
-			s.updateLastSyncResult("failed", fmt.Sprintf("push: %v", err))
-			return nil, fmt.Errorf("push: %w", err)
+	case localChanged && !remoteChanged:
+		// Only the local content is newer. Re-anchor the clone on the
+		// remote head and publish the local content as one commit on top
+		// of it, so the push is a fast-forward (any unpushed local
+		// commits are squashed — they were never shared).
+		if err := repo.ResetToRemote(config.Branch); err != nil {
+			s.updateLastSyncResult("failed", fmt.Sprintf("reset: %v", err))
+			return nil, fmt.Errorf("reset: %w", err)
 		}
-		s.updateLastSyncResult("success", "")
-		return &SyncResult{Direction: SyncPush, Message: "配置已上传"}, nil
+		return s.pushLocalConfig(repo, encKey, username, token)
 
-	case SyncPull:
-		if err := repo.Pull(username, token); err != nil {
-			s.updateLastSyncResult("failed", fmt.Sprintf("pull: %v", err))
-			return nil, fmt.Errorf("pull: %w", err)
+	case !localChanged && remoteChanged:
+		// Only the remote moved — silent pull.
+		if err := repo.ResetToRemote(config.Branch); err != nil {
+			s.updateLastSyncResult("failed", fmt.Sprintf("reset: %v", err))
+			return nil, fmt.Errorf("reset: %w", err)
 		}
 		if err := DecryptConfigFiles(s.repoPath, s.dataDir, encKey, s.passwordStore); err != nil {
 			s.updateLastSyncResult("failed", fmt.Sprintf("decrypt files: %v", err))
@@ -260,25 +332,103 @@ func (s *SyncService) Sync() (*SyncResult, error) {
 		s.updateLastSyncResult("success", "")
 		return &SyncResult{Direction: SyncPull, Message: "配置已下载"}, nil
 
-	case SyncConflict:
-		if localTime == nil {
-			t := time.Time{}
-			localTime = &t
+	default:
+		// Both sides changed content since the merge base — a genuine
+		// conflict; let the user pick a direction.
+		localTime, err := repo.CommitTime(*heads.Local)
+		if err != nil {
+			s.updateLastSyncResult("failed", err.Error())
+			return nil, err
 		}
-		if remoteTime == nil {
-			t := time.Time{}
-			remoteTime = &t
+		remoteTime, err := repo.CommitTime(*heads.Remote)
+		if err != nil {
+			s.updateLastSyncResult("failed", err.Error())
+			return nil, err
 		}
+		s.updateLastSyncResult("conflict", "")
 		return &SyncResult{
 			Direction: SyncConflict,
 			Conflict: &ConflictInfo{
-				LocalTime:  *localTime,
-				RemoteTime: *remoteTime,
+				LocalTime:  localTime,
+				RemoteTime: remoteTime,
 			},
 		}, nil
 	}
+}
 
-	return &SyncResult{Message: "已是最新"}, nil
+// pushLocalConfig encrypts the local config into the repo, commits it on
+// top of the current HEAD and pushes.
+func (s *SyncService) pushLocalConfig(repo *GitRepo, encKey []byte, username, token string) (*SyncResult, error) {
+	if err := EncryptConfigFiles(s.dataDir, s.repoPath, encKey, s.keychain, s.passwordStore); err != nil {
+		s.updateLastSyncResult("failed", fmt.Sprintf("encrypt files: %v", err))
+		return nil, fmt.Errorf("encrypt files: %w", err)
+	}
+	if _, err := repo.StageAndCommit(commitMsg("uniTerm config sync")); err != nil {
+		s.updateLastSyncResult("failed", fmt.Sprintf("commit: %v", err))
+		return nil, fmt.Errorf("commit: %w", err)
+	}
+	if err := repo.Push(username, token); err != nil {
+		s.updateLastSyncResult("failed", fmt.Sprintf("push: %v", err))
+		return nil, fmt.Errorf("push: %w", err)
+	}
+	s.updateLastSyncResult("success", "")
+	return &SyncResult{Direction: SyncPush, Message: "配置已上传"}, nil
+}
+
+// dataMatchesCommit compares the local config dir with the config as
+// committed at hash. A decrypt error is surfaced, not swallowed
+// (SYNC-P1-11).
+func (s *SyncService) dataMatchesCommit(repo *GitRepo, encKey []byte, hash plumbing.Hash) (bool, error) {
+	dir, cleanup, err := s.decryptCommitToDir(repo, encKey, &hash)
+	if err != nil {
+		return false, err
+	}
+	defer cleanup()
+	same, err := compareConfigDirs(s.dataDir, dir, s.keychain, s.passwordStore)
+	if err != nil {
+		return false, err
+	}
+	return same, nil
+}
+
+// decryptCommitToDir extracts the synced files as committed at hash and
+// decrypts them into a fresh temp dir. A nil hash yields an empty dir
+// (nothing committed at that side). The caller owns cleanup via the
+// returned function.
+func (s *SyncService) decryptCommitToDir(repo *GitRepo, encKey []byte, hash *plumbing.Hash) (string, func(), error) {
+	cipherDir, err := os.MkdirTemp("", "sync-cipher-")
+	if err != nil {
+		return "", nil, err
+	}
+	plainDir, err := os.MkdirTemp("", "sync-plain-")
+	if err != nil {
+		os.RemoveAll(cipherDir)
+		return "", nil, err
+	}
+	cleanup := func() {
+		os.RemoveAll(cipherDir)
+		os.RemoveAll(plainDir)
+	}
+	if hash != nil {
+		if err := repo.ExtractCommitFiles(*hash, cipherDir); err != nil {
+			cleanup()
+			return "", nil, err
+		}
+		if err := DecryptConfigFiles(cipherDir, plainDir, encKey, nil); err != nil {
+			cleanup()
+			return "", nil, fmt.Errorf("decrypt commit: %w", err)
+		}
+	}
+	return plainDir, cleanup, nil
+}
+
+// dirsDiffer reports whether the two decrypted config directories differ.
+func dirsDiffer(a, b string, kc *Keychain, ps PasswordStore) (bool, error) {
+	same, err := compareConfigDirs(a, b, kc, ps)
+	if err != nil {
+		return false, err
+	}
+	return !same, nil
 }
 
 // ResolveConflict handles a conflict by forcing push or reset.
@@ -307,24 +457,55 @@ func (s *SyncService) ResolveConflict(useLocal bool) (*SyncResult, error) {
 		return nil, fmt.Errorf("encryption key: %w", err)
 	}
 
+	// SYNC-P1-11: same guard as Sync — a key that cannot open the
+	// existing ciphertext must abort before anything is pushed.
+	if repoHasFiles(s.repoPath) {
+		if err := verifyDecryption(s.repoPath, encKey); err != nil {
+			s.updateLastSyncResult("password_mismatch", err.Error())
+			return nil, err
+		}
+	}
+
+	// Learn the remote state first — same ordering rule as Sync.
+	if err := repo.Fetch(username, token); err != nil {
+		if !errors.Is(err, ggittransport.ErrEmptyRemoteRepository) {
+			return nil, fmt.Errorf("fetch: %w", err)
+		}
+	}
+	heads, err := repo.ResolveBranchHeads(config.Branch)
+	if err != nil {
+		return nil, fmt.Errorf("resolve heads: %w", err)
+	}
+
 	if useLocal {
+		// Re-anchor the clone on the remote head and publish the local
+		// content as one commit on top of it. The push is then a
+		// fast-forward — force-pushing here orphaned the other machines'
+		// heads and made them conflict again on their next open, creating
+		// an endless resolve-conflict ping-pong.
+		if heads.Remote != nil {
+			if err := repo.ResetToRemote(config.Branch); err != nil {
+				return nil, fmt.Errorf("reset: %w", err)
+			}
+		}
 		if err := EncryptConfigFiles(s.dataDir, s.repoPath, encKey, s.keychain, s.passwordStore); err != nil {
 			return nil, fmt.Errorf("encrypt files: %w", err)
 		}
 		if _, err := repo.StageAndCommit(commitMsg("uniTerm config sync (resolve conflict)")); err != nil {
 			return nil, fmt.Errorf("commit: %w", err)
 		}
-		if err := repo.ForcePush(username, token); err != nil {
-			return nil, fmt.Errorf("force push: %w", err)
+		if err := repo.Push(username, token); err != nil {
+			return nil, fmt.Errorf("push: %w", err)
 		}
 		s.updateLastSyncResult("success", "")
 		return &SyncResult{Direction: SyncPush, Message: "已用本地配置覆盖远端"}, nil
 	}
 
-	if err := repo.ResetToRemote(config.Branch); err != nil {
-		return nil, fmt.Errorf("reset to remote: %w", err)
+	if heads.Remote != nil {
+		if err := repo.ResetToRemote(config.Branch); err != nil {
+			return nil, fmt.Errorf("reset: %w", err)
+		}
 	}
-
 	if err := DecryptConfigFiles(s.repoPath, s.dataDir, encKey, s.passwordStore); err != nil {
 		return nil, fmt.Errorf("decrypt files: %w", err)
 	}
@@ -869,26 +1050,6 @@ func (s *SyncService) DeleteRepo() error {
 // repo is a privacy regression (SYNC-P1-4).
 func commitMsg(action string) string {
 	return fmt.Sprintf("%s | %s", action, time.Now().Format(time.RFC3339))
-}
-
-// compareLocalWithRepo decrypts repo files and compares them with local config.
-// Returns true if the local config content matches what's already in the repo.
-// A decrypt error is surfaced (not swallowed) so callers can refuse to push
-// over an undecryptable remote (SYNC-P1-11).
-func (s *SyncService) compareLocalWithRepo(encKey []byte) (bool, error) {
-	if !repoHasFiles(s.repoPath) {
-		return false, nil
-	}
-	tmpDir, err := os.MkdirTemp("", "sync-cmp")
-	if err != nil {
-		return false, err
-	}
-	defer os.RemoveAll(tmpDir)
-
-	if err := DecryptConfigFiles(s.repoPath, tmpDir, encKey, nil); err != nil {
-		return false, fmt.Errorf("decrypt remote: %w", err)
-	}
-	return compareConfigDirs(s.dataDir, tmpDir, s.keychain, s.passwordStore)
 }
 
 // repoHasFiles returns true if the repo directory contains encrypted config files.

--- a/backend/sync/sync_service.go
+++ b/backend/sync/sync_service.go
@@ -554,12 +554,14 @@ func getConfigModTime(dir string) time.Time {
 }
 
 // isConfigDirEmpty returns true if the config dir has no meaningful data.
-// Counts every persisted JSON the app cares about — not only connections —
-// so a user with settings / AI / quick-commands but no connections is not
-// treated as "empty" and silently overwritten on first sync
-// (SYNC-P0-1).
+// Counts every synced JSON — not only connections — so a user with settings
+// / quick-commands but no connections is not treated as "empty" and silently
+// overwritten on first sync (SYNC-P0-1). Uses syncedFiles rather than every
+// persisted JSON: ai-sessions.json / skills.json are local-only and never
+// synced, so their presence must not block a first-sync pull (their files
+// are not touched by decrypt either).
 func isConfigDirEmpty(dir string) bool {
-	for _, name := range []string{"connections.json", "settings.json", "quickCommands.json", "ai-sessions.json", "skills.json", "tunnels.json", "identities.json", "proxies.json"} {
+	for _, name := range syncedFiles {
 		path := filepath.Join(dir, name)
 		data, err := os.ReadFile(path)
 		if err != nil {
@@ -589,7 +591,7 @@ func isConfigDirEmpty(dir string) bool {
 // normalized to plaintext on the local side before comparison so both sides
 // are comparable.
 func compareConfigDirs(localDir, remoteDir string, kc *Keychain, ps PasswordStore) (bool, error) {
-	for _, name := range []string{"connections.json", "settings.json", "quickCommands.json", "tunnels.json", "identities.json", "proxies.json"} {
+	for _, name := range syncedFiles {
 		same, err := compareConfigFiles(filepath.Join(localDir, name), filepath.Join(remoteDir, name), kc, ps)
 		if err != nil {
 			return false, err
@@ -787,8 +789,7 @@ func (s *SyncService) ChangePassword(oldPassword, newPassword string) error {
 	// Re-encrypt every existing repo ciphertext: decrypt with oldKey,
 	// re-encrypt with newKey, atomic rename. A crash before the rename
 	// leaves the original ciphertext intact and decryptable with oldKey.
-	repoFiles := []string{"connections.json", "settings.json", "quickCommands.json", "tunnels.json", "identities.json", "proxies.json"}
-	for _, name := range repoFiles {
+	for _, name := range syncedFiles {
 		srcPath := filepath.Join(s.repoPath, name)
 		ciphertext, err := os.ReadFile(srcPath)
 		if err != nil {
@@ -892,7 +893,7 @@ func (s *SyncService) compareLocalWithRepo(encKey []byte) (bool, error) {
 
 // repoHasFiles returns true if the repo directory contains encrypted config files.
 func repoHasFiles(repoPath string) bool {
-	for _, name := range []string{"connections.json", "settings.json", "quickCommands.json", "tunnels.json", "identities.json", "proxies.json"} {
+	for _, name := range syncedFiles {
 		if _, err := os.Stat(filepath.Join(repoPath, name)); os.IsNotExist(err) {
 			return false
 		}

--- a/backend/sync/synced_files.go
+++ b/backend/sync/synced_files.go
@@ -1,0 +1,20 @@
+package sync
+
+// syncedFiles is the single source of truth for the config files that
+// participate in cloud sync. Encrypt (crypto.go), decrypt (crypto.go),
+// content comparison (sync_service.go), the git commit whitelist (git.go),
+// the empty-dir probe (isConfigDirEmpty) and the password-rotation file list
+// (ChangePassword) all iterate this slice so their scopes can never drift
+// apart again.
+//
+// ai-sessions.json and skills.json are intentionally absent — they are
+// local-only data and must never be committed to the sync repo (a stray
+// ai-sessions.json left in the repo dir from an old build stays untracked).
+var syncedFiles = []string{
+	"connections.json",
+	"settings.json",
+	"quickCommands.json",
+	"tunnels.json",
+	"identities.json",
+	"proxies.json",
+}

--- a/backend/sync/whitelist_test.go
+++ b/backend/sync/whitelist_test.go
@@ -43,9 +43,14 @@ func initTestRepo(t *testing.T, repoPath string) *GitRepo {
 }
 
 // TestStageAndCommitWhitelist verifies SYNC-P1-9: StageAndCommit only stages
-// the nine whitelisted filenames, never wt.Add("."). A stray file
-// representing an SSH key (id_rsa) dropped into the sync dir must NOT be
-// committed plaintext.
+// the synced config files (syncedFiles, shared with encrypt/decrypt/compare)
+// plus the repo metadata files .sync-salt and README.md — never wt.Add(".").
+// A stray file representing an SSH key (id_rsa) dropped into the sync dir
+// must NOT be committed plaintext.
+//
+// tunnels.json is an explicit regression guard: it was missing from the old
+// hand-written commit whitelist, so tunnel changes were encrypted into the
+// repo but never committed or synced.
 func TestStageAndCommitWhitelist(t *testing.T) {
 	repoPath := t.TempDir()
 	g := initTestRepo(t, repoPath)
@@ -53,15 +58,11 @@ func TestStageAndCommitWhitelist(t *testing.T) {
 	// Whitelisted files — should be staged. The list mirrors the
 	// exact names StageAndCommit iterates over.
 	whitelisted := map[string]string{
-		"connections.json":   `{"connections":[]}`,
-		"settings.json":      `{"theme":"dark"}`,
-		"ai-sessions.json":   `[]`,
-		"skills.json":        `[]`,
-		"quickCommands.json": `[]`,
-		"identities.json":    `{"identities":[]}`,
-		"proxies.json":       `{"proxies":[]}`,
-		".sync-salt":         base64.StdEncoding.EncodeToString([]byte("0123456789abcdef")),
-		"README.md":          "# sync repo\n",
+		".sync-salt": base64.StdEncoding.EncodeToString([]byte("0123456789abcdef")),
+		"README.md":  "# sync repo\n",
+	}
+	for _, name := range syncedFiles {
+		whitelisted[name] = "{}"
 	}
 	for name, content := range whitelisted {
 		if err := os.WriteFile(filepath.Join(repoPath, name), []byte(content), 0600); err != nil {
@@ -70,12 +71,15 @@ func TestStageAndCommitWhitelist(t *testing.T) {
 	}
 
 	// Stray files — must NOT be staged. Models an attacker dropping
-	// ~/.ssh/id_rsa into the sync directory.
+	// ~/.ssh/id_rsa into the sync directory, plus the local-only store
+	// files that must never ride along into the sync repo.
 	stray := map[string]string{
-		"id_rsa":     "-----BEGIN RSA PRIVATE KEY-----\nMOCK\n-----END RSA PRIVATE KEY-----",
-		"secret.txt": "internal passwords",
-		"notes.md":   "echo pwned",
-		"backup.tgz": "binary",
+		"id_rsa":           "-----BEGIN RSA PRIVATE KEY-----\nMOCK\n-----END RSA PRIVATE KEY-----",
+		"secret.txt":       "internal passwords",
+		"notes.md":         "echo pwned",
+		"backup.tgz":       "binary",
+		"ai-sessions.json": `[]`,
+		"skills.json":      `[]`,
 	}
 	for name, content := range stray {
 		if err := os.WriteFile(filepath.Join(repoPath, name), []byte(content), 0600); err != nil {


### PR DESCRIPTION
## Summary

Fixes #745.

Two machines used alternately (never running at the same time) hit the
"config conflict" dialog on every single open of the app, even when
nothing had been changed. Two defects in the sync engine compounded:

### 1. Commit-before-fetch turned "not pulled yet" into a divergence

`Sync()` encrypted and committed local changes on top of the *stale*
local clone head, and only then fetched. Any difference between the
local data dir and the clone — which includes simply being behind the
other machine — became a local commit rooted at the old remote head.
The other machine's newer commit was then discovered on fetch, the two
heads diverged, and the conflict dialog popped. With per-machine state
(e.g. settings rewritten on app exit) this fired on literally every
open.

`Sync()` now fetches **first** and analyzes content three-way against
the merge base (local data dir vs merge base vs remote head):

- only the remote moved → **silent pull**
- only local content is newer → the clone is re-anchored on the remote
  head and the local content is published as one commit on top of it
  (the push is a fast-forward; unpushed commits from a previously
  failed push are squashed into it)
- content identical on both sides but heads diverged (re-encrypt noise,
  random IVs) → the history is healed silently
- both sides changed since the merge base → genuine conflict, dialog

### 2. Force-push conflict resolution created an endless ping-pong

`ResolveConflict(useLocal)` force-pushed a commit rooted at the stale
local head, which orphaned the *other* machine's head — guaranteeing it
would conflict again on its next open, forever.

Resolution now re-anchors on the remote head and pushes a normal
(fast-forward) commit, so other machines' heads stay reachable and
history stays linear. `ForcePush` is removed entirely.

### Safety guards preserved

- SYNC-P1-11: a key that cannot decrypt the existing ciphertext aborts
  the sync before anything is pushed (moved into a `verifyDecryption`
  check ahead of all push paths).
- The wrong-password sync status test passes unchanged.

### File-list unification (first commit)

The synced-file list was hand-written in six places and had drifted:

- `tunnels.json` was compared and encrypted but missing from the git
  commit whitelist — tunnel changes were never actually synced, and the
  repo worktree stayed dirty forever, burning an encrypt+commit cycle
  on every sync
- `ai-sessions.json` / `skills.json` were in the commit whitelist
  while never being encrypted into the repo; they are local-only data

All six call sites (encrypt, decrypt, compare, commit whitelist,
`isConfigDirEmpty`, `ChangePassword`) now iterate a single
`syncedFiles` source of truth, and the whitelist test builds its
expectations from it.

## Testing

- `go build ./...`, `go vet` clean
- New flow tests in `sync_flow_test.go`:
  - silent pull when only the remote advanced (the issue regression)
  - conflict only when both sides changed content
  - remote history stays fast-forwardable after a local resolution
    (anti-force-push regression)
  - diverged heads with identical content heal silently
  - recovery from an unpushed local commit
- Existing sync package tests (wrong-password status, ChangePassword
  salt/ciphertext rotation, whitelist) pass unchanged

---

## 摘要

修复 #745。

两台交替使用的电脑（从不同时开机）每次打开应用都会弹出“配置冲突”对话框，即使什么都没改。同步引擎的两个缺陷叠加导致了该问题：

### 1. 先提交后拉取，把“还没拉取”变成了历史分叉

`Sync()` 在**过期的**本地克隆 HEAD 上加密并提交本地变更，之后才 fetch。本地数据与克隆之间的任何差异——包括仅仅落后于另一台机器——都会变成一个以旧远端 HEAD 为父提交的本地提交。fetch 发现对方的新提交后两个 HEAD 分叉，冲突弹窗弹出。叠加每台机器自身的状态变化（如退出时重写设置），导致每次打开必然触发。

现在 `Sync()` **先 fetch**，再以 merge-base 为基准做三方内容分析（本地数据 vs 基准 vs 远端 HEAD）：

- 仅远端更新 → **静默拉取**
- 仅本地内容更新 → 克隆重置到远端 HEAD 后，将本地内容作为其上的一个新提交正常推送（快进；之前推送失败遗留的未推送提交被压平合并）
- 两边内容一致但 HEAD 分叉（重加密噪音/随机 IV）→ 静默治愈历史
- 自基准以来双方都改了内容 → 才是真实冲突，弹窗

### 2. 冲突解决使用 force-push，造成无限乒乓

`ResolveConflict(useLocal)` 以过期的本地 HEAD 为父提交强推，孤儿化了**另一台**机器的 HEAD——保证它下次打开必然再次冲突，无限循环。

现在解决冲突时先锚定到远端 HEAD，再正常推送（快进），其他机器的 HEAD 始终可达，历史保持线性。`ForcePush` 已彻底移除。

### 安全守卫保留

- SYNC-P1-11：无法解密既有密文的钥匙在任何推送前中止同步（移至所有推送路径之前的 `verifyDecryption` 检查）。
- 密码错误时同步状态的原有测试保持不变。

### 文件清单统一（第一个提交）

同步文件清单此前在 6 处手写且已漂移：

- `tunnels.json` 参与比较和加密，但不在 git 提交白名单里——隧道变更从未真正同步，且仓库工作区永远 dirty，每次同步都空转一轮“加密+提交”
- `ai-sessions.json` / `skills.json` 在提交白名单里，却从未被加密进仓库；它们属于本机数据

6 处调用点（加密、解密、比较、提交白名单、`isConfigDirEmpty`、`ChangePassword`）现在统一引用唯一的 `syncedFiles`，白名单测试的期望也由它生成。

## 测试

- `go build ./...`、`go vet` 通过
- 新增流程测试 `sync_flow_test.go`：
  - 仅远端更新时静默拉取（本 issue 回归）
  - 双方都改内容才弹冲突
  - 本地方向解决冲突后远端历史保持可快进（反 force-push 回归）
  - 内容一致但 HEAD 分叉时静默治愈
  - 未推送本地提交的恢复
- sync 包既有测试（密码错误状态、ChangePassword 盐/密文轮换、白名单）全部通过