### PR TITLE
fix(terminal): fix dropped/duplicated keystrokes when typing with an IME on macOS

### DIFF
--- a/backend/store/local_state_store.go
+++ b/backend/store/local_state_store.go
@@ -32,6 +32,13 @@ type LocalState struct {
 	// ExternalEditor command used to open remote files in an external editor
 	// (SFTP "edit externally"). Local-only preference, never synced.
 	ExternalEditor string `json:"externalEditor"`
+	// ImeCompatibility routes single-character IME-committed input through
+	// xterm's direct delivery path on macOS, working around phantom
+	// keyCode-229 keydowns that make fast typing drop characters. Pointer +
+	// omitempty so older local_state.json files (which lack this field)
+	// still load; nil means the frontend default (enabled on macOS, off
+	// elsewhere).
+	ImeCompatibility *bool `json:"imeCompatibility,omitempty"`
 }
 
 type LocalStateStore struct {

--- a/frontend/src/components/BaseTerminal.vue
+++ b/frontend/src/components/BaseTerminal.vue
@@ -811,34 +811,6 @@ function handleTerminalKey(e: KeyboardEvent): boolean {
   // Check global shortcuts first (Ctrl+Shift+/Alt+ combos)
   if (e.type === 'keydown' && !onTerminalKey(e)) return false
 
-  // macOS 26/27 beta: the first letter typed right after toggling Caps Lock
-  // arrives with keyCode 229 (the IME "composing" code) despite no real
-  // composition, so xterm's CompositionHelper swallows it and it only appears
-  // on the next keystroke (upstream xtermjs/xterm.js#5887, issue #483). keyCode
-  // 229 never fires for an ordinary letter key, and we further require Caps Lock
-  // on + an uppercase A–Z so lowercase IME composition (pinyin's first key) is
-  // untouched — re-inject the char through the normal onData pipeline ourselves.
-  if (
-    isMac &&
-    e.type === 'keydown' &&
-    e.keyCode === 229 &&
-    !e.isComposing &&
-    e.getModifierState('CapsLock') &&
-    /^[A-Z]$/.test(e.key) &&
-    !e.ctrlKey && !e.metaKey && !e.altKey &&
-    (props.mode === 'ssh' || props.mode === 'local')
-  ) {
-    e.preventDefault()
-    // terminal.input() sends the character via triggerDataEvent. Tell
-    // xterm's internal _keyDownHandled flag that this key was already
-    // processed so _keyPress won't fire a second triggerDataEvent.
-    // Without this, _keyPress fires because _keyDownHandled is never set
-    // in the workaround path → same character sent twice.
-    ;(terminal as any)._keyDownHandled = true
-    terminal?.input(e.key)
-    return false
-  }
-
   // A bare modifier key (Shift/Ctrl/Alt/Meta held alone) produces no input, yet
   // xterm's _keyDown still runs and, with scrollOnUserInput=true, fires
   // scrollToBottom() — yanking the viewport back to the bottom when the user

--- a/frontend/src/components/SettingsTab.vue
+++ b/frontend/src/components/SettingsTab.vue
@@ -563,6 +563,18 @@
               <el-switch :model-value="settingsStore.settings.terminal.aiTranscription ?? true" @update:model-value="(v: boolean) => { settingsStore.settings.terminal.aiTranscription = v; settingsStore.save() }" />
             </div>
           </div>
+
+          <!-- Local-only preference (local_state.json, never synced). macOS
+               only: the patched input path is a WKWebView workaround. -->
+          <div v-if="isMac" class="setting-card">
+            <div class="setting-info">
+              <div class="setting-title">{{ t('settings.imeCompatibility') }}</div>
+              <div class="setting-desc">{{ t('settings.imeCompatibilityDesc') }}</div>
+            </div>
+            <div class="setting-control">
+              <el-switch :model-value="localStateStore.state.imeCompatibility ?? true" @update:model-value="(v: boolean) => localStateStore.update({ imeCompatibility: v })" />
+            </div>
+          </div>
         </div>
 
         <h2 class="section-title" style="margin-top: 28px">{{ t('settings.session') }}</h2>

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -406,6 +406,8 @@
   "settings.smartCompletionDesc": "Verlaufs- und KI-Vorschläge beim Tippen anzeigen",
   "settings.aiTranscription": "KI-Transkription",
   "settings.aiTranscriptionDesc": "KI-basierte Befehlsvorschläge beim Tippen (API-Key erforderlich)",
+  "settings.imeCompatibility": "IME-Kompatibilitätsmodus",
+  "settings.imeCompatibilityDesc": "Übergibt unter macOS Zeichen direkt an das Terminal, wenn eine Eingabemethode Tastenanschläge als Komposition markiert, und behebt so verlorene oder doppelte Zeichen bei schneller Eingabe",
   "settings.fetchModels": "Modelle abrufen",
   "settings.fetchModelsSuccess": "{connCount} Modelle abgerufen",
   "settings.fetchModelsFailed": "Modelle konnten nicht abgerufen werden",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -406,6 +406,8 @@
   "settings.smartCompletionDesc": "Show history and AI suggestions while typing",
   "settings.aiTranscription": "AI Transcription",
   "settings.aiTranscriptionDesc": "Suggest command rewrites via AI when typing (requires API key configured)",
+  "settings.imeCompatibility": "IME Compatibility Mode",
+  "settings.imeCompatibilityDesc": "Delivers typed characters directly when an input method marks keystrokes as composing on macOS, fixing dropped or duplicated input when typing fast",
   "settings.fetchModels": "Fetch Models",
   "settings.fetchModelsSuccess": "Fetched {count} models",
   "settings.fetchModelsFailed": "Failed to fetch models",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -406,6 +406,8 @@
   "settings.smartCompletionDesc": "Mostrar sugerencias del historial y de la IA mientras escribe",
   "settings.aiTranscription": "Transcripción IA",
   "settings.aiTranscriptionDesc": "Sugerir reescrituras de comandos mediante IA mientras escribe (requiere clave API)",
+  "settings.imeCompatibility": "Modo de compatibilidad con IME",
+  "settings.imeCompatibilityDesc": "Entrega directamente al terminal los caracteres tecleados en macOS cuando un método de entrada marca las teclas como en composición, corrigiendo la pérdida o duplicación de caracteres al escribir rápido",
   "settings.fetchModels": "Obtener modelos",
   "settings.fetchModelsSuccess": "{connCount} modelos obtenidos",
   "settings.fetchModelsFailed": "Error al obtener modelos",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -406,6 +406,8 @@
   "settings.smartCompletionDesc": "Afficher les suggestions d'historique et de IA pendant la saisie",
   "settings.aiTranscription": "Transcription IA",
   "settings.aiTranscriptionDesc": "Suggérer des réécritures de commandes via IA pendant la saisie (clé API requise)",
+  "settings.imeCompatibility": "Mode de compatibilité IME",
+  "settings.imeCompatibilityDesc": "Transmet directement au terminal les caractères saisis sur macOS lorsqu’un mode de saisie marque les touches comme en composition, corrigeant les caractères perdus ou dupliqués lors de la frappe rapide",
   "settings.fetchModels": "Récupérer les modèles",
   "settings.fetchModelsSuccess": "{connCount} modèles récupérés",
   "settings.fetchModelsFailed": "Échec de la récupération des modèles",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -406,6 +406,8 @@
   "settings.smartCompletionDesc": "入力中に履歴と AI の候補を表示",
   "settings.aiTranscription": "AI 文字起こし",
   "settings.aiTranscriptionDesc": "入力中に AI によるコマンドの書き換え候補を表示（API キーの設定が必要）",
+  "settings.imeCompatibility": "IME互換モード",
+  "settings.imeCompatibilityDesc": "macOSでIMEが変換中と判定したキー入力をターミナルへ直接渡し、高速入力時の文字の欠落や重複を修正します",
   "settings.fetchModels": "モデルを取得",
   "settings.fetchModelsSuccess": "{connCount}件のモデルを取得しました",
   "settings.fetchModelsFailed": "モデルの取得に失敗しました",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -406,6 +406,8 @@
   "settings.smartCompletionDesc": "입력 중에 기록 및 AI 제안 표시",
   "settings.aiTranscription": "AI 트랜스크라이빙",
   "settings.aiTranscriptionDesc": "입력 중 AI 명령어 재작성 제안 표시 (API 키 필요)",
+  "settings.imeCompatibility": "IME 호환 모드",
+  "settings.imeCompatibilityDesc": "macOS에서 입력기가 조합 중으로 표시하는 키 입력을 터미널로 직접 전달하여, 빠른 입력 시 글자가 누락되거나 중복되는 문제를 수정합니다",
   "settings.fetchModels": "모델 가져오기",
   "settings.fetchModelsSuccess": "{connCount}개의 모델을 가져왔습니다",
   "settings.fetchModelsFailed": "모델을 가져오지 못했습니다",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -406,6 +406,8 @@
   "settings.smartCompletionDesc": "Показывать историю и подсказки ИИ при вводе",
   "settings.aiTranscription": "Транскрипция ИИ",
   "settings.aiTranscriptionDesc": "Предлагать переписанные команды через ИИ при вводе (требуется API-ключ)",
+  "settings.imeCompatibility": "Режим совместимости IME",
+  "settings.imeCompatibilityDesc": "На macOS передаёт вводимые символы в терминал напрямую, когда метод ввода помечает нажатия клавиш как составные, исправляя потерю или дублирование символов при быстром наборе",
   "settings.fetchModels": "Получить модели",
   "settings.fetchModelsSuccess": "Получено моделей: {connCount}",
   "settings.fetchModelsFailed": "Не удалось получить модели",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -406,6 +406,8 @@
   "settings.smartCompletionDesc": "输入时显示历史命令和 AI 补全建议",
   "settings.aiTranscription": "AI 转写",
   "settings.aiTranscriptionDesc": "输入时通过 AI 提供命令改写建议（需先配置 API Key）",
+  "settings.imeCompatibility": "输入法兼容模式",
+  "settings.imeCompatibilityDesc": "在 macOS 上将输入法标记为组字状态的按键直接送入终端，修复快速输入时丢字或重复的问题",
   "settings.fetchModels": "拉取模型列表",
   "settings.fetchModelsSuccess": "已拉取 {count} 个模型",
   "settings.fetchModelsFailed": "拉取模型列表失败",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -406,6 +406,8 @@
   "settings.smartCompletionDesc": "輸入時顯示歷史命令和 AI 補全建議",
   "settings.aiTranscription": "AI 轉寫",
   "settings.aiTranscriptionDesc": "輸入時透過 AI 提供命令改寫建議（需先設定 API Key）",
+  "settings.imeCompatibility": "輸入法相容模式",
+  "settings.imeCompatibilityDesc": "在 macOS 上將輸入法標記為組字狀態的按鍵直接送入終端，修復快速輸入時漏字或重複的問題",
   "settings.fetchModels": "拉取模型列表",
   "settings.fetchModelsSuccess": "已拉取 {connCount} 個模型",
   "settings.fetchModelsFailed": "拉取模型列表失敗",

--- a/frontend/src/services/terminalManager.ts
+++ b/frontend/src/services/terminalManager.ts
@@ -8,6 +8,7 @@ import { useSettingsStore } from '../stores/settingsStore'
 import { useLocalStateStore } from '../stores/localStateStore'
 import type { CustomTerminalTheme } from '../types/settings'
 import { formatFontFamily } from '../utils/formatFontFamily'
+import { installImeCompatibilityPatch } from '../utils/xtermImeCompatibility'
 import {
   bufferRowSource,
   createLineRegistry,
@@ -57,6 +58,8 @@ export interface ManagedTerminal {
   /** Subscription to terminal.onResize — reflows the buffer, so the registry
    * must be re-keyed to the rows lines now start at. */
   resizeDispose: { dispose(): void } | null
+  /** IME compatibility patch installed on this terminal (macOS only). */
+  imeDispose: { dispose(): void } | null
 }
 
 const terminals = new Map<string, ManagedTerminal>()
@@ -166,6 +169,11 @@ export function acquireTerminal(
     // AFTER loadAddon — the unicode property is provided by the addon.
     terminal.unicode.activeVersion = '11'
 
+    // IME compatibility (macOS): deliver single-char input directly when an
+    // IME marks keystrokes with the phantom keyCode 229, instead of relying
+    // on xterm's racy deferred textarea diff that drops/duplicates chars
+    // under fast typing. The patch reads the setting per event, so toggling
+    // it applies to already-created terminals too.
     managed = {
       terminal,
       fitAddon,
@@ -181,6 +189,11 @@ export function acquireTerminal(
       lineOffset: 0,
       trimDispose: null,
       resizeDispose: null,
+      imeDispose: installImeCompatibilityPatch(terminal, () => {
+        const localState = useLocalStateStore()
+        // nil = unset → default enabled (the patch only installs on macOS).
+        return localState.state.imeCompatibility ?? true
+      }),
     }
 
     // Track scrollback trimming so line-numbers / timestamps stay continuous
@@ -239,6 +252,8 @@ export function releaseTerminal(sessionId: string, ref: string): void {
       managed.trimDispose = null
       managed.resizeDispose?.dispose()
       managed.resizeDispose = null
+      managed.imeDispose?.dispose()
+      managed.imeDispose = null
       managed.terminal.dispose()
       terminals.delete(sessionId)
     }, 500)
@@ -255,6 +270,8 @@ export function disposeTerminal(sessionId: string): void {
   managed.trimDispose = null
   managed.resizeDispose?.dispose()
   managed.resizeDispose = null
+  managed.imeDispose?.dispose()
+  managed.imeDispose = null
   managed.terminal.dispose()
   terminals.delete(sessionId)
 }

--- a/frontend/src/utils/xtermImeCompatibility.test.ts
+++ b/frontend/src/utils/xtermImeCompatibility.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { installImeCompatibilityPatch } from './xtermImeCompatibility'
+
+interface FakeCore {
+  _inputEvent: (this: Record<string, unknown>, ev: InputEvent) => boolean
+  _keyDownSeen: boolean
+  _compositionHelper: Record<string, unknown>
+  textarea: {
+    listeners: Map<string, EventListener>
+    addEventListener: (type: string, fn: EventListener) => void
+    removeEventListener: (type: string, fn: EventListener) => void
+  }
+}
+
+function makeFakeCore(inputEventResult: boolean = true) {
+  const calls: { keyDownSeenAtCall: boolean | undefined }[] = []
+  const core: FakeCore = {
+    _inputEvent: function (this: Record<string, unknown>, _ev: InputEvent) {
+      calls.push({ keyDownSeenAtCall: this._keyDownSeen as boolean | undefined })
+      return inputEventResult
+    },
+    _keyDownSeen: true,
+    _compositionHelper: { _isComposing: false, _isSendingComposition: false },
+    textarea: {
+      listeners: new Map(),
+      addEventListener(type: string, fn: EventListener) {
+        core.textarea.listeners.set(type, fn)
+      },
+      removeEventListener(type: string, fn: EventListener) {
+        if (core.textarea.listeners.get(type) === fn) core.textarea.listeners.delete(type)
+      },
+    },
+  }
+  return { core, calls }
+}
+
+function fakeTerminal(core: FakeCore) {
+  return { _core: core } as unknown as import('@xterm/xterm').Terminal
+}
+
+function keydown(keyCode: number) {
+  return { keyCode } as KeyboardEvent
+}
+
+function insertText(data: string, opts: { isComposing?: boolean } = {}) {
+  return {
+    inputType: 'insertText',
+    data,
+    isComposing: opts.isComposing ?? false,
+  } as unknown as InputEvent
+}
+
+beforeEach(() => {
+  vi.stubGlobal('navigator', { userAgent: 'Macintosh; Intel Mac OS X 10_15_7' })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('installImeCompatibilityPatch', () => {
+  it('is a no-op on non-mac platforms', () => {
+    vi.stubGlobal('navigator', { userAgent: 'Windows NT 10.0' })
+    const { core, calls } = makeFakeCore()
+    const disposable = installImeCompatibilityPatch(fakeTerminal(core), () => true)
+    expect(core._inputEvent).toBe(core._inputEvent)
+    expect(core.textarea.listeners.size).toBe(0)
+    disposable.dispose()
+    expect(calls).toHaveLength(0)
+  })
+
+  it('does not patch when xterm internals are missing', () => {
+    const disposable = installImeCompatibilityPatch({ _core: {} } as never, () => true)
+    expect(disposable.dispose).toBeTypeOf('function')
+    disposable.dispose()
+  })
+
+  it('forces direct delivery for a single printable char after a 229 keydown', () => {
+    const { core, calls } = makeFakeCore()
+    installImeCompatibilityPatch(fakeTerminal(core), () => true)
+
+    core.textarea.listeners.get('keydown')!(keydown(229))
+    core._inputEvent.call(core, insertText('a'))
+
+    // Original handler must see _keyDownSeen cleared (direct path)...
+    expect(calls).toEqual([{ keyDownSeenAtCall: false }])
+    // ...and the flag restored afterwards so xterm bookkeeping stays intact.
+    expect(core._keyDownSeen).toBe(true)
+  })
+
+  it('leaves input untouched without a preceding 229 keydown', () => {
+    const { core, calls } = makeFakeCore()
+    installImeCompatibilityPatch(fakeTerminal(core), () => true)
+
+    core.textarea.listeners.get('keydown')!(keydown(65))
+    core._inputEvent.call(core, insertText('a'))
+
+    expect(calls).toEqual([{ keyDownSeenAtCall: true }])
+  })
+
+  it('only forces once per keydown', () => {
+    const { core, calls } = makeFakeCore()
+    installImeCompatibilityPatch(fakeTerminal(core), () => true)
+
+    core.textarea.listeners.get('keydown')!(keydown(229))
+    core._inputEvent.call(core, insertText('a'))
+    core._inputEvent.call(core, insertText('b'))
+
+    expect(calls).toEqual([
+      { keyDownSeenAtCall: false },
+      { keyDownSeenAtCall: true },
+    ])
+  })
+
+  it('leaves real composition untouched', () => {
+    const { core, calls } = makeFakeCore()
+    installImeCompatibilityPatch(fakeTerminal(core), () => true)
+
+    core.textarea.listeners.get('keydown')!(keydown(229))
+    core._inputEvent.call(core, insertText('a', { isComposing: true }))
+    expect(calls).toEqual([{ keyDownSeenAtCall: true }])
+
+    core._compositionHelper._isComposing = true
+    core.textarea.listeners.get('keydown')!(keydown(229))
+    core._inputEvent.call(core, insertText('a'))
+    expect(calls).toEqual([
+      { keyDownSeenAtCall: true },
+      { keyDownSeenAtCall: true },
+    ])
+  })
+
+  it('leaves multi-character and non-insertText input untouched', () => {
+    const { core, calls } = makeFakeCore()
+    installImeCompatibilityPatch(fakeTerminal(core), () => true)
+
+    core.textarea.listeners.get('keydown')!(keydown(229))
+    core._inputEvent.call(core, insertText('ab'))
+    expect(calls).toEqual([{ keyDownSeenAtCall: true }])
+
+    core.textarea.listeners.get('keydown')!(keydown(229))
+    core._inputEvent.call(core, { inputType: 'deleteContentBackward' } as unknown as InputEvent)
+    expect(calls).toEqual([
+      { keyDownSeenAtCall: true },
+      { keyDownSeenAtCall: true },
+    ])
+  })
+
+  it('is inert when disabled', () => {
+    const { core, calls } = makeFakeCore()
+    let enabled = true
+    installImeCompatibilityPatch(fakeTerminal(core), () => enabled)
+
+    core.textarea.listeners.get('keydown')!(keydown(229))
+    core._inputEvent.call(core, insertText('a'))
+    expect(calls).toEqual([{ keyDownSeenAtCall: false }])
+
+    enabled = false
+    core.textarea.listeners.get('keydown')!(keydown(229))
+    core._inputEvent.call(core, insertText('b'))
+    expect(calls).toEqual([
+      { keyDownSeenAtCall: false },
+      { keyDownSeenAtCall: true },
+    ])
+  })
+
+  it('dispose restores the original handler and removes the keydown listener', () => {
+    const { core } = makeFakeCore()
+    const original = core._inputEvent
+    const disposable = installImeCompatibilityPatch(fakeTerminal(core), () => true)
+
+    expect(core._inputEvent).not.toBe(original)
+    expect(core.textarea.listeners.has('keydown')).toBe(true)
+
+    disposable.dispose()
+    expect(core._inputEvent).toBe(original)
+    expect(core.textarea.listeners.size).toBe(0)
+  })
+})

--- a/frontend/src/utils/xtermImeCompatibility.ts
+++ b/frontend/src/utils/xtermImeCompatibility.ts
@@ -1,0 +1,145 @@
+import type { Terminal } from '@xterm/xterm'
+
+// IME compatibility patch for xterm.js on macOS (WKWebView).
+//
+// Root cause: with an IME active, WKWebView reports ordinary keystrokes as
+// keydown keyCode=229 ("composition" code) even when no real composition is
+// running. xterm records `_keyDownSeen = true` on every keydown, and its
+// `_inputEvent` fast path (`insertText` → direct delivery) requires
+// `!ev.composed || !_keyDownSeen` — so the character is diverted to
+// CompositionHelper's deferred textarea-diff fallback. That fallback races
+// under fast typing and drops or duplicates characters (the "must type
+// slowly" symptom).
+//
+// Fix: replace `core._inputEvent` with a wrapper that, when an `insertText`
+// event carries a single printable ASCII character right after a
+// keyCode-229 keydown while NO composition is actually active, temporarily
+// clears `_keyDownSeen` so the character takes the direct delivery path.
+// The guard conditions are deliberately conservative — real IME
+// composition (pinyin, kana, hangul) is never touched.
+//
+// The wrapper reads `isEnabled` on every input event, so toggling the
+// setting takes effect immediately on already-created terminals.
+
+export interface Disposable {
+  dispose(): void
+}
+
+interface XtermCompositionHelperInternals {
+  _isComposing?: unknown
+  _isSendingComposition?: unknown
+  isComposing?: unknown
+}
+
+interface XtermCoreInternals {
+  _inputEvent?: (this: XtermCoreInternals, ev: InputEvent) => boolean
+  _keyDownSeen?: boolean
+  _compositionHelper?: XtermCompositionHelperInternals
+  textarea?: {
+    addEventListener: typeof EventTarget.prototype.addEventListener
+    removeEventListener: typeof EventTarget.prototype.removeEventListener
+  } | null
+}
+
+type TerminalWithCore = Terminal & { _core?: XtermCoreInternals }
+
+const PRINTABLE_ASCII = /^[\x20-\x7E]$/
+
+const noopDisposable: Disposable = { dispose() {} }
+
+function isMacPlatform(): boolean {
+  return /Mac|iPhone|iPad/.test(navigator.userAgent)
+}
+
+function isCompositionActive(helper: XtermCompositionHelperInternals): boolean {
+  return (
+    helper._isComposing === true ||
+    helper._isSendingComposition === true ||
+    helper.isComposing === true
+  )
+}
+
+/**
+ * Installs the IME compatibility patch on the given terminal.
+ *
+ * Only does anything on macOS (the keyCode-229 phantom keydown behavior is
+ * WKWebView-specific). The returned Disposable restores the original
+ * internals; call it when the terminal is disposed.
+ *
+ * @param isEnabled called on each input event to decide whether the patch
+ *   is active — lets the setting toggle apply without recreating terminals.
+ */
+export function installImeCompatibilityPatch(
+  terminal: Terminal,
+  isEnabled: () => boolean,
+): Disposable {
+  if (!isMacPlatform()) {
+    return noopDisposable
+  }
+
+  const core = (terminal as TerminalWithCore)._core
+  const helper = core?._compositionHelper
+  if (
+    !core ||
+    !helper ||
+    typeof core._inputEvent !== 'function' ||
+    typeof core._keyDownSeen !== 'boolean' ||
+    !core.textarea ||
+    typeof core.textarea.addEventListener !== 'function'
+  ) {
+    // xterm internals changed shape — fail safe by not patching at all.
+    return noopDisposable
+  }
+
+  // Track whether the most recent keydown was the phantom keyCode 229.
+  // Capture phase so it runs before xterm's own textarea keydown listener.
+  let latestKeydownWas229 = false
+  const onKeyDown = (ev: KeyboardEvent) => {
+    latestKeydownWas229 = ev.keyCode === 229
+  }
+  core.textarea.addEventListener('keydown', onKeyDown, true)
+
+  const originalInputEvent = core._inputEvent
+  const patchedInputEvent = function patchedInputEvent(
+    this: XtermCoreInternals,
+    ev: InputEvent,
+  ): boolean {
+    const was229 = latestKeydownWas229
+    latestKeydownWas229 = false
+
+    if (
+      !isEnabled() ||
+      ev.inputType !== 'insertText' ||
+      !ev.data ||
+      !PRINTABLE_ASCII.test(ev.data) ||
+      ev.isComposing ||
+      isCompositionActive(helper) ||
+      !was229 ||
+      this._keyDownSeen !== true
+    ) {
+      return originalInputEvent!.call(this, ev)
+    }
+
+    // Force the direct delivery path: clear the poisoned `_keyDownSeen` for
+    // the duration of the original handler, then restore it so xterm's own
+    // keyup bookkeeping stays consistent.
+    const saved = this._keyDownSeen
+    this._keyDownSeen = false
+    try {
+      return originalInputEvent!.call(this, ev)
+    } finally {
+      this._keyDownSeen = saved
+    }
+  }
+
+  core._inputEvent = patchedInputEvent
+
+  return {
+    dispose() {
+      core.textarea?.removeEventListener('keydown', onKeyDown, true)
+      if (core._inputEvent === patchedInputEvent) {
+        core._inputEvent = originalInputEvent
+      }
+    },
+  }
+}


### PR DESCRIPTION
Closes #833. May also address #483 and #655.

## Problem

On macOS with a third-party Chinese IME active, keystrokes must be typed slowly one by one — typing at normal speed drops characters. Two related reports exist: the first letter after toggling Caps Lock is lost (#483), and uppercase input can produce duplicated characters (#655).

## Root cause

When an IME is active, WKWebView reports ordinary keystrokes with `keyCode=229` (the composition key code) even when no real composition is running. xterm.js sets `_keyDownSeen` on every keydown, and its input-event fast path only delivers `insertText` when the event does not follow a seen keydown — so committed characters are diverted to a deferred textarea-diff fallback. That fallback races under fast typing (key rollover) and drops or duplicates characters, which explains the "must type slowly" symptom.

## Fix

- Replace the terminal's input-event handler when the terminal is created: a single printable character arriving right after a keyCode-229 keydown while no composition is active is forced through the direct delivery path. The guard conditions are conservative — real IME composition (pinyin, kana, hangul) is never touched.
- Add an "IME Compatibility Mode" toggle to the terminal interaction settings, shown on macOS only. It is stored in the local-only state file and never cloud-synced. It defaults to enabled on macOS, and toggling applies immediately to already-created terminals.
- Remove the previous narrow workaround that re-injected uppercase keys after toggling Caps Lock; the new patch covers that case for all keys, not just A–Z.

## Testing

- Frontend unit tests (including 9 new ones covering the patch), full frontend build, Go build/vet/tests and the full app build all pass.
- Actual macOS behavior needs on-device verification with the affected input methods: fast typing (the reporter's case), the first letter after toggling Caps Lock, and duplicated uppercase input.

---

关闭 #833，同时可能解决 #483 和 #655。

## 问题

macOS 上开启第三方中文输入法时，必须一个键一个键慢敲才能正常输入，正常速度打字会丢字符。相关报告还有两个：Caps Lock 切换后首字母丢失（#483）、大写输入出现重复字符（#655）。

## 根因

输入法激活时，WKWebView 会把普通按键的 keydown 报成 `keyCode=229`（组字键码），即使并未真正处于组字状态。xterm.js 在每次 keydown 都会置位 `_keyDownSeen`，而它的输入事件快速通路要求 `insertText` 事件不跟随已见过的 keydown——于是已上屏字符被转入一个延迟的 textarea diff 兜底逻辑。该逻辑在快速输入（按键滚动）下存在竞态，导致丢字或重复，正对应"必须慢敲才跟手"的症状。

## 修复

- 在终端创建时替换其输入事件处理：紧随 keyCode-229 keydown 到达的单个可打印字符、且未处于真实组字状态时，强制走直接投递通路。防护条件保守，拼音/假名/韩文等真实组字过程不受影响。
- 在终端交互设置中新增「输入法兼容模式」开关，仅 macOS 显示。设置存放在仅本地的状态文件中，不做云同步；macOS 上默认开启，切换后立即对已创建的终端生效。
- 移除原先针对 Caps Lock 切换后大写首键的窄修复；新补丁对该场景全按键生效，不再限于 A–Z。

## 测试

- 前端单元测试（含补丁新增 9 个）、前端构建、Go build/vet/test 与应用整体构建均通过。
- macOS 上的实际效果需在相关输入法下实测：快速输入（报告者场景）、Caps Lock 切换后首键、大写重复输入。
