### PR TITLE
perf(startup): show window on commit-navigation and drop top-level await

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -8,6 +8,7 @@ import App from './App.vue'
 import './style.css'
 import { Window } from '@wailsio/runtime'
 import { useSettingsStore } from './stores/settingsStore'
+import { setLocale } from './i18n'
 
 Window.SetTitle('uniTerm')
 
@@ -22,7 +23,17 @@ app.use(pinia)
 app.use(ElementPlus)
 
 const settingsStore = useSettingsStore()
-await settingsStore.init()
+// Sync locale from navigator before mount (default 'system' → resolves from
+// navigator.language, zero IPC) so the first paint is already in the user's
+// language; init() re-resolves with the persisted preference once loaded.
+setLocale('system')
+// Fire settings init without awaiting: top-level await here used to block the
+// module's completion, which delayed the page load event, which delayed Wails'
+// window Show() — seconds of dock-icon-but-no-window on slow first paint. All
+// settings consumers are reactive (computed/watch/template), so values apply
+// themselves once init lands. applyTheme() on the loaded defaults runs before
+// mount anyway (init() calls it synchronously after its awaits settle).
+settingsStore.init()
 
 app.mount('#app')
 

--- a/main.go
+++ b/main.go
@@ -222,6 +222,19 @@ func main() {
 	app.window = window
 	w3app.RegisterService(application.NewService(app))
 
+	// Show the window as soon as the page's DOM is committed (content starts
+	// rendering) instead of waiting for Wails' default, which defers Show until
+	// WebViewDidFinishNavigation — i.e. after the multi-MB bundle is parsed and
+	// executed. On macOS the window is created hidden and only shown via that
+	// late callback, so users see the dock icon for seconds before anything
+	// appears. Commit fires well before that; the body background (dark in
+	// style.css) is already the right colour, so the early show paints a clean
+	// dark window instead of white. Finish-navigation still runs its own
+	// Show(), which is idempotent.
+	window.OnWindowEvent(events.Mac.WebViewDidCommitNavigation, func(*application.WindowEvent) {
+		window.Show()
+	})
+
 	err := w3app.Run()
 	if err != nil {
 		log.Writef("Wails run error: %v", err)


### PR DESCRIPTION
### Summary / 摘要

macOS 启动时 Dock 图标先出现、窗口延迟约 2 秒才弹出。本 PR 从两方面消除这段滞后：

1. **提前窗口显示时机**：Wails v3 默认在 `WebViewDidFinishNavigation`（页面完全加载，含多 MB bundle 解析执行）才 `Show()`。改为监听 `WebViewDidCommitNavigation`（DOM 提交、内容开始渲染）立即显示。`style.css` 的 `html:not([data-theme])` 兜底背景为深色，与窗口 `BackgroundColour` 一致，提前显示只看到干净的深色窗口、不会闪白；原 finish-navigation 的 `Show()` 仍会执行且幂等。
2. **去掉前端入口顶层 await**：`main.ts` 的 `await settingsStore.init()` 阻塞模块执行 → 拖住页面 `load` 事件 → 拖住 `didFinishNavigation` → 进一步顺延显示。排查确认所有设置消费者均为响应式（computed/watch/template，`BaseTerminal` 另有 deep watcher 兜底），故 `init()` 改为不等待执行，值到位后自动应用；`mount` 前先同步 `setLocale('system')`（纯 navigator 解析、零 IPC）保证首屏语言正确，`init()` 落地后按持久化设置覆盖。

### Changes / 改动

- `main.go`：注册 `WebViewDidCommitNavigation` 窗口事件，触发 `window.Show()`。
- `frontend/src/main.ts`：顶层 `await settingsStore.init()` → `settingsStore.init()`（fire-and-forget），并加 `setLocale('system')` 同步首屏语言。

### Validation / 验证

- 启动计时（Swift 工具 spawn 进程 + CGWindowList 按 PID 轮询窗口 on-screen）：
  - 冷启动：2113 ms → 893 ms（提前 ~1.2s）
  - 热启动 ×5：271 ms 均值 → 265 ms 均值（无回退）
- `go build -tags production` / `go test .` 通过。
- `vue-tsc --noEmit` 错误数与 main 基线完全一致（存量问题，零新增）。
- `vite build` 成功，bundle 体积与 main 重建基线一致。

Closes #793