### PR TITLE
fix(conn): allow saving WSL connections (host validation exemption)

### DIFF
--- a/frontend/src/components/ConnectionForm.vue
+++ b/frontend/src/components/ConnectionForm.vue
@@ -1562,7 +1562,7 @@ function normalizeForm(): ConnectionConfig {
   if (redisSentinel) {
     if (!normalized.redisSentinels?.trim()) throw new Error(t('conn.redisSentinelsRequired'))
     if (!normalized.redisMasterName?.trim()) throw new Error(t('conn.redisMasterNameRequired'))
-  } else if (normalized.type !== 'local' && normalized.type !== 'serial' && normalized.type !== 'k8s' && normalized.type !== 'container' && !normalized.host.trim()) {
+  } else if (normalized.type !== 'local' && normalized.type !== 'wsl' && normalized.type !== 'serial' && normalized.type !== 'k8s' && normalized.type !== 'container' && !normalized.host.trim()) {
     throw new Error(t('conn.hostRequired'))
   }
   if (normalized.type === 's3') {

--- a/frontend/src/components/ConnectionForm.vue
+++ b/frontend/src/components/ConnectionForm.vue
@@ -1643,8 +1643,9 @@ async function onTest() {
   let config: ConnectionConfig
   try {
     config = normalizeForm()
-  } catch {
-    // Host / required field empty; silently return like onSave/onConnect.
+  } catch (e: any) {
+    // 表单校验失败（如必填字段为空）；把错误提示出来而不是静默返回。
+    msg.error(e?.message || String(e))
     return
   }
   testStatus.value = 'checking'
@@ -1669,7 +1670,8 @@ function onSave() {
       resetForm()
     }
   } catch (e: any) {
-    // Host empty, silently return
+    // 表单校验失败（如必填字段为空）；提示错误并保持对话框打开。
+    msg.error(e?.message || String(e))
   }
 }
 
@@ -1684,7 +1686,8 @@ function onConnectOnly() {
       resetForm()
     }
   } catch (e: any) {
-    // Host empty
+    // 表单校验失败（如必填字段为空）；提示错误并保持对话框打开。
+    msg.error(e?.message || String(e))
   }
 }
 
@@ -1699,7 +1702,8 @@ function onConnect() {
       resetForm()
     }
   } catch (e: any) {
-    // Host empty
+    // 表单校验失败（如必填字段为空）；提示错误并保持对话框打开。
+    msg.error(e?.message || String(e))
   }
 }
 </script>


### PR DESCRIPTION
## Summary
- WSL connections have no host field, but the host-required check in `normalizeForm()` only exempted local/serial/k8s/container types. Saving a WSL connection always threw, and the error was swallowed silently, so the Save button appeared to do nothing.
- Add `wsl` to the host-validation exemption list in ConnectionForm.
- Also stop swallowing form validation errors: onSave/onConnectOnly/onConnect/onTest now show the validation message via `msg.error` and keep the dialog open, instead of failing silently.

## Verification
- `npm run build` passes.
- Manually verified: a WSL connection can now be saved without filling any host; invalid forms (e.g. empty host on SSH) now show an error toast.

---
## 摘要
- WSL 类型连接没有主机字段，但 `normalizeForm()` 中的主机必填校验只豁免了 local/serial/k8s/container。保存 WSL 连接时必然抛错，且错误被静默吞掉，表现为点击保存无反应。
- 在 ConnectionForm 的主机校验豁免列表中加入 `wsl`。
- 同时不再静默吞掉表单校验错误：onSave/onConnectOnly/onConnect/onTest 现在通过 `msg.error` 提示校验消息并保持对话框打开。

## 验证
- `npm run build` 通过。
- 已手动验证：不填主机即可保存 WSL 连接；非法表单（如 SSH 主机为空）现在会弹出错误提示。