### PR TITLE
fix(panel): add right-click menu to panel header, aligned with tab menu

### DIFF
--- a/frontend/src/components/Panel.vue
+++ b/frontend/src/components/Panel.vue
@@ -6,7 +6,13 @@
     draggable="true"
     @dragstart="emit('dragstart', $event)"
   >
-    <div v-if="showHeader" class="panel-header" :class="{ 'ai-locked': isAILocked }" @dblclick.stop>
+    <div
+      v-if="showHeader"
+      class="panel-header"
+      :class="{ 'ai-locked': isAILocked }"
+      @dblclick.stop
+      @contextmenu="onHeaderContextMenu"
+    >
       <div class="panel-header-left">
         <span class="panel-icon-wrapper">
           <component :is="panelIcon" class="panel-type-icon" />
@@ -26,6 +32,7 @@
           @keydown.escape="cancelEdit"
           @blur="confirmEdit"
           @click.stop
+          @contextmenu.stop
         />
       </div>
       <div class="panel-header-actions">
@@ -59,8 +66,19 @@
             <MenuItem :shortcut="menuShortcut('duplicateSession')" @click="emit('duplicate', panel.id); moreMenuVisible = false">
               {{ t('tab.duplicate') }}
             </MenuItem>
+            <MenuItem @click="forceReconnect(); moreMenuVisible = false">{{ t('tab.reconnect') }}</MenuItem>
+            <MenuItem v-if="serverHost" @click="copyHostAddress">{{ t('tab.copyHostAddress') }}</MenuItem>
+            <MenuItem :shortcut="menuShortcut('lockAI')" @click="toggleAiLockFromMenu">
+              {{ isAILocked ? t('terminal.aiLocked') : t('terminal.lockAI') }}
+            </MenuItem>
             <MenuItem @click="renamePanel">{{ t('tab.rename') }}</MenuItem>
             <MenuItem v-if="panel.config?.id" @click="locateConnection">{{ t('tab.locate') }}</MenuItem>
+            <MenuItem
+              v-if="(panel.type === 'ssh' || panel.type === 'local' || panel.type === 'wsl') && workspaceId"
+              @click="toggleBroadcastTarget"
+            >
+              {{ isPanelBroadcastTarget ? t('tab.unbroadcast') : t('tab.broadcast') }}
+            </MenuItem>
 
             <!-- ② 会话文本操作 -->
             <MenuDivider />
@@ -80,6 +98,12 @@
             <MenuItem v-if="panel.type === 'ssh'" @click="connectSftp(); moreMenuVisible = false">{{ t(connectFileMenuKey(panel.config)) }}</MenuItem>
             <MenuItem v-if="panel.type === 'ssh'" @click="uploadFileRz(); moreMenuVisible = false">{{ t('terminal.uploadFileRz') }}</MenuItem>
             <MenuItem v-if="panel.type === 'ssh'" @click="connectMonitor(); moreMenuVisible = false">{{ t('sidebar.connectMonitor') }}</MenuItem>
+
+            <!-- ④ 关闭 -->
+            <MenuDivider />
+            <MenuItem :shortcut="menuShortcut('closePanel')" @click="emit('close', panel.id); moreMenuVisible = false">
+              {{ t('tab.close') }}
+            </MenuItem>
           </Menu>
         </div>
         <button class="panel-close" @click.stop="emit('close', panel.id)"><X :size="14" /></button>
@@ -128,6 +152,7 @@ import { waitForTerminalSize } from '../services/terminalManager'
 import { connectFileMenuKey } from '../utils/fileTransferUtils'
 import type { ConnectionConfig } from '../types/session'
 import type { CredentialResult } from './CredentialPrompt.vue'
+import { Clipboard } from '@wailsio/runtime'
 
 // Escape sequences to disable all xterm mouse tracking modes.
 // When a terminal app (e.g. opencode, vim, tmux) enables mouse tracking
@@ -223,6 +248,48 @@ function toggleMoreMenu(e: MouseEvent) {
   const opening = !moreMenuVisible.value
   moreMenuRef.value?.toggle(e.currentTarget)
   if (opening) refreshOutputLogState()
+}
+
+// Right-click on the panel header opens the SAME menu as the "..." button
+// (one shared Menu instance), so the two entry points can never drift apart.
+function onHeaderContextMenu(e: MouseEvent) {
+  e.preventDefault()
+  e.stopPropagation()
+  moreMenuRef.value?.openAt(e.clientX, e.clientY)
+  refreshOutputLogState()
+}
+
+// Connection host (IP or hostname) — empty for local/wsl/serial panels.
+const serverHost = computed(() => props.panel.config?.host || '')
+
+const isPanelBroadcastTarget = computed(() =>
+  tabStore.isPanelBroadcasting(props.panel.id)
+)
+
+function toggleAiLockFromMenu() {
+  emit('toggleAiLock', props.panel.id)
+  moreMenuVisible.value = false
+}
+
+// Equivalent to Ctrl+click on the header broadcast button: toggle THIS panel
+// (not the whole workspace) as a broadcast target.
+function toggleBroadcastTarget() {
+  tabStore.toggleBroadcastPanel(props.panel.id)
+  moreMenuVisible.value = false
+}
+
+async function copyHostAddress() {
+  moreMenuVisible.value = false
+  const host = serverHost.value
+  if (!host) return
+  // Wails clipboard, falling back to the browser API when the runtime is
+  // absent (plain dev in a browser) or the call fails.
+  let ok = false
+  try { ok = await Clipboard.SetText(host) } catch { ok = false }
+  if (!ok) {
+    try { await navigator.clipboard.writeText(host) } catch { /* no clipboard */ }
+  }
+  msg.success(t('tab.hostCopied', { host }))
 }
 
 async function refreshOutputLogState() {


### PR DESCRIPTION
Follow-up to #849 (item 2): right-clicking a panel title bar previously did nothing — the panel actions were only reachable through the "..." button, and that menu had fewer items than the tab context menu.

Changes:

- Right-click on the panel header now opens a context menu at the pointer. It shares the same `Menu` instance as the "..." button, so the two entry points can never drift apart.
- Added the missing panel-level items to align with the tab context menu:
  - Reconnect (reuses the existing force-reconnect path)
  - Copy host address
  - Lock/unlock AI (with shortcut hint)
  - Set/cancel as broadcast target (equivalent to Ctrl+click on the header broadcast button)
  - Close panel (with shortcut hint)
- Tab-only concepts (tab lock, close other/close right tabs) are intentionally not added, since panels have no counterpart for them.
- All labels reuse existing i18n keys; no new translations.

---


#849 的第 2 项：此前面板标题栏右键无响应，面板操作只能通过"⋯"按钮访问，且菜单项比标签右键菜单少。

改动内容：

- 面板标题栏右键现在会在鼠标位置弹出菜单，与"⋯"按钮共用同一个 `Menu` 实例，两个入口永远保持一致。
- 补齐面板级别适用的菜单项，与标签右键菜单对齐：
  - 重连（复用现有的强制重连逻辑）
  - 复制主机地址
  - 锁定/解锁 AI（带快捷键提示）
  - 设为/取消广播目标（等价于标题栏广播按钮的 Ctrl+点击）
  - 关闭面板（带快捷键提示）
- 标签特有概念（锁定标签、关闭其他/右侧标签）有意不加，面板没有对应物。
- 文案全部复用现有 i18n key，无新增翻译。

Closes #849