### PR TITLE
fix(terminal): restore Wails Clipboard import so right-click paste works again

### DIFF
--- a/frontend/src/composables/useTerminalMenu.test.ts
+++ b/frontend/src/composables/useTerminalMenu.test.ts
@@ -49,6 +49,7 @@ vi.mock('../stores/settingsStore', () => ({
 }))
 
 import { useTerminalMenu } from './useTerminalMenu'
+import { Clipboard } from '@wailsio/runtime'
 
 function buildMenu(getSelection: () => string) {
   return useTerminalMenu({ getSelection, onPaste: vi.fn() })
@@ -108,6 +109,23 @@ describe('useTerminalMenu.writeClipboard', () => {
     mockSettingsStore.settings.terminal.rightClickAction = 'paste'
     const m = buildMenu(() => '')
     m.onContextMenu(new FakeMouseEvent() as any)
+    expect(m.menuVisible.value).toBe(false)
+  })
+
+  // Regression: the Wails Clipboard import was dropped from useTerminalMenu,
+  // so the bare `Clipboard` reference resolved to the DOM global (the Clipboard
+  // API interface) and Clipboard.Text() threw inside the swallowed try/catch —
+  // right-click paste did nothing while every test still stayed green. The
+  // paste dispatch must actually reach onPaste through the Wails runtime.
+  it('pastes clipboard text via onPaste when rightClickAction is "paste"', async () => {
+    mockSettingsStore.settings.terminal.rightClickAction = 'paste'
+    const paste = vi.fn()
+    const m = useTerminalMenu({ getSelection: () => '', onPaste: paste })
+    vi.mocked(Clipboard.Text).mockResolvedValueOnce('clipboard-content')
+    m.onContextMenu(new FakeMouseEvent() as any)
+    await flushAsync()
+    expect(Clipboard.Text).toHaveBeenCalled()
+    expect(paste).toHaveBeenCalledWith('clipboard-content')
     expect(m.menuVisible.value).toBe(false)
   })
 

--- a/frontend/src/composables/useTerminalMenu.ts
+++ b/frontend/src/composables/useTerminalMenu.ts
@@ -1,5 +1,6 @@
 import { ref } from 'vue'
 import type { Ref } from 'vue'
+import { Clipboard } from '@wailsio/runtime'
 import { useSettingsStore } from '../stores/settingsStore'
 import { writeClipboard } from './useClipboardWrite'
 export interface UseTerminalMenuOptions {


### PR DESCRIPTION
## Summary

Right-click paste in the terminal silently stopped working: with the right-click action set to *paste*, a plain right-click did nothing, while Ctrl+Shift+V, middle-click paste and the context-menu copy/paste items kept working.

Root cause: when the private clipboard writer was extracted from `useTerminalMenu` into `useClipboardWrite` (introduced by the fix for #827), the `import { Clipboard } from '@wailsio/runtime'` line left with it — but the `Clipboard.Text()` call inside `pasteFromClipboard()` stayed behind. The bare `Clipboard` reference then resolved to the DOM global `Clipboard` interface (the Clipboard API constructor), which has no `Text` method. The resulting `TypeError` was swallowed by the surrounding `try/catch`, so the paste dispatch died silently.

The regression slipped through because:
- TypeScript does not flag it — `lib.dom` declares a global `Clipboard` type, so the bare reference is a valid identifier;
- `vite build` does not type-check;
- the existing test only asserted that the menu does not open on right-click, not that a paste actually happens.

### Changes
- Restore the `Clipboard` import in `useTerminalMenu.ts` (one line).
- Add a regression test: with `rightClickAction = 'paste'`, a right-click must call `Clipboard.Text` and forward the clipboard content to `onPaste`. The new test fails on the unfixed code.

### Verification
- New regression test fails before the fix, passes after.
- Full frontend suite: 35 files / 346 tests, all green.

---

## 摘要

终端右键粘贴静默失效：右键动作设为"直接粘贴"时，普通右键毫无反应；而 Ctrl+Shift+V、中键粘贴、右键菜单里的复制/粘贴均正常。

根因：将 `useTerminalMenu` 内私有的剪贴板写入逻辑抽取到 `useClipboardWrite`（随 #827 的修复引入）时，`import { Clipboard } from '@wailsio/runtime'` 一并被带走，但 `pasteFromClipboard()` 中的 `Clipboard.Text()` 调用留在了原地。裸引用 `Clipboard` 在运行时解析到 DOM 全局的 `Clipboard` 接口（Clipboard API 构造器），其上不存在 `Text` 方法；抛出的 `TypeError` 被外层 `try/catch` 吞掉，粘贴分发就此静默中断。

回归漏网的原因：
- TypeScript 不报错 —— `lib.dom` 声明了全局 `Clipboard` 类型，裸引用是合法标识符；
- `vite build` 不做类型检查；
- 既有测试只断言右键不弹菜单，未断言粘贴真正发生。

### 改动
- 在 `useTerminalMenu.ts` 恢复 `Clipboard` 导入（1 行）。
- 新增回归测试：`rightClickAction = 'paste'` 时右键必须调用 `Clipboard.Text` 并把剪贴板内容传给 `onPaste`；该测试在未修复的代码上失败。

### 验证
- 回归测试在修复前失败、修复后通过。
- 前端全量测试：35 个文件 / 346 个用例全部通过。
