### PR TITLE
feat(sftp): map WSL /mnt drive mounts onto the local filesystem

### DIFF
--- a/backend/session/wsl_file_session.go
+++ b/backend/session/wsl_file_session.go
@@ -280,8 +280,65 @@ func fileItemsFromDir(dir string, entries []os.DirEntry) []FileItem {
 
 // --- listing ---------------------------------------------------------------
 
+// wslMountLocalPath maps a POSIX path under /mnt/<drive> to the corresponding
+// local Windows path when the first segment is a single, existing drive letter;
+// otherwise ok is false and the caller stays on the wsl.localhost share.
+// Matching is case-insensitive (/mnt/C == /mnt/c); non-drive mounts such as
+// /mnt/wsl never map.
+func wslMountLocalPath(p string) (string, bool) {
+	rest, found := strings.CutPrefix(p, "/mnt/")
+	if !found {
+		return "", false
+	}
+	letter, tail := rest, ""
+	if i := strings.Index(rest, "/"); i >= 0 {
+		letter, tail = rest[:i], rest[i+1:]
+	}
+	if len(letter) != 1 {
+		return "", false
+	}
+	drive := strings.ToUpper(letter) + `:\`
+	if _, err := os.Stat(drive); err != nil {
+		return "", false
+	}
+	if tail == "" {
+		return drive, true
+	}
+	return filepath.Join(drive, filepath.FromSlash(tail)), true
+}
+
+// listMntRoot synthesizes the /mnt listing: the 9P share denies the
+// mountpoint, but its drive children are the local drives, so each existing
+// Windows drive is rendered as a lowercase directory named after the mount
+// (c, d, ...). Non-drive mounts cannot be enumerated from Windows and are
+// omitted.
+func (s *WSLFileSession) listMntRoot() FileListResult {
+	files := make([]FileItem, 0, 8)
+	if drives, err := s.ListLocalDrives(); err == nil {
+		for _, d := range drives {
+			files = append(files, FileItem{
+				Name:    strings.ToLower(d.Name[:1]),
+				ModTime: d.ModTime,
+				Mode:    "drwxr-xr-x",
+				IsDir:   true,
+			})
+		}
+	}
+	return FileListResult{Files: files, Dir: "/mnt"}
+}
+
 func (s *WSLFileSession) ListRemote(dir string) (FileListResult, error) {
 	d := s.resolveRemote(dir)
+	if d == "/mnt" {
+		return s.listMntRoot(), nil
+	}
+	if local, ok := wslMountLocalPath(d); ok {
+		entries, err := os.ReadDir(local)
+		if err != nil {
+			return FileListResult{}, err
+		}
+		return FileListResult{Files: fileItemsFromDir(local, entries), Dir: d}, nil
+	}
 	entries, err := os.ReadDir(s.uncPath(d))
 	if err != nil {
 		return FileListResult{}, s.shareError(d, err)
@@ -378,24 +435,59 @@ func (s *WSLFileSession) readlinkTarget(p string) (string, error) {
 	return t, nil
 }
 
+// canonicalPath resolves p with `readlink -f`, replacing EVERY symlink in the
+// path — last component or mid-path — with its real target; plain paths come
+// back unchanged. The 9P redirector cannot open a path crossing a link ("The
+// directory name is invalid"), so any path it will open must be canonical
+// first. Errors mean the path's parent chain is broken.
+func (s *WSLFileSession) canonicalPath(p string) (string, error) {
+	out, err := exec.Command("wsl.exe", "-d", s.distro, "--", "readlink", "-f", p).Output()
+	if err != nil {
+		return "", err
+	}
+	t := strings.TrimSpace(string(out))
+	if !strings.HasPrefix(t, "/") {
+		return "", fmt.Errorf("not a path: %s", p)
+	}
+	return t, nil
+}
+
 func (s *WSLFileSession) ChangeRemoteDir(dir string) (FileListResult, error) {
 	d := s.resolveRemote(dir)
+	if d == "/mnt" {
+		s.cwd = d
+		return s.listMntRoot(), nil
+	}
+	if local, ok := wslMountLocalPath(d); ok {
+		fi, err := os.Stat(local)
+		if err != nil {
+			// Linux symlinks on a mounted drive are LX reparse points the
+			// Windows side cannot resolve (Stat fails); canonicalize via
+			// the distro and continue at the real target, like the
+			// share-side fallback below.
+			if canon, cerr := s.canonicalPath(d); cerr == nil && canon != d {
+				return s.ChangeRemoteDir(canon)
+			}
+			return FileListResult{}, err
+		}
+		if !fi.IsDir() {
+			return FileListResult{}, fmt.Errorf("not a directory: %s", d)
+		}
+		s.cwd = d
+		return s.ListRemote(d)
+	}
+	// Canonicalize before touching the share: a link anywhere in the path —
+	// the entry itself or mid-path (a stale cwd restored from cache/history)
+	// — makes every open fail ("The directory name is invalid"). Plain paths
+	// come back unchanged; a resolved target re-enters the full dispatch so
+	// one under /mnt maps to the local drive view.
+	if canon, cerr := s.canonicalPath(d); cerr == nil && canon != d {
+		return s.ChangeRemoteDir(canon)
+	}
 	fi, statErr := os.Stat(s.uncPath(d))
 	if statErr == nil && fi.IsDir() {
 		s.cwd = d
 		return s.ListRemote(d)
-	}
-	// The share cannot traverse symbolic links: Stat surfaces the link as a
-	// non-dir reparse point (or errors outright), and open fails with
-	// "cannot be resolved by the system". When the path is a link to a
-	// directory, continue at its real target so symlinked directories stay
-	// navigable — like the SFTP/SCP backends — with the breadcrumb showing
-	// the resolved path.
-	if target, terr := s.readlinkTarget(d); terr == nil && target != d {
-		if fi2, err2 := os.Stat(s.uncPath(target)); err2 == nil && fi2.IsDir() {
-			s.cwd = target
-			return s.ListRemote(target)
-		}
 	}
 	if statErr != nil {
 		// /mnt Windows-drive mounts are denied by the share (drive→WSL→drive
@@ -426,6 +518,9 @@ func (s *WSLFileSession) wslMountDrive(d string) string {
 // --- remote attributes / dirs ----------------------------------------------
 
 func (s *WSLFileSession) MakeDir(dir string) error {
+	if local, ok := wslMountLocalPath(s.resolveRemote(dir)); ok {
+		return os.Mkdir(local, 0o755)
+	}
 	return os.Mkdir(s.uncPath(s.resolveRemote(dir)), 0o755)
 }
 
@@ -455,6 +550,12 @@ func (s *WSLFileSession) Remove(p string, recursive bool) error {
 	if c == "/" || c == "." {
 		return fmt.Errorf("refusing to delete path: %s", c)
 	}
+	if local, ok := wslMountLocalPath(c); ok {
+		if recursive {
+			return os.RemoveAll(local)
+		}
+		return os.Remove(local)
+	}
 	full := s.uncPath(c)
 	if recursive {
 		return os.RemoveAll(full)
@@ -463,10 +564,18 @@ func (s *WSLFileSession) Remove(p string, recursive bool) error {
 }
 
 func (s *WSLFileSession) Rename(oldName, newName string) error {
+	oldL, oldOK := wslMountLocalPath(s.resolveRemote(oldName))
+	newL, newOK := wslMountLocalPath(s.resolveRemote(newName))
+	if oldOK && newOK {
+		return os.Rename(oldL, newL)
+	}
 	return os.Rename(s.uncPath(s.resolveRemote(oldName)), s.uncPath(s.resolveRemote(newName)))
 }
 
 func (s *WSLFileSession) Chmod(p string, mode os.FileMode) error {
+	if local, ok := wslMountLocalPath(s.resolveRemote(p)); ok {
+		return os.Chmod(local, mode)
+	}
 	return os.Chmod(s.uncPath(s.resolveRemote(p)), mode)
 }
 
@@ -474,22 +583,27 @@ func (s *WSLFileSession) Chmod(p string, mode os.FileMode) error {
 
 // uncPathResolved returns the UNC path for a POSIX remote path. Symbolic
 // links cannot be traversed through the wsl.localhost share (Stat surfaces
-// them as ModeIrregular reparse points and open fails), so when the path is
-// a link it resolves to the real target's UNC form via `readlink -f`;
-// ordinary paths return the plain UNC form unchanged.
+// them as ModeIrregular reparse points and open fails), so the path is
+// canonicalized via `readlink -f` — following a final-component link or
+// healing one mid-path (e.g. from a stale cwd). Ordinary paths return the
+// plain UNC form unchanged.
 func (s *WSLFileSession) uncPathResolved(remotePath string) string {
 	full := s.uncPath(remotePath)
 	if fi, err := os.Stat(full); err == nil && fi.Mode()&os.ModeIrregular == 0 {
 		return full
 	}
-	if target, terr := s.readlinkTarget(remotePath); terr == nil {
-		return s.uncPath(target)
+	if canon, cerr := s.canonicalPath(remotePath); cerr == nil {
+		return s.uncPath(canon)
 	}
 	return full
 }
 
 func (s *WSLFileSession) GetContent(remotePath string) ([]byte, error) {
-	b, err := os.ReadFile(s.uncPathResolved(s.resolveRemote(remotePath)))
+	p := s.resolveRemote(remotePath)
+	if local, ok := wslMountLocalPath(p); ok {
+		return os.ReadFile(local)
+	}
+	b, err := os.ReadFile(s.uncPathResolved(p))
 	if isShareTraverseErr(err) {
 		return nil, fmt.Errorf("cannot open %s: symbolic links cannot be traversed through the WSL file share", remotePath)
 	}
@@ -497,16 +611,30 @@ func (s *WSLFileSession) GetContent(remotePath string) ([]byte, error) {
 }
 
 func (s *WSLFileSession) PutContent(remotePath string, content []byte) error {
-	return os.WriteFile(s.uncPathResolved(s.resolveRemote(remotePath)), content, 0o644)
+	p := s.resolveRemote(remotePath)
+	if local, ok := wslMountLocalPath(p); ok {
+		return os.WriteFile(local, content, 0o644)
+	}
+	return os.WriteFile(s.uncPathResolved(p), content, 0o644)
 }
 
 func (s *WSLFileSession) Copy(oldPath, newPath string) error {
+	oldL, oldOK := wslMountLocalPath(s.resolveRemote(oldPath))
+	newL, newOK := wslMountLocalPath(s.resolveRemote(newPath))
+	if oldOK && newOK {
+		return copyPath(oldL, newL, nil)
+	}
 	return copyPath(s.uncPath(s.resolveRemote(oldPath)), s.uncPath(s.resolveRemote(newPath)), nil)
 }
 
 func (s *WSLFileSession) Move(oldPath, newPath string) error {
-	oldU := s.uncPath(s.resolveRemote(oldPath))
-	newU := s.uncPath(s.resolveRemote(newPath))
+	oldL, oldOK := wslMountLocalPath(s.resolveRemote(oldPath))
+	newL, newOK := wslMountLocalPath(s.resolveRemote(newPath))
+	oldU, newU := oldL, newL
+	if !oldOK || !newOK {
+		oldU = s.uncPath(s.resolveRemote(oldPath))
+		newU = s.uncPath(s.resolveRemote(newPath))
+	}
 	if err := os.Rename(oldU, newU); err == nil {
 		return nil
 	}
@@ -519,23 +647,29 @@ func (s *WSLFileSession) Move(oldPath, newPath string) error {
 // --- transfers ---------------------------------------------------------------
 
 func (s *WSLFileSession) Get(remotePath, localPath string, recursive bool) (string, error) {
-	return s.startLocalTransfer("download", s.resolveLocal(localPath), s.uncPathResolved(s.resolveRemote(remotePath)))
+	return s.startLocalTransfer("download", s.resolveLocal(localPath), s.resolveRemote(remotePath))
 }
 
 func (s *WSLFileSession) Put(localPath, remotePath string, recursive bool) (string, error) {
-	return s.startLocalTransfer("upload", s.resolveLocal(localPath), s.uncPathResolved(s.resolveRemote(remotePath)))
+	return s.startLocalTransfer("upload", s.resolveLocal(localPath), s.resolveRemote(remotePath))
 }
 
 // startLocalTransfer copies a file or tree between the Windows-local pane and
-// the WSL UNC path. Both endpoints are on the same machine, so this is a local
-// copy; a Task is reported through the usual OSC 633 transfer events so the
-// frontend TransferPanel stays in sync.
+// the WSL filesystem. Both endpoints are on the same machine, so this is a
+// local copy; a Task is reported through the usual OSC 633 transfer events so
+// the frontend TransferPanel stays in sync. remote is the POSIX display path;
+// the OS path behind it is the /mnt drive mapping when one applies, the
+// wsl.localhost UNC form otherwise.
 func (s *WSLFileSession) startLocalTransfer(tfType, local, remote string) (string, error) {
-	src := remote
+	remoteOS, ok := wslMountLocalPath(remote)
+	if !ok {
+		remoteOS = s.uncPathResolved(remote)
+	}
+	src := remoteOS
 	dst := local
 	if tfType == "upload" {
 		src = local
-		dst = remote
+		dst = remoteOS
 	}
 	total, err := dirSize(src)
 	if err != nil {

--- a/backend/session/wsl_file_session_test.go
+++ b/backend/session/wsl_file_session_test.go
@@ -5,7 +5,9 @@ package session
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -271,6 +273,158 @@ func TestWSLListRemoteSymlinkTypes(t *testing.T) {
 	}
 }
 
+// Entering a directory symlink must land on its canonical target and keep
+// navigating from there: the 9P redirector can Stat the link itself (following
+// the final component) but fails to open any path crossing it ("The directory
+// name is invalid"), so cwd must never hold an unresolved link path.
+func TestWSLChangeRemoteDirIntoSymlinkThenChild(t *testing.T) {
+	distro := wslTestDistro(t)
+	wsl := func(script string) {
+		t.Helper()
+		if out, err := exec.Command("wsl.exe", "-d", distro, "--", "sh", "-c", script).CombinedOutput(); err != nil {
+			t.Fatalf("wsl %q: %v: %s", script, err, out)
+		}
+	}
+	dir := fmt.Sprintf("/tmp/uniterm-symtest-%d", time.Now().UnixNano())
+	// Relative link target on purpose: readlink -f must canonicalize it.
+	wsl(fmt.Sprintf("mkdir -p '%s/real/sub' && printf hi > '%s/real/sub/inside.txt' && ln -sfn real '%s/af'", dir, dir, dir))
+	defer exec.Command("wsl.exe", "-d", distro, "--", "rm", "-rf", dir).Run()
+
+	s := &WSLFileSession{
+		baseSession: baseSession{sessionType: "wsl-file"},
+		distro:      distro,
+		root:        "//wsl.localhost/" + distro,
+		cwd:         dir,
+	}
+	res, err := s.ChangeRemoteDir("af")
+	if err != nil {
+		t.Fatalf("ChangeRemoteDir(af) failed: %v", err)
+	}
+	if want := dir + "/real"; res.Dir != want || s.cwd != want {
+		t.Errorf("entering af: dir=%q cwd=%q, want %q", res.Dir, s.cwd, want)
+	}
+	// The child must be reachable from the canonical cwd (no link mid-path).
+	res2, err := s.ChangeRemoteDir("sub")
+	if err != nil {
+		t.Fatalf("ChangeRemoteDir(sub) failed: %v", err)
+	}
+	if want := dir + "/real/sub"; res2.Dir != want {
+		t.Errorf("child dir = %q, want %q", res2.Dir, want)
+	}
+	found := false
+	for _, f := range res2.Files {
+		if f.Name == "inside.txt" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("listing missing inside.txt: %+v", res2.Files)
+	}
+}
+
+// A symlink whose target lives on a mounted drive (e.g. a sysroot under
+// /mnt/c) must enter the mapped local-drive view: the share itself cannot
+// open any path into /mnt, with or without the link on the way.
+func TestWSLChangeRemoteDirSymlinkToMntTarget(t *testing.T) {
+	distro := wslTestDistro(t)
+	tmp := os.TempDir()
+	vol := filepath.VolumeName(tmp)
+	if len(vol) != 2 || vol[1] != ':' {
+		t.Skipf("TempDir %q is not on a drive letter", tmp)
+	}
+	posixTarget := "/mnt/" + strings.ToLower(vol[:1]) + filepath.ToSlash(tmp[2:]) + fmt.Sprintf("/uniterm-mnt-linkto-%d", time.Now().UnixNano())
+	localTarget := filepath.FromSlash(posixTarget[len("/mnt/x"):])
+	localTarget = vol + `\` + strings.TrimPrefix(localTarget, `\`)
+	if err := os.MkdirAll(filepath.Join(localTarget, "sub"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(localTarget, "sub", "inside.txt"), []byte("hi"), 0o644); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+	defer os.RemoveAll(localTarget)
+
+	linkDir := fmt.Sprintf("/tmp/uniterm-mnt-link-%d", time.Now().UnixNano())
+	if out, err := exec.Command("wsl.exe", "-d", distro, "--", "sh", "-c",
+		fmt.Sprintf("mkdir -p '%s' && ln -sfn '%s' '%s/af'", linkDir, posixTarget, linkDir)).CombinedOutput(); err != nil {
+		t.Fatalf("wsl: %v: %s", err, out)
+	}
+	defer exec.Command("wsl.exe", "-d", distro, "--", "rm", "-rf", linkDir).Run()
+
+	s := &WSLFileSession{
+		baseSession: baseSession{sessionType: "wsl-file"},
+		distro:      distro,
+		root:        "//wsl.localhost/" + distro,
+		cwd:         linkDir,
+	}
+	res, err := s.ChangeRemoteDir("af")
+	if err != nil {
+		t.Fatalf("ChangeRemoteDir(af) failed: %v", err)
+	}
+	if res.Dir != posixTarget || s.cwd != posixTarget {
+		t.Errorf("entering af: dir=%q cwd=%q, want %q", res.Dir, s.cwd, posixTarget)
+	}
+	res2, err := s.ChangeRemoteDir("sub")
+	if err != nil {
+		t.Fatalf("ChangeRemoteDir(sub) failed: %v", err)
+	}
+	if want := posixTarget + "/sub"; res2.Dir != want {
+		t.Errorf("child dir = %q, want %q", res2.Dir, want)
+	}
+	found := false
+	for _, f := range res2.Files {
+		if f.Name == "inside.txt" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("listing missing inside.txt: %+v", res2.Files)
+	}
+}
+
+// A cwd that still holds an unresolved link (restored cache / history from an
+// older session) must not poison child navigation or content reads: the share
+// cannot open any path crossing a link, mid-path included, so change-dir and
+// content ops heal the path via `readlink -f` before giving up.
+func TestWSLMidPathLinkHealing(t *testing.T) {
+	distro := wslTestDistro(t)
+	wsl := func(script string) {
+		t.Helper()
+		if out, err := exec.Command("wsl.exe", "-d", distro, "--", "sh", "-c", script).CombinedOutput(); err != nil {
+			t.Fatalf("wsl %q: %v: %s", script, err, out)
+		}
+	}
+	dir := fmt.Sprintf("/tmp/uniterm-symtest-%d", time.Now().UnixNano())
+	wsl(fmt.Sprintf("mkdir -p '%s/real/lib' && printf hi > '%s/real/lib/inside.txt' && printf yo > '%s/real/notes.txt' && ln -sfn real '%s/af'", dir, dir, dir, dir))
+	defer exec.Command("wsl.exe", "-d", distro, "--", "rm", "-rf", dir).Run()
+
+	s := &WSLFileSession{
+		baseSession: baseSession{sessionType: "wsl-file"},
+		distro:      distro,
+		root:        "//wsl.localhost/" + distro,
+		cwd:         dir + "/af", // the link path itself, as a stale cwd would be
+	}
+	// Content reads under the stale link path must heal the same way.
+	if b, err := s.GetContent("notes.txt"); err != nil || string(b) != "yo" {
+		t.Errorf("GetContent(notes.txt) = %q, %v; want %q", b, err, "yo")
+	}
+	res, err := s.ChangeRemoteDir("lib")
+	if err != nil {
+		t.Fatalf("ChangeRemoteDir(lib) failed: %v", err)
+	}
+	if want := dir + "/real/lib"; res.Dir != want || s.cwd != want {
+		t.Errorf("healed dir=%q cwd=%q, want %q", res.Dir, s.cwd, want)
+	}
+	found := false
+	for _, f := range res.Files {
+		if f.Name == "inside.txt" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("listing missing inside.txt: %+v", res.Files)
+	}
+}
+
 // The wsl.exe invocation that creates a symbolic link inside the distro (the
 // wsl.localhost UNC share cannot create Linux links).
 func TestWSLSymlinkCmd(t *testing.T) {
@@ -278,5 +432,242 @@ func TestWSLSymlinkCmd(t *testing.T) {
 	want := []string{"wsl.exe", "-d", "Ubuntu-22.04", "--", "ln", "-s", "/home/u/target", "/home/u/link"}
 	if !reflect.DeepEqual(cmd.Args, want) {
 		t.Errorf("wslSymlinkCmd args = %v, want %v", cmd.Args, want)
+	}
+}
+
+// /mnt/<drive>/... paths are the local Windows drive reached through WSL, so
+// they map to the plain local path when the first segment is a single, existing
+// drive letter; anything else (non-drive mounts, missing drives) stays on the
+// 9P share path.
+func TestWSLMountLocalPath(t *testing.T) {
+	absent := ""
+	for _, letter := range "ABCDEFGHIJKLMNOPQRSTUVWXYZ" {
+		if _, err := os.Stat(string(letter) + `:\`); err != nil {
+			absent = string(letter)
+			break
+		}
+	}
+	cases := []struct {
+		posix string
+		want  string
+		ok    bool
+	}{
+		{"/mnt/c", `C:\`, true},
+		{"/mnt/C", `C:\`, true},
+		{"/mnt/c/Users", `C:\Users`, true},
+		{"/mnt", "", false},
+		{"/mnt/wsl", "", false},
+		{"/mnt/cfoo", "", false},
+		{"/home/user", "", false},
+	}
+	if absent != "" {
+		cases = append(cases, struct {
+			posix string
+			want  string
+			ok    bool
+		}{"/mnt/" + strings.ToLower(absent), "", false})
+	}
+	for _, c := range cases {
+		got, ok := wslMountLocalPath(c.posix)
+		if ok != c.ok || got != c.want {
+			t.Errorf("wslMountLocalPath(%q) = %q, %v; want %q, %v", c.posix, got, ok, c.want, c.ok)
+		}
+	}
+}
+
+// ListRemote on /mnt itself is a synthesized view of the local drive letters
+// (the 9P share denies the mountpoint), so navigation / -> /mnt -> /mnt/c is
+// seamless.
+func TestWSLListMntRoot(t *testing.T) {
+	s := &WSLFileSession{distro: "Ubuntu"}
+	res, err := s.ListRemote("/mnt")
+	if err != nil {
+		t.Fatalf("ListRemote(/mnt) failed: %v", err)
+	}
+	if res.Dir != "/mnt" {
+		t.Errorf("Dir = %q, want /mnt", res.Dir)
+	}
+	want := map[string]bool{}
+	if drives, err := s.ListLocalDrives(); err == nil {
+		for _, d := range drives {
+			want[strings.ToLower(d.Name[:1])] = true
+		}
+	}
+	if len(want) == 0 {
+		t.Skip("no local drives found")
+	}
+	got := map[string]bool{}
+	for _, f := range res.Files {
+		if !f.IsDir {
+			t.Errorf("drive entry %q should be a directory: %+v", f.Name, f)
+		}
+		got[f.Name] = true
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("listing = %v, want %v", got, want)
+	}
+}
+
+// Entering /mnt/c lands on the local drive: the listing matches the real C:\
+// contents and the cwd is the POSIX mount path.
+func TestWSLChangeRemoteDirMnt(t *testing.T) {
+	if _, err := os.Stat(`C:\`); err != nil {
+		t.Skip("no C: drive")
+	}
+	s := &WSLFileSession{distro: "Ubuntu", root: "//wsl.localhost/Ubuntu"}
+	res, err := s.ChangeRemoteDir("/mnt/c")
+	if err != nil {
+		t.Fatalf("ChangeRemoteDir(/mnt/c) failed: %v", err)
+	}
+	if res.Dir != "/mnt/c" {
+		t.Errorf("Dir = %q, want /mnt/c", res.Dir)
+	}
+	if s.cwd != "/mnt/c" {
+		t.Errorf("cwd = %q, want /mnt/c", s.cwd)
+	}
+	local, err := os.ReadDir(`C:\`)
+	if err != nil {
+		t.Fatalf("ReadDir(C:\\) failed: %v", err)
+	}
+	if len(res.Files) != len(local) {
+		t.Errorf("listing has %d entries, C:\\ has %d", len(res.Files), len(local))
+	}
+}
+
+// Content operations under /mnt/<drive> hit the real local file, so editing a
+// file seen in the WSL pane edits the Windows copy.
+func TestWSLContentMappedMnt(t *testing.T) {
+	tmp := os.TempDir()
+	vol := filepath.VolumeName(tmp)
+	if len(vol) != 2 || vol[1] != ':' {
+		t.Skipf("TempDir %q is not on a drive letter", tmp)
+	}
+	posix := "/mnt/" + strings.ToLower(vol[:1]) + filepath.ToSlash(tmp[2:]) + "/uniterm-mnt-test.txt"
+	local := filepath.Join(tmp, "uniterm-mnt-test.txt")
+	defer os.Remove(local)
+
+	if err := os.WriteFile(local, []byte("hi"), 0o644); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+	s := &WSLFileSession{distro: "Ubuntu", root: "//wsl.localhost/Ubuntu"}
+	got, err := s.GetContent(posix)
+	if err != nil {
+		t.Fatalf("GetContent(%q) failed: %v", posix, err)
+	}
+	if string(got) != "hi" {
+		t.Errorf("GetContent = %q, want %q", got, "hi")
+	}
+	if err := s.PutContent(posix, []byte("bye")); err != nil {
+		t.Fatalf("PutContent failed: %v", err)
+	}
+	if b, err := os.ReadFile(local); err != nil || string(b) != "bye" {
+		t.Errorf("PutContent missed the local file: %q, %v", b, err)
+	}
+}
+
+// A download from /mnt/<drive> copies between two local paths and reports the
+// POSIX mount path as the task's remote path.
+func TestWSLGetMappedMnt(t *testing.T) {
+	tmp, err := os.MkdirTemp("", "uniterm-mnt-dl-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	defer os.RemoveAll(tmp)
+	vol := filepath.VolumeName(tmp)
+	if len(vol) != 2 || vol[1] != ':' {
+		t.Skipf("temp dir %q is not on a drive letter", tmp)
+	}
+	posix := "/mnt/" + strings.ToLower(vol[:1]) + filepath.ToSlash(tmp[2:])
+	src := filepath.Join(tmp, "in.txt")
+	if err := os.WriteFile(src, []byte("payload"), 0o644); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+
+	s := &WSLFileSession{
+		baseSession: baseSession{sessionType: "wsl-file"},
+		distro:      "Ubuntu",
+		root:        "//wsl.localhost/Ubuntu",
+		localFSOps:  newLocalFSOps(),
+		transfers:   map[string]*TransferTask{},
+	}
+	dst := filepath.Join(tmp, "out.txt")
+	id, err := s.Get(posix+"/in.txt", dst, false)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	// The task deletes itself on completion; read it right away.
+	s.mu.Lock()
+	task := s.transfers[id]
+	s.mu.Unlock()
+	if task == nil || task.RemotePath != posix+"/in.txt" {
+		t.Errorf("task RemotePath = %q, want %q", taskRemotePath(task), posix+"/in.txt")
+	}
+	out := dst
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		if b, rerr := os.ReadFile(out); rerr == nil {
+			if string(b) != "payload" {
+				t.Fatalf("copied content = %q, want %q", b, "payload")
+			}
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("copy never produced %s", out)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+func taskRemotePath(t *TransferTask) string {
+	if t == nil {
+		return ""
+	}
+	return t.RemotePath
+}
+
+// A symlink created inside the distro on a mounted drive is an LX reparse
+// point the Windows side cannot resolve, so the mapped-path Stat fails.
+// Entering it must fall back to `readlink -f` and continue at the link's real
+// target, matching the share-side symlink fallback.
+func TestWSLChangeRemoteDirMntSymlinkFallback(t *testing.T) {
+	distro := wslTestDistro(t)
+	tmp := os.TempDir()
+	vol := filepath.VolumeName(tmp)
+	if len(vol) != 2 || vol[1] != ':' {
+		t.Skipf("TempDir %q is not on a drive letter", tmp)
+	}
+	posixTmp := "/mnt/" + strings.ToLower(vol[:1]) + filepath.ToSlash(tmp[2:])
+	base := fmt.Sprintf("%s/uniterm-mnt-sym-%d", posixTmp, time.Now().UnixNano())
+	wsl := func(script string) {
+		t.Helper()
+		if out, err := exec.Command("wsl.exe", "-d", distro, "--", "sh", "-c", script).CombinedOutput(); err != nil {
+			t.Fatalf("wsl %q: %v: %s", script, err, out)
+		}
+	}
+	// Relative link target on purpose: readlink -f must canonicalize it.
+	wsl(fmt.Sprintf("mkdir -p '%s/real' && printf hi > '%s/real/inside.txt' && ln -s real '%s/dlink'", base, base, base))
+	defer os.RemoveAll(filepath.Join(tmp, filepath.Base(base)))
+
+	s := &WSLFileSession{
+		baseSession: baseSession{sessionType: "wsl-file"},
+		distro:      distro,
+		root:        "//wsl.localhost/" + distro,
+		cwd:         base,
+	}
+	res, err := s.ChangeRemoteDir("dlink")
+	if err != nil {
+		t.Fatalf("ChangeRemoteDir(dlink) failed: %v", err)
+	}
+	if want := base + "/real"; res.Dir != want {
+		t.Errorf("resolved dir = %q, want %q", res.Dir, want)
+	}
+	found := false
+	for _, f := range res.Files {
+		if f.Name == "inside.txt" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("target listing missing inside.txt: %+v", res.Files)
 	}
 }

--- a/frontend/src/components/FileSidebar.vue
+++ b/frontend/src/components/FileSidebar.vue
@@ -170,7 +170,7 @@ import FileEditorDialog from './FileEditorDialog.vue'
 import FileGenericDialog from './FileGenericDialog.vue'
 import FileConflictDialog from './FileConflictDialog.vue'
 import { Events } from '@wailsio/runtime'
-import { useTransferTaskEvents } from '../composables/useTransferTasks'
+import { useTransferTaskEvents, watchNewTransferTasks } from '../composables/useTransferTasks'
 import { queuedSessionWrite } from '../services/sessionWriter'
 
 const { t } = useI18n()
@@ -186,7 +186,6 @@ const transferHeight = ref(130)
 // The transfer panel starts COLLAPSED (only its button bar shows) and a new
 // transfer expands it — the user can always re-collapse via the bar's toggle.
 const sidebarTransferCollapsed = ref(true)
-const seenTransferIds = new Set<string>()
 
 let refreshTimer: ReturnType<typeof setTimeout> | null = null
 let refreshDebounce: ReturnType<typeof setTimeout> | null = null
@@ -199,14 +198,7 @@ const sessionId = computed(() => companionStore.currentSftpSessionId)
 const transferKey = computed(() => companionStore.transferKey || 'companion-sftp')
 const transferTasks = computed(() => panelStore.getTransferTasks(transferKey.value))
 // Auto-expand the collapsed panel whenever a NEW transfer task appears.
-watch(transferTasks, (tasks) => {
-  for (const task of tasks) {
-    if (!seenTransferIds.has(task.id)) {
-      seenTransferIds.add(task.id)
-      sidebarTransferCollapsed.value = false
-    }
-  }
-})
+watchNewTransferTasks(() => transferTasks.value, () => { sidebarTransferCollapsed.value = false })
 const transferEvents = useTransferTaskEvents(
   () => transferTasks.value,
   () => sessionId.value,

--- a/frontend/src/components/FileTabContent.vue
+++ b/frontend/src/components/FileTabContent.vue
@@ -193,7 +193,7 @@ import { reconnectFileTransferPanel, isPanelReconnecting } from '../composables/
 import { isConnectionLostError, supportsRemoteSymlink } from '../utils/fileTransferUtils'
 import { bindExtEditUploadedToast } from '../composables/useFilePanel'
 import { Events } from '@wailsio/runtime'
-import { useTransferTaskEvents } from '../composables/useTransferTasks'
+import { useTransferTaskEvents, watchNewTransferTasks } from '../composables/useTransferTasks'
 
 const props = defineProps<{
   panelId: string
@@ -441,19 +441,10 @@ watch(() => panel.value?.sessionId, async (newId, oldId) => {
 // (a manual collapse only hides the panel until the next task starts). The
 // persisted flag remembers the last visibility across restarts but never
 // suppresses the auto-pop.
-const seenTransferTaskIds = new Set<string>()
-watch(() => transferTasks.map(t => t.id).join('|'), () => {
-  let hasNewTask = false
-  for (const task of transferTasks) {
-    if (!seenTransferTaskIds.has(task.id)) {
-      seenTransferTaskIds.add(task.id)
-      hasNewTask = true
-    }
-  }
-  if (hasNewTask && !settingsStore.sftpTransferPanelVisible) {
-    settingsStore.sftpTransferPanelVisible = true
-  }
-})
+watchNewTransferTasks(
+  () => transferTasks,
+  () => { settingsStore.sftpTransferPanelVisible = true },
+)
 
 // A fast-connecting session (e.g. S3) can emit session:status 'connected' before
 // this panel binds its sessionId, so the connected-event handler and a mount-time

--- a/frontend/src/composables/useTransferTasks.test.ts
+++ b/frontend/src/composables/useTransferTasks.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { nextTick, reactive } from 'vue'
 
 const handlers: Record<string, (ev: any) => void> = {}
 vi.mock('@wailsio/runtime', () => ({
@@ -10,7 +11,7 @@ vi.mock('@wailsio/runtime', () => ({
   },
 }))
 
-import { useTransferTaskEvents, buildSkipList } from './useTransferTasks'
+import { useTransferTaskEvents, buildSkipList, watchNewTransferTasks } from './useTransferTasks'
 
 function fireTransfer(payload: any) {
   handlers['sftp:transfer']({ data: payload })
@@ -100,6 +101,45 @@ describe('useTransferTaskEvents', () => {
     })
     expect(tasks[0].localPath).toBe('C:/data/big.bin')
     expect(tasks[0].remotePath).toBe('/srv/big.bin')
+  })
+})
+
+describe('watchNewTransferTasks', () => {
+  // Regression: watching the tasks array by reference (a computed that only
+  // returns it) never fires when tasks are pushed, so the sidebar transfer
+  // panel stayed collapsed. The watcher must track the task ids themselves.
+  it('fires when a new task id is pushed and not for in-place updates', async () => {
+    const tasks = reactive<any[]>([])
+    const onNew = vi.fn()
+    watchNewTransferTasks(() => tasks, onNew)
+    await nextTick()
+    expect(onNew).not.toHaveBeenCalled()
+
+    tasks.push({ id: 'dl-1' })
+    await nextTick()
+    expect(onNew).toHaveBeenCalledTimes(1)
+
+    // Progress mutations must not re-trigger.
+    tasks[0].percentage = 50
+    await nextTick()
+    expect(onNew).toHaveBeenCalledTimes(1)
+
+    tasks.push({ id: 'dl-2' })
+    await nextTick()
+    expect(onNew).toHaveBeenCalledTimes(2)
+  })
+
+  it('treats a pre-populated list as new only when it changes', async () => {
+    const tasks = reactive<any[]>([{ id: 'dl-1' }])
+    const onNew = vi.fn()
+    watchNewTransferTasks(() => tasks, onNew)
+    await nextTick()
+    // Lazy watch: registration alone does not expand the panel.
+    expect(onNew).not.toHaveBeenCalled()
+
+    tasks.push({ id: 'dl-1b' })
+    await nextTick()
+    expect(onNew).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/frontend/src/composables/useTransferTasks.ts
+++ b/frontend/src/composables/useTransferTasks.ts
@@ -1,4 +1,4 @@
-import { onUnmounted } from 'vue'
+import { onUnmounted, watch } from 'vue'
 import { Events } from '@wailsio/runtime'
 import type { TransferTaskUI } from '../stores/panelStore'
 
@@ -147,6 +147,26 @@ export function useTransferTaskEvents(
   onUnmounted(unbind)
 
   return { bind, unbind }
+}
+
+/**
+ * Fire onNew() when the task list gains at least one task id not seen before
+ * (used to auto-expand a collapsed transfer panel). The getter must READ the
+ * task ids — watching the array by reference never fires when tasks are pushed
+ * into it, which is how the sidebar's auto-expand broke once.
+ */
+export function watchNewTransferTasks(getTasks: () => TransferTaskUI[], onNew: () => void) {
+  const seen = new Set<string>()
+  watch(() => getTasks().map(t => t.id).join('|'), () => {
+    let hasNew = false
+    for (const task of getTasks()) {
+      if (!seen.has(task.id)) {
+        seen.add(task.id)
+        hasNew = true
+      }
+    }
+    if (hasNew) onNew()
+  })
 }
 
 /**

--- a/frontend/src/utils/fileTransferUtils.test.ts
+++ b/frontend/src/utils/fileTransferUtils.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest'
+import { supportsRemoteSymlink } from './fileTransferUtils'
+
+// "New link" must appear wherever the backend can create symbolic links. The
+// WSL dual-pane file window carries config type 'wsl-file' (the companion
+// sidebar uses 'wsl'), and both are served by the WSL file session.
+describe('supportsRemoteSymlink', () => {
+  it('accepts every backend with link semantics', () => {
+    for (const type of ['ssh', 'sftp', 'scp', 'wsl', 'wsl-file']) {
+      expect(supportsRemoteSymlink({ type })).toBe(true)
+    }
+  })
+
+  it('rejects protocols without link semantics', () => {
+    for (const type of ['ftp', 'smb', 'webdav', 's3', 'local', 'serial']) {
+      expect(supportsRemoteSymlink({ type })).toBe(false)
+    }
+    expect(supportsRemoteSymlink(null)).toBe(false)
+    expect(supportsRemoteSymlink(undefined)).toBe(false)
+  })
+})

--- a/frontend/src/utils/fileTransferUtils.ts
+++ b/frontend/src/utils/fileTransferUtils.ts
@@ -15,11 +15,13 @@ export function connectFileMenuKey(config?: { type?: string; fileTransferProto?:
 }
 
 // True when the connection's remote filesystem can create symbolic links
-// (SSH = SFTP/SCP companion or standalone, and WSL). FTP, SMB, WebDAV and S3
-// have no link semantics, so their file panels hide the "new link" entry.
+// (SSH = SFTP/SCP companion or standalone, and WSL — 'wsl' for the companion
+// sidebar's terminal config, 'wsl-file' for the dual-pane file window). FTP,
+// SMB, WebDAV and S3 have no link semantics, so their file panels hide the
+// "new link" entry.
 export function supportsRemoteSymlink(config?: { type?: string } | null): boolean {
   if (!config) return false
-  return config.type === 'ssh' || config.type === 'sftp' || config.type === 'scp' || config.type === 'wsl'
+  return config.type === 'ssh' || config.type === 'sftp' || config.type === 'scp' || config.type === 'wsl' || config.type === 'wsl-file'
 }
 
 // True when an operation failed because the transport died rather than because


### PR DESCRIPTION
## Summary

WSL file sessions reach the distro through the wsl.localhost 9P share, which refuses every path into /mnt (the drive-to-WSL-to-drive loopback), and cannot open any path crossing a symbolic link mid-way. This PR:

- **Maps /mnt/<drive>/... to the local Windows drive**: when the first segment is a single, existing drive letter, listing, navigation, content read/write, mkdir/remove/rename/chmod, copy/move and Get/Put transfers run directly against the local disk. Listing /mnt itself is synthesized from the local drive letters, so / -> /mnt -> /mnt/c navigates seamlessly. Non-drive mounts and missing drives keep the previous share behavior and guidance error.
- **Canonicalizes symlink paths before touching the share**: entering a directory (or reading a file, or transferring) resolves the full path via readlink -f, so links at the tail, mid-path (e.g. a stale cwd restored from cache/history), or nested chains all land on the real target. A resolved target under /mnt re-enters the drive mapping. This fixes navigation into symlinked directories failing with "The directory name is invalid" after the first hop.
- **Restores the new-link entry in the dual-pane WSL file window**: the window rewrites the connection type to wsl-file, which the symlink-capability whitelist did not recognize.
- **Auto-expands the transfer panel when a task starts**: the sidebar watched the task list through a computed that only returns the array reference and never re-evaluates on push, so the panel stayed collapsed; the new-task detection is extracted into a shared composable used by both the sidebar and the dual-pane window.

## Test plan

- [x] go test ./backend/... — 14 WSL session tests, including real-distro integration tests for drive mapping, /mnt synthesized listing, symlink-to-/mnt-target navigation and mid-path link healing
- [x] Frontend vitest suite (344 tests) including new cases for the symlink whitelist and the auto-expand regression
- [x] go build ./... and vite build

---

## 摘要

WSL 文件会话通过 wsl.localhost 9P 共享访问发行版，该共享拒绝所有 /mnt 路径（盘符→WSL→盘符回环），且无法打开任何穿越符号链接中间段的路径。本 PR：

- **将 /mnt/<盘符>/... 映射到本地 Windows 磁盘**：当首段是单个且本机存在的盘符时，列目录、导航、内容读写、建目录/删除/改名/改权限、复制/移动及 Get/Put 传输均直接操作本地磁盘；/mnt 本身的列表由本地盘符合成，/ -> /mnt -> /mnt/c 导航连贯。非盘符挂载和缺失盘符保持原有共享行为与引导性报错。
- **访问共享前先规范化符号链接路径**：进入目录（以及读文件、传输）先通过 readlink -f 解析完整路径——链接在末尾、中间（如缓存/历史恢复的残留 cwd）或多级嵌套都会落到真实目标；解析结果若位于 /mnt 下则重新进入盘符映射。修复了进入软链目录后继续导航报 "The directory name is invalid" 的问题。
- **恢复双栏 WSL 文件窗口的"新建链接"入口**：双栏窗口将连接类型改写为 wsl-file，而符号链接能力白名单未包含该值，导致入口消失。
- **传输任务启动时自动展开传输面板**：侧栏通过仅返回数组引用的 computed 监听任务列表，push 不会触发，面板始终收起；现将新任务检测提取为共享 composable，侧栏与双栏窗口统一使用。

## 测试

- [x] go test ./backend/... —— 14 个 WSL 会话测试，含真实发行版集成测试（盘符映射、/mnt 合成列表、软链目标在 /mnt 下的导航、中间段链接救治）
- [x] 前端 vitest 全量 344 个测试，含符号链接白名单与自动展开回归的新用例
- [x] go build ./... 与 vite build