### PR TITLE
feat(wsl): add WSL terminal with file-transfer support

### DIFF
--- a/app_terminal.go
+++ b/app_terminal.go
@@ -237,7 +237,7 @@ func (a *App) CreateSession(sessionType string, config session.ConnectionConfig)
 	} else if sessionType == "x11-desktop" {
 		// x11-desktop uses its own X11DesktopConnect entry point; the
 		// generic Connect goroutine must never call s.Connect() here.
-	} else if sessionType == "ssh" || sessionType == "local" || sessionType == "telnet" || sessionType == "mosh" || sessionType == "serial" {
+	} else if sessionType == "ssh" || sessionType == "local" || sessionType == "wsl" || sessionType == "telnet" || sessionType == "mosh" || sessionType == "serial" {
 		// Terminal session types that mount xterm: defer Connect until
 		// SessionStart is called after the frontend measures real cols/rows.
 		// Without this gap Claude Code draws tables at the 80x24 default

--- a/backend/session/local_ops.go
+++ b/backend/session/local_ops.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	osUser "os/user"
 	"path/filepath"
+	"strings"
 	"time"
 )
 
@@ -41,8 +42,15 @@ func (o *localFSOps) ListLocal(dir string) (FileListResult, error) {
 			modTime = fi.ModTime()
 		}
 		owner := ""
+		// Windows reports the owner as "COMPUTERNAME\user", verbose in the
+		// owner column; keep only the user part (same nicing SFTP had before it
+		// was folded into this shared helper).
 		if currentUser, err := osUser.Current(); err == nil {
-			owner = currentUser.Username
+			if i := strings.LastIndexByte(currentUser.Username, '\\'); i >= 0 {
+				owner = currentUser.Username[i+1:]
+			} else {
+				owner = currentUser.Username
+			}
 		}
 		isDir := e.IsDir()
 		if fi != nil && fi.Mode()&os.ModeSymlink != 0 {

--- a/backend/session/manager.go
+++ b/backend/session/manager.go
@@ -42,6 +42,12 @@ func (sm *SessionManager) Create(sessionType string, config ConnectionConfig) (S
 	case "local":
 		s = NewLocalSession(config.ID)
 
+	case "wsl":
+		s = NewWSLSession(config.ID)
+
+	case "wsl-file":
+		s = NewWSLFileSession(config.ID)
+
 	case "database":
 		s = NewDatabaseSession(config.ID)
 

--- a/backend/session/session.go
+++ b/backend/session/session.go
@@ -45,14 +45,14 @@ type ConnectionConfig struct {
 	// credentials at connect time.
 	IdentityId string `json:"identityId,omitempty"`
 	// Password is stored in plaintext JSON. Will be migrated to OS keychain in a future iteration.
-	Password string  `json:"password,omitempty"`
-	KeyPath  string  `json:"keyPath,omitempty"`
+	Password string `json:"password,omitempty"`
+	KeyPath  string `json:"keyPath,omitempty"`
 	// KeyContent holds the inline private-key text (PEM) for authType "keyText".
 	// When set, the connection authenticates from the text directly instead of
 	// reading KeyPath from disk. Encrypted at rest and normalized across cloud
 	// sync exactly like passwords so it stays portable across devices (#720).
-	KeyContent string `json:"keyContent,omitempty"`
-	GroupId  *string `json:"groupId,omitempty"`
+	KeyContent string  `json:"keyContent,omitempty"`
+	GroupId    *string `json:"groupId,omitempty"`
 	// RDP-specific fields
 	RdpFixedWidth  int  `json:"rdpFixedWidth,omitempty"`
 	RdpFixedHeight int  `json:"rdpFixedHeight,omitempty"`
@@ -82,7 +82,7 @@ type ConnectionConfig struct {
 	DBName   string `json:"dbName,omitempty"`   // default database name
 	DBParams string `json:"dbParams,omitempty"` // extra DSN query parameters, e.g. "sslmode=require&connect_timeout=30"
 	// Elasticsearch / OpenSearch fields
-	EsUseSSL     bool   `json:"esUseSsl,omitempty"`   // use HTTPS
+	EsUseSSL     bool   `json:"esUseSsl,omitempty"`     // use HTTPS
 	EsPathPrefix string `json:"esPathPrefix,omitempty"` // optional path prefix, e.g. "/es"
 	EsSkipVerify bool   `json:"esSkipVerify,omitempty"` // insecureSkipVerify for self-signed certs
 	// Redis Sentinel fields (only used when RedisMode == "sentinel")

--- a/backend/session/sftp_session.go
+++ b/backend/session/sftp_session.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"net"
 	"os"
-	osUser "os/user"
 	"path"
 	"path/filepath"
 	"strconv"
@@ -17,17 +16,17 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/ys-ll/uniterm/backend/utils"
 	"github.com/pkg/sftp"
+	"github.com/ys-ll/uniterm/backend/utils"
 	"golang.org/x/crypto/ssh"
 )
 
 type SFTPSession struct {
 	baseSession
+	localFSOps // Windows-local pane, shared with FTP/SMB/WebDAV/S3/WSL
 	sshClient  *ssh.Client
 	sftpClient *sftp.Client
 	cwd        string
-	localCwd   string
 	mu         sync.RWMutex
 	transfers  map[string]*TransferTask
 	taskSeq    int64
@@ -42,16 +41,15 @@ type SFTPSession struct {
 }
 
 func NewSFTPSession(id string) *SFTPSession {
-	homeDir, _ := os.UserHomeDir()
 	return &SFTPSession{
 		baseSession: baseSession{
 			id:          id,
 			sessionType: "sftp",
 			status:      StatusDisconnected,
 		},
-		cwd:       "/",
-		localCwd:  homeDir,
-		transfers: make(map[string]*TransferTask),
+		localFSOps: newLocalFSOps(),
+		cwd:        "/",
+		transfers:  make(map[string]*TransferTask),
 	}
 }
 
@@ -77,7 +75,7 @@ func (s *SFTPSession) Connect(config ConnectionConfig) error {
 		Auth:            authMethods,
 		Timeout:         30 * time.Second,
 		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
-		Config: sshAlgorithms(),
+		Config:          sshAlgorithms(),
 	}
 
 	addr := net.JoinHostPort(config.Host, strconv.Itoa(config.Port))
@@ -259,14 +257,14 @@ func (s *SFTPSession) IsConnected() bool {
 
 // FileItem represents a file entry returned to the frontend.
 type FileItem struct {
-	Name    string `json:"name"`
-	Size    int64  `json:"size"`
-	ModTime string `json:"modTime"`
-	Mode    string `json:"mode"`
-	IsDir   bool   `json:"isDir"`
-	IsHidden bool  `json:"isHidden"`
-	Owner   string `json:"owner"`
-	Group   string `json:"group"`
+	Name     string `json:"name"`
+	Size     int64  `json:"size"`
+	ModTime  string `json:"modTime"`
+	Mode     string `json:"mode"`
+	IsDir    bool   `json:"isDir"`
+	IsHidden bool   `json:"isHidden"`
+	Owner    string `json:"owner"`
+	Group    string `json:"group"`
 }
 
 // FileListResult wraps files + current directory for a list response.
@@ -468,81 +466,6 @@ func (s *SFTPSession) listRemoteUnlocked(dir string) (FileListResult, error) {
 	return FileListResult{Files: files, Dir: dir}, nil
 }
 
-func (s *SFTPSession) ListLocal(dir string) (FileListResult, error) {
-	if dir == "" {
-		dir = s.localCwd
-	} else if !filepath.IsAbs(dir) {
-		dir = filepath.Join(s.localCwd, dir)
-	}
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		return FileListResult{}, err
-	}
-	files := make([]FileItem, 0, len(entries))
-	for _, e := range entries {
-		fi, _ := e.Info()
-		var size int64
-		var mode os.FileMode
-		var modTime time.Time
-		if fi != nil {
-			size = fi.Size()
-			mode = fi.Mode()
-			modTime = fi.ModTime()
-		}
-		owner := ""
-		// Windows reports the owner as "COMPUTERNAME\user", which is verbose in
-		// the owner column; keep only the user part.
-		if currentUser, err := osUser.Current(); err == nil {
-			if i := strings.LastIndexByte(currentUser.Username, '\\'); i >= 0 {
-				owner = currentUser.Username[i+1:]
-			} else {
-				owner = currentUser.Username
-			}
-		}
-		isDir := e.IsDir()
-		if fi != nil && fi.Mode()&os.ModeSymlink != 0 {
-			if target, err := os.Stat(filepath.Join(dir, e.Name())); err == nil {
-				isDir = target.IsDir()
-			}
-		}
-		isHidden := e.Name() != "" && e.Name()[0] == '.'
-		if !isHidden {
-			isHidden = isPathHidden(filepath.Join(dir, e.Name()))
-		}
-		files = append(files, FileItem{
-			Name:     e.Name(),
-			Size:     size,
-			ModTime:  modTime.Format(time.RFC3339),
-			Mode:     mode.String(),
-			IsDir:    isDir,
-			IsHidden: isHidden,
-			Owner:    owner,
-		})
-	}
-	return FileListResult{Files: files, Dir: dir}, nil
-}
-
-func (s *SFTPSession) ListLocalDrives() ([]FileItem, error) {
-	var drives []FileItem
-	for _, letter := range "ABCDEFGHIJKLMNOPQRSTUVWXYZ" {
-		root := string(letter) + ":\\"
-		fi, err := os.Stat(root)
-		if err != nil {
-			continue
-		}
-		if fi.IsDir() {
-			drives = append(drives, FileItem{
-				Name:    root,
-				Size:    0,
-				ModTime: fi.ModTime().Format(time.RFC3339),
-				Mode:    fi.Mode().String(),
-				IsDir:   true,
-			})
-		}
-	}
-	return drives, nil
-}
-
 func (s *SFTPSession) ChangeRemoteDir(dir string) (FileListResult, error) {
 	if err := s.requireClient(); err != nil {
 		return FileListResult{}, err
@@ -563,25 +486,6 @@ func (s *SFTPSession) ChangeRemoteDir(dir string) (FileListResult, error) {
 	s.cwd = real
 	s.mu.Unlock()
 	return s.ListRemote(real)
-}
-
-func (s *SFTPSession) ChangeLocalDir(dir string) (FileListResult, error) {
-	target := dir
-	if !filepath.IsAbs(dir) {
-		target = filepath.Join(s.localCwd, dir)
-	}
-	fi, err := os.Stat(target)
-	if err != nil {
-		return FileListResult{}, fmt.Errorf("no such directory: %s", target)
-	}
-	if !fi.IsDir() {
-		return FileListResult{}, fmt.Errorf("not a directory: %s", target)
-	}
-	abs, _ := filepath.Abs(target)
-	s.mu.Lock()
-	s.localCwd = abs
-	s.mu.Unlock()
-	return s.ListLocal(abs)
 }
 
 func (s *SFTPSession) MakeDir(dir string) error {
@@ -768,98 +672,6 @@ func (s *SFTPSession) Put(localPath, remotePath string, recursive bool) (string,
 	}
 	s.startTransfer(task)
 	return task.ID, nil
-}
-
-// --- Local file operations ---
-
-func (s *SFTPSession) LocalRemove(p string, recursive bool) error {
-	if !filepath.IsAbs(p) {
-		p = filepath.Join(s.localCwd, p)
-	}
-	if recursive {
-		return os.RemoveAll(p)
-	}
-	fi, err := os.Stat(p)
-	if err != nil {
-		return err
-	}
-	if fi.IsDir() {
-		entries, err := os.ReadDir(p)
-		if err != nil {
-			return err
-		}
-		if len(entries) > 0 {
-			return fmt.Errorf("directory not empty (%d items)", len(entries))
-		}
-	}
-	return os.Remove(p)
-}
-
-func (s *SFTPSession) LocalRename(oldName, newName string) error {
-	old := oldName
-	if !filepath.IsAbs(old) {
-		old = filepath.Join(s.localCwd, old)
-	}
-	newPath := newName
-	if !filepath.IsAbs(newPath) {
-		newPath = filepath.Join(s.localCwd, newPath)
-	}
-	return os.Rename(old, newPath)
-}
-
-func (s *SFTPSession) LocalMkdir(dir string) error {
-	p := dir
-	if !filepath.IsAbs(p) {
-		p = filepath.Join(s.localCwd, p)
-	}
-	return os.MkdirAll(p, 0755)
-}
-
-// LocalGetContent reads a local file's full content.
-func (s *SFTPSession) LocalGetContent(localPath string) ([]byte, error) {
-	p := localPath
-	if !filepath.IsAbs(p) {
-		p = filepath.Join(s.localCwd, p)
-	}
-	return os.ReadFile(p)
-}
-
-// LocalPutContent writes content to a local file, creating parent directories as needed.
-func (s *SFTPSession) LocalPutContent(localPath string, content []byte) error {
-	p := localPath
-	if !filepath.IsAbs(p) {
-		p = filepath.Join(s.localCwd, p)
-	}
-	if err := os.MkdirAll(filepath.Dir(p), 0755); err != nil {
-		return err
-	}
-	return os.WriteFile(p, content, 0644)
-}
-
-// LocalCopy copies a local file or directory.
-func (s *SFTPSession) LocalCopy(oldPath, newPath string) error {
-	old := oldPath
-	if !filepath.IsAbs(old) {
-		old = filepath.Join(s.localCwd, old)
-	}
-	n := newPath
-	if !filepath.IsAbs(n) {
-		n = filepath.Join(s.localCwd, n)
-	}
-	return localCopyRecursive(old, n)
-}
-
-// LocalMove moves a local file or directory (rename, same filesystem only).
-func (s *SFTPSession) LocalMove(oldPath, newPath string) error {
-	old := oldPath
-	if !filepath.IsAbs(old) {
-		old = filepath.Join(s.localCwd, old)
-	}
-	n := newPath
-	if !filepath.IsAbs(n) {
-		n = filepath.Join(s.localCwd, n)
-	}
-	return os.Rename(old, n)
 }
 
 // PutContent writes raw content directly to a remote file via SFTP.
@@ -1095,11 +907,11 @@ func (s *SFTPSession) ResumeTransfer(taskID string) error {
 	}
 	task.paused = false
 	task.Status = "running"
-		close(task.pauseCh)
-		task.pauseCh = make(chan struct{})
-		s.emitTransferStart(task)
-		return nil
-	}
+	close(task.pauseCh)
+	task.pauseCh = make(chan struct{})
+	s.emitTransferStart(task)
+	return nil
+}
 
 // --- Recursive helpers ---
 
@@ -1224,7 +1036,7 @@ func (s *SFTPSession) startTransfer(task *TransferTask) {
 		if s.sem != nil {
 			select {
 			case s.sem <- struct{}{}:
-			defer func() { <-s.sem }()
+				defer func() { <-s.sem }()
 			case <-task.ctx.Done():
 				task.Status = "cancelled"
 				s.emitTransferComplete(task)

--- a/backend/session/wsl_file_session.go
+++ b/backend/session/wsl_file_session.go
@@ -1,0 +1,622 @@
+//go:build windows
+// +build windows
+
+package session
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// WSLFileSession is the file-transfer companion for a WSL terminal. The "remote"
+// filesystem is the WSL distribution's own view reached through the Windows UNC
+// path `//wsl.localhost/<distro>/...`, so every remote operation is a plain os
+// call — no SFTP subsystem, no bundled server, no SSH credentials.
+//
+// It implements fileTransferSession, so all existing Sftp* bindings and the
+// frontend file panel dispatch through it unchanged. Remote paths are kept in
+// POSIX form (e.g. /home/user) so the frontend breadcrumb renders normally;
+// they are translated to the UNC path at the os boundary.
+//
+// NOTE: the wsl.localhost share is only reachable with FORWARD slashes on this
+// system (backslash UNC returns path-not-found), and `filepath` would rewrite
+// them to backslashes, so all UNC path building uses "/" joining.
+type WSLFileSession struct {
+	baseSession
+	distro string
+	root   string // //wsl.localhost/<distro> (absolute; no trailing separator)
+	cwd    string // remote cwd in POSIX form, e.g. /home/user
+
+	localFSOps // Windows-local pane (ListLocal / Local* / ListLocalDrives)
+
+	mu        sync.RWMutex
+	transfers map[string]*TransferTask
+	taskSeq   int64
+
+	// uid/gid -> name maps loaded once from /etc/passwd and /etc/group so
+	// listings can render real owner/group names instead of numbers.
+	mapOnce  sync.Once
+	userMap  map[int]string
+	groupMap map[int]string
+
+	connectCancel context.CancelFunc
+}
+
+// compile-time guarantees that the WSL file session satisfies the Session
+// contract. (fileTransferSession is asserted at runtime via getSftp and lives
+// in the app package, so it can't be referenced here.)
+var _ Session = (*WSLFileSession)(nil)
+
+func NewWSLFileSession(id string) *WSLFileSession {
+	return &WSLFileSession{
+		baseSession: baseSession{
+			id:          id,
+			sessionType: "wsl-file",
+			status:      StatusDisconnected,
+		},
+		localFSOps: newLocalFSOps(),
+		transfers:  make(map[string]*TransferTask),
+	}
+}
+
+// Connect resolves the distro (config.Distro, else config.ShellPath wsl://name),
+// probes the user home inside the distro and marks the session connected.
+func (s *WSLFileSession) Connect(config ConnectionConfig) error {
+	distro, _ := parseWSLPath(config.ShellPath)
+	if distro == "" {
+		s.setStatus(StatusError)
+		return fmt.Errorf("empty WSL distribution name")
+	}
+	s.distro = distro
+	s.root = `//wsl.localhost/` + distro
+	s.setStatus(StatusConnecting)
+	ctx, cancel := context.WithCancel(context.Background())
+	s.connectCancel = cancel
+	s.cwd = s.resolveHome(ctx, distro)
+	s.setStatus(StatusConnected)
+	return nil
+}
+
+// resolveHome asks the WSL distro for $HOME of its default user, returning a
+// POSIX path. Falls back to / (distro root) if the probe fails or the distro is
+// not running — the user can still navigate to a real directory afterwards.
+func (s *WSLFileSession) resolveHome(ctx context.Context, distro string) string {
+	if home, ok := s.probeHome(ctx, distro); ok {
+		return home
+	}
+	return "/"
+}
+
+func (s *WSLFileSession) probeHome(ctx context.Context, distro string) (string, bool) {
+	cmd := exec.CommandContext(ctx, "wsl.exe", "-d", distro, "--", "sh", "-c", "echo $HOME")
+	out, err := cmd.Output()
+	if err != nil {
+		return "", false
+	}
+	home := strings.TrimSpace(string(out))
+	if home == "" || !strings.HasPrefix(home, "/") {
+		return "", false
+	}
+	return home, true
+}
+
+// --- path helpers ----------------------------------------------------------
+
+func (s *WSLFileSession) resolveRemote(p string) string {
+	if p == "" {
+		return path.Clean(s.cwd)
+	}
+	if !strings.HasPrefix(p, "/") {
+		p = path.Join(s.cwd, p)
+	}
+	return path.Clean(p)
+}
+
+// uncPath translates a POSIX remote path to the absolute forward-slash UNC path
+// under the distro root, e.g. /home/user -> //wsl.localhost/Ubuntu/home/user.
+func (s *WSLFileSession) uncPath(p string) string {
+	rel := strings.Trim(p, "/")
+	if rel == "" {
+		return s.root
+	}
+	return s.root + "/" + rel
+}
+
+func (s *WSLFileSession) resolveLocal(p string) string {
+	if !filepath.IsAbs(p) {
+		return filepath.Join(s.localCwd, p)
+	}
+	return filepath.Clean(p)
+}
+
+// joinEntry appends name to a directory. UNC roots stay forward-slashed (see the
+// type doc comment); ordinary local paths use filepath.Join.
+func joinEntry(dir, name string) string {
+	if strings.HasPrefix(dir, `//`) || strings.HasPrefix(dir, `\\`) {
+		return dir + "/" + name
+	}
+	return filepath.Join(dir, name)
+}
+
+// fileItemsFromDir builds FileItem entries from an os.ReadDir result.
+func fileItemsFromDir(dir string, entries []os.DirEntry) []FileItem {
+	files := make([]FileItem, 0, len(entries))
+	for _, e := range entries {
+		fi, err := e.Info()
+		var mode os.FileMode
+		var modTime time.Time
+		var size int64
+		if err == nil {
+			mode = fi.Mode()
+			modTime = fi.ModTime()
+			size = fi.Size()
+		}
+		isDir := e.IsDir()
+		full := joinEntry(dir, e.Name())
+		if err == nil && mode&os.ModeSymlink != 0 {
+			if target, terr := os.Stat(full); terr == nil && target.IsDir() {
+				isDir = true
+			}
+		}
+		isHidden := e.Name() != "" && e.Name()[0] == '.'
+		if !isHidden {
+			isHidden = isPathHidden(full)
+		}
+		files = append(files, FileItem{
+			Name:     e.Name(),
+			Size:     size,
+			ModTime:  modTime.Format(time.RFC3339),
+			Mode:     mode.String(),
+			IsDir:    isDir,
+			IsHidden: isHidden,
+			Owner:    "",
+		})
+	}
+	return files
+}
+
+// --- listing ---------------------------------------------------------------
+
+func (s *WSLFileSession) ListRemote(dir string) (FileListResult, error) {
+	d := s.resolveRemote(dir)
+	entries, err := os.ReadDir(s.uncPath(d))
+	if err != nil {
+		return FileListResult{}, err
+	}
+	files := fileItemsFromDir(s.uncPath(d), entries)
+	s.applyOwnerGroups(files, d)
+	return FileListResult{Files: files, Dir: d}, nil
+}
+
+// --- owner/group resolution (matching SFTP's /etc/passwd + /etc/group) -------
+
+func (s *WSLFileSession) ensureNameMaps() {
+	s.mapOnce.Do(func() {
+		s.userMap = map[int]string{}
+		s.groupMap = map[int]string{}
+		if b, err := os.ReadFile(s.uncPath("/etc/passwd")); err == nil {
+			parseLinuxNameMap(b, s.userMap, 2)
+		}
+		if b, err := os.ReadFile(s.uncPath("/etc/group")); err == nil {
+			parseLinuxNameMap(b, s.groupMap, 2)
+		}
+	})
+}
+
+// applyOwnerGroups fills Owner/Group on the listing. os.Stat through the
+// wsl.localhost share yields no POSIX uid/gid, so the per-directory numeric
+// uid/gid come from a single `wsl ls -ln` call, then mapped via /etc/passwd +
+// /etc/group. Failures degrade to empty owner/group rather than aborting the
+// listing.
+func (s *WSLFileSession) applyOwnerGroups(files []FileItem, dir string) {
+	s.ensureNameMaps()
+	if len(files) == 0 {
+		return
+	}
+	out, err := exec.Command("wsl.exe", "-d", s.distro, "--", "ls", "-lAn", dir).Output()
+	if err != nil {
+		return
+	}
+	if len(files) == 0 {
+		return
+	}
+	m := make(map[string][2]int, len(files))
+	for _, line := range strings.Split(string(out), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 8 {
+			continue
+		}
+		uid, err1 := strconv.Atoi(fields[2])
+		gid, err2 := strconv.Atoi(fields[3])
+		if err1 != nil || err2 != nil {
+			continue
+		}
+		m[strings.Join(fields[8:], " ")] = [2]int{uid, gid}
+	}
+	for i := range files {
+		og, ok := m[files[i].Name]
+		if !ok {
+			continue
+		}
+		files[i].Owner = s.nameForID(s.userMap, og[0])
+		files[i].Group = s.nameForID(s.groupMap, og[1])
+	}
+}
+
+func (s *WSLFileSession) nameForID(m map[int]string, id int) string {
+	if n, ok := m[id]; ok {
+		return n
+	}
+	return fmt.Sprintf("%d", id)
+}
+
+func (s *WSLFileSession) ChangeRemoteDir(dir string) (FileListResult, error) {
+	d := s.resolveRemote(dir)
+	fi, err := os.Stat(s.uncPath(d))
+	if err != nil {
+		// Windows-drive drvfs mounts (/mnt/<X>) aren't reachable through the
+		// wsl.localhost share — Windows denies the drive→WSL→drive loopback
+		// (ERROR_ACCESS_DENIED). Those files are the same as the local drive,
+		// so guide the user to the local pane instead of failing silently.
+		if os.IsPermission(err) && strings.HasPrefix(d, "/mnt/") {
+			return FileListResult{}, fmt.Errorf("cannot open %s: /mnt Windows-drive mounts aren't reachable through the WSL file share (open %s from the local pane instead)", d, s.wslMountDrive(d))
+		}
+		return FileListResult{}, err
+	}
+	if !fi.IsDir() {
+		return FileListResult{}, fmt.Errorf("not a directory: %s", d)
+	}
+	s.cwd = d
+	return s.ListRemote(d)
+}
+
+// wslMountDrive maps a /mnt/<letter> mount path back to its Windows drive
+// (e.g. /mnt/c -> C:\) for the error hint above.
+func (s *WSLFileSession) wslMountDrive(d string) string {
+	rest := strings.TrimPrefix(d, "/mnt/")
+	if i := strings.Index(rest, "/"); i >= 0 {
+		rest = rest[:i]
+	}
+	if len(rest) == 1 {
+		return strings.ToUpper(rest) + `:\`
+	}
+	return d
+}
+
+// The Windows-local pane (ListLocal / ChangeLocalDir / ListLocalDrives /
+// LocalRemove / LocalRename / LocalMkdir / LocalGetContent / LocalPutContent /
+// LocalCopy / LocalMove) is provided by the embedded localFSOps via method
+// promotion, exactly like SMB/FTP/WebDAV/S3/SCP — nothing to delegate here.
+
+// --- remote attributes / dirs ----------------------------------------------
+
+func (s *WSLFileSession) MakeDir(dir string) error {
+	return os.Mkdir(s.uncPath(s.resolveRemote(dir)), 0o755)
+}
+
+func (s *WSLFileSession) Remove(p string, recursive bool) error {
+	c := s.resolveRemote(p)
+	if c == "/" || c == "." {
+		return fmt.Errorf("refusing to delete path: %s", c)
+	}
+	full := s.uncPath(c)
+	if recursive {
+		return os.RemoveAll(full)
+	}
+	return os.Remove(full)
+}
+
+func (s *WSLFileSession) Rename(oldName, newName string) error {
+	return os.Rename(s.uncPath(s.resolveRemote(oldName)), s.uncPath(s.resolveRemote(newName)))
+}
+
+func (s *WSLFileSession) Chmod(p string, mode os.FileMode) error {
+	return os.Chmod(s.uncPath(s.resolveRemote(p)), mode)
+}
+
+// --- content read/write ------------------------------------------------------
+
+func (s *WSLFileSession) GetContent(remotePath string) ([]byte, error) {
+	return os.ReadFile(s.uncPath(s.resolveRemote(remotePath)))
+}
+
+func (s *WSLFileSession) PutContent(remotePath string, content []byte) error {
+	return os.WriteFile(s.uncPath(s.resolveRemote(remotePath)), content, 0o644)
+}
+
+func (s *WSLFileSession) Copy(oldPath, newPath string) error {
+	return copyPath(s.uncPath(s.resolveRemote(oldPath)), s.uncPath(s.resolveRemote(newPath)), nil)
+}
+
+func (s *WSLFileSession) Move(oldPath, newPath string) error {
+	oldU := s.uncPath(s.resolveRemote(oldPath))
+	newU := s.uncPath(s.resolveRemote(newPath))
+	if err := os.Rename(oldU, newU); err == nil {
+		return nil
+	}
+	if err := copyPath(oldU, newU, nil); err != nil {
+		return err
+	}
+	return os.RemoveAll(oldU)
+}
+
+// --- transfers ---------------------------------------------------------------
+
+func (s *WSLFileSession) Get(remotePath, localPath string, recursive bool) (string, error) {
+	return s.startLocalTransfer("download", s.resolveLocal(localPath), s.uncPath(s.resolveRemote(remotePath)))
+}
+
+func (s *WSLFileSession) Put(localPath, remotePath string, recursive bool) (string, error) {
+	return s.startLocalTransfer("upload", s.resolveLocal(localPath), s.uncPath(s.resolveRemote(remotePath)))
+}
+
+// startLocalTransfer copies a file or tree between the Windows-local pane and
+// the WSL UNC path. Both endpoints are on the same machine, so this is a local
+// copy; a Task is reported through the usual OSC 633 transfer events so the
+// frontend TransferPanel stays in sync.
+func (s *WSLFileSession) startLocalTransfer(tfType, local, remote string) (string, error) {
+	src := remote
+	dst := local
+	if tfType == "upload" {
+		src = local
+		dst = remote
+	}
+	total, err := dirSize(src)
+	if err != nil {
+		return "", err
+	}
+	prefix := "ul"
+	if tfType == "download" {
+		prefix = "dl"
+	}
+	task := &TransferTask{
+		ID:         s.nextTaskID(prefix),
+		Type:       tfType,
+		LocalPath:  local,
+		RemotePath: remote,
+		Total:      total,
+		Status:     "running",
+	}
+	task.start()
+	s.mu.Lock()
+	s.transfers[task.ID] = task
+	s.mu.Unlock()
+	s.emitTransferStart(task)
+	go func() {
+		defer func() {
+			task.done()
+			s.mu.Lock()
+			delete(s.transfers, task.ID)
+			s.mu.Unlock()
+		}()
+		if err := copyPath(src, dst, task); err != nil {
+			task.Status = "error"
+			s.emitTransferEvent(task, err)
+			return
+		}
+		task.Progress = task.Total
+		task.Status = "done"
+		s.emitTransferProgress(task)
+		s.emitTransferComplete(task)
+	}()
+	return task.ID, nil
+}
+
+// dirSize sums the bytes of a file or all files under a directory tree.
+func dirSize(p string) (int64, error) {
+	fi, err := os.Stat(p)
+	if err != nil {
+		return 0, err
+	}
+	if !fi.IsDir() {
+		return fi.Size(), nil
+	}
+	var total int64
+	var walk func(string) error
+	walk = func(dir string) error {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			return err
+		}
+		for _, e := range entries {
+			if ei, err := e.Info(); err == nil && !ei.IsDir() {
+				total += ei.Size()
+				continue
+			}
+			full := joinEntry(dir, e.Name())
+			if fi2, err := os.Stat(full); err == nil && fi2.IsDir() {
+				if err := walk(full); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	}
+	return total, walk(p)
+}
+
+// copyPath copies a file or directory tree. task, if non-nil, receives byte
+// progress updates and pauses/cancels via transferTask.
+func copyPath(src, dst string, task *TransferTask) error {
+	fi, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+	if fi.IsDir() {
+		if err := os.MkdirAll(dst, 0o755); err != nil {
+			return err
+		}
+		entries, err := os.ReadDir(src)
+		if err != nil {
+			return err
+		}
+		for _, e := range entries {
+			if err := copyPath(joinEntry(src, e.Name()), joinEntry(dst, e.Name()), task); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	return copyFile(src, dst, task)
+}
+
+func copyFile(src, dst string, task *TransferTask) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	if task != nil {
+		task.waitIfPaused() // blocks while paused / returns on cancel
+	}
+	buf := make([]byte, 64*1024)
+	for {
+		task.waitIfPaused()
+		n, rerr := in.Read(buf)
+		if n > 0 {
+			if _, werr := out.Write(buf[:n]); werr != nil {
+				out.Close()
+				return werr
+			}
+			if task != nil {
+				task.Progress += int64(n)
+			}
+		}
+		if rerr == io.EOF {
+			break
+		}
+		if rerr != nil {
+			out.Close()
+			return rerr
+		}
+	}
+	return out.Close()
+}
+
+func (s *WSLFileSession) CancelTransfer(taskID string) error {
+	s.mu.Lock()
+	t, ok := s.transfers[taskID]
+	s.mu.Unlock()
+	if !ok {
+		return fmt.Errorf("task not found: %s", taskID)
+	}
+	if t.cancel != nil {
+		t.cancel()
+	}
+	return nil
+}
+
+func (s *WSLFileSession) PauseTransfer(taskID string) error {
+	s.mu.Lock()
+	t, ok := s.transfers[taskID]
+	s.mu.Unlock()
+	if !ok {
+		return fmt.Errorf("task not found: %s", taskID)
+	}
+	t.paused = true
+	t.Status = "paused"
+	s.emitTransferComplete(t)
+	return nil
+}
+
+func (s *WSLFileSession) ResumeTransfer(taskID string) error {
+	s.mu.Lock()
+	t, ok := s.transfers[taskID]
+	s.mu.Unlock()
+	if !ok {
+		return fmt.Errorf("task not found: %s", taskID)
+	}
+	t.paused = false
+	t.Status = "running"
+	close(t.pauseCh)
+	t.pauseCh = make(chan struct{})
+	s.emitTransferStart(t)
+	return nil
+}
+
+func (s *WSLFileSession) nextTaskID(prefix string) string {
+	return fmt.Sprintf("%s-%d", prefix, atomic.AddInt64(&s.taskSeq, 1))
+}
+
+// --- Session interface --------------------------------------------------------
+
+func (s *WSLFileSession) Write(data []byte) error {
+	return fmt.Errorf("not a terminal session")
+}
+
+func (s *WSLFileSession) Resize(_, _ int) error { return nil }
+
+func (s *WSLFileSession) IsConnected() bool {
+	return s.Status() == StatusConnected
+}
+
+func (s *WSLFileSession) Disconnect() error {
+	if s.connectCancel != nil {
+		s.connectCancel()
+	}
+	s.mu.Lock()
+	for _, t := range s.transfers {
+		if t.cancel != nil {
+			t.cancel()
+		}
+	}
+	s.mu.Unlock()
+	s.setStatus(StatusDisconnected)
+	return nil
+}
+
+// --- transfer event emission (OSC 633 window-reporting, like SFTP) -----------
+
+func (s *WSLFileSession) emitTransferStart(task *TransferTask) {
+	name := path.Base(task.RemotePath)
+	if task.Type == "download" {
+		name = path.Base(task.RemotePath)
+	}
+	payload := map[string]interface{}{
+		"type": "sftp:transfer", "taskId": task.ID, "event": "start",
+		"tfType": task.Type, "name": name, "total": task.Total,
+	}
+	jsonBytes, _ := json.Marshal(payload)
+	s.emitData([]byte("\x1b]633;S" + string(jsonBytes) + "\x07"))
+}
+
+func (s *WSLFileSession) emitTransferProgress(task *TransferTask) {
+	payload := map[string]interface{}{
+		"type": "sftp:transfer", "taskId": task.ID, "event": "progress",
+		"progress": task.Progress, "total": task.Total,
+	}
+	jsonBytes, _ := json.Marshal(payload)
+	s.emitData([]byte("\x1b]633;S" + string(jsonBytes) + "\x07"))
+}
+
+func (s *WSLFileSession) emitTransferComplete(task *TransferTask) {
+	payload := map[string]interface{}{
+		"type": "sftp:transfer", "taskId": task.ID, "event": "complete", "status": task.Status,
+	}
+	jsonBytes, _ := json.Marshal(payload)
+	s.emitData([]byte("\x1b]633;S" + string(jsonBytes) + "\x07"))
+}
+
+func (s *WSLFileSession) emitTransferEvent(task *TransferTask, err error) {
+	payload := map[string]interface{}{
+		"type": "sftp:transfer", "taskId": task.ID, "event": "complete",
+		"status": "error", "error": err.Error(),
+	}
+	jsonBytes, _ := json.Marshal(payload)
+	s.emitData([]byte("\x1b]633;S" + string(jsonBytes) + "\x07"))
+}

--- a/backend/session/wsl_file_session_stub.go
+++ b/backend/session/wsl_file_session_stub.go
@@ -1,0 +1,32 @@
+//go:build !windows
+// +build !windows
+
+package session
+
+import "fmt"
+
+// WSLFileSession is a stub for non-Windows platforms (WSL only exists on
+// Windows). It satisfies the Session interface but Connect always errors. WSL
+// file transfers are therefore never reachable on mac/linux builds.
+type WSLFileSession struct {
+	baseSession
+}
+
+func NewWSLFileSession(id string) *WSLFileSession {
+	return &WSLFileSession{
+		baseSession: baseSession{
+			id:          id,
+			sessionType: "wsl-file",
+			status:      StatusDisconnected,
+		},
+	}
+}
+
+func (s *WSLFileSession) Connect(_ ConnectionConfig) error {
+	return fmt.Errorf("WSL is only supported on Windows")
+}
+
+func (s *WSLFileSession) Disconnect() error     { return nil }
+func (s *WSLFileSession) IsConnected() bool     { return false }
+func (s *WSLFileSession) Resize(_, _ int) error { return nil }
+func (s *WSLFileSession) Write(_ []byte) error  { return nil }

--- a/backend/session/wsl_session.go
+++ b/backend/session/wsl_session.go
@@ -1,0 +1,36 @@
+//go:build windows
+// +build windows
+
+package session
+
+import (
+	"fmt"
+	"strings"
+)
+
+// WSLSession is a terminal session that launches a WSL distribution via
+// wsl.exe. It reuses LocalSession's entire ConPTY / pending-size / decode
+// machinery by composition, overriding only the two things that differ: the
+// reported session type and a Connect that always forces the `wsl://<distro>`
+// shell. This keeps the PTY plumbing in a single implementation instead of a
+// copy-paste variant.
+type WSLSession struct {
+	*LocalSession
+}
+
+func NewWSLSession(id string) *WSLSession {
+	return &WSLSession{LocalSession: NewLocalSession(id)}
+}
+
+// Type reports "wsl" so type-routing (panel/companion) keys off the WSL type
+// even though the underlying engine is the local ConPTY session.
+func (s *WSLSession) Type() string { return "wsl" }
+
+// Connect requires a `wsl://<distro>` shell path and delegates the rest to
+// LocalSession, which launches wsl.exe -d <distro> for that shell.
+func (s *WSLSession) Connect(config ConnectionConfig) error {
+	if !strings.HasPrefix(strings.ToLower(config.ShellPath), "wsl://") {
+		return fmt.Errorf("WSL session requires a wsl://<distro> shell path")
+	}
+	return s.LocalSession.Connect(config)
+}

--- a/backend/session/wsl_session_stub.go
+++ b/backend/session/wsl_session_stub.go
@@ -1,0 +1,31 @@
+//go:build !windows
+// +build !windows
+
+package session
+
+import "fmt"
+
+// WSLSession is a stub for non-Windows platforms (WSL only exists on Windows).
+// It satisfies the Session interface but Connect always returns an error.
+type WSLSession struct {
+	baseSession
+}
+
+func NewWSLSession(id string) *WSLSession {
+	return &WSLSession{
+		baseSession: baseSession{
+			id:          id,
+			sessionType: "wsl",
+			status:      StatusDisconnected,
+		},
+	}
+}
+
+func (s *WSLSession) Connect(_ ConnectionConfig) error {
+	return fmt.Errorf("WSL is only supported on Windows")
+}
+
+func (s *WSLSession) Disconnect() error     { return nil }
+func (s *WSLSession) IsConnected() bool     { return false }
+func (s *WSLSession) Resize(_, _ int) error { return nil }
+func (s *WSLSession) Write(_ []byte) error  { return nil }

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -12,7 +12,7 @@
       @tab-dragstart="onTabDragStart"
     />
     <div class="main-content">
-      <Sidebar ref="sidebarRef" :visible="sidebarVisible" @toggle="sidebarVisible = !sidebarVisible" @connect="onConnect" @connect-only="onConnectOnly" @connect-serial="showSerialDialog = true" @connect-sftp="(c: any) => { const p = tabStore.activeTab; onConnectSftp(c, p?.type === 'start' ? p : undefined) }" @connect-ftp="(c: any) => { const p = tabStore.activeTab; onConnectFtp(c, p?.type === 'start' ? p : undefined) }" @connect-smb="(c: any) => { const p = tabStore.activeTab; onConnectSmb(c, p?.type === 'start' ? p : undefined) }" @connect-webdav="(c: any) => { const p = tabStore.activeTab; onConnectWebdav(c, p?.type === 'start' ? p : undefined) }" @connect-s3="(c: any) => { const p = tabStore.activeTab; onConnectS3(c, p?.type === 'start' ? p : undefined) }" @connect-rdp="(c: any) => { const p = tabStore.activeTab; onConnectRDP(c, p?.type === 'start' ? p : undefined) }" @connect-vnc="(c: any) => { const p = tabStore.activeTab; onConnectVNC(c, p?.type === 'start' ? p : undefined) }" @connect-spice="(c: any) => { const p = tabStore.activeTab; onConnectSPICE(c, p?.type === 'start' ? p : undefined) }" @connect-x11-desktop="(c: any) => { const p = tabStore.activeTab; onConnectX11Desktop(c, p?.type === 'start' ? p : undefined) }" @connect-d-b="(c: any) => { const p = tabStore.activeTab; onConnectDB(c, p?.type === 'start' ? p : undefined) }" @connect-monitor="(c: any) => { const p = tabStore.activeTab; onConnectMonitor(c, p?.type === 'start' ? p : undefined) }" @connect-k8s="(c: any) => { const p = tabStore.activeTab; onConnectK8s(c, p?.type === 'start' ? p : undefined) }" />
+      <Sidebar ref="sidebarRef" :visible="sidebarVisible" @toggle="sidebarVisible = !sidebarVisible" @connect="onConnect" @connect-only="onConnectOnly" @connect-serial="showSerialDialog = true" @connect-sftp="(c: any) => { const p = tabStore.activeTab; onConnectSftp(c, p?.type === 'start' ? p : undefined) }" @connect-wsl-file="(c: any) => { const p = tabStore.activeTab; onConnectWslFile(c, p?.type === 'start' ? p : undefined) }" @connect-ftp="(c: any) => { const p = tabStore.activeTab; onConnectFtp(c, p?.type === 'start' ? p : undefined) }" @connect-smb="(c: any) => { const p = tabStore.activeTab; onConnectSmb(c, p?.type === 'start' ? p : undefined) }" @connect-webdav="(c: any) => { const p = tabStore.activeTab; onConnectWebdav(c, p?.type === 'start' ? p : undefined) }" @connect-s3="(c: any) => { const p = tabStore.activeTab; onConnectS3(c, p?.type === 'start' ? p : undefined) }" @connect-rdp="(c: any) => { const p = tabStore.activeTab; onConnectRDP(c, p?.type === 'start' ? p : undefined) }" @connect-vnc="(c: any) => { const p = tabStore.activeTab; onConnectVNC(c, p?.type === 'start' ? p : undefined) }" @connect-spice="(c: any) => { const p = tabStore.activeTab; onConnectSPICE(c, p?.type === 'start' ? p : undefined) }" @connect-x11-desktop="(c: any) => { const p = tabStore.activeTab; onConnectX11Desktop(c, p?.type === 'start' ? p : undefined) }" @connect-d-b="(c: any) => { const p = tabStore.activeTab; onConnectDB(c, p?.type === 'start' ? p : undefined) }" @connect-monitor="(c: any) => { const p = tabStore.activeTab; onConnectMonitor(c, p?.type === 'start' ? p : undefined) }" @connect-k8s="(c: any) => { const p = tabStore.activeTab; onConnectK8s(c, p?.type === 'start' ? p : undefined) }" />
       <div class="tab-area">
         <template v-if="activeTab">
           <KeepAlive>
@@ -834,6 +834,9 @@ onMounted(async () => {
   window.addEventListener('app:connect-sftp', ((e: CustomEvent) => {
     const d = e.detail; const c = d?.config || d; if (c) { const prev = tabStore.activeTab; onConnectSftp(c, prev?.type === 'start' ? prev : undefined) }
   }) as EventListener)
+  window.addEventListener('app:connect-wsl-file', ((e: CustomEvent) => {
+    const d = e.detail; const c = d?.config || d; if (c) { const prev = tabStore.activeTab; onConnectWslFile(c, prev?.type === 'start' ? prev : undefined) }
+  }) as EventListener)
   window.addEventListener('app:connect-monitor', ((e: CustomEvent) => {
     const d = e.detail; const c = d?.config || d; if (c) { const prev = tabStore.activeTab; onConnectMonitor(c, prev?.type === 'start' ? prev : undefined) }
   }) as EventListener)
@@ -1342,7 +1345,7 @@ async function onConnect(config: ConnectionConfig, keepOpen?: boolean, wasEdit?:
   }
 
   const panel = panelStore.createPanel(config, config.type)
-  const displayTitle = config.name || (config.type === 'local'
+  const displayTitle = config.name || (config.type === 'local' || config.type === 'wsl'
     ? getShellLabel(config.shellPath)
     : config.type === 'serial'
     ? `${config.serialPort || 'Serial'} (${config.serialBaudRate || 115200})`
@@ -1393,7 +1396,20 @@ function getShellLabel(path: string): string {
 }
 
 async function createLocalTerminalWithShell(shellPath: string, keepOpen?: boolean) {
+  // A `wsl://<distro>` shell opens a dedicated WSL terminal (own session type),
+  // everything else stays a normal local terminal.
+  const distro = parseWslFromShell(shellPath)
+  if (distro) return createWslTerminal(distro, keepOpen)
   await createLocalTerminal(shellPath, keepOpen)
+}
+
+/** Parses the distro name from a `wsl://<distro>` shell path, else null. */
+function parseWslFromShell(shellPath?: string): string | null {
+  if (shellPath && shellPath.toLowerCase().startsWith('wsl://')) {
+    const distro = shellPath.slice(6)
+    return distro || null
+  }
+  return null
 }
 
 const pendingGroupId = ref<string | undefined>(undefined)
@@ -1496,6 +1512,57 @@ async function createLocalTerminal(shellPath?: string, keepOpen?: boolean) {
   }
 }
 
+// WSL terminal: a dedicated session type (`wsl`) that launches wsl.exe inside
+// the distro and supports the file sidebar via its companion WSL file session.
+async function createWslTerminal(distro: string, keepOpen?: boolean) {
+  const shellPath = 'wsl://' + distro
+  const panel = panelStore.createPanel(null, 'wsl')
+  const shellName = getShellLabel(shellPath)
+  panelStore.updateTitle(panel.id, shellName)
+
+  try {
+    const stableId = `wsl-terminal:${distro.toLowerCase().replace(/\s+/g, '-')}`
+    const config: ConnectionConfig = {
+      id: stableId,
+      name: shellName,
+      type: 'wsl' as any,
+      host: '',
+      port: 0,
+      user: '',
+      authType: 'password' as any,
+      shellPath,
+      initialCols: 0,
+      initialRows: 0,
+    }
+    panel.config = config
+    connectionStore.add(config)
+    // WSL terminal sessions are temporary — don't record in history
+    const info = await CreateSession('wsl', config)
+    panelStore.bindSession(panel.id, info.id)
+    sessionStore.initSession(info.id)
+    const prev = tabStore.activeTab
+    const tab = prev?.type === 'start' && !keepOpen
+      ? tabStore.replaceStartTab(prev.id, panel.title, panel.id)
+      : tabStore.createTerminalTab(panel.title, panel.id)
+    panelStore.movePanelToTab(panel.id, tab.id)
+
+    const size = await waitForTerminalSize(info.id)
+    if (size.cols > 0 && size.rows > 0) {
+      config.initialCols = size.cols
+      config.initialRows = size.rows
+    }
+    try {
+      await SessionStart(info.id, config)
+    } catch (e) {
+      console.error('Failed to start wsl session:', e)
+      CloseSession(info.id).catch(() => {})
+    }
+  } catch (e) {
+    console.error('Failed to create wsl terminal:', e)
+    panelStore.removePanel(panel.id)
+  }
+}
+
 async function onConnectSftp(config: ConnectionConfig, prevStart?: any) {
   connectionStore.add(config)
 
@@ -1521,6 +1588,29 @@ async function onConnectSftp(config: ConnectionConfig, prevStart?: any) {
     panelStore.bindSession(panel.id, info.id)
   } catch (e) {
     console.error('Failed to create SFTP session:', e)
+    tabStore.closeTab(tab.id)
+    panelStore.removePanel(panel.id)
+  }
+}
+
+// Standalone file tab for a WSL distro opened from the file sidebar. The file
+// browser UI is protocol-agnostic (same two-pane layout as SFTP); the backing
+// session is a wsl-file session over //wsl.localhost that auto-connects on
+// CreateSession, so the tab just lists once it reports connected.
+async function onConnectWslFile(config: ConnectionConfig, prevStart?: any) {
+  const fileConfig: ConnectionConfig = { ...config, type: 'wsl-file' as any }
+  const panel = panelStore.createPanel(fileConfig, 'sftp')
+  const displayTitle = config.name || `WSL ${parseWslFromShell(config.shellPath) || ''}`
+  panelStore.updateTitle(panel.id, displayTitle)
+  const reposition = prevStart ? closeStartAndReposition(prevStart) : null
+  const tab = tabStore.createSFPTab(displayTitle, panel.id)
+  if (reposition) reposition(tab.id)
+  panelStore.movePanelToTab(panel.id, tab.id)
+  try {
+    const info = await CreateSession('wsl-file', fileConfig)
+    panelStore.bindSession(panel.id, info.id)
+  } catch (e) {
+    console.error('Failed to create WSL file session:', e)
     tabStore.closeTab(tab.id)
     panelStore.removePanel(panel.id)
   }

--- a/frontend/src/components/AISidebar.vue
+++ b/frontend/src/components/AISidebar.vue
@@ -653,7 +653,7 @@ const availableTerminalPanels = computed(() => {
   for (const tab of tabStore.tabs) {
     if (tab.type === 'terminal' && (tab as any).panelId) {
       const p = panelStore.getPanel((tab as any).panelId)
-      if (p && (p.type === 'ssh' || p.type === 'local') && !seen.has(p.id)) {
+      if (p && (p.type === 'ssh' || p.type === 'local' || p.type === 'wsl') && !seen.has(p.id)) {
         seen.add(p.id)
         result.push({ id: p.id, title: p.title, type: p.type, shellPath: p.config?.shellPath, config: p.config })
       }
@@ -661,7 +661,7 @@ const availableTerminalPanels = computed(() => {
     if (tab.type === 'workspace' && (tab as any).panelIds) {
       for (const pid of (tab as any).panelIds) {
         const p = panelStore.getPanel(pid)
-        if (p && (p.type === 'ssh' || p.type === 'local') && !seen.has(p.id)) {
+        if (p && (p.type === 'ssh' || p.type === 'local' || p.type === 'wsl') && !seen.has(p.id)) {
           seen.add(p.id)
           result.push({ id: p.id, title: p.title, type: p.type, shellPath: p.config?.shellPath, config: p.config })
         }

--- a/frontend/src/components/BaseTerminal.vue
+++ b/frontend/src/components/BaseTerminal.vue
@@ -522,7 +522,7 @@ async function applySuggestion(item: ReturnType<typeof suggestions.getSelectedIt
       const targets = tabStore.getAllBroadcastPanelIds()
       for (const pid of targets) {
         const p = panelStore.getPanel(pid)
-        if (p?.sessionId && (p.type === 'ssh' || p.type === 'local')) {
+        if (p?.sessionId && (p.type === 'ssh' || p.type === 'local' || p.type === 'wsl')) {
           SessionWrite(p.sessionId, '\x15')
           SessionWrite(p.sessionId, item.value)
         }
@@ -752,7 +752,7 @@ function writeTerminalInput(data: string, inAlternateScreen: boolean) {
     if (targets.length > 0) {
       for (const pid of targets) {
         const p = panelStore.getPanel(pid)
-        if (p?.sessionId && (p.type === 'ssh' || p.type === 'local')) {
+        if (p?.sessionId && (p.type === 'ssh' || p.type === 'local' || p.type === 'wsl')) {
           const translated = applyBackspaceKey(
             filtered,
             p.config?.backspaceKey,
@@ -1844,7 +1844,7 @@ async function pasteToSession(text: string) {
         for (const pid of targets) {
           const p = panelStore.getPanel(pid)
           const managed = p?.sessionId ? getManagedTerminal(p.sessionId) : undefined
-          if (p?.sessionId && (p.type === 'ssh' || p.type === 'local') && managed) {
+          if (p?.sessionId && (p.type === 'ssh' || p.type === 'local' || p.type === 'wsl') && managed) {
             // Bracket per target session — each has its own paste mode.
             // Scroll each target's viewport to the bottom too, so broadcast
             // paste behaves like keyboard input everywhere (issue 629).
@@ -1881,7 +1881,7 @@ async function pasteToSession(text: string) {
 const panel = computed(() => (props.panelId ? panelStore.getPanel(props.panelId) : undefined))
 const isSsh = computed(() => panel.value?.type === 'ssh')
 const supportsOutputLog = computed(() =>
-  !!panel.value && ['ssh', 'telnet', 'serial', 'mosh', 'local'].includes(panel.value.type),
+  !!panel.value && ['ssh', 'telnet', 'serial', 'mosh', 'local', 'wsl'].includes(panel.value.type),
 )
 
 const isOutputLogOn = ref(false)

--- a/frontend/src/components/ConnectionForm.vue
+++ b/frontend/src/components/ConnectionForm.vue
@@ -65,7 +65,7 @@
                 <el-input v-model="form.redisMasterName" placeholder="mymaster" />
               </el-form-item>
             </template>
-            <el-form-item :label="form.type === 's3' ? 'Endpoint' : form.type === 'webdav' ? 'URL' : t('conn.host')" required v-if="form.type !== 'local' && form.type !== 'serial' && form.type !== 'k8s' && form.type !== 'container' && !isRedisSentinel">
+            <el-form-item :label="form.type === 's3' ? 'Endpoint' : form.type === 'webdav' ? 'URL' : t('conn.host')" required v-if="form.type !== 'local' && form.type !== 'wsl' && form.type !== 'serial' && form.type !== 'k8s' && form.type !== 'container' && !isRedisSentinel">
               <div class="host-port-row">
                 <el-input ref="hostInputRef" v-model="form.host" class="host-input" :placeholder="form.type === 's3' ? 'e.g. https://s3.amazonaws.com' : form.type === 'webdav' ? 'https://dav.example.com/dav/' : t('conn.hostPlaceholder')" />
                 <template v-if="form.type !== 's3' && form.type !== 'webdav'">
@@ -83,7 +83,7 @@
                 <el-radio-button v-if="isElasticsearch" label="apikey">{{ t('conn.esAuthApiKey') }}</el-radio-button>
               </el-radio-group>
             </el-form-item>
-            <el-form-item v-if="form.authType !== 'identity' && form.type !== 'vnc' && form.type !== 'spice' && !(form.type === 'database' && form.dbType === 'rqlite') && form.type !== 'local' && form.type !== 'serial' && form.type !== 'tcp' && form.type !== 'k8s' && form.type !== 'container' && !isEsApiKey" :label="form.type === 's3' ? 'Access Key' : t('conn.user')">
+            <el-form-item v-if="form.authType !== 'identity' && form.type !== 'vnc' && form.type !== 'spice' && !(form.type === 'database' && form.dbType === 'rqlite') && form.type !== 'local' && form.type !== 'wsl' && form.type !== 'serial' && form.type !== 'tcp' && form.type !== 'k8s' && form.type !== 'container' && !isEsApiKey" :label="form.type === 's3' ? 'Access Key' : t('conn.user')">
               <el-input v-model="form.user" :placeholder="form.type === 's3' ? 'Access Key ID' : t('conn.userPlaceholder')" />
             </el-form-item>
             <el-form-item v-if="form.type === 'rdp' && isWindows && form.authType !== 'identity'" :label="t('conn.rdpDomain')">
@@ -110,7 +110,7 @@
                 </el-select>
               </el-form-item>
             </template>
-            <el-form-item v-if="form.type !== 'local' && form.type !== 'serial' && form.type !== 'tcp' && form.type !== 'k8s' && form.type !== 'container' && form.authType !== 'identity' && ((form.authType === 'password' && form.type !== 'rdp') || (form.type === 'rdp' && !form.rdpEnableNLA) || form.type === 'vnc' || form.type === 'spice' || form.type === 'database' || form.type === 'telnet' || form.type === 'ftp' || form.type === 'smb' || form.type === 'webdav' || form.type === 's3') && !(form.type === 'database' && form.dbType === 'rqlite')" :label="form.type === 's3' ? 'Secret Key' : (isEsApiKey ? t('conn.esApiKey') : t('conn.password'))">
+            <el-form-item v-if="form.type !== 'local' && form.type !== 'wsl' && form.type !== 'serial' && form.type !== 'tcp' && form.type !== 'k8s' && form.type !== 'container' && form.authType !== 'identity' && ((form.authType === 'password' && form.type !== 'rdp') || (form.type === 'rdp' && !form.rdpEnableNLA) || form.type === 'vnc' || form.type === 'spice' || form.type === 'database' || form.type === 'telnet' || form.type === 'ftp' || form.type === 'smb' || form.type === 'webdav' || form.type === 's3') && !(form.type === 'database' && form.dbType === 'rqlite')" :label="form.type === 's3' ? 'Secret Key' : (isEsApiKey ? t('conn.esApiKey') : t('conn.password'))">
               <el-input v-model="form.password" type="password" show-password :key="passwordInputKey" :placeholder="form.type === 's3' ? 'Secret Access Key' : (isEsApiKey ? t('conn.esApiKeyPlaceholder') : '')" />
             </el-form-item>
             <el-form-item v-if="form.type === 'rdp' && isWindows" :label="t('conn.rdpAdminSession')">
@@ -195,10 +195,10 @@
             <el-form-item v-if="form.type === 'database' && form.dbType !== 'elasticsearch' && form.dbType !== 'redis'" :label="t('db.params')">
               <el-input v-model="form.dbParams" :placeholder="defaultParamsHint" style="width:100%" />
             </el-form-item>
-            <el-form-item v-if="form.type === 'local'" :label="t('conn.shell')">
-              <el-select v-model="form.shellPath" filterable>
+            <el-form-item v-if="form.type === 'local' || form.type === 'wsl'" :label="t('conn.shell')">
+              <el-select v-model="form.shellPath" filterable allow-create clearable>
                 <el-option
-                  v-for="sh in shellOptions"
+                  v-for="sh in shellOptionsForType"
                   :key="sh.value"
                   :label="sh.label"
                   :value="sh.value"
@@ -402,10 +402,10 @@
             <el-form-item v-if="form.type === 'database'" :label="t('db.params')">
               <el-input v-model="form.dbParams" :placeholder="defaultParamsHint" style="width:100%" />
             </el-form-item>
-            <el-form-item v-if="form.type === 'database' && form.dbType === 'redis'" :label="t('conn.redisKeySeparator')">
+<el-form-item v-if="form.type === 'database' && form.dbType === 'redis'" :label="t('conn.redisKeySeparator')">
               <el-input v-model="form.redisKeySeparator" :placeholder="t('conn.redisKeySeparatorPlaceholder')" style="width: 160px" />
             </el-form-item>
-            <el-form-item v-if="form.type === 'ssh' || form.type === 'telnet' || form.type === 'mosh' || form.type === 'local'" :label="t('conn.postLoginScript')">
+            <el-form-item v-if="form.type === 'ssh' || form.type === 'telnet' || form.type === 'mosh' || form.type === 'local' || form.type === 'wsl'" :label="t('conn.postLoginScript')">
               <div class="post-login-config">
                 <el-radio-group v-model="postLoginMode" size="small">
                   <el-radio-button label="script">{{ t('conn.postLoginModeScript') }}</el-radio-button>
@@ -472,7 +472,7 @@
               </div>
             </el-form-item>
             <el-form-item
-              v-if="form.type === 'ssh' || form.type === 'telnet' || form.type === 'serial' || form.type === 'mosh' || form.type === 'local' || form.type === 'tcp'"
+              v-if="form.type === 'ssh' || form.type === 'telnet' || form.type === 'serial' || form.type === 'mosh' || form.type === 'local' || form.type === 'wsl' || form.type === 'tcp'"
               :label="t('conn.encoding')"
             >
               <el-select v-model="form.encoding" placeholder="Unicode (UTF-8)">
@@ -593,7 +593,7 @@
               </el-select>
             </el-form-item>
             <el-form-item
-              v-if="['ssh','telnet','serial','mosh','local','tcp'].includes(form.type)"
+              v-if="['ssh','telnet','serial','mosh','local','wsl','tcp'].includes(form.type)"
               :label="t('conn.logOnConnect')"
             >
               <el-switch v-model="form.logOnConnect" />
@@ -667,7 +667,7 @@ import type { ConnectionConfig, PostLoginExpectStep } from '../types/session'
 import { OpenFileDialog, OpenPrivateKeyFile, GetPlatform, ListSerialPorts, TestConnection } from '../../bindings/github.com/ys-ll/uniterm/app'
 import { ElInput } from 'element-plus'
 import { msg } from '../services/message'
-import { Plus, Trash2, ChevronDown, ChevronRight, FolderOpen, Eye, EyeOff, RefreshCw, Terminal, Monitor, Database, DatabaseZap, Layers, DatabaseSearch, SquareTerminal, Zap, Laptop, Cable, FolderUp, Folders, FileUp, HardDrive, Cloud, Globe, MonitorCloud, MonitorSmartphone, Boxes, ShipWheel, AppWindow, ArrowLeftRight, CircleCheck, CircleX } from '@lucide/vue'
+import { Plus, Trash2, ChevronDown, ChevronRight, FolderOpen, Eye, EyeOff, RefreshCw, Terminal, Monitor, Database, DatabaseZap, Layers, DatabaseSearch, SquareTerminal, Zap, Laptop, LaptopMinimal, Cable, FolderUp, Folders, FileUp, HardDrive, Cloud, Globe, MonitorCloud, MonitorSmartphone, Boxes, ShipWheel, AppWindow, ArrowLeftRight, CircleCheck, CircleX } from '@lucide/vue'
 import { listContexts } from '../services/k8sClient'
 import SyntaxEditor from './SyntaxEditor.vue'
 import type { K8sContextInfo } from '../types/k8s'
@@ -725,6 +725,7 @@ const allSubTypes = computed((): Record<string, SubTypeInfo[]> => ({
     { type: 'telnet', label: 'Telnet', icon: Terminal },
     { type: 'mosh', label: 'Mosh', icon: Zap },
     { type: 'local', label: t('conn.localTerminal'), icon: Laptop },
+    ...(isWindows.value ? [{ type: 'wsl', label: 'WSL', icon: LaptopMinimal }] : []),
     { type: 'serial', label: t('serial.title'), icon: Cable },
     { type: 'tcp', label: 'TCP', icon: ArrowLeftRight },
   ],
@@ -809,8 +810,24 @@ function getShellLabel(path: string): string {
   return path.split(/[\\/]/).pop() || path
 }
 
-const shellOptions = computed(() =>
-  settingsStore.availableShells.map(sh => ({ label: getShellLabel(sh), value: sh }))
+// Local-shell options exclude WSL entries: the ordinary local terminal type
+// never surfaces `wsl://<distro>` shells (those belong to the wsl type).
+const localShellOptions = computed(() =>
+  settingsStore.availableShells
+    .filter(sh => !sh.toLowerCase().startsWith('wsl://'))
+    .map(sh => ({ label: getShellLabel(sh), value: sh }))
+)
+
+// WSL options reuse the terminal "shell" field: their value is the `wsl://<distro>`
+// shell path (which carries the distro on the backend), not a separate field.
+const wslShellOptions = computed(() =>
+  settingsStore.availableShells
+    .filter(sh => sh.toLowerCase().startsWith('wsl://'))
+    .map(sh => ({ label: getShellLabel(sh), value: sh }))
+)
+
+const shellOptionsForType = computed(() =>
+  form.type === 'wsl' ? wslShellOptions.value : localShellOptions.value
 )
 
 const x11HintKey = computed(() => {
@@ -908,7 +925,7 @@ function onDialogOpened() {
 
 const isEdit = computed(() => !!props.editConfig?.id)
 
-const TERMINAL_TYPES = ['ssh', 'telnet', 'mosh', 'local', 'serial']
+const TERMINAL_TYPES = ['ssh', 'telnet', 'mosh', 'local', 'wsl', 'serial']
 const REMOTE_TYPES = ['rdp', 'vnc', 'spice', 'x11-desktop']
 const FILETRANSFER_TYPES = ['sftp', 'scp', 'ftp', 'ssh', 'smb', 'webdav', 's3']
 
@@ -929,13 +946,13 @@ const sshConnections = computed(() =>
     .sort((a, b) => a.name.localeCompare(b.name))
 )
 
-const TUNNEL_UNSUPPORTED = ['spice', 'mosh', 'local', 'serial', 'container']
+const TUNNEL_UNSUPPORTED = ['spice', 'mosh', 'local', 'wsl', 'serial', 'container']
 const showTunnel = computed(() =>
   !TUNNEL_UNSUPPORTED.includes(form.type)
 )
 const showProxy = computed(() => ['ssh', 'sftp', 'scp', 'monitor'].includes(form.type))
 const showAdvancedToggle = computed(() =>
-  showTunnel.value || form.type === 'ssh' || form.type === 'sftp' || form.type === 'scp' || form.type === 'telnet' || form.type === 'mosh' || form.type === 'local' || form.type === 'serial' || form.type === 'ftp' || form.type === 'database'
+  showTunnel.value || form.type === 'ssh' || form.type === 'sftp' || form.type === 'scp' || form.type === 'telnet' || form.type === 'mosh' || form.type === 'local' || form.type === 'wsl' || form.type === 'serial' || form.type === 'ftp' || form.type === 'database'
 )
 
 const isRedisSentinel = computed(() =>
@@ -1272,17 +1289,14 @@ watch(() => form.type, (newType) => {
   if (REMOTE_TYPES.includes(newType) || newType === 'database') {
     form.authType = 'password'
   }
-  if (newType === 'local' && !form.shellPath && settingsStore.availableShells.length > 0) {
-    form.shellPath = settingsStore.availableShells[0]
+  if (newType === 'local' && !form.shellPath && localShellOptions.value.length > 0) {
+    form.shellPath = localShellOptions.value[0].value
+  }
+  if (newType === 'wsl' && !form.shellPath && wslShellOptions.value.length > 0) {
+    form.shellPath = wslShellOptions.value[0].value
   }
   if (newType === 'serial') {
     scanSerialPorts()
-  }
-})
-
-watch(postLoginMode, (mode) => {
-  if (mode === 'expect' && (!form.postLoginExpectSteps || form.postLoginExpectSteps.length === 0)) {
-    addExpectStep()
   }
 })
 

--- a/frontend/src/components/FileSidebar.vue
+++ b/frontend/src/components/FileSidebar.vue
@@ -194,7 +194,7 @@ function scheduleRefresh(delay = 250) {
 }
 
 async function ensureConnected() {
-  const pid = companionStore.activeSshPanelId
+  const pid = companionStore.activeFilesPanelId
   if (!pid || !companionStore.filesVisible) return
   connecting.value = true
   connectError.value = ''
@@ -249,12 +249,15 @@ function onDropUpload(e: DragEvent) {
   // absolute path. Nothing to do on the HTML5 side.
 }
 
-// Open the current companion's SFTP as a standalone tab, mirroring the SSH
-// tab's context-menu action (which reconnects via app:connect-sftp).
+// Open the current companion's file view as a standalone tab. SSH panels open
+// an SFTP tab (mirroring the SSH tab's context-menu action); WSL panels open a
+// wsl-file tab over the distro.
 function openStandaloneSftp() {
-  const panel = panelStore.getPanel(companionStore.activeSshPanelId)
+  const pid = companionStore.activeFilesPanelId
+  const panel = pid ? panelStore.getPanel(pid) : null
   if (!panel) return
-  window.dispatchEvent(new CustomEvent('app:connect-sftp', { detail: panel }))
+  const ev = companionStore.isWslPanel(pid) ? 'app:connect-wsl-file' : 'app:connect-sftp'
+  window.dispatchEvent(new CustomEvent(ev, { detail: panel }))
 }
 
 // ── Change-permission dialog (shared FileChmodDialog) ──
@@ -337,7 +340,7 @@ function bindListeners() {
 
 /** Restore this panel's cached listing; returns true if a non-empty cache existed. */
 function restoreCache(): boolean {
-  const pid = companionStore.activeSshPanelId
+  const pid = companionStore.activeFilesPanelId
   const cached = pid ? companionStore.getFileViewCache(pid) : null
   if (!cached || !cached.files.length) return false
   cwd.value = cached.cwd
@@ -366,9 +369,9 @@ watch(sessionId, async (sid) => {
   }
 })
 
-// Persist the current listing per SSH panel so a later switch-back can restore it.
+// Persist the current listing per files panel so a later switch-back can restore it.
 watch([files, cwd], () => {
-  const pid = companionStore.activeSshPanelId
+  const pid = companionStore.activeFilesPanelId
   if (!pid) return
   companionStore.setFileViewCache(pid, { cwd: cwd.value, files: files.value })
 })
@@ -382,7 +385,7 @@ watch(() => companionStore.filesVisible, (v) => {
   }
 })
 
-watch(() => companionStore.activeSshPanelId, () => {
+watch(() => companionStore.activeFilesPanelId, () => {
   if (companionStore.filesVisible) ensureConnected()
 })
 

--- a/frontend/src/components/HistoryPanel.vue
+++ b/frontend/src/components/HistoryPanel.vue
@@ -189,7 +189,7 @@ function getTargetSessionIds(): string[] {
     const ids: string[] = []
     for (const pid of tabStore.getBroadcastPanelIdsInWorkspace(tab.id)) {
       const p = panelStore.getPanel(pid)
-      if (p?.sessionId && (p.type === 'ssh' || p.type === 'local')) {
+      if (p?.sessionId && (p.type === 'ssh' || p.type === 'local' || p.type === 'wsl')) {
         ids.push(p.sessionId)
       }
     }

--- a/frontend/src/components/Panel.vue
+++ b/frontend/src/components/Panel.vue
@@ -30,7 +30,7 @@
       </div>
       <div class="panel-header-actions">
         <button
-          v-if="(panel.type === 'ssh' || panel.type === 'local') && workspaceId"
+          v-if="(panel.type === 'ssh' || panel.type === 'local' || panel.type === 'wsl') && workspaceId"
           class="panel-broadcast"
           :class="{ active: panelBroadcastActive }"
           @click.stop="onBroadcastClick"
@@ -87,7 +87,7 @@
     </div>
     <BaseTerminal
       ref="baseTerminalRef"
-      :mode="panel.type === 'local' ? 'local' : 'ssh'"
+      :mode="panel.type === 'local' || panel.type === 'wsl' ? 'local' : 'ssh'"
       :session-id="panel.sessionId"
       :on-session-status="onSessionStatus"
       :broadcast-active="panelBroadcastActive"
@@ -99,7 +99,7 @@
 
 <script setup lang="ts">
 import { ref, watch, computed, nextTick, onMounted, onUnmounted, inject } from 'vue'
-import { Radio, Sparkles, MoreHorizontal, X, SquareTerminal, Laptop, Cable, Terminal, Zap } from '@lucide/vue'
+import { Radio, Sparkles, MoreHorizontal, X, SquareTerminal, Laptop, LaptopMinimal, Cable, Terminal, Zap } from '@lucide/vue'
 import BaseTerminal from './BaseTerminal.vue'
 import Menu from './Menu.vue'
 import MenuItem from './MenuItem.vue'
@@ -212,6 +212,7 @@ const outputLogPath = ref('')
 const panelIcon = computed(() => {
   const t = props.panel.type
   if (t === 'local') return Laptop
+  if (t === 'wsl') return LaptopMinimal
   if (t === 'serial') return Cable
   if (t === 'telnet') return Terminal
   if (t === 'mosh') return Zap

--- a/frontend/src/components/QuickCommandsPanel.vue
+++ b/frontend/src/components/QuickCommandsPanel.vue
@@ -385,7 +385,7 @@ function getTargetSessionIds(): string[] {
     const ids: string[] = []
     for (const pid of tabStore.getBroadcastPanelIdsInWorkspace(tab.id)) {
       const p = panelStore.getPanel(pid)
-      if (p?.sessionId && (p.type === 'ssh' || p.type === 'local')) {
+      if (p?.sessionId && (p.type === 'ssh' || p.type === 'local' || p.type === 'wsl')) {
         ids.push(p.sessionId)
       }
     }

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -313,10 +313,12 @@
       <MenuItem v-if="selectedConn && selectedConn.type === 'telnet'" @click="doConnect">{{ t('sidebar.connectTelnet') }}</MenuItem>
       <MenuItem v-if="selectedConn && selectedConn.type === 'mosh'" @click="doConnect">{{ t('sidebar.connectMosh') }}</MenuItem>
       <MenuItem v-if="selectedConn && selectedConn.type === 'local'" @click="doConnect">{{ t('sidebar.connectLocal') }}</MenuItem>
+      <MenuItem v-if="selectedConn && selectedConn.type === 'wsl'" @click="doConnect">{{ t('sidebar.connectWsl') }}</MenuItem>
       <MenuItem v-if="selectedConn && selectedConn.type === 'serial'" @click="emit('connectSerial')">{{ t('sidebar.connectSerial') }}</MenuItem>
       <MenuItem v-if="selectedConn && selectedConn.type === 'tcp'" @click="doConnect">{{ t('sidebar.connectTcp') }}</MenuItem>
       <!-- File Transfer -->
       <MenuItem v-if="selectedConn && selectedConn.type === 'ssh'" @click="doConnectSFTP">{{ t(connectFileMenuKey(selectedConn)) }}</MenuItem>
+      <MenuItem v-if="selectedConn && selectedConn.type === 'wsl'" @click="doConnectWslFile">{{ t('sidebar.connectWslFile') }}</MenuItem>
       <MenuItem v-if="selectedConn && selectedConn.type === 'ftp'" @click="doConnectFTP">{{ t('sidebar.connectFtp') }}</MenuItem>
       <MenuItem v-if="selectedConn && selectedConn.type === 'smb'" @click="doConnectSMB">{{ t('sidebar.connectSmb') }}</MenuItem>
       <MenuItem v-if="selectedConn && selectedConn.type === 's3'" @click="doConnectS3">{{ t('sidebar.connectS3') }}</MenuItem>
@@ -464,7 +466,7 @@
 
 <script setup lang="ts">
 import { ref, onMounted, onUnmounted, computed, watch, nextTick, provide } from 'vue'
-import { X, ChevronRight, ChevronDown, Filter, Check, Network, Zap, Clock, Plus, Palette, SquareTerminal, Terminal, FolderUp, Folders, FileUp, HardDrive, Cloud, Globe, Monitor, MonitorCloud, MonitorSmartphone, Database, DatabaseZap, Layers, DatabaseSearch, Activity, Laptop, Cable, Pencil, MoreHorizontal, FolderTree, ShipWheel, Boxes, AppWindow, ArrowLeftRight, ArrowRightLeft } from '@lucide/vue'
+import { X, ChevronRight, ChevronDown, Filter, Check, Network, Zap, Clock, Plus, Palette, SquareTerminal, Terminal, FolderUp, Folders, FileUp, HardDrive, Cloud, Globe, Monitor, MonitorCloud, MonitorSmartphone, Database, DatabaseZap, Layers, DatabaseSearch, Activity, Laptop, LaptopMinimal, Cable, Pencil, MoreHorizontal, FolderTree, ShipWheel, Boxes, AppWindow, ArrowLeftRight, ArrowRightLeft } from '@lucide/vue'
 import { ElMessageBox } from 'element-plus'
 import { msg } from '../services/message'
 import { useConnectionStore } from '../stores/connectionStore'
@@ -500,7 +502,7 @@ import { useLocalStateStore } from '../stores/localStateStore'
 defineProps<{
   visible: boolean
 }>()
-const emit = defineEmits(['connect', 'connectOnly', 'connectSftp', 'connectFtp', 'connectSmb', 'connectWebdav', 'connectS3', 'connectRdp', 'connectVnc', 'connectSpice', 'connectX11Desktop', 'connectDB', 'connectMonitor', 'connectSerial', 'connectK8s', 'toggle'])
+const emit = defineEmits(['connect', 'connectOnly', 'connectSftp', 'connectWslFile', 'connectFtp', 'connectSmb', 'connectWebdav', 'connectS3', 'connectRdp', 'connectVnc', 'connectSpice', 'connectX11Desktop', 'connectDB', 'connectMonitor', 'connectSerial', 'connectK8s', 'toggle'])
 const connectionStore = useConnectionStore()
 const settingsStore = useSettingsStore()
 const panelStore = usePanelStore()
@@ -531,7 +533,7 @@ function onFilesTabClick() {
   // companion SFTP session. Closing happens via the panel's X button, which
   // clears filesVisible and the watch below falls back to connections.
   companionStore.filesVisible = true
-  const pid = companionStore.getActiveSshPanelId()
+  const pid = companionStore.getActiveFilesPanelId()
   if (pid) companionStore.ensureSftp(pid).catch(() => {})
 }
 function onMonitorTabClick() {
@@ -1332,6 +1334,17 @@ function doConnectSFTP() {
   }
 }
 
+// Open the WSL distro's file manager in a standalone tab (wsl-file session).
+function doConnectWslFile() {
+  const ids = getSelectedConnectionIds()
+  const conns = ids.map(id => connectionStore.connections.find(c => c.id === id)).filter(Boolean) as ConnectionConfig[]
+  selectedIds.value = new Set()
+  closeMenu()
+  for (const c of conns) {
+    emit('connectWslFile', c)
+  }
+}
+
 function doConnectFTP() {
   const ids = getSelectedConnectionIds()
   const conns = ids.map(id => connectionStore.connections.find(c => c.id === id)).filter(Boolean) as ConnectionConfig[]
@@ -1850,6 +1863,7 @@ function connIcon(conn: ConnectionConfig) {
     case 'telnet': return Terminal
     case 'mosh': return Zap
     case 'local': return Laptop
+    case 'wsl': return LaptopMinimal
     case 'serial': return Cable
     case 'tcp': return ArrowLeftRight
     case 'sftp': return Folders

--- a/frontend/src/components/StartTabContent.vue
+++ b/frontend/src/components/StartTabContent.vue
@@ -95,6 +95,7 @@
                 <el-icon v-else-if="config.type === 'telnet'"><Terminal :size="28" /></el-icon>
                 <el-icon v-else-if="config.type === 'mosh'"><Zap :size="28" /></el-icon>
                 <el-icon v-else-if="config.type === 'local'"><Laptop :size="28" /></el-icon>
+                <el-icon v-else-if="config.type === 'wsl'"><LaptopMinimal :size="28" /></el-icon>
                 <el-icon v-else-if="config.type === 'serial'"><Cable :size="28" /></el-icon>
                 <el-icon v-else-if="config.type === 'tcp'"><ArrowLeftRight :size="28" /></el-icon>
                 <el-icon v-else-if="config.type === 'sftp'"><Folders :size="28" /></el-icon>
@@ -186,6 +187,7 @@
                 <el-icon v-else-if="config.type === 'telnet'"><Terminal :size="28" /></el-icon>
                 <el-icon v-else-if="config.type === 'mosh'"><Zap :size="28" /></el-icon>
                 <el-icon v-else-if="config.type === 'local'"><Laptop :size="28" /></el-icon>
+                <el-icon v-else-if="config.type === 'wsl'"><LaptopMinimal :size="28" /></el-icon>
                 <el-icon v-else-if="config.type === 'serial'"><Cable :size="28" /></el-icon>
                 <el-icon v-else-if="config.type === 'tcp'"><ArrowLeftRight :size="28" /></el-icon>
                 <el-icon v-else-if="config.type === 'sftp'"><Folders :size="28" /></el-icon>
@@ -264,6 +266,7 @@
               <el-icon v-else-if="config.type === 'telnet'"><Terminal :size="28" /></el-icon>
               <el-icon v-else-if="config.type === 'mosh'"><Zap :size="28" /></el-icon>
               <el-icon v-else-if="config.type === 'local'"><Laptop :size="28" /></el-icon>
+                <el-icon v-else-if="config.type === 'wsl'"><LaptopMinimal :size="28" /></el-icon>
               <el-icon v-else-if="config.type === 'serial'"><Cable :size="28" /></el-icon>
                 <el-icon v-else-if="config.type === 'tcp'"><ArrowLeftRight :size="28" /></el-icon>
               <el-icon v-else-if="config.type === 'sftp'"><Folders :size="28" /></el-icon>
@@ -329,10 +332,12 @@
       <MenuItem v-if="contextMenuConfig && contextMenuConfig.type === 'telnet'" :class="{ disabled: selectedIds.size > 1 }" @click="selectedIds.size <= 1 && doConnect(contextMenuConfig, $event)">{{ t('sidebar.connectTelnet') }}</MenuItem>
       <MenuItem v-if="contextMenuConfig && contextMenuConfig.type === 'mosh'" :class="{ disabled: selectedIds.size > 1 }" @click="selectedIds.size <= 1 && doConnect(contextMenuConfig, $event)">{{ t('sidebar.connectMosh') }}</MenuItem>
       <MenuItem v-if="contextMenuConfig && contextMenuConfig.type === 'local'" :class="{ disabled: selectedIds.size > 1 }" @click="selectedIds.size <= 1 && doConnect(contextMenuConfig, $event)">{{ t('sidebar.connectLocal') }}</MenuItem>
+      <MenuItem v-if="contextMenuConfig && contextMenuConfig.type === 'wsl'" :class="{ disabled: selectedIds.size > 1 }" @click="selectedIds.size <= 1 && doConnect(contextMenuConfig, $event)">{{ t('sidebar.connectWsl') }}</MenuItem>
       <MenuItem v-if="contextMenuConfig && contextMenuConfig.type === 'serial'" :class="{ disabled: selectedIds.size > 1 }" @click="selectedIds.size <= 1 && doConnectSerial(contextMenuConfig, $event)">{{ t('sidebar.connectSerial') }}</MenuItem>
       <MenuItem v-if="contextMenuConfig && contextMenuConfig.type === 'tcp'" :class="{ disabled: selectedIds.size > 1 }" @click="selectedIds.size <= 1 && doConnect(contextMenuConfig, $event)">{{ t('sidebar.connectTcp') }}</MenuItem>
       <!-- File Transfer -->
       <MenuItem v-if="contextMenuConfig && contextMenuConfig.type === 'ssh'" :class="{ disabled: selectedIds.size > 1 }" @click="selectedIds.size <= 1 && doConnectSftp(contextMenuConfig)">{{ t(connectFileMenuKey(contextMenuConfig)) }}</MenuItem>
+      <MenuItem v-if="contextMenuConfig && contextMenuConfig.type === 'wsl'" :class="{ disabled: selectedIds.size > 1 }" @click="selectedIds.size <= 1 && doConnectWslFile(contextMenuConfig)">{{ t('sidebar.connectWslFile') }}</MenuItem>
       <MenuItem v-if="contextMenuConfig && contextMenuConfig.type === 'ftp'" :class="{ disabled: selectedIds.size > 1 }" @click="selectedIds.size <= 1 && doConnectFtp(contextMenuConfig)">{{ t('sidebar.connectFtp') }}</MenuItem>
       <MenuItem v-if="contextMenuConfig && contextMenuConfig.type === 'smb'" :class="{ disabled: selectedIds.size > 1 }" @click="selectedIds.size <= 1 && doConnectSmb(contextMenuConfig)">{{ t('sidebar.connectSmb') }}</MenuItem>
       <MenuItem v-if="contextMenuConfig && contextMenuConfig.type === 's3'" :class="{ disabled: selectedIds.size > 1 }" @click="selectedIds.size <= 1 && doConnectS3(contextMenuConfig)">{{ t('sidebar.connectS3') }}</MenuItem>
@@ -442,7 +447,7 @@ import Menu from './Menu.vue'
 import MenuItem from './MenuItem.vue'
 import MenuSubmenu from './MenuSubmenu.vue'
 import MenuDivider from './MenuDivider.vue'
-import { Filter, Plus, Laptop, Cable, SquareTerminal, Terminal, Database, DatabaseZap, Layers, DatabaseSearch, Monitor, MonitorSmartphone, MonitorCloud, FolderUp, Folders, FileUp, HardDrive, Cloud, Globe, Server, Folder, FolderOpen, Zap, MoreHorizontal, ChevronDown, ShipWheel, Boxes, AppWindow, ArrowLeftRight } from '@lucide/vue'
+import { Filter, Plus, Laptop, LaptopMinimal, Cable, SquareTerminal, Terminal, Database, DatabaseZap, Layers, DatabaseSearch, Monitor, MonitorSmartphone, MonitorCloud, FolderUp, Folders, FileUp, HardDrive, Cloud, Globe, Server, Folder, FolderOpen, Zap, MoreHorizontal, ChevronDown, ShipWheel, Boxes, AppWindow, ArrowLeftRight } from '@lucide/vue'
 
 const props = defineProps<{
   tab: StartTab
@@ -1211,6 +1216,7 @@ onUnmounted(() => {
 function doConnect(config: ConnectionConfig, e: MouseEvent) { closeContextMenu(); emit('connect', config, e.ctrlKey || e.metaKey) }
 function doConnectSerial(config: ConnectionConfig, e: MouseEvent) { closeContextMenu(); emit('connect', config, e.ctrlKey || e.metaKey) }
 function doConnectSftp(config: ConnectionConfig) { closeContextMenu(); window.dispatchEvent(new CustomEvent('app:connect-sftp', { detail: config })) }
+function doConnectWslFile(config: ConnectionConfig) { closeContextMenu(); window.dispatchEvent(new CustomEvent('app:connect-wsl-file', { detail: config })) }
 function doConnectMonitor(config: ConnectionConfig) { closeContextMenu(); window.dispatchEvent(new CustomEvent('app:connect-monitor', { detail: config })) }
 function doConnectRdp(config: ConnectionConfig) { closeContextMenu(); window.dispatchEvent(new CustomEvent('app:connect-rdp', { detail: config })) }
 function doConnectVnc(config: ConnectionConfig) { closeContextMenu(); window.dispatchEvent(new CustomEvent('app:connect-vnc', { detail: config })) }

--- a/frontend/src/components/TabItem.vue
+++ b/frontend/src/components/TabItem.vue
@@ -133,7 +133,7 @@ import Menu from './Menu.vue'
 import MenuItem from './MenuItem.vue'
 import MenuDivider from './MenuDivider.vue'
 import { Clipboard } from '@wailsio/runtime'
-import { SquareTerminal, Laptop, FolderUp, Folders, FileUp, HardDrive, Cloud, Globe, Monitor, MonitorCloud, MonitorSmartphone, Settings, Database, DatabaseZap, Layers, DatabaseSearch, Activity, Terminal, Zap, X, ArrowDownUp, LayoutDashboard, Cable, SquarePlus, Lock, ShipWheel, Box, Boxes, AppWindow, ArrowLeftRight, Radio } from '@lucide/vue'
+import { SquareTerminal, Laptop, LaptopMinimal, FolderUp, FolderOpen, Folders, FileUp, HardDrive, Cloud, Globe, Monitor, MonitorCloud, MonitorSmartphone, Settings, Database, DatabaseZap, Layers, DatabaseSearch, Activity, Terminal, Zap, X, ArrowDownUp, LayoutDashboard, Cable, SquarePlus, Lock, ShipWheel, Box, Boxes, AppWindow, ArrowLeftRight, Radio } from '@lucide/vue'
 
 const props = defineProps<{
   tab: TerminalTab | SettingsTab | SFTPTab | RDPTab | VNCTab | SPICETab | DBTab | MonitorTab | WorkspaceTab
@@ -193,6 +193,7 @@ const tabIcon = computed(() => {
     if (ct === 'smb') return HardDrive
     if (ct === 's3') return Cloud
     if (ct === 'webdav') return Globe
+    if (ct === 'wsl-file') return FolderOpen
     // SSH-based file panels follow the connection's protocol preference.
     if (ct === 'ssh') return fileTransferProto(panel?.config) === 'scp' ? FileUp : Folders
     return FolderUp
@@ -216,6 +217,7 @@ const tabIcon = computed(() => {
     const panel = panelStore.getPanel(t.panelId)
     if (panel?.type === 'k8s-exec' || panel?.type === 'container-exec') return Box
     if (panel?.type === 'local') return Laptop
+    if (panel?.type === 'wsl') return LaptopMinimal
     if (panel?.type === 'serial') return Cable
     if (panel?.type === 'tcp') return ArrowLeftRight
     if (panel?.type === 'telnet') return Terminal
@@ -235,13 +237,14 @@ const isAILocked = computed(() => {
   return tabStore.isPanelAILocked(props.tab.panelId)
 })
 
-// Whether the tab can be a broadcast target / driver. Only ssh/local-backed
-// terminal tabs (broadcast only routes ssh/local sessions) and workspace tabs.
+// Whether the tab can be a broadcast target / driver. ssh/local/wsl terminal
+// tabs (broadcast routes those sessions) and workspace tabs. WSL is a local-run
+// terminal, so it broadcasts like local.
 const canBroadcast = computed(() => {
   if (props.tab.type === 'workspace') return true
   if (props.tab.type === 'terminal') {
     const p = panelStore.getPanel((props.tab as TerminalTab).panelId)
-    return !!p && (p.type === 'ssh' || p.type === 'local')
+    return !!p && (p.type === 'ssh' || p.type === 'local' || p.type === 'wsl')
   }
   return false
 })

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -738,6 +738,8 @@
   "sidebar.connectTelnet": "Telnet verbinden",
   "sidebar.connectMosh": "Mosh verbinden",
   "sidebar.connectLocal": "Lokal verbinden",
+  "sidebar.connectWsl": "WSL verbinden",
+  "sidebar.connectWslFile": "WSL-Dateimanager",
   "serial.title": "Serial",
   "serial.portLabel": "Port",
   "serial.baudRate": "Baudrate",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -738,6 +738,8 @@
   "sidebar.connectTelnet": "Connect Telnet",
   "sidebar.connectMosh": "Connect Mosh",
   "sidebar.connectLocal": "Connect Local",
+  "sidebar.connectWsl": "Connect WSL",
+  "sidebar.connectWslFile": "WSL File Manager",
   "serial.title": "Serial",
   "serial.portLabel": "Port",
   "serial.baudRate": "Baud Rate",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -738,6 +738,8 @@
   "sidebar.connectTelnet": "Conectar Telnet",
   "sidebar.connectMosh": "Conectar Mosh",
   "sidebar.connectLocal": "Conectar local",
+  "sidebar.connectWsl": "Conectar WSL",
+  "sidebar.connectWslFile": "Administrador de archivos WSL",
   "serial.title": "Serial",
   "serial.portLabel": "Puerto",
   "serial.baudRate": "Baudios",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -736,6 +736,8 @@
   "sidebar.connectTelnet": "Connecter en Telnet",
   "sidebar.connectMosh": "Connecter en Mosh",
   "sidebar.connectLocal": "Connecter en local",
+  "sidebar.connectWsl": "Connecter WSL",
+  "sidebar.connectWslFile": "Gestionnaire de fichiers WSL",
   "serial.title": "Serial",
   "serial.portLabel": "Port",
   "serial.baudRate": "Débit",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -738,6 +738,8 @@
   "sidebar.connectTelnet": "Telnet で接続",
   "sidebar.connectMosh": "Mosh で接続",
   "sidebar.connectLocal": "ローカル接続",
+  "sidebar.connectWsl": "WSL に接続",
+  "sidebar.connectWslFile": "WSL ファイル管理",
   "serial.title": "Serial",
   "serial.portLabel": "ポート",
   "serial.baudRate": "ボーレート",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -738,6 +738,8 @@
   "sidebar.connectTelnet": "Telnet 연결",
   "sidebar.connectMosh": "Mosh 연결",
   "sidebar.connectLocal": "로컬 연결",
+  "sidebar.connectWsl": "WSL 연결",
+  "sidebar.connectWslFile": "WSL 파일 관리",
   "serial.title": "Serial",
   "serial.portLabel": "포트",
   "serial.baudRate": "보레이트",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -738,6 +738,8 @@
   "sidebar.connectTelnet": "Подключиться по Telnet",
   "sidebar.connectMosh": "Подключиться по Mosh",
   "sidebar.connectLocal": "Подключить локально",
+  "sidebar.connectWsl": "Подключить WSL",
+  "sidebar.connectWslFile": "Менеджер файлов WSL",
   "serial.title": "Serial",
   "serial.portLabel": "Порт",
   "serial.baudRate": "Скорость",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -738,6 +738,8 @@
   "sidebar.connectTelnet": "连接 Telnet",
   "sidebar.connectMosh": "连接 Mosh",
   "sidebar.connectLocal": "连接本地",
+  "sidebar.connectWsl": "连接 WSL",
+  "sidebar.connectWslFile": "WSL 文件管理",
   "serial.title": "串口",
   "serial.portLabel": "端口",
   "serial.baudRate": "波特率",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -738,6 +738,8 @@
   "sidebar.connectTelnet": "連線 Telnet",
   "sidebar.connectMosh": "連線 Mosh",
   "sidebar.connectLocal": "連線本機",
+  "sidebar.connectWsl": "連接 WSL",
+  "sidebar.connectWslFile": "WSL 檔案管理",
   "serial.title": "序列埠",
   "serial.portLabel": "連接埠",
   "serial.baudRate": "鮑率",

--- a/frontend/src/stores/companionStore.ts
+++ b/frontend/src/stores/companionStore.ts
@@ -61,7 +61,27 @@ export const useCompanionStore = defineStore('companion', () => {
     return pid
   }
 
+  function getActiveWslPanelId(): string | null {
+    const pid = tabStore.getActivePanelId()
+    if (!pid) return null
+    const panel = panelStore.getPanel(pid)
+    if (!panel || panel.type !== 'wsl') return null
+    return pid
+  }
+
+  /** Active panel that owns a file sidebar: an SSH panel or a WSL terminal. */
+  function getActiveFilesPanelId(): string | null {
+    return getActiveSshPanelId() ?? getActiveWslPanelId()
+  }
+
+  function isWslPanel(pid: string | null): boolean {
+    if (!pid) return false
+    return panelStore.getPanel(pid)?.type === 'wsl'
+  }
+
   const activeSshPanelId = computed(() => getActiveSshPanelId())
+
+  const activeFilesPanelId = computed(() => getActiveFilesPanelId())
 
   const sshConnected = computed(() => {
     const pid = activeSshPanelId.value
@@ -71,10 +91,19 @@ export const useCompanionStore = defineStore('companion', () => {
     return sessionStore.getStatus(panel.sessionId) === 'connected'
   })
 
-  const canToggle = computed(() => sshConnected.value)
+  // File sidebar is available for a connected SSH panel or a running WSL terminal.
+  const filesConnected = computed(() => {
+    const pid = activeFilesPanelId.value
+    if (!pid) return false
+    const panel = panelStore.getPanel(pid)
+    if (!panel?.sessionId) return false
+    return sessionStore.getStatus(panel.sessionId) === 'connected'
+  })
+
+  const canToggle = computed(() => filesConnected.value)
 
   const currentSftpSessionId = computed(() => {
-    const pid = activeSshPanelId.value
+    const pid = activeFilesPanelId.value
     if (!pid) return null
     return entries.value[pid]?.sftpSessionId ?? null
   })
@@ -86,7 +115,7 @@ export const useCompanionStore = defineStore('companion', () => {
   })
 
   const transferKey = computed(() => {
-    const pid = activeSshPanelId.value
+    const pid = activeFilesPanelId.value
     return pid ? `${pid}__sftp` : ''
   })
 
@@ -155,6 +184,18 @@ export const useCompanionStore = defineStore('companion', () => {
     }
     entry.creatingSftp = true
     try {
+      // WSL terminals have no SFTP subsystem — their file sidebar is served by
+      // the WSL file session over \\wsl.localhost\<distro>.
+      if (isWslPanel(sshPanelId)) {
+        config.type = 'wsl-file'
+        const info = await CreateSession('wsl-file', config)
+        entries.value = {
+          ...entries.value,
+          [sshPanelId]: { ...entries.value[sshPanelId], sftpSessionId: info.id, creatingSftp: false },
+        }
+        sessionStore.initSession(info.id)
+        return info.id
+      }
       // Honor the connection's file-transfer protocol preference: 'scp' for
       // hosts without an SFTP subsystem, 'sftp' (default) otherwise.
       const proto = fileTransferProto(config)
@@ -221,7 +262,7 @@ export const useCompanionStore = defineStore('companion', () => {
       filesVisible.value = false
       return
     }
-    const pid = getActiveSshPanelId()
+    const pid = getActiveFilesPanelId()
     if (!pid) return
     filesVisible.value = true
     await ensureSftp(pid)
@@ -295,7 +336,9 @@ export const useCompanionStore = defineStore('companion', () => {
     monitorWidth,
     entries,
     activeSshPanelId,
+    activeFilesPanelId,
     sshConnected,
+    filesConnected,
     canToggle,
     currentSftpSessionId,
     currentMonitorSessionId,
@@ -309,6 +352,8 @@ export const useCompanionStore = defineStore('companion', () => {
     setFilesWidth,
     setMonitorWidth,
     getActiveSshPanelId,
+    getActiveFilesPanelId,
+    isWslPanel,
     getFileViewCache,
     setFileViewCache,
     getMonitorViewCache,

--- a/frontend/src/stores/tabStore.ts
+++ b/frontend/src/stores/tabStore.ts
@@ -80,7 +80,7 @@ export const useTabStore = defineStore('tab', () => {
     } else {
       for (const id of tab.panelIds) {
         const p = panelStore.getPanel(id)
-        if (p && (p.type === 'ssh' || p.type === 'local')) {
+        if (p && (p.type === 'ssh' || p.type === 'local' || p.type === 'wsl')) {
           tabState.broadcastPanelIds.add(id)
         }
       }
@@ -120,7 +120,7 @@ export const useTabStore = defineStore('tab', () => {
     const ids = tab.type === 'workspace' ? tab.panelIds : 'panelId' in tab ? [tab.panelId] : []
     for (const id of ids) {
       const p = panelStore.getPanel(id)
-      if (p && (p.type === 'ssh' || p.type === 'local')) {
+      if (p && (p.type === 'ssh' || p.type === 'local' || p.type === 'wsl')) {
         tabState.broadcastPanelIds.add(id)
       }
     }

--- a/frontend/src/types/session.ts
+++ b/frontend/src/types/session.ts
@@ -17,7 +17,7 @@ export interface ConnectionConfig {
   id: string
   name: string
   remark?: string
-  type: 'ssh' | 'telnet' | 'mosh' | 'rdp' | 'vnc' | 'spice' | 'database' | 'local' | 'sftp' | 'scp' | 'monitor' | 'ftp' | 'serial' | 'smb' | 'webdav' | 's3' | 'tcp' | 'k8s' | 'container' | 'x11-desktop'
+  type: 'ssh' | 'telnet' | 'mosh' | 'rdp' | 'vnc' | 'spice' | 'database' | 'local' | 'wsl' | 'sftp' | 'scp' | 'monitor' | 'ftp' | 'serial' | 'smb' | 'webdav' | 's3' | 'tcp' | 'k8s' | 'container' | 'x11-desktop'
   host: string
   port: number
   user: string
@@ -41,7 +41,7 @@ export interface ConnectionConfig {
   // "DOMAIN\user" prefix in user is used as a fallback.
   rdpDomain?: string
   rdpAdminSession?: boolean
-  // Local terminal shell path
+  // Local terminal shell path (for WSL, `wsl://<distro>` carries the distro)
   shellPath?: string
   // Working directory for local terminal (defaults to user home)
   cwd?: string

--- a/frontend/src/types/workspace.ts
+++ b/frontend/src/types/workspace.ts
@@ -1,4 +1,4 @@
-export type PanelType = 'ssh' | 'telnet' | 'mosh' | 'sftp' | 'settings' | 'rdp' | 'vnc' | 'spice' | 'local' | 'database' | 'monitor' | 'serial' | 'tcp' | 'k8s' | 'k8s-exec' | 'container' | 'container-exec' | 'x11-desktop' | 'other'
+export type PanelType = 'ssh' | 'telnet' | 'mosh' | 'sftp' | 'settings' | 'rdp' | 'vnc' | 'spice' | 'local' | 'wsl' | 'database' | 'monitor' | 'serial' | 'tcp' | 'k8s' | 'k8s-exec' | 'container' | 'container-exec' | 'x11-desktop' | 'other'
 export type PanelStatus = 'connecting' | 'connected' | 'disconnected' | 'error'
 
 import type { ConnectionConfig } from './session'


### PR DESCRIPTION
### Summary

Add a dedicated WSL terminal type (`wsl`) and a `wsl-file` companion session that serves the file sidebar over the `//wsl.localhost/<distro>` share, mirroring the existing SSH+SFTP arrangement. The file panels reuse the protocol-agnostic `fileTransferSession` plumbing, so browse / upload / download / rename / mkdir / external-edit all work unchanged. Owner and group are rendered from the distro's `/etc/passwd` and `/etc/group`.

Also folds the SFTP local pane into the shared `localFSOps` helper so the Windows-local file operations live in a single implementation.

Closes #828

---

### 概述

新增独立的 WSL 终端类型(`wsl`)和 `wsl-file` companion 会话,通过 `//wsl.localhost/<发行版>` 共享路径提供文件边栏,与现存的 SSH+SFTP 结构对齐。文件面板复用与协议无关的 `fileTransferSession` 层,浏览 / 上传 / 下载 / 重命名 / 新建 / 外部编辑均直接可用。文件所属用户/组由发行版内的 `/etc/passwd` 与 `/etc/group` 渲染。

同时把 SFTP 的本地窗格并入共享的 `localFSOps` 助手,使 Windows 本地文件操作收敛为单一实现。

Closes #828