### PR TITLE
fix(terminal): follow app theme colors in the search bar

### DIFF
--- a/frontend/src/components/BaseTerminal.vue
+++ b/frontend/src/components/BaseTerminal.vue
@@ -2069,9 +2069,11 @@ defineExpose({
   display: flex;
   align-items: center;
   gap: 4px;
-  background: rgba(20, 23, 29, 0.88);
+  /* 跟应用主题走（与 Zmodem 面板、终端建议弹窗等悬浮控件一致）；
+     保留 88% 不透明度，让 blur 透出一点终端内容。 */
+  background: color-mix(in srgb, var(--bg-surface) 88%, transparent);
   backdrop-filter: blur(8px);
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  border: 1px solid var(--border-subtle);
   border-radius: var(--radius-md);
   padding: 4px 6px;
   z-index: 50;
@@ -2111,7 +2113,7 @@ defineExpose({
   transition: all 0.15s;
 }
 .search-btn:hover {
-  background: rgba(255, 255, 255, 0.08);
+  background: var(--bg-hover);
   color: var(--text-primary);
 }
 .terminal-area :deep(.xterm) {


### PR DESCRIPTION
## Summary
- The Ctrl+F search bar over the terminal hardcoded a dark translucent background and a light border, so on light app themes the theme-driven dark text sat on the dark bar and was unreadable.
- Replace the hardcoded colors with app theme variables (`--bg-surface`, `--border-subtle`, `--bg-hover`) so the bar follows the active theme: light base with dark text on light themes, unchanged look on dark themes.
- Keep the 88% opacity + backdrop blur so a hint of the terminal still shows through.

Fixes #811

---

## 摘要
- 终端上方的 Ctrl+F 搜索栏原来写死了深色半透明背景和浅色边框，浅色应用主题下主题变量给出的深色文字落在深色底上，几乎不可读。
- 将写死的颜色替换为应用主题变量（`--bg-surface`、`--border-subtle`、`--bg-hover`），搜索栏跟随当前主题：浅色主题下自动变为浅底深字，深色主题下观感不变。
- 保留 88% 不透明度与背景模糊，仍能隐约透出终端内容。

Fixes #811