### PR TITLE
Improve connection form UX and update notes rendering

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -747,26 +747,13 @@ function onWheel(e: WheelEvent) {
 
 // Platform digit shortcuts: macOS uses Cmd/Option, Windows and Linux use
 // Ctrl/Alt. Cmd/Ctrl+1…9 switches tabs, Alt/Option+1…9 switches workspace
-// panels; Ctrl/Cmd+Shift+Enter maximizes the active panel. The tab-switch
-// modifier is user-configurable (keyboard.tabSwitchModifier); when it claims
-// the Alt-only combo the panel shortcuts step aside and their badges hide.
+// panels. The tab-switch modifier is user-configurable
+// (keyboard.tabSwitchModifier); when it claims the Alt-only combo the panel
+// shortcuts step aside and their badges hide. (Panel maximize moved into the
+// configurable shortcut system.)
 let isMac = false
 function onPlatformSystemShortcut(e: KeyboardEvent) {
   if (e.defaultPrevented) return
-  const workspaceMaximizeShortcut = e.shiftKey && !e.altKey && (
-    (isMac && e.metaKey && !e.ctrlKey) ||
-    (!isMac && e.ctrlKey && !e.metaKey)
-  )
-  if (workspaceMaximizeShortcut && e.code === 'Enter') {
-    const tab = tabStore.activeTab
-    if (!tab || tab.type !== 'workspace' || !tab.activePanelId) return
-    e.preventDefault()
-    e.stopImmediatePropagation()
-    const panelId = tab.activePanelId
-    tabStore.toggleWorkspacePanelMaximize(tab.id)
-    nextTick(() => focusPanelTerminal(panelId))
-    return
-  }
   const digitMatch = e.code.match(/^Digit([1-9])$/)
   if (digitMatch) {
     const target = matchDigitShortcut(e, isMac, settingsStore.settings.keyboard.tabSwitchModifier)
@@ -1030,6 +1017,13 @@ const actionHandlers: Record<ShortcutAction, () => void> = {
   },
   navigatePrev: () => navigatePanel(-1),
   navigateNext: () => navigatePanel(1),
+  maximizePanel: () => {
+    const tab = tabStore.activeTab
+    if (!tab || tab.type !== 'workspace' || !tab.activePanelId) return
+    const panelId = tab.activePanelId
+    tabStore.toggleWorkspacePanelMaximize(tab.id)
+    nextTick(() => focusPanelTerminal(panelId))
+  },
   openSettings: () => openSettings(),
   duplicateSession: () => {
     // Same logic as the tab context menu's "复制会话": delegate to the shared

--- a/frontend/src/components/AIMessage.vue
+++ b/frontend/src/components/AIMessage.vue
@@ -134,6 +134,7 @@ import { ref, computed } from 'vue'
 import { Copy, Check, BookOpen, Terminal } from '@lucide/vue'
 import { useAIStore } from '../stores/aiStore'
 import { useI18n } from '../i18n'
+import { sanitizeRenderedHtml } from '../utils/markdown'
 import type { AIMessage } from '../types/ai'
 
 const props = defineProps<{ message: AIMessage; searchText?: string }>()
@@ -639,30 +640,8 @@ function escapeHtml(text: string): string {
     .replace(/\n/g, '<br>')
 }
 
-// Sanitize markdown-produced HTML before it's assigned to v-html.
-// Conservative strip-list: anything outside this allowlist is removed.
-// Addresses FE-01 (XSS via model output).
-function sanitizeRenderedHtml(html: string): string {
-  // Drop dangerous tags entirely (including their content).
-  const dangerousTags = [
-    'script', 'iframe', 'object', 'embed', 'style', 'form',
-    'link', 'meta', 'base', 'svg', 'math',
-  ]
-  for (const tag of dangerousTags) {
-    const re = new RegExp(`<${tag}\\b[\\s\\S]*?<\\/${tag}>`, 'gi')
-    html = html.replace(re, '')
-    const reSelf = new RegExp(`<${tag}\\b[^>]*\\/?>`, 'gi')
-    html = html.replace(reSelf, '')
-  }
-  // Strip on*="..." event-handler attributes (any attribute starting with on).
-  html = html.replace(/\s+on[a-z]+\s*=\s*("[^"]*"|'[^']*'|[^\s>]+)/gi, '')
-  // Strip javascript:/data:/vbscript: URL schemes in href/src.
-  html = html.replace(
-    /\s+(href|src|action|formaction|xlink:href)\s*=\s*("\s*(?:javascript|data|vbscript):[^"]*"|'\s*(?:javascript|data|vbscript):[^']*'|(?:javascript|data|vbscript):[^\s>]+)/gi,
-    '',
-  )
-  return html
-}
+// sanitizeRenderedHtml lives in utils/markdown.ts so other v-html surfaces
+// (e.g. the update changelog) share the same allowlist.
 </script>
 
 <style scoped>

--- a/frontend/src/components/ConnectionForm.vue
+++ b/frontend/src/components/ConnectionForm.vue
@@ -76,10 +76,10 @@
             </el-form-item>
             <el-form-item v-if="form.type === 'ssh' || form.type === 'scp' || form.type === 'sftp' || form.type === 'mosh' || form.type === 'x11-desktop' || isElasticsearch" :label="t('conn.authType')">
               <el-radio-group v-model="form.authType">
+                <el-radio-button v-if="form.type === 'ssh' || form.type === 'scp' || form.type === 'sftp' || form.type === 'mosh' || form.type === 'x11-desktop'" value="identity">{{ t('conn.identity') }}</el-radio-button>
                 <el-radio-button value="password">{{ t('conn.password') }}</el-radio-button>
                 <el-radio-button v-if="form.type === 'ssh' || form.type === 'scp' || form.type === 'sftp' || form.type === 'mosh' || form.type === 'x11-desktop'" value="key">{{ t('conn.keyPath') }}</el-radio-button>
                 <el-radio-button v-if="form.type === 'ssh' || form.type === 'scp' || form.type === 'sftp' || form.type === 'mosh' || form.type === 'x11-desktop'" value="keyText">{{ t('conn.keyText') }}</el-radio-button>
-                <el-radio-button v-if="form.type === 'ssh' || form.type === 'scp' || form.type === 'sftp' || form.type === 'mosh' || form.type === 'x11-desktop'" value="identity">{{ t('conn.identity') }}</el-radio-button>
                 <el-radio-button v-if="form.type === 'ssh' || form.type === 'scp' || form.type === 'sftp' || form.type === 'mosh' || form.type === 'x11-desktop'" value="kerberos">{{ t('conn.kerberos') }}</el-radio-button>
                 <el-radio-button v-if="(isWindows || isMac) && (form.type === 'ssh' || form.type === 'scp' || form.type === 'sftp' || form.type === 'mosh' || form.type === 'x11-desktop')" value="agent">{{ t('conn.sshAgent') }}</el-radio-button>
                 <el-radio-button v-if="isElasticsearch" value="apikey">{{ t('conn.esAuthApiKey') }}</el-radio-button>
@@ -1026,7 +1026,7 @@ const form = reactive<ConnectionConfig>({
   groupId: undefined,
   rdpFixedWidth: -1,
   rdpFixedHeight: -1,
-  rdpSmartSizing: true,
+  rdpSmartSizing: false,
   rdpEnableNLA: true,
   rdpDomain: '',
   rdpAdminSession: false,
@@ -1330,10 +1330,12 @@ watch(() => form.type, (newType) => {
   if (REMOTE_TYPES.includes(newType) || newType === 'database') {
     form.authType = 'password'
   }
-  if (newType === 'local' && !form.shellPath && localShellOptions.value.length > 0) {
+  // The shell ("terminal type") is specific to local/wsl; always reset to the
+  // new type's default instead of inheriting the previous type's shell path.
+  if (newType === 'local' && localShellOptions.value.length > 0) {
     form.shellPath = localShellOptions.value[0].value
   }
-  if (newType === 'wsl' && !form.shellPath && wslShellOptions.value.length > 0) {
+  if (newType === 'wsl' && wslShellOptions.value.length > 0) {
     form.shellPath = wslShellOptions.value[0].value
   }
   if (newType === 'serial') {
@@ -1358,9 +1360,19 @@ watch(() => form.dbType, (newType) => {
   }
 })
 
-// Clear the identity reference when switching away from the identity auth type.
+// Clear the identity reference when switching away from the identity auth
+// type, and don't carry credentials (username, password/passphrase, key path,
+// key content, kerberos realm) across an auth type switch — each type owns its
+// own fields. Skip while hydrating the form from an existing config, or
+// opening the edit dialog would wipe the stored credentials.
 watch(() => form.authType, (val) => {
+  if (hydrating.value) return
   if (val !== 'identity') form.identityId = ''
+  if (val !== 'kerberos') form.kerberosRealm = ''
+  form.user = ''
+  form.password = ''
+  form.keyPath = ''
+  form.keyContent = ''
 })
 
 function resetForm() {
@@ -1383,7 +1395,7 @@ function resetForm() {
   form.groupId = undefined
   form.rdpFixedWidth = -1
   form.rdpFixedHeight = -1
-  form.rdpSmartSizing = true
+  form.rdpSmartSizing = false
   form.rdpEnableNLA = true
   form.rdpDomain = ''
   form.rdpAdminSession = false
@@ -1856,9 +1868,9 @@ function onConnect() {
   align-items: center;
   justify-content: center;
   gap: 3px;
-  width: 72px;
+  min-width: 64px;
   height: 52px;
-  padding: 4px;
+  padding: 4px 8px;
   border: 1px solid var(--border-subtle);
   border-radius: var(--radius-md);
   background: transparent;

--- a/frontend/src/components/Panel.vue
+++ b/frontend/src/components/Panel.vue
@@ -212,7 +212,10 @@ const workspaceTab = computed(() =>
   props.workspaceId ? tabStore.tabs.find(tab => tab.id === props.workspaceId && tab.type === 'workspace') : undefined
 )
 const isMaximized = computed(() => workspaceTab.value?.maximizedPanelId === props.panel.id)
-const maximizeShortcut = computed(() => isMac ? '⌘⇧↩' : 'Ctrl+Shift+Enter')
+// Panel maximize is a configurable shortcut; the tooltip must reflect the
+// current binding (and hide when the user cleared it) instead of hardcoding
+// Ctrl+Shift+Enter.
+const maximizeShortcut = computed(() => menuShortcut('maximizePanel'))
 const maximizeTitle = computed(() => {
   const label = t(isMaximized.value ? 'workspace.restorePanel' : 'workspace.maximizePanel')
   return maximizeShortcut.value ? `${label} (${maximizeShortcut.value})` : label

--- a/frontend/src/components/UpdateDialog.vue
+++ b/frontend/src/components/UpdateDialog.vue
@@ -17,9 +17,8 @@
         {{ t('settings.updatePackageManager') }}
       </div>
 
-      <div v-if="changelogText" class="update-dialog-changelog">
-        <pre>{{ changelogText }}</pre>
-      </div>
+      <!-- Release notes are markdown; render as sanitized HTML -->
+      <div v-if="changelogHtml" class="update-dialog-changelog" v-html="changelogHtml"></div>
 
       <div v-if="updateCheck.updatePhase === 'error'" class="update-dialog-error">
         {{ t('settings.updateFailed') }}: {{ updateCheck.updateError }}
@@ -43,6 +42,13 @@
       </div>
     </div>
     <template #footer>
+      <el-button
+        v-if="updateCheck.updatePhase === 'idle' || updateCheck.updatePhase === 'error'"
+        :disabled="!releaseUrl"
+        @click="openRelease"
+      >
+        {{ t('settings.openRelease') }}
+      </el-button>
       <el-button v-if="updateCheck.updatePhase === 'idle' || updateCheck.updatePhase === 'error'" @click="updateCheck.closeUpdateDialog()">
         {{ t('settings.updateLater') }}
       </el-button>
@@ -59,8 +65,10 @@
 
 <script setup lang="ts">
 import { computed } from 'vue'
+import { Browser } from '@wailsio/runtime'
 import { useUpdateCheck } from '../composables/useUpdateCheck'
-import { useI18n } from '../i18n'
+import { useI18n, locale } from '../i18n'
+import { renderMarkdownHtml, sanitizeRenderedHtml } from '../utils/markdown'
 
 const { t } = useI18n()
 const updateCheck = useUpdateCheck()
@@ -70,12 +78,31 @@ const locked = computed(() =>
   updateCheck.updatePhase === 'applying' || updateCheck.updatePhase === 'restarting'
 )
 
-// Release notes are markdown; render as plain text with a sane cap.
-const changelogText = computed(() => {
+// Release notes have a fixed layout: English section first, then the Chinese
+// one under the "### 更新内容" heading. zh locales show the Chinese section,
+// other locales the English part; if the marker is missing (unexpected
+// format), fall back to the full body.
+const changelogHtml = computed(() => {
   const body = updateCheck.updateInfo?.changelog || ''
   if (!body) return ''
-  return body.length > 6000 ? body.slice(0, 6000) + '\n…' : body
+  const zhIdx = body.search(/^#{2,3}\s+更新内容\s*$/m)
+  if (zhIdx < 0) {
+    return sanitizeRenderedHtml(renderMarkdownHtml(body))
+  }
+  const isZh = locale.value === 'zh-CN' || locale.value === 'zh-TW'
+  if (!isZh) {
+    return sanitizeRenderedHtml(renderMarkdownHtml(body.slice(0, zhIdx)))
+  }
+  // Keep the leading version heading (e.g. "## v1.9.2") above the Chinese section.
+  const header = body.match(/^#{1,6}\s+[^\n]*\n?/)
+  return sanitizeRenderedHtml(renderMarkdownHtml((header ? header[0] : '') + body.slice(zhIdx)))
 })
+
+const releaseUrl = computed(() => updateCheck.updateInfo?.releaseUrl || '')
+
+function openRelease() {
+  if (releaseUrl.value) Browser.OpenURL(releaseUrl.value)
+}
 
 function fmtSize(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`
@@ -103,21 +130,55 @@ function fmtSize(bytes: number): string {
   margin-bottom: 10px;
 }
 .update-dialog-changelog {
-  max-height: 260px;
+  max-height: 320px;
   overflow-y: auto;
   background: var(--bg-overlay);
   border: 1px solid var(--border-subtle);
   border-radius: 6px;
   padding: 10px 12px;
   margin-bottom: 12px;
-}
-.update-dialog-changelog pre {
-  margin: 0;
-  white-space: pre-wrap;
-  word-break: break-word;
-  font-size: 12px;
-  line-height: 1.55;
+  font-size: 12.5px;
+  line-height: 1.6;
   font-family: var(--font-ui);
+  color: var(--text-primary);
+}
+.update-dialog-changelog :deep(h2) {
+  font-size: 14px;
+  margin: 0 0 8px;
+}
+.update-dialog-changelog :deep(h3) {
+  font-size: 13px;
+  margin: 12px 0 6px;
+}
+.update-dialog-changelog :deep(p) {
+  margin: 6px 0;
+}
+.update-dialog-changelog :deep(ul) {
+  margin: 6px 0;
+  padding-left: 18px;
+}
+.update-dialog-changelog :deep(li) {
+  margin: 3px 0;
+}
+.update-dialog-changelog :deep(a) {
+  color: var(--accent);
+  text-decoration: none;
+}
+.update-dialog-changelog :deep(a:hover) {
+  text-decoration: underline;
+}
+.update-dialog-changelog :deep(code) {
+  background: var(--bg-overlay);
+  border: 1px solid var(--border-subtle);
+  border-radius: 3px;
+  padding: 0 4px;
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+}
+.update-dialog-changelog :deep(hr) {
+  border: none;
+  border-top: 1px solid var(--border-subtle);
+  margin: 10px 0;
 }
 .update-dialog-error {
   color: #f56c6c;

--- a/frontend/src/composables/useUpdateCheck.ts
+++ b/frontend/src/composables/useUpdateCheck.ts
@@ -4,7 +4,7 @@ import { msg } from '../services/message'
 import { CheckForUpdate, GetAppInfo, DownloadUpdate, ApplyUpdate, GetUpdateChannel } from '../../bindings/github.com/ys-ll/uniterm/app'
 import { useI18n, locale } from '../i18n'
 import { useSettingsStore } from '../stores/settingsStore'
-import { Browser, Events } from '@wailsio/runtime'
+import { Events } from '@wailsio/runtime'
 import type { UpdateInfo } from '../types/settings'
 
 const CHECK_TIMEOUT = 15000
@@ -109,15 +109,7 @@ function showUpdateNotification(info: UpdateInfo) {
   const linkStyle = { color: 'inherit', textDecoration: 'underline', cursor: 'pointer' }
   ElMessage({
     message: h('div', null, [
-      h('span', null, `${t('settings.foundNewVersion')}: ${info.latest} `),
-      h('a', {
-        href: '#',
-        style: linkStyle,
-        onClick: (e: Event) => {
-          e.preventDefault()
-          Browser.OpenURL(info.releaseUrl)
-        },
-      }, t('settings.openRelease')),
+      h('span', null, `${t('settings.foundNewVersion')}: ${info.latest}`),
       canInstall ? h('span', null, ' · ') : null,
       canInstall ? h('a', {
         href: '#',

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -1121,6 +1121,7 @@
   "shortcut.prevTab": "Vorheriger Tab",
   "shortcut.navigatePrev": "Vorheriges Panel",
   "shortcut.navigateNext": "Nächstes Panel",
+  "shortcut.maximizePanel": "Bereich maximieren",
   "shortcut.closePanel": "Panel/Tab schließen",
   "shortcut.toggleSidebar": "Verbindungsseitenleiste umschalten",
   "shortcut.openQuickCommands": "Schnellbefehle öffnen",

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -1400,7 +1400,7 @@
   "settings.storageSecurity": "Speicher & Sicherheit",
   "settings.appearance": "Erscheinungsbild",
   "settings.aiFontSize": "KI-Schriftgröße",
-  "settings.aiFontSizeDesc": "Schriftgröße für KI-Nachrichten und den Eingabeeditor. Standard: 15.",
+  "settings.aiFontSizeDesc": "Schriftgröße für KI-Nachrichten und den Eingabeeditor. Standard: 12.",
   "settings.interaction": "Interaktion",
   "settings.session": "Sitzung",
   "conn.esAuthType": "ES Auth",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -486,7 +486,7 @@
   "settings.browse": "Browse…",
   "settings.maxTurns": "Max Autonomous Rounds",
   "settings.aiFontSize": "AI Font Size",
-  "settings.aiFontSizeDesc": "Font size for AI messages and the input editor. Default 15.",
+  "settings.aiFontSizeDesc": "Font size for AI messages and the input editor. Default 12.",
   "settings.maxTurnsDesc": "Maximum autonomous interaction rounds per AI request. Set to 0 for unlimited. Default 20.",
   "settings.modelList": "Model List",
   "settings.modelListDesc": "Configure and manage AI models",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1128,6 +1128,7 @@
   "shortcut.prevTab": "Previous Tab",
   "shortcut.navigatePrev": "Previous Panel",
   "shortcut.navigateNext": "Next Panel",
+  "shortcut.maximizePanel": "Maximize Panel",
   "shortcut.closePanel": "Close Panel/Tab",
   "shortcut.toggleSidebar": "Toggle Connection Sidebar",
   "shortcut.openQuickCommands": "Open Quick Commands",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -1400,7 +1400,7 @@
   "settings.storageSecurity": "Almacenamiento y seguridad",
   "settings.appearance": "Apariencia",
   "settings.aiFontSize": "Tamaño de fuente de IA",
-  "settings.aiFontSizeDesc": "Tamaño de fuente para los mensajes de IA y el editor de entrada. Predeterminado: 15.",
+  "settings.aiFontSizeDesc": "Tamaño de fuente para los mensajes de IA y el editor de entrada. Predeterminado: 12.",
   "settings.interaction": "Interacción",
   "settings.session": "Sesión",
   "conn.esAuthType": "ES Auth",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -1121,6 +1121,7 @@
   "shortcut.prevTab": "Pestaña anterior",
   "shortcut.navigatePrev": "Panel anterior",
   "shortcut.navigateNext": "Panel siguiente",
+  "shortcut.maximizePanel": "Maximizar panel",
   "shortcut.closePanel": "Cerrar panel/pestaña",
   "shortcut.toggleSidebar": "Mostrar/ocultar barra lateral",
   "shortcut.openQuickCommands": "Abrir comandos rápidos",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -1118,6 +1118,7 @@
   "shortcut.prevTab": "Onglet précédent",
   "shortcut.navigatePrev": "Panneau précédent",
   "shortcut.navigateNext": "Panneau suivant",
+  "shortcut.maximizePanel": "Agrandir le panneau",
   "shortcut.closePanel": "Fermer le panneau/l'onglet",
   "shortcut.toggleSidebar": "Afficher/masquer la barre latérale",
   "shortcut.openQuickCommands": "Ouvrir les commandes rapides",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -1395,7 +1395,7 @@
   "settings.storageSecurity": "Stockage et sécurité",
   "settings.appearance": "Apparence",
   "settings.aiFontSize": "Taille de police de l’IA",
-  "settings.aiFontSizeDesc": "Taille de police des messages de l’IA et de l’éditeur de saisie. Valeur par défaut : 15.",
+  "settings.aiFontSizeDesc": "Taille de police des messages de l’IA et de l’éditeur de saisie. Valeur par défaut : 12.",
   "settings.interaction": "Interaction",
   "settings.session": "Session",
   "conn.esAuthType": "ES Auth",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -1400,7 +1400,7 @@
   "settings.storageSecurity": "ストレージとセキュリティ",
   "settings.appearance": "外観",
   "settings.aiFontSize": "AIフォントサイズ",
-  "settings.aiFontSizeDesc": "AIメッセージと入力エディターのフォントサイズです。既定値は15です。",
+  "settings.aiFontSizeDesc": "AIメッセージと入力エディターのフォントサイズです。既定値は12です。",
   "settings.interaction": "操作",
   "settings.session": "セッション",
   "conn.esAuthType": "ES Auth",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -1121,6 +1121,7 @@
   "shortcut.prevTab": "前のタブ",
   "shortcut.navigatePrev": "前のパネル",
   "shortcut.navigateNext": "次のパネル",
+  "shortcut.maximizePanel": "パネルを最大化",
   "shortcut.closePanel": "パネル/タブを閉じる",
   "shortcut.toggleSidebar": "接続サイドバーの切り替え",
   "shortcut.openQuickCommands": "クイックコマンドを開く",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -1121,6 +1121,7 @@
   "shortcut.prevTab": "이전 탭",
   "shortcut.navigatePrev": "이전 패널",
   "shortcut.navigateNext": "다음 패널",
+  "shortcut.maximizePanel": "패널 최대화",
   "shortcut.closePanel": "패널/탭 닫기",
   "shortcut.toggleSidebar": "연결 사이드바 전환",
   "shortcut.openQuickCommands": "빠른 명령 열기",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -1400,7 +1400,7 @@
   "settings.storageSecurity": "저장소 및 보안",
   "settings.appearance": "외관",
   "settings.aiFontSize": "AI 글꼴 크기",
-  "settings.aiFontSizeDesc": "AI 메시지와 입력 편집기의 글꼴 크기입니다. 기본값은 15입니다.",
+  "settings.aiFontSizeDesc": "AI 메시지와 입력 편집기의 글꼴 크기입니다. 기본값은 12입니다.",
   "settings.interaction": "상호작용",
   "settings.session": "세션",
   "conn.esAuthType": "ES Auth",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -1121,6 +1121,7 @@
   "shortcut.prevTab": "Предыдущая вкладка",
   "shortcut.navigatePrev": "Предыдущая панель",
   "shortcut.navigateNext": "Следующая панель",
+  "shortcut.maximizePanel": "Развернуть панель",
   "shortcut.closePanel": "Закрыть панель/вкладку",
   "shortcut.toggleSidebar": "Переключить боковую панель",
   "shortcut.openQuickCommands": "Открыть быстрые команды",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -1400,7 +1400,7 @@
   "settings.storageSecurity": "Хранилище и безопасность",
   "settings.appearance": "Внешний вид",
   "settings.aiFontSize": "Размер шрифта ИИ",
-  "settings.aiFontSizeDesc": "Размер шрифта сообщений ИИ и редактора ввода. По умолчанию: 15.",
+  "settings.aiFontSizeDesc": "Размер шрифта сообщений ИИ и редактора ввода. По умолчанию: 12.",
   "settings.interaction": "Взаимодействие",
   "settings.session": "Сеанс",
   "conn.esAuthType": "ES Auth",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -1128,6 +1128,7 @@
   "shortcut.prevTab": "上一个标签",
   "shortcut.navigatePrev": "前一个面板",
   "shortcut.navigateNext": "后一个面板",
+  "shortcut.maximizePanel": "最大化面板",
   "shortcut.closePanel": "关闭面板/标签",
   "shortcut.toggleSidebar": "开/关连接边栏并搜索",
   "shortcut.openQuickCommands": "打开快捷命令并搜索",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -486,7 +486,7 @@
   "settings.browse": "浏览…",
   "settings.maxTurns": "AI 自主交互最大轮次",
   "settings.aiFontSize": "AI 字体大小",
-  "settings.aiFontSizeDesc": "AI 对话正文和输入框的字体大小，默认 15",
+  "settings.aiFontSizeDesc": "AI 对话正文和输入框的字体大小，默认 12",
   "settings.maxTurnsDesc": "AI 自主执行命令与反馈的对话轮数上限。设为 0 表示不限制。默认 20。",
   "settings.modelList": "模型列表",
   "settings.modelListDesc": "配置和管理 AI 模型",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -1128,6 +1128,7 @@
   "shortcut.prevTab": "上一個標籤",
   "shortcut.navigatePrev": "前一個面板",
   "shortcut.navigateNext": "後一個面板",
+  "shortcut.maximizePanel": "最大化面板",
   "shortcut.closePanel": "關閉面板/標籤",
   "shortcut.toggleSidebar": "開/關連線邊欄並搜尋",
   "shortcut.openQuickCommands": "開啟快速命令並搜尋",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -486,7 +486,7 @@
   "settings.browse": "瀏覽…",
   "settings.maxTurns": "AI 自主互動最大輪次",
   "settings.aiFontSize": "AI 字體大小",
-  "settings.aiFontSizeDesc": "AI 對話正文和輸入框的字體大小，預設 15",
+  "settings.aiFontSizeDesc": "AI 對話正文和輸入框的字體大小，預設 12",
   "settings.maxTurnsDesc": "AI 自主執行命令與回饋的對話輪數上限。設為 0 表示不限制。預設 20。",
   "settings.modelList": "模型列表",
   "settings.modelListDesc": "設定和管理 AI 模型",

--- a/frontend/src/types/settings.ts
+++ b/frontend/src/types/settings.ts
@@ -308,7 +308,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   },
   ai: {
     maxTurns: 20,
-    fontSize: 15,
+    fontSize: 12,
     models: [
       {
         id: 'model-default',

--- a/frontend/src/types/settings.ts
+++ b/frontend/src/types/settings.ts
@@ -147,6 +147,7 @@ export type ShortcutAction =
   | 'focusAI' | 'focusTerminal' | 'lockAI'
   | 'closePanel'
   | 'navigatePrev' | 'navigateNext'
+  | 'maximizePanel'
   | 'duplicateSession'
   | 'terminalSearch'
   | 'openSettings'
@@ -182,6 +183,7 @@ export const SHORTCUT_LABELS: Record<ShortcutAction, string> = {
   prevTab: 'shortcut.prevTab',
   navigatePrev: 'shortcut.navigatePrev',
   navigateNext: 'shortcut.navigateNext',
+  maximizePanel: 'shortcut.maximizePanel',
   closePanel: 'shortcut.closePanel',
   toggleSidebar: 'shortcut.toggleSidebar',
   openQuickCommands: 'shortcut.openQuickCommands',
@@ -210,6 +212,9 @@ export const DEFAULT_KEYBOARD: KeyboardSettings = {
   closePanel: { ctrl: true, shift: true, alt: false, key: 'q' },
   navigatePrev: { ctrl: false, shift: false, alt: true, key: 'arrowleft' },
   navigateNext: { ctrl: false, shift: false, alt: true, key: 'arrowright' },
+  // loadKeybindings aliases Ctrl+→Meta+ for macOS, so the default covers
+  // Cmd+Shift+Enter on Mac and Ctrl+Shift+Enter elsewhere.
+  maximizePanel: { ctrl: true, shift: true, alt: false, key: 'enter' },
   lockAI: { ctrl: true, shift: true, alt: false, key: 'l' },
   duplicateSession: { ctrl: true, shift: true, alt: false, key: 'd' },
   terminalSearch: { ctrl: true, shift: true, alt: false, key: 'f' },

--- a/frontend/src/utils/markdown.ts
+++ b/frontend/src/utils/markdown.ts
@@ -1,0 +1,90 @@
+// Dependency-free markdown helpers shared by surfaces that render markdown
+// into v-html (AI messages, update changelog). Keep in sync with
+// AIMessage.sanitize.test.ts, which mirrors sanitizeRenderedHtml.
+
+// Sanitize markdown-produced HTML before it's assigned to v-html.
+// Conservative strip-list: anything outside this allowlist is removed.
+export function sanitizeRenderedHtml(html: string): string {
+  // Drop dangerous tags entirely (including their content).
+  const dangerousTags = [
+    'script', 'iframe', 'object', 'embed', 'style', 'form',
+    'link', 'meta', 'base', 'svg', 'math',
+  ]
+  for (const tag of dangerousTags) {
+    const re = new RegExp(`<${tag}\\b[\\s\\S]*?<\\/${tag}>`, 'gi')
+    html = html.replace(re, '')
+    const reSelf = new RegExp(`<${tag}\\b[^>]*\\/?>`, 'gi')
+    html = html.replace(reSelf, '')
+  }
+  // Strip on*="..." event-handler attributes (any attribute starting with on).
+  html = html.replace(/\s+on[a-z]+\s*=\s*("[^"]*"|'[^']*'|[^\s>]+)/gi, '')
+  // Strip javascript:/data:/vbscript: URL schemes in href/src.
+  html = html.replace(
+    /\s+(href|src|action|formaction|xlink:href)\s*=\s*("\s*(?:javascript|data|vbscript):[^"]*"|'\s*(?:javascript|data|vbscript):[^']*'|(?:javascript|data|vbscript):[^\s>]+)/gi,
+    '',
+  )
+  return html
+}
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+}
+
+function renderInline(md: string): string {
+  return md
+    .replace(/`([^`]+)`/g, '<code>$1</code>')
+    .replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')
+    .replace(/\[([^\]]+)\]\(([^)\s]+)\)/g, '<a href="$2" target="_blank" rel="noopener">$1</a>')
+}
+
+// Minimal markdown renderer covering the constructs release notes use:
+// headings, unordered lists, bold, inline code, links, horizontal rules and
+// paragraphs. The output must still go through sanitizeRenderedHtml before
+// being bound to v-html.
+export function renderMarkdownHtml(source: string): string {
+  const lines = escapeHtml(source).split(/\r?\n/)
+  const out: string[] = []
+  let listOpen = false
+  const closeList = () => {
+    if (listOpen) {
+      out.push('</ul>')
+      listOpen = false
+    }
+  }
+  for (const raw of lines) {
+    const line = raw.trimEnd()
+    if (!line.trim()) {
+      closeList()
+      continue
+    }
+    const heading = line.match(/^(#{1,6})\s+(.*)$/)
+    if (heading) {
+      closeList()
+      const level = heading[1].length
+      out.push(`<h${level}>${renderInline(heading[2])}</h${level}>`)
+      continue
+    }
+    if (/^(-{3,}|\*{3,})$/.test(line.trim())) {
+      closeList()
+      out.push('<hr>')
+      continue
+    }
+    const item = line.match(/^\s*[-*]\s+(.*)$/)
+    if (item) {
+      if (!listOpen) {
+        out.push('<ul>')
+        listOpen = true
+      }
+      out.push(`<li>${renderInline(item[1])}</li>`)
+      continue
+    }
+    closeList()
+    out.push(`<p>${renderInline(line)}</p>`)
+  }
+  closeList()
+  return out.join('\n')
+}


### PR DESCRIPTION
## Summary

UX polish for the connection form and the update flow:

### Connection form
- Default RDP smart sizing to off for new connections
- Reset the shell (terminal type) when switching between local and WSL instead of inheriting the previous type's value
- Clear username / password / key path / key content when switching auth type (guarded during hydration so opening the edit dialog does not wipe stored credentials); Elasticsearch password/API-key switching behaves the same
- Move the identity (credential store) option first in the auth type group
- Auto-size the subtype buttons with a minimum width so longer labels widen the button instead of being clipped

### Shortcuts
- Make the panel-maximize shortcut (Ctrl/Cmd+Shift+Enter) a configurable entry in the shortcut settings; the panel button tooltip now reads the current binding instead of hardcoding it

### Settings
- Lower the default AI font size from 15 to 12 (existing saved settings keep their value)

### Update notes
- Remove the view-details link from the new-version toast
- Render the changelog as markdown via a shared renderer + sanitizer, and remove the 6000-character truncation
- Show the Chinese or English section of the release notes based on the UI language (Simplified/Traditional Chinese show the Chinese section); fall back to the full body if the section marker is missing
- Add a view-details button to the update dialog footer

---

## 概要

连接表单与更新流程的体验优化：

### 连接表单
- 新建 RDP 连接默认关闭智能缩放
- 本地 / WSL 类型切换时重置终端类型（Shell），不再继承上一个类型的值
- 切换认证类型时清空用户名 / 密码 / 密钥路径 / 密钥内容（加载已有配置时加守卫，避免打开编辑框误清已保存凭据）；Elasticsearch 的密码 / API Key 切换同样生效
- 认证类型组中「密钥库」移到第一位
- 子类型按钮按内容自适应宽度并设置最小宽度，长标签自动加宽而不再被裁剪

### 快捷键
- 面板最大化快捷键（Ctrl/Cmd+Shift+Enter）纳入快捷键设置，可改键 / 清除；面板按钮提示改为实时读取当前绑定

### 设置
- AI 字体大小默认值由 15 调整为 12（已保存过设置的用户不受影响）

### 更新说明
- 新版本提示框移除「查看详情」链接
- 更新日志以 Markdown 渲染（共享渲染器 + 过滤器），并去掉 6000 字截断
- 按界面语言显示中文或英文分节（简体 / 繁体中文显示中文部分）；解析失败时回退展示全部内容
- 更新对话框底部新增「查看详情」按钮

Closes #625 