### PR TITLE
feat(local): add administrator Command Prompt and PowerShell terminals

### DIFF
--- a/app_windows.go
+++ b/app_windows.go
@@ -11,6 +11,7 @@ import (
 	"unicode/utf16"
 	"unsafe"
 
+	"github.com/ys-ll/uniterm/backend/session"
 	"golang.org/x/sys/windows"
 )
 
@@ -59,6 +60,18 @@ func (a *App) GetAvailableShells() []string {
 	if distros, _ := listWSLDistros(); len(distros) > 0 {
 		for _, d := range distros {
 			shells = append(shells, "wsl://"+d)
+		}
+	}
+	// Administrator variants ride on the detected cmd/powershell paths (UAC
+	// elevation via the broker in backend/session/local_admin_windows.go).
+	// Only offered when uniTerm itself is unelevated — as admin they would be
+	// indistinguishable duplicates of the plain entries.
+	if !session.IsProcessElevated() {
+		for _, sh := range shells {
+			base := strings.ToLower(filepath.Base(sh))
+			if base == "cmd.exe" || base == "powershell.exe" {
+				shells = append(shells, session.AdminShellPathPrefix+sh)
+			}
 		}
 	}
 	return shells

--- a/backend/session/local_admin_broker_windows.go
+++ b/backend/session/local_admin_broker_windows.go
@@ -1,0 +1,187 @@
+//go:build windows
+// +build windows
+
+package session
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/UserExistsError/conpty"
+	"golang.org/x/sys/windows"
+)
+
+// RunLocalPtyBroker implements uniTerm's administrator-shell broker mode. The
+// unelevated app launches a copy of itself with the "runas" verb and the
+// --local-pty-broker argument; that elevated copy (this code) never touches
+// the webview or app stores — it spawns the requested shell inside a ConPTY
+// and relays bytes between the pseudo console and the control pipe until
+// either side goes away. It returns true when args selected broker mode; main
+// exits without initializing the app in that case.
+func RunLocalPtyBroker(args []string) bool {
+	if len(args) != 3 || args[1] != "--local-pty-broker" {
+		return false
+	}
+	os.Exit(serveLocalPtyBroker(args[2]))
+	return true
+}
+
+// serveLocalPtyBroker serves one elevated shell and returns the process exit
+// code, so tests can run it in-process.
+func serveLocalPtyBroker(pipeName string) int {
+	pipe, err := dialPtyBrokerPipe(pipeName)
+	if err != nil {
+		return 1
+	}
+	// Announce the connection; the app waits for this frame instead of
+	// ConnectNamedPipe (see startElevatedPty).
+	if err := ptyFrameWriteTo(pipe, ptyFrameHello, nil); err != nil {
+		pipe.Close()
+		return 1
+	}
+
+	frameType, payload, err := ptyFrameReadFrom(pipe)
+	if err != nil {
+		pipe.Close()
+		return 1
+	}
+	if frameType != ptyFrameSpawn {
+		pipe.Close()
+		return 1
+	}
+	var spec localPtySpawn
+	if err := json.Unmarshal(payload, &spec); err != nil {
+		pipe.Close()
+		return 1
+	}
+
+	if !conpty.IsConPtyAvailable() {
+		noteAndClose(pipe, "ConPTY is not available on this Windows version")
+		return 1
+	}
+
+	cols, rows := spec.Cols, spec.Rows
+	if cols <= 0 || rows <= 0 {
+		cols, rows = 80, 24
+	}
+	cpty, err := conpty.Start(spec.CommandLine,
+		conpty.ConPtyDimensions(cols, rows),
+		conpty.ConPtyWorkDir(spec.WorkDir),
+		conpty.ConPtyEnv(os.Environ()))
+	if err != nil {
+		noteAndClose(pipe, fmt.Sprintf("start shell: %v", err))
+		return 1
+	}
+
+	// The app side vanished (tab closed, app quit, pipe broke): kill the
+	// shell so it cannot linger elevated with no one attached.
+	pipeBroken := make(chan struct{})
+	shellExited := make(chan struct{})
+	var brokenOnce, killOnce sync.Once
+	signalPipeBroken := func() { brokenOnce.Do(func() { close(pipeBroken) }) }
+	terminate := func() {
+		killOnce.Do(func() {
+			cpty.Close()
+			// ClosePseudoConsole ends the console session; make sure the
+			// client itself is gone even if it somehow survived.
+			if proc, err := windows.OpenProcess(windows.PROCESS_TERMINATE, false, uint32(cpty.Pid())); err == nil {
+				windows.TerminateProcess(proc, 1)
+				windows.CloseHandle(proc)
+			}
+		})
+	}
+
+	// ConPTY output → app.
+	go func() {
+		buf := make([]byte, 4096)
+		for {
+			n, err := cpty.Read(buf)
+			if n > 0 {
+				if ptyFrameWriteTo(pipe, ptyFrameData, buf[:n]) != nil {
+					signalPipeBroken()
+					return
+				}
+			}
+			if err != nil {
+				close(shellExited)
+				return
+			}
+		}
+	}()
+
+	// App input / resize → ConPTY.
+	go func() {
+		for {
+			frameType, payload, err := ptyFrameReadFrom(pipe)
+			if err != nil {
+				signalPipeBroken()
+				return
+			}
+			switch frameType {
+			case ptyFrameInput:
+				if len(payload) > 0 {
+					cpty.Write(payload)
+				}
+			case ptyFrameResize:
+				if len(payload) >= 4 {
+					cols := int(payload[0]) | int(payload[1])<<8
+					rows := int(payload[2]) | int(payload[3])<<8
+					cpty.Resize(cols, rows)
+				}
+			}
+		}
+	}()
+
+	select {
+	case <-pipeBroken:
+		terminate()
+		pipe.Close()
+		return 1
+	case <-shellExited:
+		ptyFrameWriteTo(pipe, ptyFrameExited, nil)
+		pipe.Close()
+		return 0
+	}
+}
+
+// noteAndClose tells the app why no shell could be started: the note travels
+// as PTY output (the terminal shows it), the exited frame ends the session.
+func noteAndClose(pipe *os.File, note string) {
+	ptyFrameWriteTo(pipe, ptyFrameData, []byte("\r\n[administrator shell: "+note+"]\r\n"))
+	ptyFrameWriteTo(pipe, ptyFrameExited, nil)
+	pipe.Close()
+}
+
+// dialPtyBrokerPipe connects to the app's control pipe. The pipe exists
+// before the broker is launched, but retry briefly anyway to absorb
+// scheduling jitter between ShellExecuteEx returning and the broker starting.
+func dialPtyBrokerPipe(pipeName string) (*os.File, error) {
+	deadline := time.Now().Add(10 * time.Second)
+	namePtr, err := windows.UTF16PtrFromString(pipeName)
+	if err != nil {
+		return nil, err
+	}
+	for {
+		// FILE_FLAG_OVERLAPPED matches the server side: os.File routes the
+		// handle through Go's async I/O machinery, which is what lets the
+		// relay's blocked Read coexist with blocked Writes on this handle.
+		handle, err := windows.CreateFile(
+			namePtr,
+			windows.GENERIC_READ|windows.GENERIC_WRITE,
+			0, nil, windows.OPEN_EXISTING, windows.FILE_FLAG_OVERLAPPED, 0)
+		if err == nil {
+			return os.NewFile(uintptr(handle), pipeName), nil
+		}
+		if !errors.Is(err, windows.ERROR_PIPE_BUSY) && !errors.Is(err, windows.ERROR_FILE_NOT_FOUND) {
+			return nil, err
+		}
+		if time.Now().After(deadline) {
+			return nil, err
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}

--- a/backend/session/local_admin_stub.go
+++ b/backend/session/local_admin_stub.go
@@ -1,0 +1,10 @@
+//go:build !windows
+// +build !windows
+
+package session
+
+// RunLocalPtyBroker is the Windows administrator-shell broker hook; on other
+// platforms administrator local terminals don't exist and this is a no-op.
+func RunLocalPtyBroker(args []string) bool {
+	return false
+}

--- a/backend/session/local_admin_test.go
+++ b/backend/session/local_admin_test.go
@@ -1,0 +1,181 @@
+//go:build windows
+// +build windows
+
+package session
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/UserExistsError/conpty"
+)
+
+func TestParseAdminShellPath(t *testing.T) {
+	const cmdPath = `C:\Windows\System32\cmd.exe`
+	for _, tc := range []struct {
+		name, in, want string
+		ok             bool
+	}{
+		{"prefixed", AdminShellPathPrefix + cmdPath, cmdPath, true},
+		{"prefixed uppercase", "ADMIN://" + cmdPath, cmdPath, true},
+		{"plain path", cmdPath, "", false},
+		{"wsl scheme", "wsl://Ubuntu", "", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := ParseAdminShellPath(tc.in)
+			if ok != tc.ok || got != tc.want {
+				t.Fatalf("ParseAdminShellPath(%q) = (%q, %v), want (%q, %v)", tc.in, got, ok, tc.want, tc.ok)
+			}
+		})
+	}
+}
+
+func TestShellNameAdminSuffix(t *testing.T) {
+	if got := shellName(AdminShellPathPrefix + `C:\Windows\System32\cmd.exe`); got != "cmd (Admin)" {
+		t.Fatalf("shellName(admin cmd) = %q, want %q", got, "cmd (Admin)")
+	}
+	if got := shellName(`C:\Windows\System32\cmd.exe`); got == "cmd (Admin)" {
+		t.Fatalf("shellName(plain cmd) = %q, must not carry the Admin suffix", got)
+	}
+}
+
+// TestAdminPtyBrokerRelay drives the full broker protocol in-process, without
+// elevation: the test plays the app side (pipe server, spawn frame, adminPty)
+// while serveLocalPtyBroker runs in a goroutine playing the broker.
+func TestAdminPtyBrokerRelay(t *testing.T) {
+	if !conpty.IsConPtyAvailable() {
+		t.Skip("ConPTY not available on this Windows version")
+	}
+
+	suffix := make([]byte, 8)
+	if _, err := rand.Read(suffix); err != nil {
+		t.Fatal(err)
+	}
+	pipeName := `\\.\pipe\uniterm-pty-test-` + hex.EncodeToString(suffix)
+
+	handle, err := createPtyPipeServer(pipeName)
+	if err != nil {
+		t.Fatalf("pipe server: %v", err)
+	}
+	brokerDone := make(chan int, 1)
+
+	p := &adminPty{f: os.NewFile(uintptr(handle), pipeName)}
+	defer p.Close()
+
+	go func() { brokerDone <- serveLocalPtyBroker(pipeName) }()
+
+	// Same handshake as production: broker hello, then the spawn request.
+	brokerGone := make(chan struct{})
+	if err := p.waitBrokerHello(brokerGone, 10*time.Second); err != nil {
+		t.Fatalf("handshake: %v", err)
+	}
+
+	comspec := os.Getenv("ComSpec")
+	if comspec == "" {
+		comspec = `C:\Windows\System32\cmd.exe`
+	}
+	specBytes, err := json.Marshal(localPtySpawn{
+		CommandLine: fmt.Sprintf(`"%s" /k`, comspec),
+		Cols:        80,
+		Rows:        25,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := ptyFrameWriteTo(p.f, ptyFrameSpawn, specBytes); err != nil {
+		t.Fatalf("send spawn: %v", err)
+	}
+
+	// ConPTY suppresses cmd's classic banner, so drive the round trip
+	// directly: the echoed command text plus its output must come back
+	// through the relay.
+	const marker = "UNITERM_ADMIN_RELAY_OK"
+	if _, err := p.Write([]byte("echo " + marker + "\r\n")); err != nil {
+		t.Fatalf("write input: %v", err)
+	}
+	waitForMarker(t, p, marker, 20*time.Second)
+
+	if err := p.Resize(100, 30); err != nil {
+		t.Fatalf("resize: %v", err)
+	}
+
+	// Closing the pipe must make the broker kill the shell and exit — an
+	// elevated process must never linger without its owner.
+	p.Close()
+	select {
+	case code := <-brokerDone:
+		t.Logf("broker exited with code %d", code)
+	case <-time.After(10 * time.Second):
+		t.Fatal("broker did not exit after the control pipe closed")
+	}
+}
+
+// waitForMarker accumulates relayed PTY output until substr appears. The
+// watchdog closes the pipe on timeout so a blocked read unwinds and the
+// failure path actually fires instead of hanging to the test timeout.
+func waitForMarker(t *testing.T, p *adminPty, substr string, timeout time.Duration) {
+	t.Helper()
+	type outcome struct {
+		acc []byte
+		err error
+	}
+	done := make(chan outcome, 1)
+	go func() {
+		acc := make([]byte, 0, 8192)
+		buf := make([]byte, 4096)
+		for {
+			n, err := p.Read(buf)
+			acc = append(acc, buf[:n]...)
+			if bytes.Contains(acc, []byte(substr)) {
+				done <- outcome{acc, nil}
+				return
+			}
+			if err != nil {
+				done <- outcome{acc, err}
+				return
+			}
+		}
+	}()
+	select {
+	case o := <-done:
+		if o.err != nil {
+			t.Fatalf("relay closed before %q appeared (saw %q): %v", substr, truncateOutput(o.acc), o.err)
+		}
+	case <-time.After(timeout):
+		p.Close()
+		t.Fatalf("timed out waiting for %q", substr)
+	}
+}
+
+func truncateOutput(b []byte) string {
+	const max = 512
+	if len(b) > max {
+		return string(b[:max]) + "..."
+	}
+	return string(b)
+}
+
+// TestFrameRoundTrip pins the wire format: type/length framing with u16
+// little-endian payload lengths.
+func TestFrameRoundTrip(t *testing.T) {
+	payloads := [][]byte{nil, []byte("x"), bytes.Repeat([]byte{0xAB}, ptyFrameMaxPayload)}
+	for _, want := range payloads {
+		var buf bytes.Buffer
+		if err := ptyFrameWriteTo(&buf, ptyFrameData, want); err != nil {
+			t.Fatalf("write frame (len %d): %v", len(want), err)
+		}
+		gotType, gotPayload, err := ptyFrameReadFrom(&buf)
+		if err != nil {
+			t.Fatalf("read frame (len %d): %v", len(want), err)
+		}
+		if gotType != ptyFrameData || !bytes.Equal(gotPayload, want) {
+			t.Fatalf("round trip mismatch: type=%d len=%d want len=%d", gotType, len(gotPayload), len(want))
+		}
+	}
+}

--- a/backend/session/local_admin_windows.go
+++ b/backend/session/local_admin_windows.go
@@ -1,0 +1,384 @@
+//go:build windows
+// +build windows
+
+package session
+
+import (
+	"crypto/rand"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sync"
+	"time"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// AdminShellPathPrefix marks a local-terminal ShellPath that must be launched
+// with administrator privileges (UAC elevation), e.g.
+// "admin://C:\Windows\System32\cmd.exe". It mirrors the wsl:// scheme: the
+// prefix carries the launch mode, the rest is the ordinary shell path.
+const AdminShellPathPrefix = "admin://"
+
+// errElevationCancelled reports that the user dismissed the UAC prompt.
+var errElevationCancelled = errors.New("the UAC elevation prompt was cancelled")
+
+// ParseAdminShellPath splits an admin:// ShellPath into the plain shell path.
+// ok is false when path does not carry the admin:// prefix.
+func ParseAdminShellPath(path string) (inner string, ok bool) {
+	const prefix = AdminShellPathPrefix
+	if len(path) < len(prefix) || lowerASCII(path[:len(prefix)]) != prefix {
+		return "", false
+	}
+	return path[len(prefix):], true
+}
+
+// lowerASCII is strings.ToLower restricted to the prefix check — the prefix is
+// pure ASCII so a full Unicode lowercase pass is unnecessary.
+func lowerASCII(s string) string {
+	b := []byte(s)
+	for i := range b {
+		if b[i] >= 'A' && b[i] <= 'Z' {
+			b[i] += 'a' - 'A'
+		}
+	}
+	return string(b)
+}
+
+// IsProcessElevated reports whether the current process runs with an elevated
+// (administrator) token. Used to skip the elevation dance when uniTerm itself
+// already runs as administrator, and to hide the admin shell options from the
+// connection form in that case (they would be indistinguishable duplicates).
+func IsProcessElevated() bool {
+	var token windows.Token
+	if err := windows.OpenProcessToken(windows.CurrentProcess(), windows.TOKEN_QUERY, &token); err != nil {
+		return false
+	}
+	defer token.Close()
+	var elevation uint32
+	var returned uint32
+	if err := windows.GetTokenInformation(token, windows.TokenElevation, (*byte)(unsafe.Pointer(&elevation)), uint32(unsafe.Sizeof(elevation)), &returned); err != nil {
+		return false
+	}
+	return elevation != 0
+}
+
+// localPtySpawn is the spawn request the unelevated app sends to the elevated
+// broker once their control pipe is connected. Traveling as the first pipe
+// message (instead of ShellExecuteEx parameters) avoids re-quoting a command
+// line through argv.
+type localPtySpawn struct {
+	CommandLine string `json:"commandLine"`
+	WorkDir     string `json:"workDir,omitempty"`
+	Cols        int    `json:"cols"`
+	Rows        int    `json:"rows"`
+}
+
+// Frame types of the broker pipe protocol. Every message is
+// [type:1][length:2 little-endian][payload]; payload length is u16 so the
+// largest frame is 64 KiB and writers must chunk larger writes.
+const (
+	ptyFrameData   = 1 // broker → app: PTY output bytes
+	ptyFrameInput  = 2 // app → broker: user keystrokes
+	ptyFrameResize = 3 // app → broker: payload cols u16 LE, rows u16 LE
+	ptyFrameExited = 4 // broker → app: the shell exited (payload: optional note)
+	ptyFrameSpawn  = 5 // app → broker: localPtySpawn JSON, sent once on connect
+	ptyFrameHello  = 6 // broker → app: empty payload announcing the connection
+)
+
+const ptyFrameHeaderSize = 3
+const ptyFrameMaxPayload = 0xFFFF
+
+func ptyFrameWriteTo(w io.Writer, frameType byte, payload []byte) error {
+	head := [ptyFrameHeaderSize]byte{frameType, byte(len(payload)), byte(len(payload) >> 8)}
+	if _, err := w.Write(head[:]); err != nil {
+		return err
+	}
+	if len(payload) == 0 {
+		return nil
+	}
+	_, err := w.Write(payload)
+	return err
+}
+
+// ptyFrameReadFrom reads one complete frame. io.EOF from the underlying pipe
+// (broken by either side) propagates unchanged; short reads become
+// io.ErrUnexpectedEOF via io.ReadFull.
+func ptyFrameReadFrom(r io.Reader) (frameType byte, payload []byte, err error) {
+	head := make([]byte, ptyFrameHeaderSize)
+	if _, err = io.ReadFull(r, head); err != nil {
+		return 0, nil, err
+	}
+	n := int(head[1]) | int(head[2])<<8
+	payload = make([]byte, n)
+	if _, err = io.ReadFull(r, payload); err != nil {
+		return 0, nil, err
+	}
+	return head[0], payload, nil
+}
+
+// waitBrokerHello blocks until the broker announces its connection with the
+// hello frame. Until the broker's first CreateFile lands, the pipe sits in
+// listening state and reads fail fast with ERROR_PIPE_LISTENING — retried
+// with a short backoff until the deadline (Go's overlapped deadline support
+// bounds the whole wait). brokerGone lets a crashed broker fail fast.
+func (p *adminPty) waitBrokerHello(brokerGone <-chan struct{}, timeout time.Duration) error {
+	if err := p.f.SetDeadline(time.Now().Add(timeout)); err != nil {
+		return fmt.Errorf("deadline: %w", err)
+	}
+	defer p.f.SetDeadline(time.Time{})
+	for {
+		frameType, _, err := ptyFrameReadFrom(p.f)
+		switch {
+		case err == nil && frameType == ptyFrameHello:
+			return nil
+		case err == nil:
+			return fmt.Errorf("unexpected frame type %d", frameType)
+		case errors.Is(err, windows.ERROR_PIPE_LISTENING):
+			select {
+			case <-brokerGone:
+				return errors.New("elevated broker exited before connecting")
+			case <-time.After(50 * time.Millisecond):
+			}
+		default:
+			return err
+		}
+	}
+}
+
+// adminPty is the app-side half of an elevated local shell: a ConPTY running
+// inside the elevated broker process, relayed over a named pipe restricted to
+// the current user. It implements the pieces LocalSession needs from a ConPTY
+// (Read/Write/Resize/Close) so the session code can treat both alike.
+type adminPty struct {
+	f *os.File
+
+	writeMu sync.Mutex
+	pending []byte // undelivered data-frame bytes (Read's buffer may be smaller)
+	exited  bool
+}
+
+// startElevatedPty launches uniTerm's PTY broker with the "runas" verb (which
+// pops the UAC prompt), waits for the broker to connect back over a named pipe
+// that only the current user may open, and hands it the spawn request.
+func startElevatedPty(spec localPtySpawn) (*adminPty, error) {
+	suffix := make([]byte, 8)
+	if _, err := rand.Read(suffix); err != nil {
+		return nil, fmt.Errorf("pipe name: %w", err)
+	}
+	pipeName := `\\.\pipe\uniterm-pty-` + hex.EncodeToString(suffix)
+
+	handle, err := createPtyPipeServer(pipeName)
+	if err != nil {
+		return nil, fmt.Errorf("create pipe: %w", err)
+	}
+
+	exe, err := os.Executable()
+	if err != nil {
+		windows.CloseHandle(handle)
+		return nil, fmt.Errorf("locate executable: %w", err)
+	}
+	brokerProc, err := shellExecuteRunAs(exe, "--local-pty-broker "+pipeName)
+	if err != nil {
+		windows.CloseHandle(handle)
+		return nil, err
+	}
+	if brokerProc != 0 {
+		defer windows.CloseHandle(brokerProc)
+	}
+
+	// Deliberately NO ConnectNamedPipe here: an overlapped handle whose
+	// connect went through ConnectNamedPipe silently black-holes every later
+	// read completion under Go's I/O machinery (verified against a minimal
+	// reproduction). A freshly created pipe instance already accepts client
+	// connections on its own — the broker announces itself with a hello
+	// frame, which doubles as the connect synchronization point.
+	p := &adminPty{f: os.NewFile(uintptr(handle), pipeName)}
+
+	// Bail early when the broker process dies (UAC approved yet the process
+	// crashed, killed) instead of riding out the full hello timeout.
+	brokerGone := make(chan struct{})
+	if brokerProc != 0 {
+		go func() {
+			windows.WaitForSingleObject(brokerProc, windows.INFINITE)
+			close(brokerGone)
+		}()
+	}
+
+	if err := p.waitBrokerHello(brokerGone, 30*time.Second); err != nil {
+		p.Close()
+		return nil, fmt.Errorf("broker handshake: %w", err)
+	}
+
+	specBytes, err := json.Marshal(spec)
+	if err == nil {
+		err = ptyFrameWriteTo(p.f, ptyFrameSpawn, specBytes)
+	}
+	if err != nil {
+		p.Close()
+		return nil, fmt.Errorf("send spawn request: %w", err)
+	}
+	return p, nil
+}
+
+// createPtyPipeServer creates the broker-side-connectable pipe. The explicit
+// security descriptor grants full access to the creating user only — without
+// it the default pipe DACL would still keep other low-integrity processes out,
+// but spelling it out documents that the pipe carries an administrator shell's
+// I/O and must not be reachable by anyone else on the machine.
+func createPtyPipeServer(pipeName string) (windows.Handle, error) {
+	token, err := windows.OpenCurrentProcessToken()
+	if err != nil {
+		return 0, err
+	}
+	defer token.Close()
+	user, err := token.GetTokenUser()
+	if err != nil {
+		return 0, err
+	}
+	sd, err := windows.SecurityDescriptorFromString("D:P(A;;GA;;;" + user.User.Sid.String() + ")")
+	if err != nil {
+		return 0, err
+	}
+	sa := &windows.SecurityAttributes{SecurityDescriptor: sd}
+	namePtr, err := windows.UTF16PtrFromString(pipeName)
+	if err != nil {
+		return 0, err
+	}
+	// FILE_FLAG_OVERLAPPED is required: os.File drives overlapped handles
+	// through Go's async I/O machinery, which is what makes a concurrent
+	// blocked Read and blocked Write on the SAME pipe handle work (the relay
+	// reads output while the session writes keystrokes). Sync-mode handles
+	// deadlock exactly there.
+	return windows.CreateNamedPipe(
+		namePtr,
+		windows.PIPE_ACCESS_DUPLEX|windows.FILE_FLAG_FIRST_PIPE_INSTANCE|windows.FILE_FLAG_OVERLAPPED,
+		windows.PIPE_TYPE_BYTE|windows.PIPE_READMODE_BYTE|windows.PIPE_WAIT|windows.PIPE_REJECT_REMOTE_CLIENTS,
+		1, 65536, 65536, 0, sa)
+}
+
+// shellExecuteRunAs launches target with the "runas" verb, which routes the
+// launch through UAC. Returns the spawned process handle (the caller closes
+// it), or errElevationCancelled when the user dismissed the prompt.
+func shellExecuteRunAs(target, parameters string) (windows.Handle, error) {
+	// SHELLEXECUTEINFOW, laid out for natural x64 alignment: field order and
+	// types match the Win32 struct so unsafe casting stays valid.
+	type shellExecuteInfo struct {
+		cbSize         uint32
+		fMask          uint32
+		hwnd           windows.HWND
+		lpVerb         uintptr
+		lpFile         uintptr
+		lpParameters   uintptr
+		lpDirectory    uintptr
+		nShow          int32
+		hInstApp       uintptr
+		lpIDList       uintptr
+		lpClass        uintptr
+		hkeyClass      windows.Handle
+		dwHotKey       uint32
+		hIconOrMonitor uintptr
+		hProcess       windows.Handle
+	}
+
+	const (
+		seeMaskNOCLOSEPROCESS = 0x00000040
+		seeMaskNOASYNC        = 0x00001000
+		swHide                = 0
+	)
+
+	verb, _ := windows.UTF16PtrFromString("runas")
+	file, _ := windows.UTF16PtrFromString(target)
+	params, _ := windows.UTF16PtrFromString(parameters)
+	info := shellExecuteInfo{
+		cbSize:       uint32(unsafe.Sizeof(shellExecuteInfo{})),
+		fMask:        seeMaskNOCLOSEPROCESS | seeMaskNOASYNC,
+		lpVerb:       uintptr(unsafe.Pointer(verb)),
+		lpFile:       uintptr(unsafe.Pointer(file)),
+		lpParameters: uintptr(unsafe.Pointer(params)),
+		nShow:        swHide,
+	}
+
+	shell32 := windows.NewLazySystemDLL("shell32.dll")
+	procShellExecuteExW := shell32.NewProc("ShellExecuteExW")
+	ret, _, _ := procShellExecuteExW.Call(uintptr(unsafe.Pointer(&info)))
+	if ret == 0 {
+		// Cancelled UAC is the common failure and deserves its own message;
+		// anything else surfaces the raw code for diagnosis.
+		if errors.Is(windows.GetLastError(), windows.ERROR_CANCELLED) {
+			return 0, errElevationCancelled
+		}
+		return 0, fmt.Errorf("ShellExecuteEx(runas) failed: %w", windows.GetLastError())
+	}
+	return info.hProcess, nil
+}
+
+// Read delivers PTY output bytes, transparently unwrapping data frames and
+// turning the broker's exited frame into io.EOF once all preceding output has
+// been handed out. Only the session's readLoop goroutine may call it.
+func (p *adminPty) Read(buf []byte) (int, error) {
+	for {
+		if len(p.pending) > 0 {
+			n := copy(buf, p.pending)
+			p.pending = p.pending[n:]
+			return n, nil
+		}
+		if p.exited {
+			return 0, io.EOF
+		}
+		frameType, payload, err := ptyFrameReadFrom(p.f)
+		if err != nil {
+			// A broken pipe means the broker (or the whole elevated shell)
+			// is gone — the same clean-EOF treatment the ConPTY path gives
+			// post-exit read errors.
+			return 0, io.EOF
+		}
+		switch frameType {
+		case ptyFrameData:
+			p.pending = append(p.pending[:0], payload...)
+		case ptyFrameExited:
+			p.exited = true
+		}
+	}
+}
+
+// Write sends user keystrokes to the broker, chunking to the u16 frame limit
+// (pasted text can exceed 64 KiB in one call).
+func (p *adminPty) Write(data []byte) (int, error) {
+	p.writeMu.Lock()
+	defer p.writeMu.Unlock()
+	written := 0
+	for written < len(data) {
+		end := written + ptyFrameMaxPayload
+		if end > len(data) {
+			end = len(data)
+		}
+		if err := ptyFrameWriteTo(p.f, ptyFrameInput, data[written:end]); err != nil {
+			return written, err
+		}
+		written = end
+	}
+	return len(data), nil
+}
+
+// Resize forwards a frontend terminal resize to the broker's ConPTY.
+func (p *adminPty) Resize(cols, rows int) error {
+	p.writeMu.Lock()
+	defer p.writeMu.Unlock()
+	payload := make([]byte, 4)
+	binary.LittleEndian.PutUint16(payload[0:], uint16(cols))
+	binary.LittleEndian.PutUint16(payload[2:], uint16(rows))
+	return ptyFrameWriteTo(p.f, ptyFrameResize, payload)
+}
+
+// Close tears down the pipe. The broker sees the broken pipe, kills the
+// elevated shell and exits. Safe to call from the session teardown path even
+// while a Read is blocked — closing the handle unblocks it with an error.
+func (p *adminPty) Close() error {
+	return p.f.Close()
+}

--- a/backend/session/local_session_windows.go
+++ b/backend/session/local_session_windows.go
@@ -6,6 +6,7 @@ package session
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -111,9 +112,11 @@ func (s *LocalSession) updateMouseTrackingState(data []byte) {
 		}
 	}
 }
+
 type LocalSession struct {
 	baseSession
 	cpty                 *conpty.ConPty
+	admin                *adminPty // elevated shell relayed from the broker process
 	stdin                io.WriteCloser
 	stdout               io.Reader
 	cmd                  *exec.Cmd
@@ -153,6 +156,16 @@ func (s *LocalSession) Connect(config ConnectionConfig) error {
 	if shell == "" {
 		shell = defaultShell()
 	}
+	displayPath := shell
+
+	// admin:// shells spawn elevated. When uniTerm itself already runs as
+	// administrator the prefix is dropped and the shell starts like any
+	// other; otherwise an elevated broker process relays the ConPTY.
+	elevate := false
+	if inner, ok := ParseAdminShellPath(shell); ok {
+		shell = inner
+		elevate = !IsProcessElevated()
+	}
 
 	// Determine working directory: use config.Cwd if set, otherwise user home.
 	workDir := config.Cwd
@@ -162,7 +175,7 @@ func (s *LocalSession) Connect(config ConnectionConfig) error {
 		}
 	}
 
-	s.title = shellName(shell)
+	s.title = shellName(displayPath)
 
 	var commandLine string
 	var cmd *exec.Cmd
@@ -196,6 +209,35 @@ func (s *LocalSession) Connect(config ConnectionConfig) error {
 
 	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
 	cmd.Dir = workDir
+
+	// Elevated shell: the ConPTY lives in the elevated broker process and is
+	// relayed to us over the control pipe, so everything below (direct
+	// conpty.Start / pipe fallback) only applies to unelevated shells.
+	if elevate {
+		cols, rows := s.GetPendingSize()
+		if cols <= 0 || rows <= 0 {
+			cols, rows = 80, 24
+		}
+		tp, err := startElevatedPty(localPtySpawn{
+			CommandLine: commandLine,
+			WorkDir:     workDir,
+			Cols:        cols,
+			Rows:        rows,
+		})
+		if errors.Is(err, errElevationCancelled) {
+			s.setStatus(StatusError)
+			return fmt.Errorf("administrator terminal: %w", err)
+		}
+		if err != nil {
+			s.setStatus(StatusError)
+			return fmt.Errorf("administrator terminal: %w", err)
+		}
+		s.admin = tp
+		s.setStatus(StatusConnected)
+		go s.readLoop()
+		go s.runPostLoginScript(config.PostLoginScript)
+		return nil
+	}
 
 	// Try ConPTY first for a real pseudo-terminal experience.
 	if conpty.IsConPtyAvailable() {
@@ -293,6 +335,9 @@ func buildCommandLine(shell string) string {
 }
 
 func shellName(path string) string {
+	if inner, ok := ParseAdminShellPath(path); ok {
+		return shellName(inner) + " (Admin)"
+	}
 	if distro, ok := parseWSLPath(path); ok {
 		return "WSL - " + distro
 	}
@@ -382,7 +427,9 @@ func (s *LocalSession) readLoop() {
 		var n int
 		var err error
 		usingConPty := s.cpty != nil
-		if usingConPty {
+		if s.admin != nil {
+			n, err = s.admin.Read(buf)
+		} else if usingConPty {
 			n, err = s.cpty.Read(buf)
 		} else {
 			n, err = s.stdout.Read(buf)
@@ -424,7 +471,9 @@ func (s *LocalSession) readLoop() {
 func (s *LocalSession) Write(data []byte) error {
 	encoded := s.encodeInput(data)
 	var err error
-	if s.cpty != nil {
+	if s.admin != nil {
+		_, err = s.admin.Write(encoded)
+	} else if s.cpty != nil {
 		_, err = s.cpty.Write(encoded)
 	} else if s.stdin != nil {
 		_, err = s.stdin.Write(encoded)
@@ -452,6 +501,11 @@ func (s *LocalSession) Write(data []byte) error {
 func (s *LocalSession) Disconnect() error {
 	s.disconnectOnce.Do(func() {
 		close(s.quit)
+		if s.admin != nil {
+			// Closing the control pipe makes the elevated broker kill the
+			// shell and exit.
+			s.admin.Close()
+		}
 		if s.cpty != nil {
 			// Close but leave the field set: readLoop, Write and Resize read
 			// s.cpty without holding a lock, and nilling it here raced them.
@@ -471,6 +525,9 @@ func (s *LocalSession) Disconnect() error {
 
 func (s *LocalSession) Resize(cols, rows int) error {
 	s.SetPendingSize(cols, rows)
+	if s.admin != nil {
+		return s.admin.Resize(cols, rows)
+	}
 	if s.cpty != nil {
 		return s.cpty.Resize(cols, rows)
 	}

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1384,6 +1384,10 @@ async function onConnect(config: ConnectionConfig, keepOpen?: boolean, wasEdit?:
 function getShellLabel(path: string): string {
   if (!path) return 'Local'
   const lower = path.toLowerCase()
+  if (lower.startsWith('admin://')) {
+    const inner = getShellLabel(path.slice(8))
+    return inner.endsWith(' (Admin)') ? inner : `${inner} (Admin)`
+  }
   if (lower.startsWith('wsl://')) {
     const distro = path.slice(6)
     return distro ? `WSL - ${distro}` : 'WSL'

--- a/frontend/src/components/ConnectionForm.vue
+++ b/frontend/src/components/ConnectionForm.vue
@@ -799,6 +799,10 @@ function onCategorySelect(catKey: string) {
 function getShellLabel(path: string): string {
   if (!path) return ''
   const lower = path.toLowerCase()
+  if (lower.startsWith('admin://')) {
+    const inner = getShellLabel(path.slice(8))
+    return inner.endsWith(' (Admin)') ? inner : `${inner} (Admin)`
+  }
   if (lower.startsWith('wsl://')) {
     const distro = path.slice(6)
     return distro ? `WSL - ${distro}` : 'WSL'

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -1841,6 +1841,10 @@ function onNewConnCommand(cmd: string) {
 function getShellLabel(path: string): string {
   if (!path) return 'Local'
   const lower = path.toLowerCase()
+  if (lower.startsWith('admin://')) {
+    const inner = getShellLabel(path.slice(8))
+    return inner.endsWith(' (Admin)') ? inner : `${inner} (Admin)`
+  }
   if (lower.startsWith('wsl://')) {
     const distro = path.slice(6)
     return distro ? `WSL - ${distro}` : 'WSL'

--- a/frontend/src/components/StartTabContent.vue
+++ b/frontend/src/components/StartTabContent.vue
@@ -604,6 +604,10 @@ function onFilterSelect(val: string) {
 function getShellLabel(path: string): string {
   if (!path) return 'Local'
   const lower = path.toLowerCase()
+  if (lower.startsWith('admin://')) {
+    const inner = getShellLabel(path.slice(8))
+    return inner.endsWith(' (Admin)') ? inner : `${inner} (Admin)`
+  }
   if (lower.startsWith('wsl://')) {
     const distro = path.slice(6)
     return distro ? `WSL - ${distro}` : 'WSL'

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/wailsapp/wails/v3/pkg/application"
 	"github.com/wailsapp/wails/v3/pkg/events"
 	"github.com/ys-ll/uniterm/backend/log"
+	"github.com/ys-ll/uniterm/backend/session"
 	"github.com/ys-ll/uniterm/backend/store"
 )
 
@@ -30,6 +31,14 @@ var devBuild = Version == "dev"
 var assets embed.FS
 
 func main() {
+	// Administrator-shell broker mode: an elevated copy of uniTerm launched
+	// via the "runas" verb relays ConPTY I/O for admin local terminals (see
+	// backend/session/local_admin_windows.go). Must run before anything else
+	// so the broker never creates a window, webview or app store.
+	if session.RunLocalPtyBroker(os.Args) {
+		return
+	}
+
 	// Capture top-level panics
 	defer func() {
 		if r := recover(); r != nil {


### PR DESCRIPTION
## Summary

Windows local terminals gain two new shell types — **Command Prompt (Admin)** and **Windows PowerShell (Admin)**. Picking one launches the shell with an elevated token (UAC) while keeping it embedded as an ordinary terminal tab: input, resize, encoding, post-login scripts and tab titles all behave like any other local terminal. Git Bash is deliberately not offered elevated.

## How it works

ConPTY is created through `CreateProcess`, which cannot cross the UAC boundary, and `ShellExecuteEx`'s `runas` verb does not expose the child's I/O handles — so the elevation runs through a broker:

1. The app creates a named pipe whose DACL grants full access to the current user only, then launches a copy of itself with the `runas` verb and `--local-pty-broker <pipe>`.
2. The elevated copy never touches the webview or app stores: it spawns the requested shell inside a ConPTY and relays a small framed protocol (data / input / resize / exited) between the pseudo console and the control pipe.
3. Closing the tab breaks the pipe; the broker kills the shell and exits, so no elevated process lingers. Cancelling the UAC prompt surfaces a clear error instead of a generic failure.
4. When uniTerm itself already runs elevated, the admin variants are hidden from the shell list (they would be indistinguishable duplicates) and any `admin://` request starts the shell directly, without the broker.

`GetAvailableShells` appends the two `admin://` entries next to their plain counterparts; the frontend shell-label helpers (start page, connection form, tab subtitles, sidebar) render them as "Command Prompt (Admin)" / "Windows PowerShell (Admin)", mirroring how `wsl://` is already carried through `ShellPath`.

## Implementation note

The control pipe must NOT be connected via `ConnectNamedPipe`. On an overlapped handle, once `ConnectNamedPipe` completes, every later read completion is silently swallowed and the relay deadlocks (verified with a minimal reproduction). The broker therefore announces itself with a hello frame, which also serves as the connect synchronization point, with `SetDeadline` bounding the wait.

## Testing

`backend/session/local_admin_test.go` drives the broker protocol in-process, without elevation:

- `admin://` path parsing and tab-title suffixing
- hello/spec handshake, a full input → ConPTY → output round trip (`echo` marker round-trips through the real relayed ConPTY), resize
- teardown: closing the control pipe makes the broker kill the shell and exit — an elevated process must never linger without its owner

`go test ./backend/session/` passes. Also verified end-to-end on Windows 11 (26200): both admin shell types connect through UAC, `whoami` confirms elevation, and closing the tab leaves no stray elevated process.