### PR TITLE
fix(db): load SQL file into editor and route multi-statement runs through script executor

### DIFF
--- a/frontend/src/components/DBQueryEditor.vue
+++ b/frontend/src/components/DBQueryEditor.vue
@@ -375,6 +375,36 @@ function isQuerySql(text: string): boolean {
   return /^\s*(WITH|SELECT|SHOW|DESCRIBE|DESC|EXPLAIN|PRAGMA)\b/i.test(stmt)
 }
 
+function hasMultipleStatements(text: string): boolean {
+  return SplitScriptLike(text).length > 1
+}
+
+// Lightweight statement count: respects quotes and line comments so a `;`
+// inside a literal doesn't count as a separator. Block comments/DELIMITER
+// don't matter for the >1 check in practice.
+function SplitScriptLike(text: string): string[] {
+  const parts: string[] = []
+  let cur = ''
+  let inSingle = false
+  let inDouble = false
+  let inBacktick = false
+  for (let i = 0; i < text.length; i++) {
+    const c = text[i]
+    const prev = i > 0 ? text[i - 1] : ''
+    if (c === "'" && !inDouble && !inBacktick && prev !== '\\') inSingle = !inSingle
+    else if (c === '"' && !inSingle && !inBacktick && prev !== '\\') inDouble = !inDouble
+    else if (c === '`' && !inSingle && !inDouble) inBacktick = !inBacktick
+    else if (c === ';' && !inSingle && !inDouble && !inBacktick) {
+      if (cur.trim()) parts.push(cur)
+      cur = ''
+      continue
+    }
+    cur += c
+  }
+  if (cur.trim()) parts.push(cur)
+  return parts
+}
+
 function normalizeSql(s: string): string {
   return s.replace(/\s+/g, ' ').trim()
 }
@@ -531,7 +561,15 @@ async function onExecute() {
   }
 
   try {
-    if (isQuerySql(toRun)) {
+    // Multi-statement scripts must run as a script: ExecuteQuery/Statement
+    // would only send the first statement (multiStatements is off in the DSN).
+    if (hasMultipleStatements(toRun)) {
+      const result = await ExecuteSQLScript(props.sessionId, props.dbName || '', toRun)
+      if (!cancelled) {
+        scriptResult.value = result
+        if (result?.failedLine) emit('cellUpdated')
+      }
+    } else if (isQuerySql(toRun)) {
       const result = await ExecuteQuery(props.sessionId, props.dbName || '', firstStatement(toRun))
       if (!cancelled) {
         queryResult.value = result
@@ -580,16 +618,32 @@ function onCancelQuery() {
 
 const scriptResult = shallowRef<ScriptResult | null>(null)
 
+// Wails v3 rejects the picker promise with "cancelled by user" when the
+// dialog is dismissed, instead of resolving with an empty path.
+function isDialogCancel(e: unknown): boolean {
+  return String(e).toLowerCase().includes('cancel')
+}
+
+// Only load files up to 1MB into the editor; larger ones run without display.
+const sqlFileEditorLimit = 1 << 20
+
 async function onOpenScriptFile() {
+  let path = ''
   try {
-    const path = await OpenFileDialogFiltered(t('db.runSqlFile'), 'SQL File', '*.sql')
-    if (!path) return
+    path = await OpenFileDialogFiltered(t('db.runSqlFile'), 'SQL File', '*.sql')
+  } catch (e) {
+    if (!isDialogCancel(e)) error.value = (e as any)?.message || String(e)
+    return
+  }
+  if (!path) return
+  try {
     const b64 = await ReadFileBase64(path)
     const text = decodeBase64(b64)
     error.value = ''
     queryResult.value = null
     execResult.value = null
     scriptResult.value = null
+    if (text.length <= sqlFileEditorLimit) sql.value = text
     loading.value = true
     cancelled = false
     const result = await ExecuteSQLScript(props.sessionId, props.dbName || '', text)


### PR DESCRIPTION
## Summary / 概要

Fixes #804（选择 SQL 文件后没有反应）。

Picking a .sql file in the MySQL query editor executed it silently with no visible feedback — on success only a small one-line footer appeared, which users read as "nothing happened", and the file content never reached the query editor. Pressing Execute on a multi-statement script also only ran the first statement.

在 MySQL 查询编辑器选择 .sql 文件后会静默执行，成功时仅在底部显示一行小字，用户感知为“没反应”，且文件内容从未出现在查询窗口。另外，对多语句脚本按“执行”只会运行第一条语句。

Root causes / 根因:
1. `onOpenScriptFile` ran `ExecuteSQLScript` directly without loading the text into the editor, so there was no visible feedback.
   `onOpenScriptFile` 直接调用 `ExecuteSQLScript`，不把文件内容放进编辑器，没有任何可见反馈。
2. `onExecute` sent the text to `ExecuteQuery`/`ExecuteStatement`, which only run the first statement (the MySQL DSN does not enable `multiStatements`).
   `onExecute` 走 `ExecuteQuery`/`ExecuteStatement`，只发送第一条语句（MySQL DSN 未开启 `multiStatements`）。
3. Dismissing the file picker rejected the Wails v3 dialog promise with "cancelled by user" and surfaced as an error (same class of issue as zmodem 4a662f7).
   取消文件选择对话框时 Wails v3 会以 "cancelled by user" reject，被当作错误弹出（与 zmodem 4a662f7 同类问题）。

## Changes / 改动

- Load the file text into the editor (up to 1MB; larger files run without display to avoid freezing) before running it, so the SQL is visible in the query window.
  选完文件先把内容加载进编辑器（≤1MB，超大的直接执行以免卡顿）再自动运行，SQL 内容在查询窗口可见。
- Route multi-statement text through `ExecuteSQLScript` in `onExecute`, reusing the existing per-statement error panel (line number + failing SQL).
  `onExecute` 对多语句文本改走 `ExecuteSQLScript`，复用现有的按语句报错面板（行号 + 失败 SQL）。
- Treat file-picker dismissal as a no-op; real dialog errors still display.
  取消文件选择对话框视为无操作；真实的对话框错误仍会显示。

## Validation / 验证

- `vue-tsc --noEmit`: no new errors (4 pre-existing errors in the file unchanged).
  `vue-tsc --noEmit`：无新增错误（文件内 4 个存量错误不变）。
- `vite build` and `go build ./...` pass.
  `vite build` 与 `go build ./...` 通过。
- Manual check on a MySQL connection: pick a .sql with CREATE+INSERT — content appears in the editor and the footer shows "N statements executed"; dismiss the picker — no error.
  手动验证 MySQL 连接：选择含 CREATE+INSERT 的 .sql——内容出现在编辑器、底部显示“已执行 N 条”；取消选择——无报错。

Closes #804