### PR TITLE
feat(ai): route AI model requests through a saved proxy

### DIFF
--- a/app.go
+++ b/app.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -2532,7 +2533,7 @@ func (a *App) GetRecentConnections() []string {
 // ChatCompletion streams the Anthropic API response via SSE, emitting Wails
 // events for each token while collecting the full message. It returns the
 // complete message JSON when the stream ends (backward-compatible).
-func (a *App) ChatCompletion(apiKey, baseURL, model string, requestJSON string, protocol string, userAgent string) (string, error) {
+func (a *App) ChatCompletion(apiKey, baseURL, model string, requestJSON string, protocol string, userAgent string, proxyID string) (string, error) {
 	// Parse the incoming request body (always Anthropic format from frontend)
 	var reqBody map[string]interface{}
 	if err := json.Unmarshal([]byte(requestJSON), &reqBody); err != nil {
@@ -2543,13 +2544,66 @@ func (a *App) ChatCompletion(apiKey, baseURL, model string, requestJSON string, 
 		userAgent = "uniTerm"
 	}
 
+	proxy, err := a.llmProxyFor(proxyID)
+	if err != nil {
+		return "", err
+	}
+
 	switch protocol {
 	case "openai":
-		return a.chatCompletionOpenAI(apiKey, baseURL, model, reqBody, userAgent)
+		return a.chatCompletionOpenAI(apiKey, baseURL, model, reqBody, userAgent, proxy)
 	case "responses":
-		return a.chatCompletionResponses(apiKey, baseURL, model, reqBody, userAgent)
+		return a.chatCompletionResponses(apiKey, baseURL, model, reqBody, userAgent, proxy)
 	}
-	return a.chatCompletionAnthropic(apiKey, baseURL, model, reqBody, userAgent)
+	return a.chatCompletionAnthropic(apiKey, baseURL, model, reqBody, userAgent, proxy)
+}
+
+// llmProxyFor resolves a saved-proxy reference into the SocksProxy used as an
+// HTTP CONNECT proxy for LLM-bound requests. Empty ID = direct connection.
+func (a *App) llmProxyFor(proxyID string) (*session.SocksProxy, error) {
+	if proxyID == "" {
+		return nil, nil
+	}
+	resolve, err := a.proxyResolver()
+	if err != nil {
+		return nil, err
+	}
+	p, ok := resolve(proxyID)
+	if !ok {
+		return nil, fmt.Errorf("referenced proxy not found or disabled: %s", proxyID)
+	}
+	return &p, nil
+}
+
+// llmHTTPClientFor returns an *http.Client whose transport routes through the
+// given upstream proxy (HTTP CONNECT for https URLs). proxy nil = shared
+// direct client (F-208 connection reuse only applies to the direct path).
+func (a *App) llmHTTPClientFor(proxy *session.SocksProxy) *http.Client {
+	if proxy == nil {
+		return a.llmHTTPClient()
+	}
+	tr := &http.Transport{
+		Proxy: func(*http.Request) (*url.URL, error) {
+			return proxyTransportURL(proxy)
+		},
+		MaxIdleConns:          100,
+		MaxIdleConnsPerHost:   8,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ResponseHeaderTimeout: 30 * time.Second,
+		ExpectContinueTimeout: 2 * time.Second,
+	}
+	return &http.Client{Transport: tr}
+}
+
+// proxyTransportURL renders a saved SOCKS5/HTTP proxy as a proxy URL for
+// http.Transport. http.Transport natively speaks SOCKS5 via the socks5 scheme.
+func proxyTransportURL(p *session.SocksProxy) (*url.URL, error) {
+	u := &url.URL{Scheme: p.Kind, Host: net.JoinHostPort(p.Host, strconv.Itoa(p.Port))}
+	if p.User != "" {
+		u.User = url.UserPassword(p.User, p.Pass)
+	}
+	return u, nil
 }
 
 // F-306: typed SSE envelope for Anthropic Messages events. Variant
@@ -2613,7 +2667,7 @@ type aiDoneEvent struct {
 }
 
 // chatCompletionAnthropic handles the native Anthropic Messages API with SSE streaming.
-func (a *App) chatCompletionAnthropic(apiKey, baseURL, model string, reqBody map[string]interface{}, userAgent string) (string, error) {
+func (a *App) chatCompletionAnthropic(apiKey, baseURL, model string, reqBody map[string]interface{}, userAgent string, proxy *session.SocksProxy) (string, error) {
 	reqBody["stream"] = true
 
 	modifiedJSON, err := json.Marshal(reqBody)
@@ -2652,7 +2706,7 @@ func (a *App) chatCompletionAnthropic(apiKey, baseURL, model string, reqBody map
 	req.Header.Set("anthropic-beta", "prompt-caching-2024-07-31")
 	req.Header.Set("User-Agent", userAgent)
 
-	client := &http.Client{Timeout: 0}
+	client := a.llmHTTPClientFor(proxy)
 	res, err := client.Do(req)
 	if err != nil {
 		if ctx.Err() == context.DeadlineExceeded {
@@ -2957,7 +3011,7 @@ type openaiStreamEvent struct {
 // chatCompletionOpenAI converts the Anthropic-format request to OpenAI,
 // calls the OpenAI Chat Completions API with SSE streaming, and converts
 // the response back to Anthropic format so the frontend sees no difference.
-func (a *App) chatCompletionOpenAI(apiKey, baseURL, model string, reqBody map[string]interface{}, userAgent string) (string, error) {
+func (a *App) chatCompletionOpenAI(apiKey, baseURL, model string, reqBody map[string]interface{}, userAgent string, proxy *session.SocksProxy) (string, error) {
 	url := strings.TrimRight(baseURL, "/") + "/chat/completions"
 
 	// --- Build OpenAI-format request body ---
@@ -3027,7 +3081,7 @@ func (a *App) chatCompletionOpenAI(apiKey, baseURL, model string, reqBody map[st
 	req.Header.Set("Authorization", "Bearer "+apiKey)
 	req.Header.Set("User-Agent", userAgent)
 
-	client := a.llmHTTPClient()
+	client := a.llmHTTPClientFor(proxy)
 	res, err := client.Do(req)
 	if err != nil {
 		if ctx.Err() == context.DeadlineExceeded {
@@ -3407,7 +3461,7 @@ type responsesStreamEvent struct {
 // Responses API, calls /responses with SSE streaming, and converts the response
 // events back to Anthropic-format events so the frontend sees no difference.
 // Stateless: full history is sent as `input` each turn; reasoning items are ignored.
-func (a *App) chatCompletionResponses(apiKey, baseURL, model string, reqBody map[string]interface{}, userAgent string) (string, error) {
+func (a *App) chatCompletionResponses(apiKey, baseURL, model string, reqBody map[string]interface{}, userAgent string, proxy *session.SocksProxy) (string, error) {
 	url := strings.TrimRight(baseURL, "/") + "/responses"
 
 	// --- Build Responses-format request body ---
@@ -3473,7 +3527,7 @@ func (a *App) chatCompletionResponses(apiKey, baseURL, model string, reqBody map
 	req.Header.Set("Authorization", "Bearer "+apiKey)
 	req.Header.Set("User-Agent", userAgent)
 
-	client := a.llmHTTPClient()
+	client := a.llmHTTPClientFor(proxy)
 	res, err := client.Do(req)
 	if err != nil {
 		if ctx.Err() == context.DeadlineExceeded {
@@ -3709,7 +3763,7 @@ type ModelInfo struct {
 // OpenAI-compatible /models endpoint with a Bearer token; anthropic hits
 // /v1/models with the x-api-key + anthropic-version headers, mirroring
 // chatCompletionAnthropic's URL and auth handling.
-func (a *App) FetchModels(apiKey, baseURL, protocol string) ([]ModelInfo, error) {
+func (a *App) FetchModels(apiKey, baseURL, protocol string, proxyID string) ([]ModelInfo, error) {
 	base := strings.TrimRight(baseURL, "/")
 
 	var url string
@@ -3739,10 +3793,14 @@ func (a *App) FetchModels(apiKey, baseURL, protocol string) ([]ModelInfo, error)
 	// F-208: share the same transport as the LLM clients so the model
 	// list call also benefits from the keep-alive pool; the request
 	// itself carries its own 10s deadline via the per-request context.
+	proxy, err := a.llmProxyFor(proxyID)
+	if err != nil {
+		return nil, err
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	req = req.WithContext(ctx)
-	res, err := a.llmHTTPClient().Do(req)
+	res, err := a.llmHTTPClientFor(proxy).Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/store/settings_store.go
+++ b/backend/store/settings_store.go
@@ -96,6 +96,9 @@ type AIModelConfig struct {
 	BaseURL  string `json:"baseURL"`
 	Model    string `json:"model"`
 	Protocol string `json:"protocol"`
+	// ProxyId references a saved outbound proxy (proxies.json) used for all
+	// HTTP traffic to this model's BaseURL. Empty = direct connection.
+	ProxyID string `json:"proxyId,omitempty"`
 }
 
 type AISettings struct {

--- a/frontend/src/components/SettingsTab.vue
+++ b/frontend/src/components/SettingsTab.vue
@@ -976,6 +976,17 @@
         <el-form-item :label="t('settings.modelApiKey')">
           <el-input v-model="modelForm.apiKey" type="password" show-password />
         </el-form-item>
+        <el-form-item :label="t('conn.proxy')">
+          <el-select v-model="modelForm.proxyId" clearable filterable style="width: 100%" :placeholder="t('settings.modelProxyPlaceholder')">
+            <el-option
+              v-for="p in proxyStore.proxies"
+              :key="p.id"
+              :label="`${p.name} (${p.kind} ${p.host}:${p.port})`"
+              :value="p.id"
+              :disabled="p.enabled === false"
+            />
+          </el-select>
+        </el-form-item>
         <el-form-item :label="t('settings.modelModel')">
           <div class="model-fetch-row">
             <el-select
@@ -1619,6 +1630,7 @@ const modelForm = reactive({
   apiKey: '',
   protocol: 'anthropic' as 'anthropic' | 'openai' | 'responses',
   userAgent: 'uniTerm' as string,
+  proxyId: '' as string,
 })
 
 function openNewModelForm() {
@@ -1649,7 +1661,8 @@ function saveModel() {
       model: modelForm.model,
       apiKey: modelForm.apiKey,
       protocol: modelForm.protocol,
-      userAgent: modelForm.userAgent || undefined
+      userAgent: modelForm.userAgent || undefined,
+      proxyId: modelForm.proxyId || undefined
     })
   }
   showModelForm.value = false
@@ -1665,6 +1678,7 @@ function resetModelForm() {
   modelForm.apiKey = ''
   modelForm.protocol = 'anthropic'
   modelForm.userAgent = 'uniTerm'
+  modelForm.proxyId = ''
   modelSuggestions.value = []
 }
 
@@ -1676,7 +1690,7 @@ async function fetchModelList() {
   modelFetching.value = true
   modelSuggestions.value = []
   try {
-    const models = await FetchModels(modelForm.apiKey, modelForm.baseURL, modelForm.protocol)
+    const models = await FetchModels(modelForm.apiKey, modelForm.baseURL, modelForm.protocol, modelForm.proxyId || '')
     modelSuggestions.value = (models || []).map(m => ({
       value: m.display_name || m.id
     }))
@@ -1709,7 +1723,8 @@ async function testConnection() {
       modelForm.model,
       testMsg,
       modelForm.protocol,
-      modelForm.userAgent || ''
+      modelForm.userAgent || '',
+      modelForm.proxyId || ''
     )
     testResult.value = true
     msg.success(t('settings.testSuccess'))

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -438,6 +438,8 @@
   "settings.modelModelPlaceholder": "Modellname auswählen oder eingeben",
   "settings.modelApiKey": "API-Schlüssel",
   "settings.modelUserAgent": "User-Agent",
+  "settings.modelProxyPlaceholder": "Kein Proxy (direkte Verbindung)",
+  "settings.modelProxyDesc": "Proxy für den Zugriff auf die Modell-API; aus gespeicherten wählen",
   "settings.modelProtocol": "Protokoll",
   "settings.cancel": "Abbrechen",
   "settings.save": "Speichern",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -438,6 +438,8 @@
   "settings.modelModelPlaceholder": "Select or enter a model name",
   "settings.modelApiKey": "API Key",
   "settings.modelUserAgent": "User-Agent",
+  "settings.modelProxyPlaceholder": "No proxy (direct connection)",
+  "settings.modelProxyDesc": "Proxy used to reach this model API; pick from saved proxies below",
   "settings.modelProtocol": "Protocol",
   "settings.cancel": "Cancel",
   "settings.save": "Save",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -438,6 +438,8 @@
   "settings.modelModelPlaceholder": "Selecciona o escribe un nombre de modelo",
   "settings.modelApiKey": "Clave de API",
   "settings.modelUserAgent": "User-Agent",
+  "settings.modelProxyPlaceholder": "Sin proxy (conexión directa)",
+  "settings.modelProxyDesc": "Proxy para acceder a la API del modelo; elija de los guardados",
   "settings.modelProtocol": "Protocolo",
   "settings.cancel": "Cancelar",
   "settings.save": "Guardar",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -438,6 +438,8 @@
   "settings.modelModelPlaceholder": "モデル名を選択または入力",
   "settings.modelApiKey": "API キー",
   "settings.modelUserAgent": "ユーザーエージェント",
+  "settings.modelProxyPlaceholder": "プロキシを使用しない（直接接続）",
+  "settings.modelProxyDesc": "このモデルAPIへの接続に使うプロキシ。保存済みプロキシから選択",
   "settings.modelProtocol": "プロトコル",
   "settings.cancel": "キャンセル",
   "settings.save": "保存",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -438,6 +438,8 @@
   "settings.modelModelPlaceholder": "모델 이름 선택 또는 입력",
   "settings.modelApiKey": "API 키",
   "settings.modelUserAgent": "User-Agent",
+  "settings.modelProxyPlaceholder": "프록시 사용 안 함 (직접 연결)",
+  "settings.modelProxyDesc": "이 모델 API 접근에 사용할 프록시, 저장된 프록시에서 선택",
   "settings.modelProtocol": "프로토콜",
   "settings.cancel": "취소",
   "settings.save": "저장",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -438,6 +438,8 @@
   "settings.modelModelPlaceholder": "Выберите или введите имя модели",
   "settings.modelApiKey": "API-ключ",
   "settings.modelUserAgent": "User-Agent",
+  "settings.modelProxyPlaceholder": "Без прокси (напрямую)",
+  "settings.modelProxyDesc": "Прокси для доступа к API модели; выберите из сохранённых",
   "settings.modelProtocol": "Протокол",
   "settings.cancel": "Отмена",
   "settings.save": "Сохранить",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -438,6 +438,8 @@
   "settings.modelModelPlaceholder": "选择或输入模型名称",
   "settings.modelApiKey": "API Key",
   "settings.modelUserAgent": "User-Agent",
+  "settings.modelProxyPlaceholder": "不使用代理（直连）",
+  "settings.modelProxyDesc": "访问该模型 API 走的代理，可选下方已保存的代理",
   "settings.modelProtocol": "协议",
   "settings.cancel": "取消",
   "settings.save": "保存",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -438,6 +438,8 @@
   "settings.modelModelPlaceholder": "選擇或輸入模型名稱",
   "settings.modelApiKey": "API 金鑰",
   "settings.modelUserAgent": "使用者代理",
+  "settings.modelProxyPlaceholder": "不使用代理（直連）",
+  "settings.modelProxyDesc": "存取該模型 API 走的代理，可選下方已儲存的代理",
   "settings.modelProtocol": "協議",
   "settings.cancel": "取消",
   "settings.save": "儲存",

--- a/frontend/src/services/llm.ts
+++ b/frontend/src/services/llm.ts
@@ -58,6 +58,7 @@ export async function chat(options: ChatOptions): Promise<void> {
   const model = activeModel?.model || ''
   const protocol = activeModel?.protocol || 'anthropic'
   const userAgent = activeModel?.userAgent || ''
+  const proxyId = activeModel?.proxyId || ''
 
   if (!apiKey) throw new Error('API key not configured')
 
@@ -84,7 +85,7 @@ export async function chat(options: ChatOptions): Promise<void> {
     if (text) streamedText += text
    })
   try {
-    responseText = await ChatCompletion(apiKey, baseURL, model, requestJSON, protocol, userAgent)
+    responseText = await ChatCompletion(apiKey, baseURL, model, requestJSON, protocol, userAgent, proxyId)
   } catch (e: any) {
     const raw = e?.message || String(e)
     if (isCancellationError(raw)) {

--- a/frontend/src/types/settings.ts
+++ b/frontend/src/types/settings.ts
@@ -109,6 +109,9 @@ export interface AIModelConfig {
   model: string
   protocol: 'anthropic' | 'openai' | 'responses'
   userAgent?: string
+  // Reference to a saved outbound proxy (proxies.json) for all traffic to
+  // this model's baseURL. Empty/undefined = direct connection.
+  proxyId?: string
 }
 
 export const USER_AGENT_PRESETS: { label: string; value: string }[] = [


### PR DESCRIPTION
Closes #772

## Summary

Users behind firewalled networks (e.g. `api.openai.com` unreachable directly) could not use the AI assistant: the Go `http.Transport` never set `Proxy`, so chat / model-list requests went out direct and timed out with `dial tcp … connectex: …` (discussion #772).

Each AI model configuration can now reference one of the **proxies already saved in uniTerm** (设置 → 代理), as suggested in the discussion. Requests to that model's `baseURL` — chat streams and model-list fetches alike — then route through the proxy (HTTP CONNECT / SOCKS5).

## Changes

- `store.AIModelConfig` gains `proxyId`; empty/missing = direct connection, so existing configs behave unchanged
- `ChatCompletion` / `FetchModels` take a `proxyID` parameter and resolve it through the existing `proxyResolver` — the #749 enable toggle and password encryption (OS keychain) apply automatically
- `llmHTTPClientFor(proxy)` builds a proxied transport: `socks5://` URL scheme for SOCKS5 (native `http.Transport` support), `Proxy` hook for HTTP proxies. The direct path keeps the shared F-208 keep-alive client
- Model form (设置 → AI 模型) gains a proxy dropdown fed by the proxy store; disabled proxies are unselectable
- i18n: `settings.modelProxyPlaceholder` / `settings.modelProxyDesc` in all 8 locales

## Validation

- `go build ./...`, `go test ./backend/...`
- `npm --prefix frontend run build`
- Manual: save a SOCKS5 proxy → attach it to an OpenAI model → 测试连接 / 拉取模型 succeed through the proxy; remove the proxy → direct again

---

## 摘要

受限网络环境（如直连 `api.openai.com` 超时）下 AI 助理不可用：Go `http.Transport` 从未设置 `Proxy`，聊天/拉模型请求直连发出直至超时（discussion #772）。

现在每个 AI 模型配置可以引用 **uniterm 已保存的代理**（设置 → 代理），如讨论区建议。发往该模型 `baseURL` 的请求（聊天流 + 模型列表）都会经过代理（HTTP CONNECT / SOCKS5）。

## 改动

- `store.AIModelConfig` 新增 `proxyId`；留空/缺省 = 直连，存量配置行为不变
- `ChatCompletion` / `FetchModels` 增加 `proxyID` 参数，经现有 `proxyResolver` 解析 —— #749 的启用开关与密码加密（系统钥匙串）自动生效
- `llmHTTPClientFor(proxy)` 构建代理传输层：SOCKS5 走 `socks5://` URL scheme（`http.Transport` 原生支持），HTTP 代理走 `Proxy` 钩子；直连路径保留 F-208 共享 keep-alive 客户端
- 模型表单（设置 → AI 模型）新增代理下拉（数据来自代理 store，停用的代理不可选）
- i18n：`settings.modelProxyPlaceholder` / `settings.modelProxyDesc`，8 语言

## 验证

- `go build ./...`、`go test ./backend/...`
- `npm --prefix frontend run build`
- 手动：保存一个 SOCKS5 代理 → 绑定到 OpenAI 模型 → 测试连接 / 拉取模型经代理成功；清掉代理 → 恢复直连