### PR TITLE
fix(connection): show username in card subtitles for identity connections

### DIFF
--- a/frontend/src/utils/quickConnect.test.ts
+++ b/frontend/src/utils/quickConnect.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+
+// identityStore (imported transitively by formatConnSubtitle) pulls in the
+// Wails bindings and event runtime; stub both so the import is side-effect safe.
+vi.mock('@wailsio/runtime', () => ({
+  Events: { On: vi.fn(() => () => {}), Off: vi.fn() },
+}))
+vi.mock('../../bindings/github.com/ys-ll/uniterm/app', () => ({
+  LoadIdentities: vi.fn(async () => ({ identities: [] })),
+  SaveIdentities: vi.fn(async () => {}),
+}))
+
+import { formatConnSubtitle } from './quickConnect'
+import { useIdentityStore } from '../stores/identityStore'
+import type { ConnectionConfig } from '../types/session'
+
+describe('formatConnSubtitle', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('shows user@host for a plain password connection', () => {
+    const cfg = { type: 'ssh', host: 'srv1', port: 22, user: 'alice', authType: 'password' } as ConnectionConfig
+    expect(formatConnSubtitle(cfg)).toBe('ssh alice@srv1')
+  })
+
+  it('resolves the username from the referenced identity', () => {
+    const identities = useIdentityStore()
+    identities.identities = [{ id: 'id-1', name: 'work', username: 'bob', authType: 'key' }]
+
+    const cfg = { type: 'ssh', host: 'srv1', port: 22, user: '', authType: 'identity', identityId: 'id-1' } as ConnectionConfig
+    expect(formatConnSubtitle(cfg)).toBe('ssh bob@srv1')
+  })
+
+  it('falls back to host-only when the identity no longer exists', () => {
+    const cfg = { type: 'ssh', host: 'srv1', port: 22, user: '', authType: 'identity', identityId: 'gone' } as ConnectionConfig
+    expect(formatConnSubtitle(cfg)).toBe('ssh srv1')
+  })
+})

--- a/frontend/src/utils/quickConnect.ts
+++ b/frontend/src/utils/quickConnect.ts
@@ -1,4 +1,5 @@
 import type { ConnectionConfig } from '../types/session'
+import { useIdentityStore } from '../stores/identityStore'
 
 // Platform detection for Windows-only features (e.g., WSLC)
 export const isWindows = /windows/i.test(navigator.userAgent)
@@ -103,7 +104,14 @@ export function formatConnSubtitle(config: ConnectionConfig, getShellLabel?: (pa
     const defaultPort = getDefaultPort(config.type, config.dbType)
     const showPort = defaultPort !== config.port && defaultPort !== undefined
     const portStr = showPort ? `:${config.port}` : ''
-    detail = config.user ? `${config.user}@${config.host}${portStr}` : `${config.host}${portStr}`
+    // Identity connections keep config.user empty by design (the username lives
+    // in the referenced identity and is materialized at connect time), so the
+    // display name is resolved from the identity store here.
+    let user = config.user
+    if (!user && config.authType === 'identity' && config.identityId) {
+      user = useIdentityStore().identities.find((i) => i.id === config.identityId)?.username || ''
+    }
+    detail = user ? `${user}@${config.host}${portStr}` : `${config.host}${portStr}`
   }
   return `${typeLabel} ${detail}`
 }


### PR DESCRIPTION
## Summary

Connections authenticated via a vault identity (密钥库) keep `config.user` empty by design — the username lives in the referenced identity and is only materialized at connect time. Because of this, the subtitle on the start-page cards and the sidebar showed only the host, missing the `user@` prefix.

`formatConnSubtitle` (shared by the start-page cards, the sidebar and the group tree) now resolves the display username from the identity store when the connection references an identity. If the identity no longer exists, it falls back to the previous host-only display.

## Changes

- `frontend/src/utils/quickConnect.ts`: resolve the username from the identity store for `authType === 'identity'` connections in `formatConnSubtitle`
- `frontend/src/utils/quickConnect.test.ts`: new unit tests (identity-resolved username, host-only fallback, plain-password regression case)

## Verification

- New test failed before the fix and passes after it
- Full frontend test suite: 326 tests across 31 files, all passing
- `vue-tsc --noEmit`: no new type errors (error count unchanged before/after)

---

## 概要

使用密钥库（Identity）认证的连接按设计将 `config.user` 留空——用户名保存在被引用的身份中，仅在连接时才物化。因此开始页卡片和边栏卡片的副标题只显示主机名，缺少 `用户名@` 前缀。

开始页卡片、边栏、分组树共用的 `formatConnSubtitle` 现在会在连接引用身份时从身份库解析展示用的用户名；若身份已不存在，回退为原来的仅主机名显示。

## 改动

- `frontend/src/utils/quickConnect.ts`：`formatConnSubtitle` 中对 `authType === 'identity'` 的连接从身份库解析用户名
- `frontend/src/utils/quickConnect.test.ts`：新增单元测试（身份解析用户名、身份缺失回退、普通密码连接回归用例）

## 验证

- 新增测试在修复前失败、修复后通过
- 前端全量测试：31 个文件 326 个用例全部通过
- `vue-tsc --noEmit`：无新增类型错误（改动前后错误数一致）