### PR TITLE
feat(local): auto-detect third-party shells on Windows

### DIFF
--- a/app_windows.go
+++ b/app_windows.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/ys-ll/uniterm/backend/session"
 	"golang.org/x/sys/windows"
+	"golang.org/x/sys/windows/registry"
 )
 
 func (a *App) GetAvailableShells() []string {
@@ -54,6 +55,19 @@ func (a *App) GetAvailableShells() []string {
 	} {
 		add(p)
 	}
+	// Third-party shells (Cygwin, MSYS2, Nushell): probe well-known install
+	// locations and the registry so they are offered automatically, without
+	// any user configuration. Added after the built-ins and before the
+	// generic PATH bash.exe fallback, whose System32 hit they preempt when a
+	// real bash exists.
+	for _, sh := range detectThirdPartyShells(probeCygwinRootdir(),
+		func(p string) bool {
+			_, err := os.Stat(p)
+			return err == nil
+		},
+		exec.LookPath) {
+		add(sh)
+	}
 	if !hasShell("bash.exe") {
 		add("bash.exe")
 	}
@@ -75,6 +89,82 @@ func (a *App) GetAvailableShells() []string {
 		}
 	}
 	return shells
+}
+
+// detectThirdPartyShells probes well-known third-party shell installs that
+// should be offered alongside the built-in shells: Cygwin bash, MSYS2 bash
+// and Nushell. cygwinRegRoot is the Cygwin setup registry probe result (""
+// when absent). Only paths that actually exist are returned; duplicates are
+// removed case-insensitively.
+func detectThirdPartyShells(cygwinRegRoot string, exists func(string) bool, lookPath func(string) (string, error)) []string {
+	var out []string
+	seen := make(map[string]bool)
+	add := func(path string) {
+		if path == "" {
+			return
+		}
+		key := strings.ToLower(path)
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		out = append(out, path)
+	}
+
+	// Cygwin: setup.exe records the install root in the registry; also probe
+	// the conventional install dirs.
+	cygwinRoots := []string{`C:\cygwin64`, `C:\cygwin`, `C:\tools\cygwin64`, `C:\tools\cygwin`}
+	if cygwinRegRoot != "" {
+		cygwinRoots = append([]string{cygwinRegRoot}, cygwinRoots...)
+	}
+	for _, root := range cygwinRoots {
+		bash := filepath.Join(root, "bin", "bash.exe")
+		if exists(bash) {
+			add(bash)
+		}
+	}
+
+	// MSYS2: bash lives under usr\bin and there is no registry entry.
+	msysRoots := []string{`C:\msys64`, `C:\msys32`, `C:\tools\msys64`, `C:\tools\msys32`}
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		msysRoots = append(msysRoots, filepath.Join(home, "msys64"), filepath.Join(home, "msys32"))
+	}
+	for _, root := range msysRoots {
+		bash := filepath.Join(root, "usr", "bin", "bash.exe")
+		if exists(bash) {
+			add(bash)
+		}
+	}
+
+	// Nushell: usually on PATH (scoop/choco/winget shims).
+	if nu, err := lookPath("nu.exe"); err == nil && nu != "" {
+		add(nu)
+	}
+
+	return out
+}
+
+// probeCygwinRootdir reads the Cygwin setup install root from the registry.
+// Returns "" when Cygwin is absent or the key cannot be read.
+func probeCygwinRootdir() string {
+	keys := []string{
+		`SOFTWARE\Cygwin\setup`,
+		`SOFTWARE\WOW6432Node\Cygwin\setup`,
+	}
+	for _, k := range keys {
+		for _, root := range []registry.Key{registry.LOCAL_MACHINE, registry.CURRENT_USER} {
+			key, err := registry.OpenKey(root, k, registry.QUERY_VALUE)
+			if err != nil {
+				continue
+			}
+			rootdir, _, err := key.GetStringValue("rootdir")
+			key.Close()
+			if err == nil && rootdir != "" {
+				return rootdir
+			}
+		}
+	}
+	return ""
 }
 
 func listWSLDistros() ([]string, error) {

--- a/app_windows_shells_test.go
+++ b/app_windows_shells_test.go
@@ -1,0 +1,96 @@
+//go:build windows
+// +build windows
+
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// detectThirdPartyShells must offer well-known third-party shell installs
+// (Cygwin, MSYS2, Nushell) alongside the built-in shells, using only paths
+// that actually exist on the host.
+func TestDetectThirdPartyShells(t *testing.T) {
+	existing := func(paths ...string) func(string) bool {
+		set := make(map[string]bool)
+		for _, p := range paths {
+			set[strings.ToLower(p)] = true
+		}
+		return func(p string) bool { return set[strings.ToLower(p)] }
+	}
+
+	t.Run("cygwin fixed path", func(t *testing.T) {
+		got := detectThirdPartyShells("",
+			existing(`C:\cygwin64\bin\bash.exe`),
+			func(string) (string, error) { return "", nil })
+		want := []string{`C:\cygwin64\bin\bash.exe`}
+		if len(got) != 1 || got[0] != want[0] {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("cygwin registry rootdir", func(t *testing.T) {
+		got := detectThirdPartyShells(`D:\cygwin`,
+			existing(`D:\cygwin\bin\bash.exe`),
+			func(string) (string, error) { return "", nil })
+		if len(got) != 1 || got[0] != `D:\cygwin\bin\bash.exe` {
+			t.Errorf("got %v, want [D:\\cygwin\\bin\\bash.exe]", got)
+		}
+	})
+
+	t.Run("registry rootdir that does not exist is skipped", func(t *testing.T) {
+		got := detectThirdPartyShells(`D:\gone`,
+			existing(`C:\cygwin64\bin\bash.exe`),
+			func(string) (string, error) { return "", nil })
+		for _, p := range got {
+			if strings.Contains(strings.ToLower(p), "d:\\gone") {
+				t.Errorf("nonexistent registry rootdir leaked into %v", got)
+			}
+		}
+		if len(got) != 1 || got[0] != `C:\cygwin64\bin\bash.exe` {
+			t.Errorf("got %v, want [C:\\cygwin64\\bin\\bash.exe]", got)
+		}
+	})
+
+	t.Run("msys2 usr bin bash", func(t *testing.T) {
+		got := detectThirdPartyShells("",
+			existing(`C:\msys64\usr\bin\bash.exe`),
+			func(string) (string, error) { return "", nil })
+		if len(got) != 1 || got[0] != `C:\msys64\usr\bin\bash.exe` {
+			t.Errorf("got %v, want [C:\\msys64\\usr\\bin\\bash.exe]", got)
+		}
+	})
+
+	t.Run("nushell via PATH", func(t *testing.T) {
+		got := detectThirdPartyShells("", func(string) bool { return false },
+			func(name string) (string, error) {
+				if name == "nu.exe" {
+					return `C:\Users\me\scoop\shims\nu.exe`, nil
+				}
+				return "", nil
+			})
+		if len(got) != 1 || got[0] != `C:\Users\me\scoop\shims\nu.exe` {
+			t.Errorf("got %v, want [nu.exe resolved path]", got)
+		}
+	})
+
+	t.Run("nothing installed yields empty", func(t *testing.T) {
+		got := detectThirdPartyShells("", func(string) bool { return false },
+			func(string) (string, error) { return "", nil })
+		if len(got) != 0 {
+			t.Errorf("got %v, want empty", got)
+		}
+	})
+
+	t.Run("duplicates are removed", func(t *testing.T) {
+		// Registry rootdir pointing at the same cygwin64 install as the fixed
+		// path candidate must not yield the shell twice.
+		got := detectThirdPartyShells(`C:\cygwin64`,
+			existing(`C:\cygwin64\bin\bash.exe`),
+			func(string) (string, error) { return "", nil })
+		if len(got) != 1 {
+			t.Errorf("got %v, want single entry", got)
+		}
+	})
+}

--- a/backend/session/local_session_shellname_test.go
+++ b/backend/session/local_session_shellname_test.go
@@ -1,0 +1,35 @@
+//go:build windows
+// +build windows
+
+package session
+
+import "testing"
+
+// shellName must disambiguate the three common Windows bash.exe flavors by
+// install path: Git for Windows, Cygwin and MSYS2 all ship a binary with the
+// same basename, and a bare "bash" tab title tells the user nothing.
+func TestShellNameDisambiguatesBashFlavors(t *testing.T) {
+	cases := []struct {
+		path string
+		want string
+	}{
+		{`C:\Program Files\Git\bin\bash.exe`, "Git Bash"},
+		{`C:\Users\me\scoop\apps\git\current\bin\bash.exe`, "Git Bash"},
+		{`C:\ProgramData\chocolatey\bin\bash.exe`, "Git Bash"},
+		{`C:\cygwin64\bin\bash.exe`, "Cygwin bash"},
+		{`D:\tools\cygwin\bin\bash.exe`, "Cygwin bash"},
+		{`C:\msys64\usr\bin\bash.exe`, "MSYS2 bash"},
+		{`C:\tools\msys32\usr\bin\bash.exe`, "MSYS2 bash"},
+		// Unknown bash installs keep the historical basename label.
+		{`E:\custom\bash.exe`, "bash"},
+		// Non-bash shells keep the basename label.
+		{`C:\Windows\System32\cmd.exe`, "cmd"},
+		{`C:\Program Files\PowerShell\7\pwsh.exe`, "pwsh"},
+		{`C:\Windows\System32\bash.exe`, "bash"},
+	}
+	for _, tc := range cases {
+		if got := shellName(tc.path); got != tc.want {
+			t.Errorf("shellName(%q) = %q, want %q", tc.path, got, tc.want)
+		}
+	}
+}

--- a/backend/session/local_session_windows.go
+++ b/backend/session/local_session_windows.go
@@ -480,6 +480,22 @@ func shellName(path string) string {
 	}
 	base := filepath.Base(path)
 	base = strings.TrimSuffix(base, ".exe")
+	// Disambiguate bash flavors by install path: Git for Windows, Cygwin and
+	// MSYS2 all ship a bash.exe, and a bare "bash" title tells the user
+	// nothing. Mirrors the frontend getShellLabel rules.
+	if strings.EqualFold(base, "bash") {
+		lower := strings.ToLower(path)
+		if strings.Contains(lower, `\git\`) || strings.Contains(lower, `/git/`) ||
+			strings.Contains(lower, "chocolatey") {
+			return "Git Bash"
+		}
+		if strings.Contains(lower, "cygwin") {
+			return "Cygwin bash"
+		}
+		if strings.Contains(lower, "msys") {
+			return "MSYS2 bash"
+		}
+	}
 	return base
 }
 

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -219,6 +219,7 @@ import { msg } from './services/message'
 import type { ConnectionConfig } from './types/session'
 import { Application, Clipboard, Events } from '@wailsio/runtime'
 import { parseQuickConnect } from './utils/quickConnect'
+import { getShellLabel as getShellLabelBase } from './utils/shellLabel'
 import { fileTransferProto } from './utils/fileTransferUtils'
 import { reconnectFileTransferPanel } from './composables/usePanelReconnect'
 
@@ -1447,21 +1448,7 @@ async function onConnect(config: ConnectionConfig, keepOpen?: boolean, wasEdit?:
 }
 
 function getShellLabel(path: string): string {
-  if (!path) return 'Local'
-  const lower = path.toLowerCase()
-  if (lower.startsWith('admin://')) {
-    const inner = getShellLabel(path.slice(8))
-    return inner.endsWith(' (Admin)') ? inner : `${inner} (Admin)`
-  }
-  if (lower.startsWith('wsl://')) {
-    const distro = path.slice(6)
-    return distro ? `WSL - ${distro}` : 'WSL'
-  }
-  if (lower.includes('pwsh')) return 'PowerShell'
-  if (lower.includes('powershell')) return 'Windows PowerShell'
-  if (lower.includes('bash')) return 'Git Bash'
-  if (lower.includes('cmd')) return 'Command Prompt'
-  return path.replace(/\\/g, '/').split('/').pop() || 'Local'
+  return getShellLabelBase(path, 'Local')
 }
 
 async function createLocalTerminalWithShell(shellPath: string, keepOpen?: boolean) {

--- a/frontend/src/components/ConnectionForm.vue
+++ b/frontend/src/components/ConnectionForm.vue
@@ -687,6 +687,7 @@ import type { K8sContextInfo } from '../types/k8s'
 import IdentityEditDialog from './IdentityEditDialog.vue'
 import ProxyEditDialog from './ProxyEditDialog.vue'
 import { isSqlDbType } from '../utils/quickConnect'
+import { getShellLabel as getShellLabelBase } from '../utils/shellLabel'
 import { backendErrorText } from '../utils/backendError'
 import type { Identity } from '../types/identity'
 import type { Proxy } from '../types/proxy'
@@ -815,21 +816,7 @@ function onCategorySelect(catKey: string) {
 }
 
 function getShellLabel(path: string): string {
-  if (!path) return ''
-  const lower = path.toLowerCase()
-  if (lower.startsWith('admin://')) {
-    const inner = getShellLabel(path.slice(8))
-    return inner.endsWith(' (Admin)') ? inner : `${inner} (Admin)`
-  }
-  if (lower.startsWith('wsl://')) {
-    const distro = path.slice(6)
-    return distro ? `WSL - ${distro}` : 'WSL'
-  }
-  if (lower.includes('pwsh')) return 'PowerShell'
-  if (lower.includes('powershell')) return 'Windows PowerShell'
-  if (lower.includes('bash')) return 'Git Bash'
-  if (lower.includes('cmd')) return 'Command Prompt'
-  return path.split(/[\\/]/).pop() || path
+  return getShellLabelBase(path)
 }
 
 // Local-shell options exclude WSL entries: the ordinary local terminal type

--- a/frontend/src/components/SettingsTab.vue
+++ b/frontend/src/components/SettingsTab.vue
@@ -1218,6 +1218,7 @@ import { ElMessage, ElMessageBox } from 'element-plus'
 import { FONT_OPTIONS, FONT_WEIGHT_OPTIONS, LANGUAGE_OPTIONS, DEFAULT_KEYBOARD, SHORTCUT_LABELS, USER_AGENT_PRESETS, FOLLOW_APP_THEME, CURSOR_STYLES, TIMESTAMP_FORMATS, SIDEBAR_TAB_ORDER, SIDEBAR_TAB_DEFAULTS } from '../types/settings'
 import { formatFontFamily, normalizeFontFamilyValue } from '../utils/formatFontFamily'
 import { backendErrorText } from '../utils/backendError'
+import { getShellLabel as getShellLabelBase } from '../utils/shellLabel'
 import SkillsManager from './SkillsManager.vue'
 import CommandsManager from './CommandsManager.vue'
 import type { AIModelConfig, ShortcutAction, KeyBinding, KeyboardSettings } from '../types/settings'
@@ -1972,17 +1973,7 @@ async function testConnection() {
 }
 
 function getShellLabel(path: string): string {
-  if (!path) return 'Local'
-  const lower = path.toLowerCase()
-  if (lower.startsWith('wsl://')) {
-    const distro = path.slice(6)
-    return distro ? `WSL - ${distro}` : 'WSL'
-  }
-  if (lower.includes('pwsh')) return 'PowerShell'
-  if (lower.includes('powershell')) return 'Windows PowerShell'
-  if (lower.includes('bash')) return 'Git Bash'
-  if (lower.includes('cmd')) return 'Command Prompt'
-  return path.split(/[\\/]/).pop() || path
+  return getShellLabelBase(path, 'Local')
 }
 
 const bgPreview = ref('')

--- a/frontend/src/components/StartTabContent.vue
+++ b/frontend/src/components/StartTabContent.vue
@@ -443,6 +443,7 @@ import { useI18n } from '../i18n'
 import { GetRecentConnections } from '../../bindings/github.com/ys-ll/uniterm/app'
 import { formatConnSubtitle, getConnectionTypeKey, getTypeCategory, formatTypeFilterLabel, getTypeFilterCatalog, isWindows } from '../utils/quickConnect'
 import { connectFileMenuKey } from '../utils/fileTransferUtils'
+import { getShellLabel as getShellLabelBase } from '../utils/shellLabel'
 import Menu from './Menu.vue'
 import MenuItem from './MenuItem.vue'
 import MenuSubmenu from './MenuSubmenu.vue'
@@ -602,21 +603,7 @@ function onFilterSelect(val: string) {
 
 // ── Shell label helper ──
 function getShellLabel(path: string): string {
-  if (!path) return 'Local'
-  const lower = path.toLowerCase()
-  if (lower.startsWith('admin://')) {
-    const inner = getShellLabel(path.slice(8))
-    return inner.endsWith(' (Admin)') ? inner : `${inner} (Admin)`
-  }
-  if (lower.startsWith('wsl://')) {
-    const distro = path.slice(6)
-    return distro ? `WSL - ${distro}` : 'WSL'
-  }
-  if (lower.includes('pwsh')) return 'PowerShell'
-  if (lower.includes('powershell')) return 'Windows PowerShell'
-  if (lower.includes('bash')) return 'Git Bash'
-  if (lower.includes('cmd')) return 'Command Prompt'
-  return path.split(/[\\/]/).pop() || path
+  return getShellLabelBase(path, 'Local')
 }
 
 // ── Recent connections ──

--- a/frontend/src/utils/shellLabel.test.ts
+++ b/frontend/src/utils/shellLabel.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest'
+import { getShellLabel } from './shellLabel'
+
+describe('getShellLabel', () => {
+  it('returns the empty fallback for an empty path', () => {
+    expect(getShellLabel('', 'Local')).toBe('Local')
+    expect(getShellLabel('', '')).toBe('')
+  })
+
+  it('labels admin:// shells with an (Admin) suffix', () => {
+    expect(getShellLabel('admin://C:\\Windows\\System32\\cmd.exe')).toBe('Command Prompt (Admin)')
+    expect(getShellLabel('admin://powershell.exe')).toBe('Windows PowerShell (Admin)')
+    // no double suffix when the inner label already ends with (Admin)
+    expect(getShellLabel('admin://wsl://Ubuntu')).toBe('WSL - Ubuntu (Admin)')
+  })
+
+  it('labels wsl:// shells with the distro name', () => {
+    expect(getShellLabel('wsl://Ubuntu-22.04')).toBe('WSL - Ubuntu-22.04')
+    expect(getShellLabel('wsl://')).toBe('WSL')
+  })
+
+  it('labels PowerShell variants', () => {
+    expect(getShellLabel('C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe')).toBe('Windows PowerShell')
+    expect(getShellLabel('C:\\Program Files\\PowerShell\\7\\pwsh.exe')).toBe('PowerShell')
+  })
+
+  it('labels Git Bash by its install path', () => {
+    expect(getShellLabel('C:\\Program Files\\Git\\bin\\bash.exe')).toBe('Git Bash')
+    expect(getShellLabel('C:\\Users\\me\\scoop\\apps\\git\\current\\bin\\bash.exe')).toBe('Git Bash')
+  })
+
+  it('labels the chocolatey bash shim as Git Bash', () => {
+    // The chocolatey shim directory carries no `git` path segment, but the
+    // bash.exe there comes from the git package.
+    expect(getShellLabel('C:\\ProgramData\\chocolatey\\bin\\bash.exe')).toBe('Git Bash')
+  })
+
+  it('labels Cygwin bash by its install path', () => {
+    expect(getShellLabel('C:\\cygwin64\\bin\\bash.exe')).toBe('Cygwin')
+    expect(getShellLabel('D:\\tools\\cygwin\\bin\\bash.exe')).toBe('Cygwin')
+  })
+
+  it('labels MSYS2 bash by its install path', () => {
+    expect(getShellLabel('C:\\msys64\\usr\\bin\\bash.exe')).toBe('MSYS2')
+    expect(getShellLabel('C:\\tools\\msys32\\usr\\bin\\bash.exe')).toBe('MSYS2')
+  })
+
+  it('falls back to the basename for unknown bash paths instead of mislabeling Git Bash', () => {
+    expect(getShellLabel('E:\\custom\\bash.exe')).toBe('bash')
+  })
+
+  it('labels Command Prompt', () => {
+    expect(getShellLabel('C:\\Windows\\System32\\cmd.exe')).toBe('Command Prompt')
+  })
+
+  it('labels Nushell', () => {
+    expect(getShellLabel('C:\\Users\\me\\scoop\\shims\\nu.exe')).toBe('Nushell')
+  })
+
+  it('falls back to the basename for unrecognized shells', () => {
+    expect(getShellLabel('C:\\tools\\fish.exe')).toBe('fish')
+  })
+})

--- a/frontend/src/utils/shellLabel.ts
+++ b/frontend/src/utils/shellLabel.ts
@@ -1,0 +1,40 @@
+// Shared local-shell label helper. The same path may appear in the start-page
+// shell dropdown, the connection form, the settings default-shell selector and
+// terminal tab titles, so every surface must label it identically.
+//
+// bash.exe needs path-based disambiguation: Git for Windows, Cygwin and MSYS2
+// all ship a bash.exe and the basename alone cannot tell them apart.
+
+function shellBasename(path: string): string {
+  const base = path.replace(/\\/g, '/').split('/').pop() || path
+  return base.replace(/\.exe$/i, '')
+}
+
+export function getShellLabel(path: string, emptyFallback = ''): string {
+  if (!path) return emptyFallback
+  const lower = path.toLowerCase()
+  if (lower.startsWith('admin://')) {
+    const inner = getShellLabel(path.slice(8), emptyFallback)
+    return inner.endsWith(' (Admin)') ? inner : `${inner} (Admin)`
+  }
+  if (lower.startsWith('wsl://')) {
+    const distro = path.slice(6)
+    return distro ? `WSL - ${distro}` : 'WSL'
+  }
+  if (lower.includes('pwsh')) return 'PowerShell'
+  if (lower.includes('powershell')) return 'Windows PowerShell'
+  if (lower.includes('bash')) {
+    // Git for Windows lives under a `git` path segment (Program Files, scoop,
+    // chocolatey), Cygwin under `cygwin*`, MSYS2 under `msys*`.
+    if (/[\\/]git[\\/]/i.test(path)) return 'Git Bash'
+    // The chocolatey shim directory carries no `git` segment, but its
+    // bash.exe comes from the git package.
+    if (lower.includes('chocolatey')) return 'Git Bash'
+    if (lower.includes('cygwin')) return 'Cygwin'
+    if (lower.includes('msys')) return 'MSYS2'
+    return shellBasename(path)
+  }
+  if (lower.includes('cmd')) return 'Command Prompt'
+  if (shellBasename(path).toLowerCase() === 'nu') return 'Nushell'
+  return shellBasename(path)
+}


### PR DESCRIPTION
## Summary

Local terminals previously offered only the built-in shells (PowerShell, CMD, Git Bash). This PR automatically detects well-known third-party shells on Windows and offers them everywhere a shell can be picked — no user configuration required:

- **Cygwin bash**: resolved via the Cygwin setup registry rootdir (HKLM/HKCU, including the WOW6432Node view) plus conventional install dirs (`C:\cygwin64`, `C:\cygwin`, `C:\tools\cygwin*`)
- **MSYS2 bash**: conventional install dirs (`C:\msys64`, `C:\msys32`, `C:\tools\msys*`, `%USERPROFILE%\msys*`)
- **Nushell**: resolved from `PATH`

Detected shells are inserted after the built-ins and before the generic `bash.exe` PATH fallback, so a real bash install preempts the System32 WSL stub. Startup needs no new logic: the existing bash heuristic already applies `--login -i`, `TERM=xterm-256color` and the UTF-8 console code-page fix, which MSYS-family bash flavors require as well.

Because Git for Windows, Cygwin and MSYS2 all ship a `bash.exe`, the frontend label and the backend tab title now disambiguate them by install path (`Git Bash` / `Cygwin` / `MSYS2`) instead of labeling every bash as Git Bash. The four duplicated `getShellLabel` implementations are consolidated into one shared utility.

## Testing

- New tests: shell-detection probing (registry rootdir, fixed paths, dedup, empty host), bash-flavor title disambiguation, and the shared label utility (12 cases)
- Full frontend suite: 364 tests pass; production build passes
- Go: root package passes; session package has only pre-existing Kerberos environment failures (reproduced on a clean checkout)

Closes #781

---

## 概要

此前本地终端只提供内建的 Shell（PowerShell、CMD、Git Bash）。本 PR 在 Windows 上自动探测常见的第三方 Shell 并在所有可选 Shell 的位置展示，无需任何用户配置：

- **Cygwin bash**：通过 setup 注册表 rootdir（HKLM/HKCU，含 WOW6432Node）及常见安装目录（`C:\cygwin64`、`C:\cygwin`、`C:\tools\cygwin*`）解析
- **MSYS2 bash**：常见安装目录（`C:\msys64`、`C:\msys32`、`C:\tools\msys*`、`%USERPROFILE%\msys*`）
- **Nushell**：从 `PATH` 解析

探测结果插入在内建 Shell 之后、通用的 `bash.exe` PATH 回退之前，真实安装的 bash 会优先于 System32 的 WSL 存根。启动无需新增逻辑：现有 bash 启发式已自动应用 `--login -i`、`TERM=xterm-256color` 和 UTF-8 控制台代码页修复，MSYS 系的 bash 同样需要这些处理。

由于 Git for Windows、Cygwin 和 MSYS2 都自带 `bash.exe`，前端标签和后端终端标题现在按安装路径区分（`Git Bash` / `Cygwin` / `MSYS2`），不再把所有 bash 一律标为 Git Bash。四处重复的 `getShellLabel` 实现收敛为一个共享工具。

## 测试

- 新增测试：Shell 探测（注册表 rootdir、固定路径、去重、空主机）、bash 标题区分、共享标签工具（12 个用例）
- 前端全套 364 个测试通过；生产构建通过
- Go：根包通过；session 包仅剩存量的 Kerberos 环境问题（干净检出上同样失败）

关联 #781