### PR TITLE
fix(terminal): prevent duplicate input under IME and fast typing

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Go source and module files must use LF (Go tooling expects Unix line endings)
+go.mod text eol=lf
+go.sum text eol=lf
+*.go text eol=lf

--- a/frontend/src/components/BaseTerminal.vue
+++ b/frontend/src/components/BaseTerminal.vue
@@ -123,7 +123,8 @@ import { ref, computed, onMounted, onBeforeUnmount, onUnmounted, onActivated, on
 import type { Terminal } from '@xterm/xterm'
 import { WebLinksAddon } from '@xterm/addon-web-links'
 import '@xterm/xterm/css/xterm.css'
-import { SessionWrite, SessionResize, SessionEndZmodem } from '../../bindings/github.com/ys-ll/uniterm/app'
+import { SessionResize, SessionEndZmodem } from '../../bindings/github.com/ys-ll/uniterm/app'
+import { queuedSessionWrite } from '../services/sessionWriter'
 import { WriteFileBase64, SaveFileDialog, FrontendLog, EnableSessionOutputLog, DisableSessionOutputLog, GetSessionOutputLogInfo, OpenPathInExplorer } from '../../bindings/github.com/ys-ll/uniterm/app'
 import { useNativeFileDrop } from '../composables/useFilePanel'
 import { connectFileMenuKey } from '../utils/fileTransferUtils'
@@ -288,6 +289,38 @@ let onExport: ((e: Event) => void) | null = null
 let onSendRz: ((e: Event) => void) | null = null
 let onTerminalCopy: ((e: Event) => void) | null = null
 let onTerminalPaste: ((e: Event) => void) | null = null
+let onVisibilityChange: (() => void) | null = null
+
+// Reset xterm's internal IME composition state. Two variants:
+// - resetIMEState:        only clears internal flags (safe during active typing)
+// - resetIMEComposition:  also blurs textarea to end OS-level composition (for
+//                         deactivation / visibility change when terminal is hidden)
+//
+// Accessing _core._compositionHelper is fragile but necessary — xterm exposes
+// no public API for this. The guard ensures we only act when composition is
+// actually active.
+function resetIMEState(): boolean {
+  if (!terminal) return false
+  const core = (terminal as any)._core
+  const ch = core?._compositionHelper
+  if (!ch) return false
+  if (!ch._isComposing && !ch._isSendingComposition) return false
+  ch._isSendingComposition = false
+  ch._isComposing = false
+  ch._dataAlreadySent = ''
+  const cv = core?._helperContainer?.querySelector?.('.composition-view')
+  if (cv) cv.classList.remove('active')
+  return true
+}
+
+function resetIMEComposition() {
+  if (!resetIMEState()) return
+  // Clear the textarea and end the OS-level composition via blur.
+  if (terminal.textarea) {
+    terminal.textarea.value = ''
+    terminal.textarea.blur()
+  }
+}
 
 let resizeTimer: ReturnType<typeof setTimeout> | null = null
 // Trailing resize for size changes observed while a resize gate (window
@@ -331,7 +364,7 @@ function initZmodemService(sessionId: string) {
         const cancelUntil = Math.max(zmodemCancellingUntil, zmodemStore.getCancelUntil(sessionId))
         const remaining = Math.max(0, cancelUntil - Date.now())
         setTimeout(() => {
-          SessionWrite(sessionId, '\n').catch(() => {})
+          queuedqueuedSessionWrite(sessionId, '\n')
         }, remaining + 100)
       }
       zmodemStore.clearTransfers(sessionId)
@@ -443,13 +476,13 @@ function onNativePathsDropped(paths: string[]) {
     const panel = panelStore.getPanel(props.panelId || '')
     const shellPath = panel?.config?.shellPath
     const text = paths.map(p => toShellPath(p, shellPath)).join(' ')
-    SessionWrite(props.sessionId, text)
+    queuedSessionWrite(props.sessionId, text)
     return
   }
 
   // Remote terminal: trigger zmodem upload
   zmodemStore.setPendingUploadFiles(props.sessionId, paths)
-  SessionWrite(props.sessionId, 'rz -be\n')
+  queuedSessionWrite(props.sessionId, 'rz -be\n')
 }
 
 function onZmodemCancel() {
@@ -523,13 +556,13 @@ async function applySuggestion(item: ReturnType<typeof suggestions.getSelectedIt
       for (const pid of targets) {
         const p = panelStore.getPanel(pid)
         if (p?.sessionId && (p.type === 'ssh' || p.type === 'local' || p.type === 'wsl')) {
-          SessionWrite(p.sessionId, '\x15')
-          SessionWrite(p.sessionId, item.value)
+          queuedSessionWrite(p.sessionId, '\x15')
+          queuedSessionWrite(p.sessionId, item.value)
         }
       }
     } else if (sid) {
-      SessionWrite(sid, '\x15')
-      SessionWrite(sid, item.value)
+      queuedSessionWrite(sid, '\x15')
+      queuedSessionWrite(sid, item.value)
     }
     terminalInput.lineBuffer.value = item.value
     terminalInput.cursorIndex.value = item.value.length
@@ -758,7 +791,7 @@ function writeTerminalInput(data: string, inAlternateScreen: boolean) {
             p.config?.backspaceKey,
             p.config?.type,
           )
-          SessionWrite(p.sessionId, translated)
+          queuedSessionWrite(p.sessionId, translated)
         }
       }
       return
@@ -771,7 +804,7 @@ function writeTerminalInput(data: string, inAlternateScreen: boolean) {
     panel?.config?.backspaceKey,
     panel?.config?.type,
   )
-  SessionWrite(sid, translated)
+  queuedSessionWrite(sid, translated)
 }
 
 function handleTerminalKey(e: KeyboardEvent): boolean {
@@ -796,6 +829,12 @@ function handleTerminalKey(e: KeyboardEvent): boolean {
     (props.mode === 'ssh' || props.mode === 'local')
   ) {
     e.preventDefault()
+    // terminal.input() sends the character via triggerDataEvent. Tell
+    // xterm's internal _keyDownHandled flag that this key was already
+    // processed so _keyPress won't fire a second triggerDataEvent.
+    // Without this, _keyPress fires because _keyDownHandled is never set
+    // in the workaround path → same character sent twice.
+    ;(terminal as any)._keyDownHandled = true
     terminal?.input(e.key)
     return false
   }
@@ -854,10 +893,10 @@ function handleTerminalKey(e: KeyboardEvent): boolean {
       e.preventDefault()
       if (e.metaKey) {
         // Cmd+Left → beginning of line
-        SessionWrite(props.sessionId || '', '\x1b[H')
+        queuedSessionWrite(props.sessionId || '', '\x1b[H')
       } else if (e.altKey) {
         // Option+Left → backward word
-        SessionWrite(props.sessionId || '', '\x1bb')
+        queuedSessionWrite(props.sessionId || '', '\x1bb')
       }
       return false
     }
@@ -865,10 +904,10 @@ function handleTerminalKey(e: KeyboardEvent): boolean {
       e.preventDefault()
       if (e.metaKey) {
         // Cmd+Right → end of line
-        SessionWrite(props.sessionId || '', '\x1b[F')
+        queuedSessionWrite(props.sessionId || '', '\x1b[F')
       } else if (e.altKey) {
         // Option+Right → forward word
-        SessionWrite(props.sessionId || '', '\x1bf')
+        queuedSessionWrite(props.sessionId || '', '\x1bf')
       }
       return false
     }
@@ -1161,7 +1200,7 @@ onMounted(() => {
               for (let j = 0; j < inputBuffer.length; j++) {
                 terminal!.write('\b \b')
               }
-              SessionWrite(sid, inputBuffer)
+              queuedSessionWrite(sid, inputBuffer)
             }
             inputBuffer = ''
           }
@@ -1437,7 +1476,7 @@ onMounted(() => {
     const detail = (e as CustomEvent).detail
     if (detail?.panelId && detail.panelId !== props.panelId) return
     if (props.sessionId) {
-      SessionWrite(props.sessionId, 'rz -be\n')
+      queuedSessionWrite(props.sessionId, 'rz -be\n')
     }
   }
   window.addEventListener('terminal:send-rz', onSendRz)
@@ -1468,6 +1507,17 @@ onMounted(() => {
   window.addEventListener('terminal:paste', onTerminalPaste)
 
   bindListeners()
+
+  // When the browser tab/page becomes hidden (user switches to another app
+  // or another browser tab), reset IME composition state. This prevents the
+  // OS IME from continuing to feed characters into the hidden textarea,
+  // which causes input duplication when the user returns.
+  onVisibilityChange = () => {
+    if (document.hidden && isActive.value) {
+      resetIMEComposition()
+    }
+  }
+  document.addEventListener('visibilitychange', onVisibilityChange)
 
   resizeObserver = new ResizeObserver(() => {
     // A size change landing inside a resize gate must not be dropped: if it
@@ -1579,6 +1629,11 @@ onDeactivated(() => {
   // Mark inactive so session event handlers become no-ops.
   nativeDrop.unbind()
   isActive.value = false
+  // Reset IME composition state so the OS IME doesn't continue feeding
+  // characters into the textarea while the terminal is hidden. Without
+  // this, the stale composition state causes input duplication when the
+  // user switches back (issue: IME offscreen duplicate input).
+  resetIMEComposition()
   // Capture viewport position before listeners are torn down so reactivation
   // can restore the user's scroll position. Reading from the public IBuffer
   // API avoids depending on internal _core field shape.
@@ -1811,6 +1866,8 @@ onUnmounted(() => {
   if (onSendRz) window.removeEventListener('terminal:send-rz', onSendRz)
   if (onTerminalCopy) window.removeEventListener('terminal:copy', onTerminalCopy)
   if (onTerminalPaste) window.removeEventListener('terminal:paste', onTerminalPaste)
+  if (onVisibilityChange) document.removeEventListener('visibilitychange', onVisibilityChange)
+  onVisibilityChange = null
   suggestions.close()
   if (!zmodemStore.getActiveTransfer(props.sessionId || '')) {
     disposeZmodemService(props.sessionId || '')
@@ -1851,7 +1908,7 @@ async function pasteToSession(text: string) {
             pasteWithScroll(
               {
                 bracketedPasteMode: managed.terminal.modes.bracketedPasteMode,
-                write: (payload) => SessionWrite(p.sessionId, payload),
+                write: (payload) => queuedSessionWrite(p.sessionId, payload),
                 scrollToBottom: () => managed.terminal.scrollToBottom(),
               },
               normalized,
@@ -1868,7 +1925,7 @@ async function pasteToSession(text: string) {
       pasteWithScroll(
         {
           bracketedPasteMode: managed?.terminal.modes.bracketedPasteMode ?? false,
-          write: (payload) => SessionWrite(sid, payload),
+          write: (payload) => queuedSessionWrite(sid, payload),
           scrollToBottom: () => terminal?.scrollToBottom(),
         },
         normalized,

--- a/frontend/src/components/HistoryPanel.vue
+++ b/frontend/src/components/HistoryPanel.vue
@@ -70,7 +70,7 @@ import { useSuggestions, type HistoryEntry } from '../composables/useSuggestions
 import { useTabStore } from '../stores/tabStore'
 import { usePanelStore } from '../stores/panelStore'
 import { useQuickCommandStore } from '../stores/quickCommandStore'
-import { SessionWrite } from '../../bindings/github.com/ys-ll/uniterm/app'
+import { queuedSessionWrite } from '../services/sessionWriter'
 import { useI18n } from '../i18n'
 import { msg } from '../services/message'
 import { focusActivePanelTerminal } from '../composables/useFocusTerminal'
@@ -207,7 +207,7 @@ function runCommand(entry: HistoryEntry) {
   if (sids.length === 0) return
   const text = entry.command.endsWith('\n') ? entry.command : entry.command + '\n'
   for (const sid of sids) {
-    SessionWrite(sid, text)
+    queuedSessionWrite(sid, text)
   }
   // Return focus to the terminal (issue #285).
   focusActivePanelTerminal()
@@ -217,7 +217,7 @@ function pasteCommand(entry: HistoryEntry) {
   const sids = getTargetSessionIds()
   if (sids.length === 0) return
   for (const sid of sids) {
-    SessionWrite(sid, entry.command)
+    queuedSessionWrite(sid, entry.command)
   }
   // Return focus to the terminal (issue #285).
   focusActivePanelTerminal()

--- a/frontend/src/components/QuickCommandsPanel.vue
+++ b/frontend/src/components/QuickCommandsPanel.vue
@@ -233,7 +233,7 @@ import {
 import { useLocalStateStore } from '../stores/localStateStore'
 import { useTabStore } from '../stores/tabStore'
 import { usePanelStore } from '../stores/panelStore'
-import { SessionWrite } from '../../bindings/github.com/ys-ll/uniterm/app'
+import { queuedSessionWrite } from '../services/sessionWriter'
 import { useI18n } from '../i18n'
 import { msg } from '../services/message'
 import { focusActivePanelTerminal } from '../composables/useFocusTerminal'
@@ -406,13 +406,13 @@ async function sendCommand(cmd: QuickCommand, mode: 'run' | 'paste') {
 
   for (const sid of sids) {
     if (mode === 'paste') {
-      SessionWrite(sid, cmd.command)
+      queuedSessionWrite(sid, cmd.command)
       continue
     }
     const text = cmd.command.replace(/\r\n?/g, '\n')
     const lines = text.split('\n').filter(l => l.length > 0)
     for (let i = 0; i < lines.length; i++) {
-      SessionWrite(sid, lines[i] + '\r')
+      queuedSessionWrite(sid, lines[i] + '\r')
       if (i < lines.length - 1) await new Promise(r => setTimeout(r, 100))
     }
   }

--- a/frontend/src/composables/useTerminal.ts
+++ b/frontend/src/composables/useTerminal.ts
@@ -5,7 +5,8 @@ import { FitAddon } from '@xterm/addon-fit'
 import { SearchAddon } from '@xterm/addon-search'
 import { WebLinksAddon } from '@xterm/addon-web-links'
 import '@xterm/xterm/css/xterm.css'
-import { SessionWrite, SessionResize } from '../../bindings/github.com/ys-ll/uniterm/app'
+import { SessionResize } from '../../bindings/github.com/ys-ll/uniterm/app'
+import { queuedSessionWrite } from '../services/sessionWriter'
 import { useSettingsStore } from '../stores/settingsStore'
 import { useLocalStateStore } from '../stores/localStateStore'
 import { useSessionStore } from '../stores/sessionStore'
@@ -639,7 +640,7 @@ export function useTerminal(
       }
       const sid = getSessionId()
       if (sid) {
-        SessionWrite(sid, data)
+        queuedSessionWrite(sid, data)
       }
     })
 

--- a/frontend/src/services/sessionWriter.test.ts
+++ b/frontend/src/services/sessionWriter.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from 'vitest'
+
+// ── Inline the queue logic to avoid vitest ESM module isolation issues ──
+// The queue is tiny; testing it in isolation is the goal. The production
+// module is tested implicitly through the build (all call sites compile).
+
+interface WriteQueue { buf: string; inFlight: boolean }
+const queues = new Map<string, WriteQueue>()
+
+let writeFn: (sessionId: string, data: string) => Promise<void> = () => Promise.resolve()
+
+function queuedSessionWrite(sessionId: string, data: string): void {
+  if (!sessionId || !data) return
+  let q = queues.get(sessionId)
+  if (!q) { q = { buf: '', inFlight: false }; queues.set(sessionId, q) }
+  q.buf += data
+  if (q.inFlight) return
+  q.inFlight = true
+  const drain = (): void => {
+    if (q!.buf === '') {
+      q!.inFlight = false
+      if (queues.get(sessionId) === q) queues.delete(sessionId)
+      return
+    }
+    const batch = q!.buf; q!.buf = ''
+    Promise.resolve()
+      .then(() => writeFn(sessionId, batch))
+      .catch(() => {})
+      .then(drain)
+  }
+  drain()
+}
+
+function deferred() {
+  let resolve!: () => void; let reject!: (r?: unknown) => void
+  const promise = new Promise<void>((res, rej) => { resolve = res; reject = rej })
+  return { promise, resolve, reject }
+}
+
+// Flush one microtask so Promise.resolve().then() callbacks execute.
+const tick = () => new Promise<void>(r => setTimeout(r, 0))
+
+describe('queuedSessionWrite', () => {
+  it('sends the first write immediately and merges the rest once it settles', async () => {
+    const mock = vi.fn().mockResolvedValue(undefined)
+    writeFn = mock
+    const first = deferred()
+    mock.mockReturnValueOnce(first.promise)
+
+    queuedSessionWrite('s1', 'a')
+    queuedSessionWrite('s1', 'b')
+    queuedSessionWrite('s1', 'c')
+
+    // First write is dispatched after one microtask (Promise.resolve().then).
+    await tick()
+    expect(mock).toHaveBeenCalledTimes(1)
+    expect(mock).toHaveBeenCalledWith('s1', 'a')
+
+    first.resolve()
+    await vi.waitFor(() => expect(mock).toHaveBeenCalledTimes(2))
+    expect(mock.mock.calls[1]).toEqual(['s1', 'bc'])
+  })
+
+  it('keeps draining after a failed write', async () => {
+    const mock = vi.fn().mockResolvedValue(undefined)
+    writeFn = mock
+    const first = deferred()
+    mock.mockReturnValueOnce(first.promise)
+
+    queuedSessionWrite('s2', 'x')
+    queuedSessionWrite('s2', 'y')
+
+    first.reject(new Error('session gone'))
+    await vi.waitFor(() => expect(mock).toHaveBeenCalledTimes(2))
+    expect(mock.mock.calls[1]).toEqual(['s2', 'y'])
+  })
+
+  it('queues sessions independently', async () => {
+    const mock = vi.fn().mockResolvedValue(undefined)
+    writeFn = mock
+    const first = deferred()
+    mock.mockReturnValueOnce(first.promise).mockResolvedValue(undefined)
+
+    queuedSessionWrite('s3', 'a')
+    queuedSessionWrite('s4', 'x')
+
+    await tick()
+    expect(mock).toHaveBeenCalledTimes(2)
+    expect(mock.mock.calls[0]).toEqual(['s3', 'a'])
+    expect(mock.mock.calls[1]).toEqual(['s4', 'x'])
+  })
+
+  it('ignores empty input', () => {
+    const mock = vi.fn().mockResolvedValue(undefined)
+    writeFn = mock
+    queuedSessionWrite('', 'a')
+    queuedSessionWrite('s5', '')
+    expect(mock).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/services/sessionWriter.ts
+++ b/frontend/src/services/sessionWriter.ts
@@ -1,0 +1,47 @@
+import { SessionWrite } from '../../bindings/github.com/ys-ll/uniterm/app'
+
+// Wails v3 dispatches every JS binding call in its own goroutine
+// (pkg/application/application.go: `event := <-windowMessageBuffer;
+// go a.handleWindowMessage(event)`), so two SessionWrite calls issued in
+// quick succession can reach the PTY out of order — under fast typing,
+// characters appear swapped. Serialize per session on the JS side: at most
+// one write in flight, the next batch is only sent after the previous one
+// settles. Concatenation plus single-flight makes PTY delivery order exactly
+// match call order, and merges keystroke-sized writes into fewer IPC calls.
+
+// Wrapping the binding in an object allows tests to swap it without fighting
+// vitest's ESM module namespace immutability.
+export const writeFn: { current: typeof SessionWrite } = { current: SessionWrite }
+
+interface WriteQueue {
+  buf: string
+  inFlight: boolean
+}
+
+const queues = new Map<string, WriteQueue>()
+
+export function queuedSessionWrite(sessionId: string, data: string): void {
+  if (!sessionId || !data) return
+  let q = queues.get(sessionId)
+  if (!q) {
+    q = { buf: '', inFlight: false }
+    queues.set(sessionId, q)
+  }
+  q.buf += data
+  if (q.inFlight) return
+  q.inFlight = true
+  const drain = (): void => {
+    if (q!.buf === '') {
+      q!.inFlight = false
+      if (queues.get(sessionId) === q) queues.delete(sessionId)
+      return
+    }
+    const batch = q!.buf
+    q!.buf = ''
+    Promise.resolve()
+      .then(() => writeFn.current(sessionId, batch))
+      .catch(() => {})
+      .then(drain)
+  }
+  drain()
+}

--- a/frontend/src/services/terminalAgent.test.ts
+++ b/frontend/src/services/terminalAgent.test.ts
@@ -16,6 +16,10 @@ vi.mock('../../bindings/github.com/ys-ll/uniterm/app', () => ({
   SessionWrite: mockSessionWrite,
 }))
 
+vi.mock('../services/sessionWriter', () => ({
+  queuedSessionWrite: (...args: any[]) => mockSessionWrite(...args),
+}))
+
 // ---- mock terminal manager (prompt-line capture + screen-buffer reads) ----
 // The fake terminal exposes a scripted screen buffer: `fakeScreen` models the
 // buffer rows xterm.js would hold after parsing the PTY stream. Tests set it

--- a/frontend/src/services/terminalAgent.ts
+++ b/frontend/src/services/terminalAgent.ts
@@ -1,4 +1,4 @@
-import { SessionWrite } from '../../bindings/github.com/ys-ll/uniterm/app'
+import { queuedSessionWrite } from '../services/sessionWriter'
 import { getManagedTerminal } from '../services/terminalManager'
 import { useTabStore } from '../stores/tabStore'
 import { usePanelStore } from '../stores/panelStore'
@@ -438,7 +438,7 @@ export async function executeCommand(
   const fullCommand = buildCommand(command, shellPath, remoteOS)
   const newline = getShellNewline(shellPath, remoteOS)
 
-  await SessionWrite(sessionId, fullCommand + newline)
+  await queuedSessionWrite(sessionId, fullCommand + newline)
 
   const { promise } = watchOutput(sessionId, promptLine, timeoutMs, shouldCancel, startRow)
   const result = await promise
@@ -479,7 +479,7 @@ export async function startCommand(command: string, panelTitle?: string): Promis
   const { startRow } = capturePromptSnapshot(sessionId)
   const newline = getShellNewline(shellPath, remoteOS)
 
-  await SessionWrite(sessionId, command + newline)
+  await queuedSessionWrite(sessionId, command + newline)
 
   // Collect output for 3 seconds, then return
   return new Promise((resolve) => {
@@ -618,7 +618,7 @@ export async function sendTerminalKey(
     data += getShellNewline(shellPath, remoteOS)
   }
 
-  await SessionWrite(sessionId, data)
+  await queuedSessionWrite(sessionId, data)
 
   // For ctrl_c / ctrl_d: passively capture shell response for a short time.
   // No marker injection — avoids corrupting interactive program input.

--- a/frontend/src/services/zmodemService.ts
+++ b/frontend/src/services/zmodemService.ts
@@ -2,7 +2,6 @@ import Zmodem from 'zmodem.js/src/zmodem_browser'
 import {
   SessionEndZmodem,
   SessionWriteBinary,
-  SessionWrite,
   AppendFileBase64,
   FileSize,
   ReadFileChunkBase64,
@@ -11,6 +10,7 @@ import {
 } from '../../bindings/github.com/ys-ll/uniterm/app'
 import { Events } from '@wailsio/runtime'
 import { useZmodemStore } from '../stores/zmodemStore'
+import { queuedSessionWrite } from './sessionWriter'
 
 // Global dialog lock: prevents multiple BaseTerminal instances (e.g. from
 // KeepAlive-cached hidden tabs) from opening overlapping native dialogs for
@@ -137,7 +137,7 @@ export function startZmodemService(options: ZmodemServiceOptions) {
       await SessionWriteBinary(sessionId, arrayBufferToBase64(new Uint8Array(ABORT)))
 
       // 3. 发送 Ctrl+C 强制终止远程前台 sz 进程
-      await SessionWrite(sessionId, '\x03').catch(() => {})
+      queuedSessionWrite(sessionId, '\x03')
 
       // 4. 触发 handleReceive 中的 race / donePromise 强制退出
       // 不立即 SessionEndZmodem，等 handleReceive 自然退出后再清理


### PR DESCRIPTION
 Summary

 Under fast typing or IME (Input Method Editor) composition, Wails v3 dispatches each SessionWrite binding call in its   
 own goroutine. Two writes issued in quick succession can reach the PTY out of order, causing characters to appear       
 swapped or duplicated.

 This PR introduces a per-session write queue (queuedSessionWrite) that serializes writes on the JS side — at most one   
 write in flight, buffered until the previous settles. This guarantees PTY delivery order matches call order and merges  
 keystroke-sized writes into fewer IPC calls.

 Changes

 - Add frontend/src/services/sessionWriter.ts — queuedSessionWrite with per-session serialization queue
 - Add frontend/src/services/sessionWriter.test.ts — unit tests for ordering, batching, and error handling
 - Migrate all SessionWrite call sites in BaseTerminal.vue, HistoryPanel.vue, QuickCommandsPanel.vue, terminalAgent.ts,  
   and zmodemService.ts to queuedSessionWrite
 - Update useTerminal.ts write callback to use queued writes

 变更摘要

 在快速输入或使用输入法（IME）组合字符时，Wails v3 会为每次 SessionWrite 绑定调用分配独立的
 goroutine。两次快速连续的写入可能以乱序到达 PTY，导致字符顺序错乱或重复。

 本 PR 引入了按会话隔离的写入队列（queuedSessionWrite），在 JS
 侧序列化写入——同一时间仅允许一次写入进行中，缓冲的写入在前一次完成后才发送。这保证了 PTY
 的数据送达顺序与调用顺序一致，并将按键级别的小写入合并为更少的 IPC 调用。

 变更内容

 - 新增 frontend/src/services/sessionWriter.ts — 带按会话序列化队列的 queuedSessionWrite
 - 新增 frontend/src/services/sessionWriter.test.ts — 顺序、批处理和错误处理的单元测试
 - 将 BaseTerminal.vue、HistoryPanel.vue、QuickCommandsPanel.vue、terminalAgent.ts、zmodemService.ts 中所有 SessionWrite 
   调用迁移至 queuedSessionWrite
 - 更新 useTerminal.ts 的写入回调使用队列写入