### PR TITLE
fix(file-transfer): auto-reconnect when refresh hits a dead session

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -218,6 +218,7 @@ import type { ConnectionConfig } from './types/session'
 import { Application, Clipboard, Events } from '@wailsio/runtime'
 import { parseQuickConnect } from './utils/quickConnect'
 import { fileTransferProto } from './utils/fileTransferUtils'
+import { reconnectFileTransferPanel } from './composables/usePanelReconnect'
 
 const bgDataUrl = ref('')
 
@@ -1981,24 +1982,13 @@ async function reconnectMonitorPanel(panel: { id: string; sessionId: string | nu
   }
 }
 
-// Force-reconnect a file-transfer panel (sftp/ftp/smb/webdav/s3). Like database
-// and monitor, the session is created in App.vue; its type string equals
-// config.type. The tab content reads the session from the panel reactively.
+// Force-reconnect a file-transfer panel (sftp/ftp/smb/webdav/s3). The actual
+// close→create→rebind orchestration lives in usePanelReconnect, shared with
+// the refresh-triggered auto-reconnect in the file tab content.
 async function reconnectSftpPanel(panel: { id: string; sessionId: string | null; config: ConnectionConfig | null }) {
-  const oldId = panel.sessionId
-  if (oldId) {
-    try { await CloseSession(oldId) } catch (_) {}
-  }
-  const cfg = panel.config
-  if (!cfg || !cfg.type) return
   try {
-    // SSH-based file panels carry the protocol preference on the config; the
-    // file-transfer types (ftp/smb/...) already match their session type.
-    const proto = fileTransferProto(cfg)
-    const sessionType = cfg.type === 'ssh' ? proto : cfg.type
-    const info = await CreateSession(sessionType, cfg)
-    panelStore.bindSession(panel.id, info.id)
-    sessionStore.initSession(info.id)
+    const newId = await reconnectFileTransferPanel(panel.id)
+    if (!newId) panelStore.updateStatus(panel.id, 'error')
   } catch (e: any) {
     panelStore.updateStatus(panel.id, 'error')
     msg.error(`${t('tab.reconnectFailed')}: ${e?.message || String(e)}`)

--- a/frontend/src/components/FileTabContent.vue
+++ b/frontend/src/components/FileTabContent.vue
@@ -167,6 +167,8 @@ import {
   useEditorBridge, useNativeFileDrop, remoteFileOps, localFileOps,
   resolveRemoteTarget, resolveLocalTarget, joinPath, autoRename,
 } from '../composables/useFilePanel'
+import { reconnectFileTransferPanel, isPanelReconnecting } from '../composables/usePanelReconnect'
+import { isConnectionLostError } from '../utils/fileTransferUtils'
 import { bindExtEditUploadedToast } from '../composables/useFilePanel'
 import { Events } from '@wailsio/runtime'
 import { useTransferTaskEvents } from '../composables/useTransferTasks'
@@ -237,6 +239,7 @@ const remoteListing = useFileListing({
   list: SftpListRemote,
   changeDir: SftpChangeRemoteDir,
   resolveTarget: resolveRemoteTarget,
+  onListError: onRemoteListError,
 })
 const localListing = useFileListing({
   sid: () => panel.value?.sessionId ?? undefined,
@@ -261,6 +264,35 @@ const {
   cwd: localCwd, files: localFiles, loading: loadingLocal,
   onRefresh: onRefreshLocal, onNavigate: onLocalNavigate, onCancelLoad: onCancelLoadLocal,
 } = localListing
+
+// Auto-reconnect when a remote listing/navigation hits a dead session (used to
+// toast "connection lost" on every refresh with no way back except closing the
+// tab). A disconnect is detected either from the error wording or from the
+// session's own status; then the shared panel-reconnect flow (same one the tab
+// right-click 「重连」 uses) brings up a fresh session and the listing reloads
+// once. Returns true so the generic error toast is suppressed whenever we took
+// over — including when the reconnect itself failed (it reports its own error).
+async function onRemoteListError(err: string): Promise<boolean> {
+  const panel = panelStore.getPanel(props.panelId)
+  if (!panel?.config) return false
+  let connected = false
+  try {
+    const sessions = await ListSessions()
+    connected = sessions.find(s => s.id === panel.sessionId)?.status === 'connected'
+  } catch { /* status unknown — treat as disconnected */ }
+  if (connected && !isConnectionLostError(err)) return false
+  if (!isPanelReconnecting(props.panelId)) {
+    msg.warning(t('sftp.reconnecting'))
+  }
+  try {
+    const newId = await reconnectFileTransferPanel(props.panelId)
+    if (newId) onRefreshRemote()
+    else msg.error(t('tab.reconnectFailed'))
+  } catch (e: any) {
+    msg.error(`${t('tab.reconnectFailed')}: ${e?.message || String(e)}`)
+  }
+  return true
+}
 
 const remotePanel = useFilePanel({
   sid: () => panel.value?.sessionId,

--- a/frontend/src/composables/useFilePanel.ts
+++ b/frontend/src/composables/useFilePanel.ts
@@ -645,8 +645,9 @@ export function useFileListing(opts: {
   listTimeoutMs?: number
   /** Called after a successful list (e.g. drive-letter refresh). */
   afterList?: (dir: string) => Promise<void> | void
-  /** Return true when the error was fully handled (no generic toast). */
-  onListError?: (err: string) => boolean | void
+  /** Return true when the error was fully handled (no generic toast). May be
+   *  async (e.g. an auto-reconnect that decides after a status check). */
+  onListError?: (err: string) => boolean | void | Promise<boolean | void>
   onListSuccess?: () => void
 }) {
   const cwd = ref(opts.initialDir ?? '')
@@ -672,7 +673,7 @@ export function useFileListing(opts: {
     } catch (e: any) {
       if (v !== version) return
       const err = e?.toString?.() || String(e)
-      if (opts.onListError?.(err)) return
+      if (await opts.onListError?.(err)) return
       msg.error(err)
     } finally {
       if (v === version) loading.value = false
@@ -693,7 +694,9 @@ export function useFileListing(opts: {
       await opts.afterList?.(result.dir)
     } catch (e: any) {
       if (v !== version) return
-      msg.error(e?.toString?.() || String(e))
+      const err = e?.toString?.() || String(e)
+      if (await opts.onListError?.(err)) return
+      msg.error(err)
     } finally {
       if (v === version) loading.value = false
     }

--- a/frontend/src/composables/usePanelReconnect.ts
+++ b/frontend/src/composables/usePanelReconnect.ts
@@ -1,0 +1,79 @@
+// Reconnect orchestration for file-transfer panels (sftp/scp/ftp/smb/webdav/
+// s3/wsl-file — every panel whose tab content is the protocol-agnostic file
+// browser). Extracted from App.vue's reconnectSftpPanel so the tab right-click
+// 「重连」 and the refresh-triggered auto-reconnect share one implementation:
+// close the old session, create a fresh one from the panel's stored config,
+// rebind the panel, and wait for the new session to report connected.
+import { CreateSession, CloseSession, ListSessions } from '../../bindings/github.com/ys-ll/uniterm/app'
+import { usePanelStore } from '../stores/panelStore'
+import { useSessionStore } from '../stores/sessionStore'
+import { fileTransferProto } from '../utils/fileTransferUtils'
+
+// One in-flight reconnect per panel: concurrent triggers (refresh spam, a
+// burst of failed listings) share the same attempt instead of stacking
+// close/create cycles. Keyed by panel id; removed on completion.
+const inflight = new Map<string, Promise<string | null>>()
+
+// How long to wait for the fresh session to report connected. Matches the
+// SSH dial timeout on the backend (30s); polling covers both synchronously
+// connecting types (SFTP/S3, already up when CreateSession returns) and
+// async ones (FTP) that flip to connected a moment later.
+const CONNECT_TIMEOUT_MS = 30_000
+const CONNECT_POLL_MS = 300
+
+export function isPanelReconnecting(panelId: string): boolean {
+  return inflight.has(panelId)
+}
+
+// Reconnect a file-transfer panel. Resolves with the NEW session id once the
+// session is connected; resolves null when the fresh session fails to come up
+// (the session:status 'error' path already toasts the backend's connect error)
+// or rejects with the underlying error when the reconnect itself could not run.
+// Returns via the shared in-flight promise when a reconnect for this panel is
+// already running.
+export function reconnectFileTransferPanel(panelId: string): Promise<string | null> {
+  const existing = inflight.get(panelId)
+  if (existing) return existing
+  const attempt = doReconnect(panelId).finally(() => inflight.delete(panelId))
+  inflight.set(panelId, attempt)
+  return attempt
+}
+
+async function doReconnect(panelId: string): Promise<string | null> {
+  const panelStore = usePanelStore()
+  const sessionStore = useSessionStore()
+  const panel = panelStore.getPanel(panelId)
+  const cfg = panel?.config
+  if (!cfg || !cfg.type) return null
+
+  const oldId = panel.sessionId
+  if (oldId) {
+    try { await CloseSession(oldId) } catch (_) {}
+  }
+  // SSH-based file panels carry the protocol preference on the config; the
+  // file-transfer types (ftp/smb/...) already match their session type.
+  const proto = fileTransferProto(cfg)
+  const sessionType = cfg.type === 'ssh' ? proto : cfg.type
+  const info = await CreateSession(sessionType, cfg)
+  panelStore.bindSession(panelId, info.id)
+  sessionStore.initSession(info.id)
+  const ok = await waitUntilConnected(info.id)
+  return ok ? info.id : null
+}
+
+async function waitUntilConnected(sid: string): Promise<boolean> {
+  const deadline = Date.now() + CONNECT_TIMEOUT_MS
+  while (Date.now() < deadline) {
+    try {
+      const sessions = await ListSessions()
+      // ListSessions comes from the untyped Wails bindings (same as callers
+      // like FileTabContent's probe), so the shape is annotated locally.
+      const status = (sessions as Array<{ id: string; status: string }>)
+        .find(s => s.id === sid)?.status
+      if (status === 'connected') return true
+      if (status === 'error' || status === 'disconnected') return false
+    } catch { /* transient IPC failure — keep polling until the deadline */ }
+    await new Promise(r => setTimeout(r, CONNECT_POLL_MS))
+  }
+  return false
+}

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -271,6 +271,7 @@
   "sftp.done": "Fertig",
   "sftp.error": "Fehler",
   "sftp.connectError": "SFTP-Verbindung fehlgeschlagen",
+  "sftp.reconnecting": "Verbindung verloren, wird neu verbunden…",
   "sftp.dropHere": "Dateien hier ablegen",
   "sftp.upload": "Hochladen",
   "sftp.downloadTo": "Herunterladen nach...",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -271,6 +271,7 @@
   "sftp.done": "Done",
   "sftp.error": "Error",
   "sftp.connectError": "SFTP connection failed",
+  "sftp.reconnecting": "Connection lost, reconnecting…",
   "sftp.dropHere": "Drop files here",
   "sftp.upload": "Upload",
   "sftp.downloadTo": "Download to...",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -271,6 +271,7 @@
   "sftp.done": "Completado",
   "sftp.error": "Error",
   "sftp.connectError": "Error de conexión SFTP",
+  "sftp.reconnecting": "Conexión perdida, reconectando…",
   "sftp.dropHere": "Suelte archivos aquí",
   "sftp.upload": "Subir",
   "sftp.downloadTo": "Descargar en...",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -271,6 +271,7 @@
   "sftp.done": "Terminé",
   "sftp.error": "Erreur",
   "sftp.connectError": "Échec de la connexion SFTP",
+  "sftp.reconnecting": "Connexion perdue, reconnexion…",
   "sftp.dropHere": "Déposer les fichiers ici",
   "sftp.upload": "Téléverser",
   "sftp.downloadTo": "Télécharger vers...",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -271,6 +271,7 @@
   "sftp.done": "完了",
   "sftp.error": "エラー",
   "sftp.connectError": "SFTP 接続に失敗しました",
+  "sftp.reconnecting": "接続が切断されました。再接続中…",
   "sftp.dropHere": "ここにファイルをドロップ",
   "sftp.upload": "アップロード",
   "sftp.downloadTo": "ダウンロード先...",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -271,6 +271,7 @@
   "sftp.done": "완료",
   "sftp.error": "오류",
   "sftp.connectError": "SFTP 연결 실패",
+  "sftp.reconnecting": "연결이 끊어졌습니다. 다시 연결 중…",
   "sftp.dropHere": "여기에 파일을 놓으세요",
   "sftp.upload": "업로드",
   "sftp.downloadTo": "다운로드 위치...",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -271,6 +271,7 @@
   "sftp.done": "Готово",
   "sftp.error": "Ошибка",
   "sftp.connectError": "Ошибка подключения SFTP",
+  "sftp.reconnecting": "Соединение потеряно, выполняется переподключение…",
   "sftp.dropHere": "Перетащите файлы сюда",
   "sftp.upload": "Загрузить",
   "sftp.downloadTo": "Скачать в...",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -271,6 +271,7 @@
   "sftp.done": "完成",
   "sftp.error": "失败",
   "sftp.connectError": "SFTP 连接失败",
+  "sftp.reconnecting": "连接已断开，正在重新连接…",
   "sftp.dropHere": "拖动文件到此处",
   "sftp.upload": "上传",
   "sftp.downloadTo": "下载到...",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -271,6 +271,7 @@
   "sftp.done": "完成",
   "sftp.error": "失敗",
   "sftp.connectError": "SFTP 連線失敗",
+  "sftp.reconnecting": "連線已中斷，正在重新連線…",
   "sftp.dropHere": "拖曳檔案到此處",
   "sftp.upload": "上傳",
   "sftp.downloadTo": "下載到...",

--- a/frontend/src/utils/fileTransferUtils.ts
+++ b/frontend/src/utils/fileTransferUtils.ts
@@ -13,3 +13,14 @@ export function fileTransferProto(config?: { type?: string; fileTransferProto?: 
 export function connectFileMenuKey(config?: { type?: string; fileTransferProto?: 'sftp' | 'scp' } | null): string {
   return fileTransferProto(config) === 'scp' ? 'sidebar.connectScp' : 'sidebar.connectSftp'
 }
+
+// True when an operation failed because the transport died rather than because
+// the remote side rejected the request. Covers pkg/sftp's "connection lost"
+// (SFTP/SCP), crypto/ssh and net package wording, and the HTTP transport
+// errors surfaced by WebDAV/S3. A matching error means retrying on a fresh
+// connection may succeed — anything else (e.g. "no such directory") would
+// fail again, so callers can skip the reconnect.
+export function isConnectionLostError(err?: string | null): boolean {
+  if (!err) return false
+  return /connection lost|not connected|use of closed network connection|broken pipe|connection reset|connection refused|unexpected eof|\beof\b|already closed|ssh: disconnected/i.test(err)
+}


### PR DESCRIPTION
## Problem

When a file-transfer connection (SFTP/FTP/SMB/WebDAV/S3/WSL) dropped, clicking refresh only popped a transport error toast (e.g. `RuntimeError: connection lost`) every time — the panel never recovered. The only way back was the tab right-click "Reconnect" menu item.

## Fix

- Detect the disconnect when a remote listing/navigation fails, either from the error wording (connection lost / EOF / broken pipe / reset, covering every backend's transport errors) or from the session's own status.
- On disconnect, automatically run the same close → recreate → rebind flow the tab right-click reconnect uses, show a "reconnecting" notice, then reload the listing once. Concurrent triggers share one in-flight reconnect per panel instead of stacking attempts.
- Retry exactly once: if the fresh session comes up but the listing still fails, fall back to the plain error toast — no reconnect loops.
- The reconnect orchestration moves from App.vue into a shared composable so the manual right-click reconnect and the automatic one cannot drift.
- The disconnect check lives in the shared listing engine, so every file tab type is covered uniformly.

## Testing

- `vue-tsc --noEmit`: error count unchanged from baseline
- `npm run build`: passes
- Manual: connect SFTP, drop the connection (stop sshd / disconnect network), click refresh — panel reconnects and reloads instead of stacking error toasts

Closes #823

---

## 问题

文件传输连接（SFTP/FTP/SMB/WebDAV/S3/WSL）断开后，点刷新只会反复弹出传输错误提示（如 `RuntimeError: connection lost`），面板无法恢复，只能靠标签右键的「重新连接」。

## 修复

- 远端列表/目录导航失败时，从错误措辞（connection lost / EOF / broken pipe / reset，覆盖各后端的传输层报错）或会话自身状态判断是否断连。
- 断连时自动走与标签右键「重新连接」相同的 关闭 → 重建 → 重绑 流程，提示「正在重新连接」，然后刷新一次列表；同一面板的并发触发共享一次在途重连，不会堆叠。
- 只重试一次：新会话连上了但列表仍失败则回落为普通错误提示，不会形成重连风暴。
- 重连编排从 App.vue 抽成共享 composable，右键手动重连与自动重连共用一套实现。
- 断连判断放在共享的列表引擎里，所有文件传输标签类型统一生效。

## 测试

- `vue-tsc --noEmit`：错误数与基线一致
- `npm run build`：通过
- 手动验证：连接 SFTP 后断开连接（停 sshd / 断网），点刷新——面板自动重连并刷新，不再堆错误提示

Closes #823