### PR TITLE
fix(ui): keep screen preview frosted blur in production builds

### DIFF
--- a/build/Taskfile.yml
+++ b/build/Taskfile.yml
@@ -27,7 +27,9 @@ tasks:
       - sh: npm version
         msg: "Looks like npm isn't installed. Npm is part of the Node installer: https://nodejs.org/en/download/"
     cmds:
-      - npm install
+      # --no-audit/--prefer-offline: npm's audit request takes 40+s on some
+      # machines, starving the dev-mode vite server past the app's 5s wait.
+      - npm install --no-audit --prefer-offline
 
   install:frontend:deps:bun:
     dir: frontend

--- a/frontend/src/components/TerminalScreenPreview.vue
+++ b/frontend/src/components/TerminalScreenPreview.vue
@@ -101,7 +101,9 @@ const popupStyle = computed(() => ({
   // Mix the terminal background toward a light blue so the popup reads as a
   // distinct overlay instead of blending with the terminal; rendered
   // translucent + CSS backdrop blur (see .terminal-screen-preview) for a
-  // frosted-glass look.
+  // frosted-glass look. tintBlue() falls back to opaque black for
+  // non-hex backgrounds (transparent in background-image mode), so the
+  // popup is never invisible.
   background: withAlpha(tintBlue(bgColor.value, 0.3), 0.85),
   color: fgColor.value,
   fontSize: fontCss.value.fontSize,
@@ -163,8 +165,11 @@ function withAlpha(color: string, alpha: number): string {
  */
 function tintBlue(color: string, ratio: number): string {
   const m = /^#([0-9a-f]{3}|[0-9a-f]{6})$/i.exec(color.trim())
-  if (!m) return color
-  let hex = m[1]
+  // Non-hex input used to pass through unchanged. In background-image mode
+  // the terminal's theme background is 'transparent', which rendered the
+  // popup fully invisible; treat it as opaque black instead — it tints to
+  // the same dark blue as a black-background terminal.
+  let hex = m ? m[1] : '000000'
   if (hex.length === 3) {
     hex = hex.split('').map((ch) => ch + ch).join('')
   }
@@ -528,9 +533,12 @@ onBeforeUnmount(unbind)
   padding: 2px 4px;
   box-sizing: content-box;
   /* Frosted glass: translucent background (inline, theme-tinted) + backdrop
-     blur so the content beneath the popup shows through, blurred. */
+     blur so the content beneath the popup shows through, blurred. Keep this
+     the ONLY backdrop-filter declaration in the rule: pairing it with the
+     -webkit- alias makes the CSS minifier merge the two into the prefixed
+     form, which WebView2 (Chromium) does not honor — that silently removed
+     the blur in production builds. */
   backdrop-filter: blur(8px);
-  -webkit-backdrop-filter: blur(8px);
   /* Display-only: never intercepts the mouse, so hovering/clicking near it
      keeps working and the preview keeps refreshing underneath. */
   pointer-events: none;


### PR DESCRIPTION
## Summary

Two fixes for the terminal screen preview popup losing its frosted-glass blur in production builds:

- **Drop the `-webkit-backdrop-filter` alias.** The CSS minifier (lightningcss in rolldown-vite) merges a `backdrop-filter` declaration with its `-webkit-` alias and keeps only the last one. The prefixed form was last, WebView2 (Chromium) does not honor it, so production builds silently lost the blur while dev served unminified CSS and was unaffected. Keeping only the standard declaration avoids the merge entirely.
- **Fall back to opaque black for non-hex terminal backgrounds** in the popup tint: with a background image enabled, the terminal theme background is `transparent`, which passed straight through both color helpers and rendered the popup fully invisible.

Also fixes dev-mode startup racing (separate commit): `npm install`'s audit network request took 40s+ on some machines, delaying the vite dev server past the app's short frontend-devserver wait, so `wails3 dev` aborted before any window appeared. Pinned `--no-audit --prefer-offline` (verified ~1.2s vs ~46s).

## Test

- `wails3 build` production binary: preview popup shows the tinted translucent background + backdrop blur with background image on and off
- `wails3 dev`: starts cleanly, popup blur unaffected
- Verified via CDP that the built stylesheet now contains the unprefixed `backdrop-filter: blur(8px)` and the computed style resolves

---

## 摘要

修复终端画面预览弹窗在生产构建中失去毛玻璃模糊效果的两个问题：

- **移除 `-webkit-backdrop-filter` 别名**：CSS 压缩器（rolldown-vite 的 lightningcss）会把 `backdrop-filter` 与其 `-webkit-` 别名合并、只保留最后一条。前缀形式排在最后且 WebView2（Chromium）不识别，导致生产构建静默丢失模糊效果，而 dev 模式使用未压缩 CSS 不受影响。只保留标准声明即可完全避开合并。
- **弹窗底色对非 hex 终端背景回退为不透明黑色**：开启背景图时终端主题背景为 `transparent`，此前会原样透传，弹窗完全不可见。

另有独立 commit 修复 dev 模式启动竞态：`npm install` 的 audit 网络请求在某些机器上耗时 40 秒以上，vite dev server 因此晚于应用的短超时等待，`wails3 dev` 启动直接失败。固定使用 `--no-audit --prefer-offline`（实测约 1.2 秒，对比原先约 46 秒）。

## 验证

- 生产二进制：背景图开 / 关两种模式下，预览弹窗均有半透明底色 + 毛玻璃模糊
- `wails3 dev` 正常启动，弹窗模糊不受影响
- 通过 CDP 确认产物样式表包含未加前缀的 `backdrop-filter: blur(8px)` 且计算样式正确解析
