### PR TITLE
feat(tab): broadcast input across tabs and workspaces

### DIFF
--- a/frontend/src/components/BaseTerminal.vue
+++ b/frontend/src/components/BaseTerminal.vue
@@ -517,8 +517,8 @@ async function applySuggestion(item: ReturnType<typeof suggestions.getSelectedIt
     // Replace entire line with Ctrl+U. Using backspaces only works when the
     // replacement is exactly the currentToken; for multi-token input (e.g.
     // "git che" → "git checkout") backspaces leave the earlier text behind.
-    if (props.broadcastActive && props.workspaceId) {
-      const targets = tabStore.getBroadcastPanelIdsInWorkspace(props.workspaceId)
+    if (props.broadcastActive) {
+      const targets = tabStore.getAllBroadcastPanelIds()
       for (const pid of targets) {
         const p = panelStore.getPanel(pid)
         if (p?.sessionId && (p.type === 'ssh' || p.type === 'local')) {
@@ -746,8 +746,8 @@ function writeTerminalInput(data: string, inAlternateScreen: boolean) {
   // Don't send empty input - avoids extra blank line when pressing Enter with no command
   if (!sid || !filtered) return
 
-  if (props.broadcastActive && props.workspaceId) {
-    const targets = tabStore.getBroadcastPanelIdsInWorkspace(props.workspaceId)
+  if (props.broadcastActive) {
+    const targets = tabStore.getAllBroadcastPanelIds()
     if (targets.length > 0) {
       for (const pid of targets) {
         const p = panelStore.getPanel(pid)
@@ -1835,8 +1835,8 @@ async function pasteToSession(text: string) {
 
     // Broadcast mode: write to every target panel instead of only this
     // session (issue #597 — pasted command must sync like keyboard input).
-    if (props.broadcastActive && props.workspaceId) {
-      const targets = tabStore.getBroadcastPanelIdsInWorkspace(props.workspaceId)
+    if (props.broadcastActive) {
+      const targets = tabStore.getAllBroadcastPanelIds()
       if (targets.length > 0) {
         for (const pid of targets) {
           const p = panelStore.getPanel(pid)

--- a/frontend/src/components/TabItem.vue
+++ b/frontend/src/components/TabItem.vue
@@ -44,6 +44,12 @@
       @blur="confirmEdit"
       @click.stop
     />
+    <Radio
+      v-if="showBroadcastIcon"
+      class="tab-broadcast-icon"
+      :size="14"
+      :title="t('tab.unbroadcast')"
+    />
     <button
       v-if="tabCloseRight"
       class="tab-close tab-close-right"
@@ -64,6 +70,9 @@
       <MenuItem v-if="hasLocatableConnection" @click="locateHost">{{ t('tab.locate') }}</MenuItem>
       <MenuItem v-if="tab.type !== 'start' && tab.type !== 'settings'" @click="toggleLock">
         {{ tab.locked ? t('tab.unlock') : t('tab.lock') }}
+      </MenuItem>
+      <MenuItem v-if="canBroadcast" @click="toggleBroadcastTarget">
+        {{ isBroadcastTarget ? t('tab.unbroadcast') : t('tab.broadcast') }}
       </MenuItem>
 
       <!-- ② 会话文本操作 -->
@@ -124,7 +133,7 @@ import Menu from './Menu.vue'
 import MenuItem from './MenuItem.vue'
 import MenuDivider from './MenuDivider.vue'
 import { Clipboard } from '@wailsio/runtime'
-import { SquareTerminal, Laptop, FolderUp, Folders, FileUp, HardDrive, Cloud, Globe, Monitor, MonitorCloud, MonitorSmartphone, Settings, Database, DatabaseZap, Layers, DatabaseSearch, Activity, Terminal, Zap, X, ArrowDownUp, LayoutDashboard, Cable, SquarePlus, Lock, ShipWheel, Box, Boxes, AppWindow, ArrowLeftRight } from '@lucide/vue'
+import { SquareTerminal, Laptop, FolderUp, Folders, FileUp, HardDrive, Cloud, Globe, Monitor, MonitorCloud, MonitorSmartphone, Settings, Database, DatabaseZap, Layers, DatabaseSearch, Activity, Terminal, Zap, X, ArrowDownUp, LayoutDashboard, Cable, SquarePlus, Lock, ShipWheel, Box, Boxes, AppWindow, ArrowLeftRight, Radio } from '@lucide/vue'
 
 const props = defineProps<{
   tab: TerminalTab | SettingsTab | SFTPTab | RDPTab | VNCTab | SPICETab | DBTab | MonitorTab | WorkspaceTab
@@ -225,6 +234,34 @@ const isAILocked = computed(() => {
   if (props.tab.type !== 'terminal') return false
   return tabStore.isPanelAILocked(props.tab.panelId)
 })
+
+// Whether the tab can be a broadcast target / driver. Only ssh/local-backed
+// terminal tabs (broadcast only routes ssh/local sessions) and workspace tabs.
+const canBroadcast = computed(() => {
+  if (props.tab.type === 'workspace') return true
+  if (props.tab.type === 'terminal') {
+    const p = panelStore.getPanel((props.tab as TerminalTab).panelId)
+    return !!p && (p.type === 'ssh' || p.type === 'local')
+  }
+  return false
+})
+
+// Tab-level broadcast status — derived from broadcastPanelIds, so it stays in
+// sync with each panel's broadcast button.
+const isBroadcastTarget = computed(() =>
+  tabStore.isTabBroadcastTarget(props.tab.id)
+)
+
+// When the right-side close button shows (right-close setting + hover + not
+// locked), it replaces the broadcast status icon exactly like the left close
+// button replaces the tab icon in the default layout. Otherwise the icon stays
+// visible. In the default (left-close) layout there is no right close button,
+// so the icon is always shown.
+const showBroadcastIcon = computed(() =>
+  canBroadcast.value &&
+  isBroadcastTarget.value &&
+  !(tabCloseRight.value && hovered.value && !props.tab.locked)
+)
 
 
 const hasActiveTransfers = computed(() => {
@@ -413,6 +450,15 @@ function toggleLock() {
   closeContextMenu()
 }
 
+function toggleBroadcastTarget() {
+  if (isBroadcastTarget.value) {
+    tabStore.disableBroadcastForTab(props.tab.id)
+  } else {
+    tabStore.enableBroadcastForTab(props.tab.id)
+  }
+  closeContextMenu()
+}
+
 function toggleAiLock() {
   if (props.tab.type === 'terminal') {
     emit('toggleAiLock', props.tab.panelId)
@@ -569,7 +615,7 @@ onMounted(async () => {
   align-items: center;
   gap: 2px;
   height: 28px;
-  min-width: 120px;
+  min-width: 144px;
   padding: 0 12px;
   margin: 0 1px;
   cursor: pointer;
@@ -632,6 +678,17 @@ onMounted(async () => {
   width: 14px;
   height: 14px;
   color: var(--text-muted);
+}
+/* Broadcast status icon sits in the right-side close-button slot, mirrored
+   vertically/horizontally with it. It's toggled off (v-if) whenever the close
+   button is shown, so the two never overlap — same as the tab icon being
+   replaced by the left close button in the default layout. */
+.tab-broadcast-icon {
+  position: absolute;
+  right: 12px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--accent);
 }
 .tab-notification-dot {
   position: absolute;
@@ -707,5 +764,10 @@ onMounted(async () => {
 }
 .tab-close-right-ghost {
   visibility: hidden;
+  /* Hide instantly on mouse-leave: `.tab-close` carries transition:all, and
+     visibility is a transitionable property, so a visible→hidden ghost would
+     otherwise linger for the transition duration — overlapping the broadcast
+     status icon that swaps in via v-if at the same slot. */
+  transition: visibility 0s;
 }
 </style>

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -125,6 +125,8 @@
   "tab.copyHostAddress": "Hostadresse kopieren",
   "tab.hostCopied": "Hostadresse kopiert: {host}",
   "tab.rename": "Umbenennen",
+  "tab.broadcast": "An diesen Tab übertragen",
+  "tab.unbroadcast": "Übertragung an diesen Tab abbrechen",
   "tab.locate": "Verbindung finden",
   "tab.closeRight": "Tabs rechts schließen",
   "tab.closeLeft": "Tabs links schließen",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -125,6 +125,8 @@
   "tab.copyHostAddress": "Copy Host Address",
   "tab.hostCopied": "Host address copied: {host}",
   "tab.rename": "Rename",
+  "tab.broadcast": "Broadcast to this tab",
+  "tab.unbroadcast": "Cancel broadcast to this tab",
   "tab.locate": "Locate connection",
   "tab.closeRight": "Close Tabs to the Right",
   "tab.closeLeft": "Close Tabs to the Left",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -125,6 +125,8 @@
   "tab.copyHostAddress": "Copiar dirección del host",
   "tab.hostCopied": "Dirección del host copiada: {host}",
   "tab.rename": "Renombrar",
+  "tab.broadcast": "Retransmitir a esta pestaña",
+  "tab.unbroadcast": "Cancelar retransmisión a esta pestaña",
   "tab.locate": "Localizar conexión",
   "tab.closeRight": "Cerrar pestañas a la derecha",
   "tab.closeLeft": "Cerrar pestañas a la izquierda",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -125,6 +125,8 @@
   "tab.copyHostAddress": "Copier l'adresse de l'hôte",
   "tab.hostCopied": "Adresse de l'hôte copiée : {host}",
   "tab.rename": "Renommer",
+  "tab.broadcast": "Diffuser vers cet onglet",
+  "tab.unbroadcast": "Annuler la diffusion vers cet onglet",
   "tab.locate": "Localiser la connexion",
   "tab.closeRight": "Fermer les onglets à droite",
   "tab.closeLeft": "Fermer les onglets à gauche",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -125,6 +125,8 @@
   "tab.copyHostAddress": "ホストアドレスをコピー",
   "tab.hostCopied": "ホストアドレスをコピーしました：{host}",
   "tab.rename": "名前を変更",
+  "tab.broadcast": "このタブにブロードキャスト",
+  "tab.unbroadcast": "このタブへのブロードキャストをキャンセル",
   "tab.locate": "接続先を探す",
   "tab.closeRight": "右側のタブを閉じる",
   "tab.closeLeft": "左側のタブを閉じる",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -125,6 +125,8 @@
   "tab.copyHostAddress": "호스트 주소 복사",
   "tab.hostCopied": "호스트 주소가 복사되었습니다: {host}",
   "tab.rename": "이름 변경",
+  "tab.broadcast": "이 탭에 브로드캐스트",
+  "tab.unbroadcast": "이 탭으로의 브로드캐스트 취소",
   "tab.locate": "연결 위치 찾기",
   "tab.closeRight": "오른쪽 탭 닫기",
   "tab.closeLeft": "왼쪽 탭 닫기",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -125,6 +125,8 @@
   "tab.copyHostAddress": "Скопировать адрес хоста",
   "tab.hostCopied": "Адрес хоста скопирован: {host}",
   "tab.rename": "Переименовать",
+  "tab.broadcast": "Вещать в эту вкладку",
+  "tab.unbroadcast": "Отменить вещание в эту вкладку",
   "tab.locate": "Найти подключение",
   "tab.closeRight": "Закрыть вкладки справа",
   "tab.closeLeft": "Закрыть вкладки слева",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -125,6 +125,8 @@
   "tab.copyHostAddress": "复制主机地址",
   "tab.hostCopied": "已复制主机地址：{host}",
   "tab.rename": "重命名",
+  "tab.broadcast": "广播到该标签",
+  "tab.unbroadcast": "取消广播到该标签",
   "tab.locate": "定位到连接",
   "tab.closeRight": "关闭右侧标签",
   "tab.closeLeft": "关闭左侧标签",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -125,6 +125,8 @@
   "tab.copyHostAddress": "複製主機位址",
   "tab.hostCopied": "已複製主機位址：{host}",
   "tab.rename": "重新命名",
+  "tab.broadcast": "廣播到該標籤",
+  "tab.unbroadcast": "取消廣播到該標籤",
   "tab.locate": "定位到連接",
   "tab.closeRight": "關閉右側分頁",
   "tab.closeLeft": "關閉左側分頁",

--- a/frontend/src/stores/tabStore.ts
+++ b/frontend/src/stores/tabStore.ts
@@ -96,6 +96,50 @@ export const useTabStore = defineStore('tab', () => {
     }
   }
 
+  // Tab-level broadcast target helpers. A tab is a "broadcast target" when any
+  // broadcastable (ssh/local) panel it holds participates in broadcast — a
+  // single panel for terminal tabs, every ssh/local panel for workspace tabs.
+  // These are derived from broadcastPanelIds, so tab icons and the panel
+  // broadcast buttons always stay in sync.
+
+  function isTabBroadcastTarget(tabId: string): boolean {
+    const tab = tabState.tabs.find(t => t.id === tabId)
+    if (!tab) return false
+    if (tab.type === 'workspace') {
+      return tab.panelIds.some(id => tabState.broadcastPanelIds.has(id))
+    }
+    if ('panelId' in tab) return tabState.broadcastPanelIds.has(tab.panelId)
+    return false
+  }
+
+  // Turn on broadcast for every ssh/local panel the tab holds.
+  function enableBroadcastForTab(tabId: string) {
+    const tab = tabState.tabs.find(t => t.id === tabId)
+    if (!tab) return
+    const panelStore = usePanelStore()
+    const ids = tab.type === 'workspace' ? tab.panelIds : 'panelId' in tab ? [tab.panelId] : []
+    for (const id of ids) {
+      const p = panelStore.getPanel(id)
+      if (p && (p.type === 'ssh' || p.type === 'local')) {
+        tabState.broadcastPanelIds.add(id)
+      }
+    }
+  }
+
+  // Turn off broadcast for every panel the tab holds.
+  function disableBroadcastForTab(tabId: string) {
+    const tab = tabState.tabs.find(t => t.id === tabId)
+    if (!tab) return
+    const ids = tab.type === 'workspace' ? tab.panelIds : 'panelId' in tab ? [tab.panelId] : []
+    for (const id of ids) tabState.broadcastPanelIds.delete(id)
+  }
+
+  // Every panel participating in broadcast across all tabs. Cross-tab: the
+  // input router uses this instead of workspace-scoped targets.
+  function getAllBroadcastPanelIds(): string[] {
+    return [...tabState.broadcastPanelIds]
+  }
+
   // ── Create tabs ──
 
   function createTerminalTab(name: string, panelId: string): TerminalTab {
@@ -752,10 +796,14 @@ export const useTabStore = defineStore('tab', () => {
     clearAILockedPanels,
     toggleTabLock,
     broadcastPanelIds,
+    getAllBroadcastPanelIds,
     toggleBroadcast,
     toggleBroadcastPanel,
     isBroadcasting,
     isPanelBroadcasting,
+    isTabBroadcastTarget,
+    enableBroadcastForTab,
+    disableBroadcastForTab,
     getBroadcastPanelIdsInWorkspace,
     markTabNotification,
     clearTabNotification,


### PR DESCRIPTION
## Summary

Make terminal broadcast cross-tab. Right-click a terminal tab or a workspace tab and choose "Broadcast to this tab" to mark it as a broadcast target (click again to cancel). A status icon marks the tab, and it is replaced by the right-side close button on hover.

- **Terminal tab**: marking a tab adds its ssh/local panel to the broadcast set; the icon reflects it.
- **Workspace tab**: the action enables/disables broadcast for all its ssh/local panels at once; the tab icon reflects whether any panel is broadcasting.

Input routing now sends keystrokes / paste / command completion to every broadcasting ssh/local panel across **all** tabs (instead of only within one workspace), and standalone terminal tabs can participate and drive a broadcast. As before, the driving source tab must also be marked.

Closes #665

---
## 概述

将终端广播扩展到跨标签 / 多工作区。右键终端标签或工作区标签，选择「广播到该标签」将其标记为广播目标，再次点击取消；标签上显示广播状态图标（右侧关闭按钮悬停时替换为关闭按钮）。

- **终端标签**：勾选即把该标签的 ssh/local 面板加入广播集合，图标随之出现。
- **工作区标签**：一次操作开启 / 关闭其下所有 ssh/local 面板的广播，标签图标随面板广播状态联动。

输入路由现在会把按键 / 粘贴 / 命令补全同步到全应用所有参与广播的 ssh/local 面板（不再局限于单个工作区），独立终端标签也能参与并发起广播。发起广播的源标签本身同样需勾选（与现有面板广播按钮规则一致）。

关闭 #665
