### PR TITLE
fix: route connection test through configured jump-host tunnel

### DIFF
--- a/test_connection.go
+++ b/test_connection.go
@@ -48,6 +48,16 @@ func (a *App) TestConnection(config session.ConnectionConfig) (string, error) {
 	case "container":
 		return a.testContainerConnection(mc)
 	default:
+		// Honor the jump-host tunnel exactly like a real session connect
+		// (CreateSession): establish the local forward first, point the
+		// probe at the listener, then tear the tunnel down when done.
+		if mc.TunnelSSHConnID != "" {
+			key := uuid.New().String()
+			if err := a.setupJumpHostTunnel(key, mc.Type, &mc); err != nil {
+				return "", err
+			}
+			defer a.tunnelService.Stop(key)
+		}
 		return session.ProbeConnection(mc)
 	}
 }

--- a/test_connection_tunnel_test.go
+++ b/test_connection_tunnel_test.go
@@ -1,0 +1,175 @@
+package main
+
+// End-to-end regression coverage for the tunnel path of App.TestConnection.
+// The fake target below is unreachable directly (nothing listens on the port);
+// it is only reachable through the fake SSH jump host via direct-tcpip
+// forwarding, so a passing probe proves the connection actually rode the
+// tunnel instead of dialing the target address directly.
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"fmt"
+	"io"
+	"net"
+	"testing"
+
+	"golang.org/x/crypto/ssh"
+
+	"github.com/ys-ll/uniterm/backend/session"
+	"github.com/ys-ll/uniterm/backend/store"
+)
+
+// stubPasswordStore satisfies store.PasswordStore without any crypto.
+type stubPasswordStore struct{}
+
+func (stubPasswordStore) Encrypt(s string) (string, error) { return s, nil }
+func (stubPasswordStore) Decrypt(s string) (string, error) { return s, nil }
+
+// unreachableLocalPort returns a loopback port with no listener, so a direct
+// dial to it always fails with connection refused.
+func unreachableLocalPort(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserve port: %v", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	ln.Close()
+	return port
+}
+
+// startFakeJumpSSHD starts a minimal SSH server that accepts password auth
+// (user "jump", password "jump-pw") and direct-tcpip channels — acting as the
+// jump host whose forwarding makes the unreachable target reachable.
+func startFakeJumpSSHD(t *testing.T) int {
+	t.Helper()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate host key: %v", err)
+	}
+	signer, err := ssh.NewSignerFromKey(priv)
+	if err != nil {
+		t.Fatalf("host signer: %v", err)
+	}
+	serverConfig := &ssh.ServerConfig{
+		PasswordCallback: func(m ssh.ConnMetadata, pw []byte) (*ssh.Permissions, error) {
+			if m.User() == "jump" && string(pw) == "jump-pw" {
+				return &ssh.Permissions{}, nil
+			}
+			return nil, fmt.Errorf("auth rejected for %q", m.User())
+		},
+	}
+	serverConfig.AddHostKey(signer)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { ln.Close() })
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				sconn, chans, reqs, err := ssh.NewServerConn(conn, serverConfig)
+				if err != nil {
+					conn.Close()
+					return
+				}
+				defer sconn.Close()
+				go func() {
+					for req := range reqs {
+						if req.WantReply {
+							_ = req.Reply(false, nil)
+						}
+					}
+				}()
+				for newChan := range chans {
+					if newChan.ChannelType() != "direct-tcpip" {
+						_ = newChan.Reject(ssh.UnknownChannelType, "unsupported")
+						continue
+					}
+					ch, chReqs, err := newChan.Accept()
+					if err != nil {
+						continue
+					}
+					go func() {
+						for req := range chReqs {
+							if req.WantReply {
+								_ = req.Reply(false, nil)
+							}
+						}
+					}()
+					// Hold the channel open and drain it until the client closes.
+					go func() {
+						_, _ = io.Copy(io.Discard, ch)
+						_ = ch.Close()
+					}()
+				}
+			}()
+		}
+	}()
+
+	return ln.Addr().(*net.TCPAddr).Port
+}
+
+// TestApp_TestConnection_RidesJumpHostTunnel locks in that TestConnection
+// honors config.TunnelSSHConnID for non-k8s/container types: the probe must
+// ride a jump-host tunnel like a real CreateSession connect does, instead of
+// dialing config.Host:Port directly.
+func TestApp_TestConnection_RidesJumpHostTunnel(t *testing.T) {
+	targetPort := unreachableLocalPort(t)
+	sshPort := startFakeJumpSSHD(t)
+
+	cs, err := store.NewConnectionStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("connection store: %v", err)
+	}
+	cs.SetPasswordStore(stubPasswordStore{})
+	if err := cs.Save(session.ConnectionStoreData{
+		Connections: []session.ConnectionConfig{{
+			ID:       "jump-1",
+			Type:     "ssh",
+			Host:     "127.0.0.1",
+			Port:     sshPort,
+			User:     "jump",
+			AuthType: "password",
+			Password: "jump-pw",
+		}},
+	}); err != nil {
+		t.Fatalf("save jump connection: %v", err)
+	}
+
+	a := NewApp("")
+	a.connectionStore = cs
+	a.tunnelService = session.NewTunnelService()
+
+	// Through the tunnel the jump host serves the direct-tcpip channel itself,
+	// so the probe succeeds even though nothing listens on targetPort.
+	desc, err := a.TestConnection(session.ConnectionConfig{
+		Type:            "tcp",
+		Host:            "127.0.0.1",
+		Port:            targetPort,
+		TunnelSSHConnID: "jump-1",
+	})
+	if err != nil {
+		t.Fatalf("TestConnection with tunnel: %v", err)
+	}
+	if desc == "" {
+		t.Fatal("TestConnection returned empty description")
+	}
+
+	// Guard: without the tunnel the same target is unreachable — proving the
+	// tunnel was what made the first probe succeed.
+	if _, err := a.TestConnection(session.ConnectionConfig{
+		Type: "tcp",
+		Host: "127.0.0.1",
+		Port: targetPort,
+	}); err == nil {
+		t.Fatal("direct probe to unreachable target unexpectedly succeeded")
+	}
+}


### PR DESCRIPTION
## Summary
- TestConnection only honored the jump-host tunnel (TunnelSSHConnID) for k8s and container types; every other probed type (ssh, tcp, database, redis, mongodb, elasticsearch, ...) dialed config.Host:Port directly, so the test result did not reflect what a real connect would do.
- TestConnection now sets up the same local port-forward that a real session connect uses (setupJumpHostTunnel) before probing, and tears the tunnel down when the probe finishes.
- Added an end-to-end regression test: the probe target has no listener and is only reachable through a fake SSH jump host forwarding direct-tcpip channels, so a passing probe proves the connection rode the tunnel.

## Verification
- New test fails before the fix (direct dial refused) and passes after
- go test ./... passes (one pre-existing, unrelated environment-dependent pprof test failure on clean main)
- go vet and go build clean

---
## 摘要
- TestConnection 此前仅对 k8s 和 container 类型处理跳板机隧道（TunnelSSHConnID），其余类型（ssh、tcp、数据库、redis、mongodb、elasticsearch 等）全部直连 config.Host:Port，导致测试结果与真实连接行为不一致。
- 现在 TestConnection 在探测前复用真实会话连接使用的同一段本地端口转发逻辑（setupJumpHostTunnel），探测结束后自动清理隧道。
- 新增端到端回归测试：探测目标端口无监听、仅可通过测试内伪造的 SSH 跳板机（direct-tcpip 转发）可达，探测通过即证明连接确实走了隧道。

## 验证
- 新测试在修复前失败（直连被拒绝），修复后通过
- go test ./... 通过（main 上存在一个与本次改动无关的环境相关的 pprof 测试失败）
- go vet 与 go build 无告警