### PR TITLE
fix(win): restore Windows 11 rounded corners on first launch

### DIFF
--- a/app_darwin.go
+++ b/app_darwin.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"unsafe"
 
 	"github.com/ys-ll/uniterm/backend/log"
 )
@@ -140,3 +141,7 @@ func (a *App) configureMacKeyRepeat() {
 		log.Writef("configureMacKeyRepeat: disabled ApplePressAndHoldEnabled for %s (key-repeat enabled)", macBundleID)
 	}()
 }
+
+// applyRoundedCorners is a no-op on macOS: window corners are handled by the
+// platform (the Windows build asks DWM for Win11 rounded corners instead).
+func applyRoundedCorners(unsafe.Pointer) {}

--- a/app_linux.go
+++ b/app_linux.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"unsafe"
 )
 
 func (a *App) findMainWindow() uintptr { return 0 }
@@ -96,3 +97,7 @@ func detectExternalEditors() []ExternalEditorOption {
 
 	return out
 }
+
+// applyRoundedCorners is a no-op on Linux: window corners are handled by the
+// platform (the Windows build asks DWM for Win11 rounded corners instead).
+func applyRoundedCorners(unsafe.Pointer) {}

--- a/app_windows.go
+++ b/app_windows.go
@@ -353,3 +353,34 @@ func detectExternalEditors() []ExternalEditorOption {
 
 	return out
 }
+
+// Win11 rounds the corners of top-level windows whose DWM frame is intact.
+// Wails' frameless windows keep WS_THICKFRAME, but Wails only extends the DWM
+// frame (DwmExtendFrameIntoClientArea) from its WM_ACTIVATE handler, and the
+// window's first activation happens inside CreateWindowEx (WS_VISIBLE) before
+// Wails' WndProc is hooked — so that first extension is missed. A freshly
+// launched binary then shows square corners until the next activation
+// (minimise/restore, alt-tab) reapplies it. Asking DWM directly for rounded
+// corners makes the first paint correct regardless of activation timing; on
+// pre-Win11 systems the unsupported attribute call fails silently, which is
+// fine.
+const (
+	dwmwaWindowCornerPreference = 33
+	dwmwcpRound                 = 2
+)
+
+var procDwmSetWindowAttribute = syscall.NewLazyDLL("dwmapi.dll").NewProc("DwmSetWindowAttribute")
+
+// applyRoundedCorners sets DWMWCP_ROUND on the given HWND.
+func applyRoundedCorners(hwnd unsafe.Pointer) {
+	if hwnd == nil {
+		return
+	}
+	preference := uint32(dwmwcpRound)
+	_, _, _ = procDwmSetWindowAttribute.Call(
+		uintptr(hwnd),
+		dwmwaWindowCornerPreference,
+		uintptr(unsafe.Pointer(&preference)),
+		unsafe.Sizeof(preference),
+	)
+}

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/go-sql-driver/mysql v1.10.0
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
+	github.com/jcmturner/gofork v1.7.6
 	github.com/jcmturner/gokrb5/v8 v8.4.4
 	github.com/jlaffaye/ftp v0.2.1
 	github.com/kevinburke/ssh_config v1.4.0
@@ -76,7 +77,6 @@ require (
 	github.com/jchv/go-winloader v0.0.0-20250406163304-c1995be93bd1 // indirect
 	github.com/jcmturner/aescts/v2 v2.0.0 // indirect
 	github.com/jcmturner/dnsutils/v2 v2.0.0 // indirect
-	github.com/jcmturner/gofork v1.7.6 // indirect
 	github.com/jcmturner/goidentity/v6 v6.0.1 // indirect
 	github.com/jcmturner/rpc/v2 v2.0.3 // indirect
 	github.com/klauspost/compress v1.18.3 // indirect

--- a/main.go
+++ b/main.go
@@ -205,6 +205,19 @@ func main() {
 		},
 	})
 
+	// Win11 rounded corners: Wails only extends the DWM frame from its
+	// WM_ACTIVATE handler, whose first firing (inside CreateWindowEx, before
+	// its WndProc is hooked) is missed — so a production binary starts with
+	// square corners until the next activation (minimise/restore). Ask DWM
+	// for rounded corners on first show instead; see win11_corners_windows.go.
+	// WindowShow reliably fires after WebView2 navigation completes, when the
+	// native window exists. Idempotent; a no-op on pre-Win11 and other OSes.
+	if runtime.GOOS == "windows" {
+		window.OnWindowEvent(events.Windows.WindowShow, func(*application.WindowEvent) {
+			applyRoundedCorners(window.NativeWindow())
+		})
+	}
+
 	// Wails v3 delivers OS file drops to Go-side window-event listeners rather
 	// than (as v2 did) auto-forwarding them to the frontend. Re-emit the dropped
 	// absolute paths under the original v2 event name so `Events.On(...)` pickers


### PR DESCRIPTION
## Description

On Windows 11, a production binary built with `wails3 build` launched without rounded window corners on first start; the corners only appeared after minimising and restoring the window. `wails3 dev` did not exhibit the problem.

### Root cause

Wails v3 extends the DWM frame (the call that provides Win11 rounded corners and the aero shadow) only from its `WM_ACTIVATE` handler. The window's first activation fires inside `CreateWindowEx` (the window is created with `WS_VISIBLE`), before Wails hooks its WndProc, so that first extension is missed. Any later activation (minimise/restore, alt-tab) reapplies it, which is exactly the reported symptom. `wails3 dev` only looked correct because its startup timing happened to trigger an extra activation.

### Fix

Ask DWM for rounded corners explicitly (`DwmSetWindowAttribute(DWMWA_WINDOW_CORNER_PREFERENCE, DWMWCP_ROUND)`) when the window is first shown (`events.Windows.WindowShow`, which reliably fires once the native window exists). The call is idempotent and fails silently on pre-Win11 systems. The Windows implementation lives in `app_windows.go` with no-op stubs for darwin/linux.

Also promotes `jcmturner/gofork` to a direct dependency: the krb5 GSSAPI tests import its `encoding/asn1` directly, which is required to marshal Kerberos messages byte-identically with gokrb5.

Closes #824

## 其他说明（中文）

### 问题

Windows 11 上，`wails3 build` 产出的二进制首次启动窗口没有系统圆角边框，最小化再还原后才会出现；`wails3 dev` 下正常。

### 根因

Wails v3 只在其 `WM_ACTIVATE` 消息处理中调用 `DwmExtendFrameIntoClientArea`（Win11 圆角与阴影的来源），但窗口以 `WS_VISIBLE` 在 `CreateWindowEx` 时立即显示并触发第一次激活，此时 Wails 的 WndProc 尚未挂载，该调用被错过；之后任意一次激活（最小化/还原、Alt+Tab）都会补上——与报告的症状完全一致。`wails3 dev` 只是启动时序恰好多触发了一次激活，掩盖了问题。

### 修复

窗口首次显示时（`events.Windows.WindowShow`，此时原生窗口句柄必然存在）显式调用 `DwmSetWindowAttribute(DWMWA_WINDOW_CORNER_PREFERENCE, DWMWCP_ROUND)` 请求圆角。调用幂等，Win10 等不支持该属性的系统上静默失败，无副作用。Windows 实现放在 `app_windows.go`，darwin/linux 为 no-op 桩。

另外将 `jcmturner/gofork` 提升为直接依赖：krb5 GSSAPI 测试直接 import 了它的 `encoding/asn1`（与 gokrb5 内部一致，保证 Kerberos 报文按字节一致地编码），`go mod tidy` 因此将其归类为直接依赖。

Closes #824