### PR TITLE
fix(ssh): report the server's auth error when keyboard-interactive is rejected cold

### DIFF
--- a/backend/session/ssh_dial.go
+++ b/backend/session/ssh_dial.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"slices"
 	"strconv"
+	"strings"
 	"time"
 
 	"golang.org/x/crypto/ssh"
@@ -43,6 +45,57 @@ func dialSSHWithCipherFallback(addr string, config *ssh.ClientConfig, dial sshCo
 	return nil, fmt.Errorf("ssh handshake: %w", lastErr)
 }
 
+// splitSSHAuthMethods separates the password/key methods from the
+// keyboard-interactive fallback. The dialer tries them in two phases — see
+// dialSSHWithAuthRetry for why keyboard-interactive must not be offered on
+// the first handshake.
+func splitSSHAuthMethods(config ConnectionConfig, kbCallback ssh.KeyboardInteractiveChallenge) ([]ssh.AuthMethod, ssh.AuthMethod) {
+	methods := makeSSHAuthMethods(config, nil)
+	if kbCallback == nil {
+		return methods, nil
+	}
+	return methods, ssh.KeyboardInteractive(kbCallback)
+}
+
+// Markers within x/crypto's error strings. The library returns both as plain
+// fmt.Errorf values with no typed sentinel, so the message is the only
+// stable handle.
+const (
+	authExhaustedMarker  = "unable to authenticate"
+	kbdIntColdFailMarker = "unexpected message type 51 (expected 60)"
+)
+
+// dialSSHWithAuthRetry dials with the primary auth methods (password/key)
+// first, and retries once with keyboard-interactive added.
+//
+// x/crypto aborts the handshake with "ssh: unexpected message type 51
+// (expected 60)" when a server answers the keyboard-interactive initiation
+// with USERAUTH_FAILURE before any info request. RFC 4252 allows that reply
+// and OpenSSH's own client treats it as a plain rejection, but servers that
+// advertise keyboard-interactive yet fail it cold are common (root login
+// restricted to keys, dropbear without PAM), so offering keyboard-interactive
+// unconditionally turned every ordinary password rejection on those hosts
+// into that cryptic protocol error. Trying it only after the primary methods
+// are exhausted keeps prompt-based logins (OTP/2FA, keyboard-interactive-only
+// servers) working while a plain rejection surfaces as the server's own auth
+// error.
+func dialSSHWithAuthRetry(addr string, config *ssh.ClientConfig, kbAuth ssh.AuthMethod, dial sshConnDialer) (*ssh.Client, error) {
+	client, err := dialSSHWithCipherFallback(addr, config, dial)
+	if kbAuth == nil || err == nil || !strings.Contains(err.Error(), authExhaustedMarker) {
+		return client, err
+	}
+	retry := *config
+	retry.Auth = append(slices.Clone(config.Auth), kbAuth)
+	client, retryErr := dialSSHWithCipherFallback(addr, &retry, dial)
+	if retryErr == nil || !strings.Contains(retryErr.Error(), kbdIntColdFailMarker) {
+		return client, retryErr
+	}
+	// The server rejects keyboard-interactive outright; report the honest
+	// auth failure from the first handshake instead of x/crypto's protocol
+	// internals.
+	return nil, err
+}
+
 // dialSSHTCP dials addr (through the upstream proxy when non-nil), performs the
 // SSH handshake, and returns a *ssh.Client. Used by the SFTP and monitor
 // sessions, which previously dialed directly via ssh.Dial.
@@ -65,7 +118,7 @@ func DialSSHClient(config ConnectionConfig) (*ssh.Client, error) {
 	kb := func(user, instruction string, questions []string, echos []bool) ([]string, error) {
 		return nil, fmt.Errorf("keyboard-interactive not supported in this context")
 	}
-	authMethods := makeSSHAuthMethods(config, kb)
+	authMethods, kbAuth := splitSSHAuthMethods(config, kb)
 	addr := net.JoinHostPort(config.Host, strconv.Itoa(config.Port))
 	clientConfig := &ssh.ClientConfig{
 		User:            config.User,
@@ -73,7 +126,7 @@ func DialSSHClient(config ConnectionConfig) (*ssh.Client, error) {
 		Timeout:         30 * time.Second,
 		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
 	}
-	return dialSSHWithCipherFallback(addr, clientConfig, func() (net.Conn, error) {
+	return dialSSHWithAuthRetry(addr, clientConfig, kbAuth, func() (net.Conn, error) {
 		return net.DialTimeout("tcp", addr, clientConfig.Timeout)
 	})
 }

--- a/backend/session/ssh_dial_test.go
+++ b/backend/session/ssh_dial_test.go
@@ -1,0 +1,201 @@
+package session
+
+import (
+	"errors"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// Throwaway ed25519 host key generated for this test file only.
+const testHostKeyPEM = `-----BEGIN OPENSSH PRIVATE KEY-----
+b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+QyNTUxOQAAACDRZOogzYJH2+dHR2DzalwSpBRlruM7iyYOPB3U73OljQAAAJAyohktMqIZ
+LQAAAAtzc2gtZWQyNTUxOQAAACDRZOogzYJH2+dHR2DzalwSpBRlruM7iyYOPB3U73OljQ
+AAAEAQ+apRyVK0+7YQsk2Eo9jqx9EWht1aU8k2RMdUD4qIr9Fk6iDNgkfb50dHYPNqXBKk
+FGWu4zuLJg48HdTvc6WNAAAACmt4bkBreG4tcGMBAgM=
+-----END OPENSSH PRIVATE KEY-----`
+
+// startAuthTestServer serves SSH connections with the given callbacks on a
+// loopback port. The accept loop runs for the whole test because
+// dialSSHWithAuthRetry reconnects for its keyboard-interactive phase.
+func startAuthTestServer(t *testing.T, config *ssh.ServerConfig) string {
+	t.Helper()
+	signer, err := ssh.ParsePrivateKey([]byte(testHostKeyPEM))
+	if err != nil {
+		t.Fatalf("parse test host key: %v", err)
+	}
+	config.AddHostKey(signer)
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { ln.Close() })
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				_, chans, reqs, err := ssh.NewServerConn(conn, config)
+				if err != nil {
+					return
+				}
+				go ssh.DiscardRequests(reqs)
+				for newCh := range chans {
+					newCh.Reject(ssh.UnknownChannelType, "handshake-only test server")
+				}
+			}()
+		}
+	}()
+	return ln.Addr().String()
+}
+
+// dialAuthTest dials addr through the patched auth flow with a password-type
+// connection config, mirroring the interactive session's call shape.
+func dialAuthTest(t *testing.T, addr, password string, kb ssh.KeyboardInteractiveChallenge) (*ssh.Client, error) {
+	t.Helper()
+	methods, kbAuth := splitSSHAuthMethods(ConnectionConfig{AuthType: "password", Password: password}, kb)
+	config := &ssh.ClientConfig{
+		User:            "tester",
+		Auth:            methods,
+		Timeout:         5 * time.Second,
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+	}
+	return dialSSHWithAuthRetry(addr, config, kbAuth, func() (net.Conn, error) {
+		return net.DialTimeout("tcp", addr, config.Timeout)
+	})
+}
+
+// Server that advertises keyboard-interactive but rejects its initiation with
+// a bare USERAUTH_FAILURE — exactly what x/crypto's server does when
+// KeyboardInteractiveCallback errors before prompting, and what real servers
+// do when the method is unusable for the account (root restricted to keys,
+// dropbear without PAM). This is the shape that used to abort the handshake
+// with "unexpected message type 51 (expected 60)".
+func newColdKeyboardInteractiveServer(password string) *ssh.ServerConfig {
+	return &ssh.ServerConfig{
+		PasswordCallback: func(conn ssh.ConnMetadata, got []byte) (*ssh.Permissions, error) {
+			if string(got) == password {
+				return &ssh.Permissions{}, nil
+			}
+			return nil, errors.New("wrong password")
+		},
+		KeyboardInteractiveCallback: func(conn ssh.ConnMetadata, challenge ssh.KeyboardInteractiveChallenge) (*ssh.Permissions, error) {
+			return nil, errors.New("keyboard-interactive unavailable")
+		},
+	}
+}
+
+func TestDialSSHWithAuthRetryColdKeyboardInteractive(t *testing.T) {
+	addr := startAuthTestServer(t, newColdKeyboardInteractiveServer("right"))
+
+	t.Run("wrong password surfaces the server's auth error, not the 51/60 protocol leak", func(t *testing.T) {
+		_, err := dialAuthTest(t, addr, "wrong", func(user, instruction string, questions []string, echos []bool) ([]string, error) {
+			return nil, errors.New("unexpected prompt")
+		})
+		if err == nil {
+			t.Fatal("expected auth failure")
+		}
+		if strings.Contains(err.Error(), kbdIntColdFailMarker) {
+			t.Fatalf("error leaks the keyboard-interactive protocol failure: %v", err)
+		}
+		if !strings.Contains(err.Error(), authExhaustedMarker) {
+			t.Fatalf("error is not a plain auth failure: %v", err)
+		}
+	})
+
+	t.Run("right password connects without ever touching keyboard-interactive", func(t *testing.T) {
+		client, err := dialAuthTest(t, addr, "right", func(user, instruction string, questions []string, echos []bool) ([]string, error) {
+			return nil, errors.New("keyboard-interactive must not be reached when the password is right")
+		})
+		if err != nil {
+			t.Fatalf("expected success: %v", err)
+		}
+		client.Close()
+	})
+}
+
+// Server where password auth is rejected and login only completes through a
+// keyboard-interactive prompt (OTP/2FA boxes, SuSE-style password-over-kbdint).
+func newKeyboardInteractiveOnlyServer(password string) *ssh.ServerConfig {
+	return &ssh.ServerConfig{
+		PasswordCallback: func(conn ssh.ConnMetadata, got []byte) (*ssh.Permissions, error) {
+			return nil, errors.New("password auth disabled")
+		},
+		KeyboardInteractiveCallback: func(conn ssh.ConnMetadata, challenge ssh.KeyboardInteractiveChallenge) (*ssh.Permissions, error) {
+			_, err := challenge("", "", []string{"Password: "}, []bool{false})
+			if err != nil {
+				return nil, err
+			}
+			return &ssh.Permissions{}, nil
+		},
+	}
+}
+
+func TestDialSSHWithAuthRetryKeyboardInteractiveFallback(t *testing.T) {
+	addr := startAuthTestServer(t, newKeyboardInteractiveOnlyServer("otp-answer"))
+
+	client, err := dialAuthTest(t, addr, "unused", func(user, instruction string, questions []string, echos []bool) ([]string, error) {
+		answers := make([]string, len(questions))
+		for i := range questions {
+			answers[i] = "otp-answer"
+		}
+		return answers, nil
+	})
+	if err != nil {
+		t.Fatalf("expected keyboard-interactive fallback to authenticate: %v", err)
+	}
+	client.Close()
+}
+
+func TestSplitSSHAuthMethodsKeepsKeyboardInteractiveOutOfFirstPhase(t *testing.T) {
+	kb := func(user, instruction string, questions []string, echos []bool) ([]string, error) {
+		return nil, errors.New("unused")
+	}
+	methods, kbAuth := splitSSHAuthMethods(ConnectionConfig{AuthType: "password", Password: "pw"}, kb)
+	if len(methods) != 1 {
+		t.Fatalf("primary methods = %d entries, want exactly the password method", len(methods))
+	}
+	if kbAuth == nil {
+		t.Fatal("keyboard-interactive method missing from the retry phase")
+	}
+	methods, kbAuth = splitSSHAuthMethods(ConnectionConfig{AuthType: "password", Password: "pw"}, nil)
+	if len(methods) != 1 || kbAuth != nil {
+		t.Fatalf("nil callback must yield no retry method, got %d methods and kbAuth=%v", len(methods), kbAuth)
+	}
+}
+
+// Live probe for servers that reproduce issue-reported handshakes, e.g.
+// UNITERM_LIVE_SSH=10.10.10.3:22 go test -run TestLiveSSH ./backend/session/
+// Sends a dummy password only; at worst it burns one failed login attempt.
+func TestLiveSSHColdKeyboardInteractiveServer(t *testing.T) {
+	addr := os.Getenv("UNITERM_LIVE_SSH")
+	if addr == "" {
+		t.Skip("set UNITERM_LIVE_SSH=host[:port] to run")
+	}
+	host, portStr, err := net.SplitHostPort(addr)
+	if err != nil {
+		host, portStr = addr, "22"
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		t.Fatalf("bad UNITERM_LIVE_SSH port: %v", err)
+	}
+	_, err = dialAuthTest(t, net.JoinHostPort(host, strconv.Itoa(port)), "__uniterm_diag__", func(user, instruction string, questions []string, echos []bool) ([]string, error) {
+		return nil, errors.New("live probe does not answer challenges")
+	})
+	if err == nil {
+		t.Fatal("expected the dummy password to be rejected")
+	}
+	if strings.Contains(err.Error(), kbdIntColdFailMarker) {
+		t.Fatalf("handshake still leaks the keyboard-interactive protocol failure: %v", err)
+	}
+	t.Logf("live probe error (should be a plain auth failure): %v", err)
+}

--- a/backend/session/ssh_session.go
+++ b/backend/session/ssh_session.go
@@ -213,7 +213,7 @@ func (s *SSHSession) Connect(config ConnectionConfig) error {
 		return answers, nil
 	}
 
-	authMethods := makeSSHAuthMethods(config, kbCallback)
+	authMethods, kbAuth := splitSSHAuthMethods(config, kbCallback)
 	addr := net.JoinHostPort(config.Host, strconv.Itoa(config.Port))
 	clientConfig := &ssh.ClientConfig{
 		User:            config.User,
@@ -222,7 +222,7 @@ func (s *SSHSession) Connect(config ConnectionConfig) error {
 		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
 	}
 
-	client, err := dialSSHWithCipherFallback(addr, clientConfig, func() (net.Conn, error) {
+	client, err := dialSSHWithAuthRetry(addr, clientConfig, kbAuth, func() (net.Conn, error) {
 		return dialFirstHop(addr, config.Proxy)
 	})
 	if err != nil {

--- a/backend/session/test_connection.go
+++ b/backend/session/test_connection.go
@@ -84,7 +84,7 @@ func probeSSH(config ConnectionConfig) (string, error) {
 	kb := func(user, instruction string, questions []string, echos []bool) ([]string, error) {
 		return nil, fmt.Errorf("interactive auth not allowed during connection test")
 	}
-	authMethods := makeSSHAuthMethods(config, kb)
+	authMethods, kbAuth := splitSSHAuthMethods(config, kb)
 	addr := net.JoinHostPort(config.Host, strconv.Itoa(config.Port))
 	clientConfig := &ssh.ClientConfig{
 		User:            config.User,
@@ -94,7 +94,7 @@ func probeSSH(config ConnectionConfig) (string, error) {
 	}
 	// Honor a materialized proxy (set by App.materializeProxy) on the first hop,
 	// mirroring the terminal session's dial path.
-	client, err := dialSSHWithCipherFallback(addr, clientConfig, func() (net.Conn, error) {
+	client, err := dialSSHWithAuthRetry(addr, clientConfig, kbAuth, func() (net.Conn, error) {
 		return dialFirstHop(addr, config.Proxy)
 	})
 	if err != nil {
@@ -111,7 +111,7 @@ func probeSFTP(config ConnectionConfig) (string, error) {
 	kb := func(user, instruction string, questions []string, echos []bool) ([]string, error) {
 		return nil, fmt.Errorf("interactive auth not allowed during connection test")
 	}
-	authMethods := makeSSHAuthMethods(config, kb)
+	authMethods, kbAuth := splitSSHAuthMethods(config, kb)
 	addr := net.JoinHostPort(config.Host, strconv.Itoa(config.Port))
 	clientConfig := &ssh.ClientConfig{
 		User:            config.User,
@@ -119,7 +119,7 @@ func probeSFTP(config ConnectionConfig) (string, error) {
 		Timeout:         15 * time.Second,
 		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
 	}
-	client, err := dialSSHWithCipherFallback(addr, clientConfig, func() (net.Conn, error) {
+	client, err := dialSSHWithAuthRetry(addr, clientConfig, kbAuth, func() (net.Conn, error) {
 		return dialFirstHop(addr, config.Proxy)
 	})
 	if err != nil {
@@ -140,7 +140,7 @@ func probeSCP(config ConnectionConfig) (string, error) {
 	kb := func(user, instruction string, questions []string, echos []bool) ([]string, error) {
 		return nil, fmt.Errorf("interactive auth not allowed during connection test")
 	}
-	authMethods := makeSSHAuthMethods(config, kb)
+	authMethods, kbAuth := splitSSHAuthMethods(config, kb)
 	addr := net.JoinHostPort(config.Host, strconv.Itoa(config.Port))
 	clientConfig := &ssh.ClientConfig{
 		User:            config.User,
@@ -148,7 +148,7 @@ func probeSCP(config ConnectionConfig) (string, error) {
 		Timeout:         15 * time.Second,
 		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
 	}
-	client, err := dialSSHWithCipherFallback(addr, clientConfig, func() (net.Conn, error) {
+	client, err := dialSSHWithAuthRetry(addr, clientConfig, kbAuth, func() (net.Conn, error) {
 		return dialFirstHop(addr, config.Proxy)
 	})
 	if err != nil {


### PR DESCRIPTION
## Summary

Password/key auth failures against servers that advertise `keyboard-interactive` but reject it outright currently abort the handshake with

```
ssh: handshake failed: ssh: unexpected message type 51 (expected 60)
```

instead of an authentication error, hiding the real cause from the user. This PR moves keyboard-interactive into a second-phase retry so a plain rejection surfaces as the server's own auth error, while prompt-driven logins (OTP/2FA, keyboard-interactive-only servers) keep working.

## Reproduction

Against an affected host (an OpenSSH 10.0 box advertising `publickey,password,keyboard-interactive`, where root cannot use a password):

- `x/crypto` client with `ssh.Password` only → clean `unable to authenticate, attempted methods [none password], no supported methods remain`
- same client with `ssh.Password` + `ssh.KeyboardInteractive` (what `makeSSHAuthMethods` builds today) → `unexpected message type 51 (expected 60)`, reproduced exactly

## Root cause

`makeSSHAuthMethods` appends keyboard-interactive as an unconditional fallback, so whenever the password/key attempt fails the client sends a keyboard-interactive initiation. Servers that advertise the method but fail it cold answer `SSH_MSG_USERAUTH_FAILURE` (51) before ever sending `SSH_MSG_USERAUTH_INFO_REQUEST` (60) — typical when the method is unusable for the account (root restricted to keys, dropbear without PAM). `x/crypto`'s `KeyboardInteractiveChallenge` treats that reply as a protocol violation and returns `unexpectedMessageError`, killing the handshake.

RFC 4252 allows the failure reply at that point, and the OpenSSH client just logs it as a plain rejection and moves on — so treating it as fatal is stricter than the reference client.

## Fix

- `splitSSHAuthMethods` separates the password/key methods from the keyboard-interactive method
- `dialSSHWithAuthRetry` dials with the primary methods first; only if authentication is exhausted does it retry once with keyboard-interactive added. If that retry dies with the cold-failure protocol error, the first handshake's honest `unable to authenticate` error is reported instead
- all `makeSSHAuthMethods` call sites with a challenge callback (interactive session, the three connection probes, container runner) go through it

## Testing

New `backend/session/ssh_dial_test.go` spins an in-process `x/crypto` server whose `KeyboardInteractiveCallback` errors without prompting — the exact cold shape:

- wrong password against the cold server → plain auth error, no protocol leak
- right password against the cold server → connects, keyboard-interactive never reached
- password-rejecting server with a real prompt (2FA shape) → still authenticates through the fallback phase
- `UNITERM_LIVE_SSH=host[:port] go test -run TestLiveSSH ./backend/session/` probes a real affected host (sends a dummy password only)

`go test ./backend/session/` passes. Also verified end-to-end against a real affected host: the app now reports `unable to authenticate, attempted methods [none password], no supported methods remain` instead of the protocol error.

## Notes

A matching (smaller) fix could arguably live in `golang.org/x/crypto/ssh` itself: a `USERAUTH_FAILURE` received before any info request could return a plain `authFailure` rather than `unexpectedMessageError`. Happy to file that upstream too — but the two-phase dial here fixes it for users regardless of the library's behavior.