### PR TITLE
fix(tab): broadcast icon shares the right close-button slot

### DIFF
--- a/frontend/src/components/TabItem.vue
+++ b/frontend/src/components/TabItem.vue
@@ -51,7 +51,7 @@
       :title="t('tab.unbroadcast')"
     />
     <button
-      v-if="tabCloseRight"
+      v-if="tabCloseRight && !showBroadcastIcon"
       class="tab-close tab-close-right"
       :class="{ 'tab-close-right-ghost': !hovered || tab.locked }"
       @click.stop="$emit('close', tab.id)"
@@ -255,11 +255,12 @@ const isBroadcastTarget = computed(() =>
   tabStore.isTabBroadcastTarget(props.tab.id)
 )
 
-// When the right-side close button shows (right-close setting + hover + not
-// locked), it replaces the broadcast status icon exactly like the left close
-// button replaces the tab icon in the default layout. Otherwise the icon stays
-// visible. In the default (left-close) layout there is no right close button,
-// so the icon is always shown.
+// The broadcast icon and the right close button share one far-right slot,
+// so they are mutually exclusive: show the icon only while actually
+// broadcasting, and while the right X would be visible (right-close setting +
+// hover + not locked) show the X instead — the template v-if's out whichever
+// one isn't shown so they never coexist. In the default (left-close) layout
+// there is no right X, so the icon is always shown.
 const showBroadcastIcon = computed(() =>
   canBroadcast.value &&
   isBroadcastTarget.value &&
@@ -682,15 +683,18 @@ onMounted(async () => {
   height: 14px;
   color: var(--text-muted);
 }
-/* Broadcast status icon sits in the right-side close-button slot, mirrored
-   vertically/horizontally with it. It's toggled off (v-if) whenever the close
-   button is shown, so the two never overlap — same as the tab icon being
-   replaced by the left close button in the default layout. */
+/* Broadcast status icon occupies the exact same far-right slot as the right
+   close button: with margin-left:auto it pushes to the edge, and the right X
+   is v-if'd out of the DOM (see template) whenever the icon is shown, so the
+   two are never siblings — the icon sits precisely where the X would. In the
+   default (left-close) layout there is no right X, so the icon always takes
+   the slot. Reserving real layout space (not absolute positioning) means it
+   never overlaps the tab name. */
 .tab-broadcast-icon {
-  position: absolute;
-  right: 12px;
-  top: 50%;
-  transform: translateY(-50%);
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  margin-left: auto;
   color: var(--accent);
 }
 .tab-notification-dot {
@@ -769,8 +773,7 @@ onMounted(async () => {
   visibility: hidden;
   /* Hide instantly on mouse-leave: `.tab-close` carries transition:all, and
      visibility is a transitionable property, so a visible→hidden ghost would
-     otherwise linger for the transition duration — overlapping the broadcast
-     status icon that swaps in via v-if at the same slot. */
+     otherwise linger for the transition duration. */
   transition: visibility 0s;
 }
 </style>


### PR DESCRIPTION
## What

The broadcast status icon (`Radio`) in the tab strip was absolutely positioned
(`position: absolute; right: 12px`), detached from the layout. In the
left-close layout it therefore reserved no layout space of its own and could
overlap long tab names instead of sitting in a dedicated slot.

## Change

- Make `.tab-broadcast-icon` an in-flow flex element with `margin-left: auto`,
  pushing it to the exact same far-right slot as the right close button.
- `v-if` the right close button out of the DOM whenever the broadcast icon is
  shown, so the two never coexist and the icon sits precisely where the X would.
- Simplify comments that described the old overlap-swap behavior.

## Result

- **Left-close layout**: while broadcasting, the icon occupies a dedicated
  far-right slot and no longer overlaps the name.
- **Right-close layout**: the icon and X share one slot and swap on hover —
  identical placement, never both visible.

---
- 广播状态图标此前是绝对定位（`position: absolute; right: 12px`），脱离布局流，在左侧关闭按钮布局下不占用自己的槽位，可能压住过长的标签名。
- 改为布局流内元素 + `margin-left: auto`，顶到与右侧关闭按钮完全相同的最右槽位。
- 广播图标显示时通过 `v-if` 把右侧关闭按钮从 DOM 移除，两者绝不同时出现，图标正好落在 X 所在的同一位置。
- 关闭按钮在左：广播时图标独占最右槽位，不再压文本；关闭按钮在右：图标与 X 共用同一位并随 hover 切换。