### PR TITLE
fix(redis): flat-list indent; separator into Advanced; copy-on-select clipboard (#827)

### DIFF
--- a/frontend/src/components/BaseTerminal.vue
+++ b/frontend/src/components/BaseTerminal.vue
@@ -137,6 +137,7 @@ import { useSessionStore } from '../stores/sessionStore'
 import { useTabStore } from '../stores/tabStore'
 import { usePanelStore } from '../stores/panelStore'
 import { useTerminalMenu } from '../composables/useTerminalMenu'
+import { writeClipboard } from '../composables/useClipboardWrite'
 import Menu from './Menu.vue'
 import MenuItem from './MenuItem.vue'
 import MenuDivider from './MenuDivider.vue'
@@ -841,7 +842,7 @@ function handleTerminalKey(e: KeyboardEvent): boolean {
     const sel = terminal?.getSelection()
     if (sel) {
       e.preventDefault()
-      navigator.clipboard.writeText(sel).catch(() => {})
+      writeClipboard(sel)
       return false
     }
     return true
@@ -1189,7 +1190,9 @@ onMounted(() => {
       const text = terminal?.getSelection()
       if (text && text !== lastSelectionText) {
         lastSelectionText = text
-        navigator.clipboard.writeText(text).catch(() => {})
+        // Wails clipboard writer: navigator.clipboard silently fails in
+        // WKWebView when the webview isn't first responder (#827).
+        writeClipboard(text)
       }
     }, 0)
   })
@@ -1447,7 +1450,7 @@ onMounted(() => {
     if (detail?.panelId && detail.panelId !== props.panelId) return
     const sel = terminal?.getSelection()
     if (sel) {
-      navigator.clipboard.writeText(sel).catch(() => {})
+      writeClipboard(sel)
     }
   }
   window.addEventListener('terminal:copy', onTerminalCopy)

--- a/frontend/src/components/ConnectionForm.vue
+++ b/frontend/src/components/ConnectionForm.vue
@@ -57,9 +57,6 @@
                 <el-radio-button label="sentinel">{{ t('conn.redisModeSentinel') }}</el-radio-button>
               </el-radio-group>
             </el-form-item>
-            <el-form-item v-if="form.type === 'database' && form.dbType === 'redis'" :label="t('conn.redisKeySeparator')">
-              <el-input v-model="form.redisKeySeparator" :placeholder="t('conn.redisKeySeparatorPlaceholder')" style="width: 160px" />
-            </el-form-item>
             <template v-if="isRedisSentinel">
               <el-form-item :label="t('conn.redisSentinels')" required>
                 <el-input v-model="form.redisSentinels" :placeholder="t('conn.redisSentinelsPlaceholder')" />
@@ -404,6 +401,9 @@
             <template v-if="showAdvanced">
             <el-form-item v-if="form.type === 'database'" :label="t('db.params')">
               <el-input v-model="form.dbParams" :placeholder="defaultParamsHint" style="width:100%" />
+            </el-form-item>
+            <el-form-item v-if="form.type === 'database' && form.dbType === 'redis'" :label="t('conn.redisKeySeparator')">
+              <el-input v-model="form.redisKeySeparator" :placeholder="t('conn.redisKeySeparatorPlaceholder')" style="width: 160px" />
             </el-form-item>
             <el-form-item v-if="form.type === 'ssh' || form.type === 'telnet' || form.type === 'mosh' || form.type === 'local'" :label="t('conn.postLoginScript')">
               <div class="post-login-config">
@@ -935,7 +935,7 @@ const showTunnel = computed(() =>
 )
 const showProxy = computed(() => ['ssh', 'sftp', 'scp', 'monitor'].includes(form.type))
 const showAdvancedToggle = computed(() =>
-  showTunnel.value || form.type === 'ssh' || form.type === 'sftp' || form.type === 'scp' || form.type === 'telnet' || form.type === 'mosh' || form.type === 'local' || form.type === 'serial' || form.type === 'ftp'
+  showTunnel.value || form.type === 'ssh' || form.type === 'sftp' || form.type === 'scp' || form.type === 'telnet' || form.type === 'mosh' || form.type === 'local' || form.type === 'serial' || form.type === 'ftp' || form.type === 'database'
 )
 
 const isRedisSentinel = computed(() =>

--- a/frontend/src/components/RedisTabContent.vue
+++ b/frontend/src/components/RedisTabContent.vue
@@ -36,7 +36,6 @@
               :class="{ selected: selectedKey === keyInfo.name }"
               @click="onSelectKey(keyInfo)"
             >
-              <span class="key-leaf-spacer" />
               <span class="key-type-badge">{{ keyInfo.type }}</span>
               <span class="key-name">{{ keyInfo.name }}</span>
             </div>

--- a/frontend/src/composables/useClipboardWrite.ts
+++ b/frontend/src/composables/useClipboardWrite.ts
@@ -1,0 +1,26 @@
+import { Clipboard } from '@wailsio/runtime'
+
+// Write to the OS clipboard. Wails' ClipboardSetText resolves false (it does
+// not reject) on focus loss / AppKit glitches, so a false return has to fall
+// through to the browser API rather than being treated as done. The browser
+// API alone is unreliable in WKWebView — navigator.clipboard.writeText
+// silently fails when the webview isn't first responder, which is exactly
+// when selection-event-driven copies fire (#827). browserWriter is also the
+// standalone path when Wails is absent (dev outside the runtime).
+type ClipboardWriter = (text: string) => Promise<boolean>
+const browserWriter: ClipboardWriter = async (text) => {
+  try { await navigator.clipboard.writeText(text); return true } catch { return false }
+}
+const wailsWriter: ClipboardWriter = async (text) => {
+  let ok = false
+  try {
+    ok = await Clipboard.SetText(text)
+  } catch {
+    ok = false
+  }
+  return ok || browserWriter(text)
+}
+
+export const writeClipboard: ClipboardWriter = typeof Clipboard.SetText === 'function'
+  ? wailsWriter
+  : browserWriter

--- a/frontend/src/composables/useTerminalMenu.ts
+++ b/frontend/src/composables/useTerminalMenu.ts
@@ -1,7 +1,7 @@
 import { ref } from 'vue'
 import type { Ref } from 'vue'
-import { Clipboard } from '@wailsio/runtime'
 import { useSettingsStore } from '../stores/settingsStore'
+import { writeClipboard } from './useClipboardWrite'
 export interface UseTerminalMenuOptions {
   getSelection: () => string
   onPaste: (text: string) => Promise<void> | void
@@ -62,28 +62,6 @@ export function useTerminalMenu(options: UseTerminalMenuOptions): UseTerminalMen
     menuVisible.value = true
     options.openAt?.(e.clientX, e.clientY)
   }
-
-  // Write to the OS clipboard. Wails' ClipboardSetText resolves false (it
-  // does not reject) on focus loss / AppKit glitches, so a false return has
-  // to fall through to the browser API rather than being treated as done.
-  // browserWriter is also the standalone path when Wails is absent (dev
-  // outside the runtime).
-  type ClipboardWriter = (text: string) => Promise<boolean>
-  const browserWriter: ClipboardWriter = async (text) => {
-    try { await navigator.clipboard.writeText(text); return true } catch { return false }
-  }
-  const wailsWriter: ClipboardWriter = async (text) => {
-    let ok = false
-    try {
-      ok = await Clipboard.SetText(text)
-    } catch {
-      ok = false
-    }
-    return ok || browserWriter(text)
-  }
-  const writeClipboard: ClipboardWriter = typeof Clipboard.SetText === 'function'
-    ? wailsWriter
-    : browserWriter
 
   function copySelection() {
     // Trust getSelection() at click time; the contextmenu-captured ref can


### PR DESCRIPTION
## Summary / 概要

三笔小修：#826 合并后的两处 Redis 收尾 + #827 选中复制失效。

Three small fixes: two Redis follow-ups after #826 plus #827.

## Changes / 改动

1. **平铺列表左对齐**（fc0fae8）：树/平铺切换加入时，平铺行被塞了树形的图标占位 spacer——平铺没有箭头列要对齐，12px 空白像莫名缩进。平铺行删除 spacer 恢复贴左；树叶子保留 spacer 与父目录箭头列对位。
   The flat list inherited the tree's leading spacer where nothing needs aligning — keys start at the left edge again.

2. **分隔符移入高级区**（6c5e00a）：Key 分组分隔符从连接表单主页面移到底部「高级」折叠区（与 DSN 额外参数同区），database 类型连接现在也显示「高级」开关。
   The key-separator preference moved into the Advanced section; database connections now show the Advanced toggle.

3. **选中后复制失效（#827）**（ba9fee7）：「选中后执行 - 复制到剪贴板」直接用 `navigator.clipboard.writeText`，WKWebView 非第一响应者时静默失败（macOS 鼠标拖选结束正是此状态，reporter 在 Tahoe 26 复现）。右键菜单复制早已用 Wails `Clipboard.SetText` + 浏览器回退解决，但该 writer 私有在 useTerminalMenu 里。现提取为 `composables/useClipboardWrite`，三条终端复制路径（选中复制、Cmd+C、Ctrl+Shift+C）统一走它。
   Copy-on-select used navigator.clipboard directly, which silently fails in WKWebView without first-responder focus; all three terminal copy paths now share the Wails-first writer with browser fallback.

## Validation / 验证

- `vite build` 通过；`vue-tsc --noEmit` 无新增错误（存量 18 不变）
- `vitest run src/composables/` 69 个测试全过（含 useTerminalMenu 的 10 个 writer 用例）
- dev 验证：平铺 key 贴左缘；Redis 表单主页面只剩「模式」、分隔符在「高级」里；设置选「复制到剪贴板」后拖选文字，剪贴板出现选中内容

Closes #827