### PR TITLE
fix: stop IME-committed Enter from triggering app shortcuts

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -37,6 +37,58 @@ settingsStore.init()
 
 app.mount('#app')
 
+// Global IME guard: swallow keydown/keyup events consumed by an IME
+// composition (e.g. Enter confirming a candidate word) before any
+// element-level handler mistakes them for app shortcuts. xterm terminals are
+// exempt — they manage their own IME pipeline.
+//
+// keydown: isComposing is the standard signal; keyCode 229 is the phantom code
+// WKWebView reports for composition keystrokes where isComposing is unreliable.
+//
+// keyup: the commit key's keyup arrives AFTER compositionend, so isComposing
+// is already false there. Track state via composition events instead: while
+// composing, keyups are blocked; on compositionend exactly one keyup (the
+// commit key's) is blocked. A real (non-IME) keydown disarms the pending
+// swallow, so a mouse-click commit (no keyup) cannot swallow the user's next
+// keystroke.
+{
+  const inTerminal = (t: EventTarget | null) =>
+    !!(t as Element | null)?.closest?.('.xterm')
+  let inComposition = false
+  let swallowNextKeyup = false
+
+  document.addEventListener('keydown', (e) => {
+    if (inTerminal(e.target)) return
+    // keyCode is deprecated, but 229 is kept deliberately: WKWebView (macOS)
+    // reports composition keystrokes as the phantom keyCode 229, and `key`
+    // ("Process") is not reliably set there.
+    if (e.isComposing || e.key === 'Process' || e.keyCode === 229) {
+      e.stopPropagation()
+      return
+    }
+    // A real keystroke invalidates a pending swallow.
+    swallowNextKeyup = false
+  }, true)
+
+  document.addEventListener('compositionstart', () => {
+    inComposition = true
+    swallowNextKeyup = false
+  }, true)
+
+  document.addEventListener('compositionend', () => {
+    inComposition = false
+    swallowNextKeyup = true
+  }, true)
+
+  document.addEventListener('keyup', (e) => {
+    if (inTerminal(e.target)) return
+    if (inComposition || swallowNextKeyup) {
+      swallowNextKeyup = false
+      e.stopPropagation()
+    }
+  }, true)
+}
+
 // Global context menu closer: broadcast to all menu components via window event
 document.addEventListener('contextmenu', () => {
   window.dispatchEvent(new CustomEvent('global:close-context-menus'))


### PR DESCRIPTION
## Summary
- With a CJK IME active, pressing Enter to commit the candidate word also fired element-level Enter handlers: in the AI sidebar the half-typed message was sent immediately (reported for macOS), and the same unguarded pattern exists in ~25 other Enter handlers across the app (search jump, tab/group rename, dialog confirm, query run, cell edit).
- Install a global capture-phase guard on the document (in `main.ts`) that stops propagation of keydowns consumed by an IME composition, plus the keyup of the key that committed it, before any element-level handler sees them. Covers both `@keydown.enter` and `@keyup.enter` sites, current and future.
- keydown detection uses `isComposing`, the standard `Process` key, and the WKWebView phantom `keyCode 229`. The commit key's keyup arrives *after* `compositionend` (with `isComposing` already false), so composition state is tracked via composition events and exactly one keyup is swallowed after compositionend; a real keydown disarms the pending swallow so a mouse-click commit cannot eat the user's next keystroke.
- Events originating inside `.xterm` pass through untouched — xterm.js manages its own IME pipeline. Non-IME typing is unaffected on all platforms.

Closes #854 (issue 2; issue 1 — uppercase swallowed in the terminal — is covered by the earlier macOS IME keystroke delivery fix #848, pending reporter confirmation)

---

## 摘要
- 使用中文输入法时，按回车确认候选词会同时触发元素层的回车处理器：AI 对话框会直接把写了一半的消息发送出去（macOS 上报告），且全应用约 25 处回车处理器都存在同样的未守卫模式（搜索跳转、标签/分组重命名、对话框确认、查询执行、单元格编辑等）。
- 在 `main.ts` 中安装 document 捕获阶段的全局守卫：IME 组合态消费的 keydown，以及确认候选词那次的 keyup，在到达任何元素级处理器之前被阻断传播。同时覆盖现有和将来的 `@keydown.enter` / `@keyup.enter` 场景。
- keydown 检测使用 `isComposing`、标准的 `Process` key 以及 WKWebView 的幻影 `keyCode 229`。确认键的 keyup 在 `compositionend` 之后才到达（此时 `isComposing` 已为 false），因此通过 composition 事件跟踪状态，在 `compositionend` 后恰好吞掉一次 keyup；任何真实 keydown 会解除待吞标记，避免鼠标点选候选词上屏（无 keyup）后误吞用户的下一次按键。
- 来自 `.xterm` 内部的事件完全放行——xterm.js 自行管理 IME 管线。所有平台上非 IME 输入不受影响。

Closes #854（问题二；问题一——终端大写字母被吞——已由先前的 macOS IME 按键直投修复 #848 覆盖，待报告者确认）

Closes #853 