### PR TITLE
feat(local): add CMD (Clink) shell entries with Tabby-style tuning

### DIFF
--- a/app.go
+++ b/app.go
@@ -229,6 +229,10 @@ func (a *App) ServiceStartup(ctx context.Context, options application.ServiceOpt
 // it until SetDataDir picks a directory; on the normal path it runs once at
 // startup. Runs exactly once either way.
 func (a *App) initStores(dataDir string, upgrade bool) {
+	// Point clink:// local shells at the app data dir (they drop a tuned
+	// clink profile next to the stores; see backend/session/local_clink.go).
+	session.SetClinkProfileDir(filepath.Join(dataDir, "clink"))
+
 	cs, err := store.NewConnectionStore(dataDir)
 	if err != nil {
 		log.Writef("Failed to init connection store: %v", err)

--- a/app_windows.go
+++ b/app_windows.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"syscall"
 	"unicode/utf16"
@@ -48,6 +49,11 @@ func (a *App) GetAvailableShells() []string {
 	add("pwsh.exe")
 	add("powershell.exe")
 	add("cmd.exe")
+	// CMD (Clink) rides the user's installed clink (1.1+); the Tabby-style
+	// profile tuning happens at session start (backend/session/local_clink.go).
+	if clink := findClink(); clink != "" {
+		shells = append(shells, session.ClinkShellPathPrefix+clink)
+	}
 	for _, p := range []string{
 		`C:\Program Files\Git\bin\bash.exe`,
 		`C:\Program Files (x86)\Git\bin\bash.exe`,
@@ -84,6 +90,11 @@ func (a *App) GetAvailableShells() []string {
 		for _, sh := range shells {
 			base := strings.ToLower(filepath.Base(sh))
 			if base == "cmd.exe" || base == "powershell.exe" {
+				shells = append(shells, session.AdminShellPathPrefix+sh)
+			}
+		}
+		for _, sh := range shells {
+			if _, ok := session.ParseClinkShellPath(sh); ok {
 				shells = append(shells, session.AdminShellPathPrefix+sh)
 			}
 		}
@@ -161,6 +172,49 @@ func probeCygwinRootdir() string {
 			key.Close()
 			if err == nil && rootdir != "" {
 				return rootdir
+			}
+		}
+	}
+	return ""
+}
+
+// findClink locates the user's clink (1.1+): PATH first (covers installs
+// that put themselves on PATH, scoop shims and chocolatey shims), then the
+// well known install directories clink's setup and package managers use.
+// The release layout ships arch-named executables (clink_x64.exe,
+// clink_arm64.exe, ... from the official zip), older/manual installs have a
+// plain clink.exe — both are accepted. Returns "" when clink is not found.
+func findClink() string {
+	archExe := map[string]string{
+		"amd64": "clink_x64.exe",
+		"arm64": "clink_arm64.exe",
+		"386":   "clink_x86.exe",
+	}[runtime.GOARCH]
+	for _, name := range []string{archExe, "clink.exe"} {
+		if name == "" {
+			continue
+		}
+		if p, err := exec.LookPath(name); err == nil {
+			return p
+		}
+	}
+	for _, dir := range []string{
+		filepath.Join(os.Getenv("ProgramFiles"), "clink"),
+		filepath.Join(os.Getenv("ProgramFiles(x86)"), "clink"),
+		filepath.Join(os.Getenv("LOCALAPPDATA"), "clink"),
+		filepath.Join(os.Getenv("USERPROFILE"), "scoop", "apps", "clink", "current"),
+		filepath.Join(os.Getenv("SCOOP"), "apps", "clink", "current"),
+	} {
+		if dir == "" {
+			continue
+		}
+		for _, name := range []string{archExe, "clink.exe"} {
+			if name == "" {
+				continue
+			}
+			p := filepath.Join(dir, name)
+			if _, err := os.Stat(p); err == nil {
+				return p
 			}
 		}
 	}

--- a/backend/session/local_admin_broker_windows.go
+++ b/backend/session/local_admin_broker_windows.go
@@ -68,10 +68,14 @@ func serveLocalPtyBroker(pipeName string) int {
 	if cols <= 0 || rows <= 0 {
 		cols, rows = 80, 24
 	}
+	env := os.Environ()
+	if len(spec.Env) > 0 {
+		env = append(env, spec.Env...)
+	}
 	cpty, err := conpty.Start(spec.CommandLine,
 		conpty.ConPtyDimensions(cols, rows),
 		conpty.ConPtyWorkDir(spec.WorkDir),
-		conpty.ConPtyEnv(os.Environ()))
+		conpty.ConPtyEnv(env))
 	if err != nil {
 		noteAndClose(pipe, fmt.Sprintf("start shell: %v", err))
 		return 1

--- a/backend/session/local_admin_windows.go
+++ b/backend/session/local_admin_windows.go
@@ -73,10 +73,14 @@ func IsProcessElevated() bool {
 // message (instead of ShellExecuteEx parameters) avoids re-quoting a command
 // line through argv.
 type localPtySpawn struct {
-	CommandLine string `json:"commandLine"`
-	WorkDir     string `json:"workDir,omitempty"`
-	Cols        int    `json:"cols"`
-	Rows        int    `json:"rows"`
+	CommandLine string   `json:"commandLine"`
+	WorkDir     string   `json:"workDir,omitempty"`
+	// Extra environment entries for the spawned shell (on top of the
+	// broker's environ); nil keeps the broker's plain environment. Used e.g.
+	// by clink:// shells to pass WT_SESSION=0 into the elevated ConPTY.
+	Env  []string `json:"env,omitempty"`
+	Cols int      `json:"cols"`
+	Rows int      `json:"rows"`
 }
 
 // Frame types of the broker pipe protocol. Every message is

--- a/backend/session/local_clink.go
+++ b/backend/session/local_clink.go
@@ -1,0 +1,131 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ClinkShellPathPrefix marks a local-terminal ShellPath that launches
+// cmd.exe with clink (https://chrisant996.github.io/clink/) injected, e.g.
+// "clink://C:\Program Files\clink\clink.exe". It mirrors the wsl:// scheme:
+// the prefix carries the launch mode, the rest is the clink executable path.
+// Combine with admin:// (admin://clink://...) for an elevated variant.
+const ClinkShellPathPrefix = "clink://"
+
+// clinkProfileDirOverride is the directory handed to clink via
+// `inject --profile`. Set by the app at startup (and on data-dir changes)
+// to <dataDir>/clink; empty falls back to the OS config dir.
+var clinkProfileDirOverride string
+
+// SetClinkProfileDir points clink sessions at dir. Called from app startup
+// with the resolved data directory so the profile lives next to the other
+// uniTerm state.
+func SetClinkProfileDir(dir string) {
+	clinkProfileDirOverride = dir
+}
+
+// ParseClinkShellPath splits a clink:// ShellPath into the clink executable
+// path. ok is false when path does not carry the clink:// prefix.
+func ParseClinkShellPath(path string) (clinkPath string, ok bool) {
+	const prefix = ClinkShellPathPrefix
+	if len(path) < len(prefix) || !strings.EqualFold(path[:len(prefix)], prefix) {
+		return "", false
+	}
+	return path[len(prefix):], true
+}
+
+// clinkProfileDir resolves the profile directory passed to clink inject.
+func clinkProfileDir() string {
+	if clinkProfileDirOverride != "" {
+		return clinkProfileDirOverride
+	}
+	if cfg, err := os.UserConfigDir(); err == nil {
+		return filepath.Join(cfg, "uniTerm", "clink")
+	}
+	return filepath.Join(os.TempDir(), "uniterm-clink")
+}
+
+// ensureClinkProfile creates the clink profile directory and drops the
+// enhanced default_settings into it. clink reads a file named
+// "default_settings" from the profile directory and applies it UNDER the
+// user's clink_settings, so these behave as tuned defaults while every value
+// stays user-overridable. Rewritten whenever the built-in content changes;
+// a failure must never block the session (clink also runs without it).
+func ensureClinkProfile() string {
+	dir := clinkProfileDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return ""
+	}
+	settings := filepath.Join(dir, "default_settings")
+	cur, err := os.ReadFile(settings)
+	if err != nil || string(cur) != clinkDefaultSettings {
+		_ = os.WriteFile(settings, []byte(clinkDefaultSettings), 0o644)
+	}
+	return dir
+}
+
+// buildClinkCommandLine builds the ConPTY command line for a clink-backed
+// cmd.exe session, in the shape Tabby uses: `cmd.exe /k <clink> inject`.
+// The inject subcommand loads clink's DLL into the running cmd process, and
+// --profile points it at uniTerm's tuned profile directory. Requires clink
+// 1.1+ (older 0.4.x releases have no --profile); on failure cmd simply stays
+// open without clink, degrading to a plain Command Prompt session.
+//
+// Quoting: cmd's /k parser strips the outermost quote pair when the /k
+// argument starts with a quote and doesn't meet its single-pair exception
+// (more than two quote characters here guarantees that), so the inner
+// command is wrapped in one extra pair — the classic `cmd /k ""a" b "c""`
+// pattern that survives spaces in both the clink path and the profile dir.
+func buildClinkCommandLine(clinkPath, profileDir string) string {
+	cmdExe := os.Getenv("ComSpec")
+	if cmdExe == "" {
+		cmdExe = "cmd.exe"
+	}
+	inner := "\"" + clinkPath + "\" inject"
+	if profileDir != "" {
+		inner += " --profile \"" + profileDir + "\""
+	}
+	return "\"" + cmdExe + "\" /k \"" + inner + "\""
+}
+
+// clinkDefaultSettings is written as the profile's default_settings. The
+// values mirror Tabby's bundled extras/clink/default_settings, which is
+// half of why clink feels so much better inside Tabby than a bare install:
+// substring + envvar-expanding completion, 25k history lines with visible
+// timestamps, syntax-colored input, and Windows-style default key bindings.
+// The other half (WT_SESSION=0, see LocalSession.Connect) tells clink the
+// host is a ConPTY terminal so it skips its own ANSI emulation layer.
+const clinkDefaultSettings = `# When this file is named "default_settings" and is in the binaries
+# directory or profile directory, it provides enhanced default settings.
+
+# Override built-in default settings with ones that provide a more
+# enhanced Clink experience.
+
+clink.default_bindings            = windows
+clink.autoupdate                  = off
+cmd.ctrld_exits                   = False
+color.arginfo                     = sgr 38;5;172
+color.argmatcher                  = sgr 1;38;5;40
+color.cmd                         = bold
+color.cmdredir                    = sgr 38;5;172
+color.cmdsep                      = sgr 38;5;135
+color.comment_row                 = sgr 38;5;87;48;5;18
+color.description                 = sgr 38;5;39
+color.doskey                      = sgr 1;38;5;75
+color.executable                  = sgr 1;38;5;33
+color.filtered                    = bold
+color.flag                        = sgr 38;5;117
+color.hidden                      = sgr 38;5;160
+color.histexpand                  = sgr 97;48;5;55
+color.horizscroll                 = sgr 38;5;16;48;5;30
+color.input                       = sgr 38;5;214
+color.readonly                    = sgr 38;5;28
+color.selected_completion         = sgr 7
+color.selection                   = sgr 38;5;16;48;5;179
+color.unrecognized                = sgr 38;5;203
+history.max_lines                 = 25000
+history.time_stamp                = show
+match.expand_envvars              = True
+match.substring                   = True
+`

--- a/backend/session/local_clink_test.go
+++ b/backend/session/local_clink_test.go
@@ -1,0 +1,100 @@
+//go:build windows
+// +build windows
+
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParseClinkShellPath(t *testing.T) {
+	const clinkPath = `C:\Program Files\clink\clink.exe`
+	for _, tc := range []struct {
+		name, in, want string
+		ok             bool
+	}{
+		{"prefixed", ClinkShellPathPrefix + clinkPath, clinkPath, true},
+		{"prefixed uppercase scheme", "CLINK://" + clinkPath, clinkPath, true},
+		{"admin composition", AdminShellPathPrefix + ClinkShellPathPrefix + clinkPath, "", false},
+		{"plain path", clinkPath, "", false},
+		{"wsl scheme", "wsl://Ubuntu", "", false},
+		{"empty", "", "", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := ParseClinkShellPath(tc.in)
+			if ok != tc.ok || got != tc.want {
+				t.Fatalf("ParseClinkShellPath(%q) = (%q, %v), want (%q, %v)", tc.in, got, ok, tc.want, tc.ok)
+			}
+		})
+	}
+}
+
+func TestBuildClinkCommandLine(t *testing.T) {
+	t.Setenv("ComSpec", `C:\Windows\System32\cmd.exe`)
+	got := buildClinkCommandLine(`C:\Program Files\clink\clink.exe`, `C:\Users\a b\AppData\Local\clink`)
+
+	// The whole /k argument is wrapped in an extra outer quote pair so cmd's
+	// /k parser strips it (leaving the inner quoting balanced) even though
+	// both the clink path and the profile dir contain spaces.
+	want := `"C:\Windows\System32\cmd.exe" /k ""C:\Program Files\clink\clink.exe" inject --profile "C:\Users\a b\AppData\Local\clink""`
+	if got != want {
+		t.Fatalf("buildClinkCommandLine =\n %q\nwant\n %q", got, want)
+	}
+	if n := strings.Count(got, `"`); n != 8 {
+		t.Fatalf("quote count = %d, want 8 (cmd pair + outer pair + two inner pairs)", n)
+	}
+}
+
+func TestBuildClinkCommandLineNoProfile(t *testing.T) {
+	t.Setenv("ComSpec", "")
+	// Empty ComSpec falls back to PATH-resolved cmd.exe; an empty profile dir
+	// must omit the --profile flag entirely, not emit `--profile ""`.
+	got := buildClinkCommandLine(`C:\clink\clink.exe`, "")
+	want := `"cmd.exe" /k ""C:\clink\clink.exe" inject"`
+	if got != want {
+		t.Fatalf("buildClinkCommandLine = %q, want %q", got, want)
+	}
+}
+
+func TestEnsureClinkProfile(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "clink")
+	SetClinkProfileDir(dir)
+	t.Cleanup(func() { SetClinkProfileDir("") })
+
+	if got := ensureClinkProfile(); got != dir {
+		t.Fatalf("ensureClinkProfile() = %q, want %q", got, dir)
+	}
+	settings := filepath.Join(dir, "default_settings")
+	cur, err := os.ReadFile(settings)
+	if err != nil {
+		t.Fatalf("default_settings not written: %v", err)
+	}
+	if string(cur) != clinkDefaultSettings {
+		t.Fatalf("default_settings content mismatch")
+	}
+
+	// Rewrites when the built-in content changes, never on unchanged reruns.
+	if err := os.WriteFile(settings, []byte("stale"), 0o644); err != nil {
+		t.Fatalf("seed stale file: %v", err)
+	}
+	ensureClinkProfile()
+	cur, err = os.ReadFile(settings)
+	if err != nil {
+		t.Fatalf("reread: %v", err)
+	}
+	if string(cur) != clinkDefaultSettings {
+		t.Fatalf("stale default_settings was not refreshed")
+	}
+}
+
+func TestShellNameClink(t *testing.T) {
+	if got := shellName(ClinkShellPathPrefix + `C:\clink\clink.exe`); got != "CMD (Clink)" {
+		t.Fatalf("shellName(clink) = %q, want %q", got, "CMD (Clink)")
+	}
+	if got := shellName(AdminShellPathPrefix + ClinkShellPathPrefix + `C:\clink\clink.exe`); got != "CMD (Clink) (Admin)" {
+		t.Fatalf("shellName(admin clink) = %q, want %q", got, "CMD (Clink) (Admin)")
+	}
+}

--- a/backend/session/local_session_windows.go
+++ b/backend/session/local_session_windows.go
@@ -173,6 +173,21 @@ func (s *LocalSession) Connect(config ConnectionConfig) error {
 		elevate = !IsProcessElevated()
 	}
 
+	// clink:// shells run cmd.exe with clink injected (Tabby-style). The
+	// WT_SESSION hint tells clink the host is a ConPTY terminal like Windows
+	// Terminal, so it renders through the terminal's native VT stream instead
+	// of its own ANSI emulation layer.
+	clinkExe := ""
+	var clinkEnv []string
+	if p, ok := ParseClinkShellPath(shell); ok {
+		clinkExe = p
+		clinkEnv = []string{"WT_SESSION=0"}
+	}
+	clinkProfile := ""
+	if clinkExe != "" {
+		clinkProfile = ensureClinkProfile()
+	}
+
 	// Determine working directory: use config.Cwd if set, otherwise user home.
 	workDir := config.Cwd
 	if workDir == "" {
@@ -203,6 +218,14 @@ func (s *LocalSession) Connect(config ConnectionConfig) error {
 			cmd = exec.Command("wsl.exe", "-d", distro)
 		}
 		cmd.Env = os.Environ()
+	} else if clinkExe != "" {
+		// Tabby-style clink injection: cmd.exe /k <clink> inject --profile
+		// <dir>, started through ConPTY (clink's DLL injection needs the
+		// console context ConPTY provides, so the pipe fallback below runs
+		// plain cmd instead).
+		commandLine = buildClinkCommandLine(clinkExe, clinkProfile)
+		cmd = exec.Command("cmd.exe")
+		cmd.Env = append(os.Environ(), clinkEnv...)
 	} else {
 		commandLine = buildCommandLine(shell)
 		lowerShell := strings.ToLower(shell)
@@ -235,6 +258,7 @@ func (s *LocalSession) Connect(config ConnectionConfig) error {
 		tp, err := startElevatedPty(localPtySpawn{
 			CommandLine: commandLine,
 			WorkDir:     workDir,
+			Env:         clinkEnv,
 			Cols:        cols,
 			Rows:        rows,
 		})
@@ -259,7 +283,11 @@ func (s *LocalSession) Connect(config ConnectionConfig) error {
 		if cols <= 0 || rows <= 0 {
 			cols, rows = 80, 24
 		}
-		c, err := conpty.Start(commandLine, conpty.ConPtyDimensions(cols, rows), conpty.ConPtyWorkDir(workDir), conpty.ConPtyEnv(os.Environ()))
+		env := os.Environ()
+		if len(clinkEnv) > 0 {
+			env = append(env, clinkEnv...)
+		}
+		c, err := conpty.Start(commandLine, conpty.ConPtyDimensions(cols, rows), conpty.ConPtyWorkDir(workDir), conpty.ConPtyEnv(env))
 		if err == nil {
 			s.cpty = c
 			if isMSYSBash {
@@ -474,6 +502,9 @@ func buildCommandLine(shell string) string {
 func shellName(path string) string {
 	if inner, ok := ParseAdminShellPath(path); ok {
 		return shellName(inner) + " (Admin)"
+	}
+	if _, ok := ParseClinkShellPath(path); ok {
+		return "CMD (Clink)"
 	}
 	if distro, ok := parseWSLPath(path); ok {
 		return "WSL - " + distro

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -1879,6 +1879,9 @@ function getShellLabel(path: string): string {
     const inner = getShellLabel(path.slice(8))
     return inner.endsWith(' (Admin)') ? inner : `${inner} (Admin)`
   }
+  if (lower.startsWith('clink://')) {
+    return 'Command Prompt (Clink)'
+  }
   if (lower.startsWith('wsl://')) {
     const distro = path.slice(6)
     return distro ? `WSL - ${distro}` : 'WSL'

--- a/frontend/src/utils/shellLabel.ts
+++ b/frontend/src/utils/shellLabel.ts
@@ -17,6 +17,9 @@ export function getShellLabel(path: string, emptyFallback = ''): string {
     const inner = getShellLabel(path.slice(8), emptyFallback)
     return inner.endsWith(' (Admin)') ? inner : `${inner} (Admin)`
   }
+  if (lower.startsWith('clink://')) {
+    return 'Command Prompt (Clink)'
+  }
   if (lower.startsWith('wsl://')) {
     const distro = path.slice(6)
     return distro ? `WSL - ${distro}` : 'WSL'


### PR DESCRIPTION
## Summary

On Windows, when clink (chrisant996/clink, 1.1+) is installed, the local-shell menu gains **Command Prompt (Clink)** plus an administrator variant, and the session is launched the way Tabby does it — which is most of why clink feels so much better inside Tabby than a bare install:

- `cmd.exe /k <clink> inject --profile <dir>` injects clink into the real cmd process at startup;
- `WT_SESSION=0` in the ConPTY environment tells clink the host is a Windows-Terminal-like ConPTY, so it renders through the terminal's native VT stream instead of its own ANSI emulation layer;
- a tuned `default_settings` is dropped into a clink profile directory under the app data dir (substring + envvar-expanding completion, 25k history lines with timestamps, syntax-colored input, Windows default bindings). clink treats it as defaults, so a user's own `clink_settings` still wins, and the profile is isolated from their global clink setup.

Everything degrades gracefully: no clink installed → no menu entries; injection fails → cmd simply stays open as a plain Command Prompt.

## Changes

- **Detection** (`app_windows.go`): PATH first, then well-known install dirs (Program Files, `%LOCALAPPDATA%\clink` — clink setup's per-user default, scoop). Both the arch-named release executables (`clink_x64.exe` / `clink_arm64.exe` / `clink_x86.exe` from the official zip) and legacy plain `clink.exe` are accepted. The `clink://<exe>` entry rides the existing shell-path scheme (`wsl://` / `admin://` style); the admin variant composes as `admin://clink://…` and is only offered when uniTerm itself is unelevated, matching the stock admin entries.
- **Launch** (`backend/session/local_clink.go`, `local_session_windows.go`): clink profile setup (idempotent, rewritten only when the built-in content changes) and the command line above; requires clink 1.1+ (`inject --profile`).
- **Broker**: `localPtySpawn` gains an optional `Env` pass-through so the elevated variant gets the same `WT_SESSION=0` treatment (broker and app ship in the same binary, no version skew).
- **Labels**: one `clink://` branch in the shared `utils/shellLabel.ts` (plus the existing inline copy in Sidebar.vue).
- **i18n**: none needed — labels follow the existing hardcoded English scheme for shell entries.
- **Tests**: `local_clink_test.go` covers scheme parsing, the `/k` command-line quoting (spaces in both the clink path and the profile dir), profile creation/idempotent rewrite, and the tab title.

## Testing

- `go build ./...`, `go vet`, `go test ./backend/session/ -run Clink`, full `wails3 build` (production) pass on Windows.
- vitest: 364 tests pass; vite build clean.
- Manually verified end-to-end in the built app with clink 1.9.32 installed to `%LOCALAPPDATA%\clink`: both menu entries appear, the session banner shows Clink, TAB completion picks up the tuned `color.executable` styling, and the profile directory (`<dataDir>\clink\default_settings`, `clink_history`) is created on first launch.

---

## 变更摘要

Windows 下检测到已安装的 clink（chrisant996/clink，1.1+）时，本地终端菜单新增 **Command Prompt (Clink)** 及其管理员变体，并按 Tabby 的方式启动会话——这正是 clink 在 Tabby 里比裸装好用得多的原因：

- `cmd.exe /k <clink> inject --profile <目录>` 在启动时把 clink 注入真实的 cmd 进程；
- ConPTY 环境里设置 `WT_SESSION=0`，让 clink 把宿主当作 Windows Terminal 类终端、走原生 VT 流渲染而不是自己的 ANSI 兼容层；
- 在应用数据目录写入一份调优过的 `default_settings`（子串与环境变量展开补全、25000 条带时间戳历史、彩色语法输入、Windows 默认键位）。clink 把它当默认值，用户自己的 `clink_settings` 仍可覆盖；profile 与全局 clink 配置相互隔离。

一切皆可优雅降级：未安装 clink → 不出现菜单项；注入失败 → cmd 照常打开，等于普通命令提示符。

## 变更内容

- **检测**（`app_windows.go`）：先 PATH，再常见安装目录（Program Files、clink 用户级默认的 `%LOCALAPPDATA%\clink`、scoop）；同时接受官方 zip 的按架构命名（`clink_x64.exe` 等）与旧版 `clink.exe`。`clink://<exe>` 条目沿用现有 shell path scheme（同 `wsl://` / `admin://` 风格）；admin 变体组合为 `admin://clink://…`，与既有 admin 条目一致，仅在 uniTerm 未提权时提供。
- **启动**（`backend/session/local_clink.go`、`local_session_windows.go`）：clink profile 准备（幂等，仅内置内容变化时重写）与上述命令行；要求 clink 1.1+（`inject --profile`）。
- **Broker**：`localPtySpawn` 增加可选 `Env` 透传，让提权变体同样获得 `WT_SESSION=0`（broker 与主程序同一二进制，无版本偏差）。
- **标签**：在共享的 `utils/shellLabel.ts` 加一处 `clink://` 分支（Sidebar.vue 既有内联副本同步）。
- **测试**：`local_clink_test.go` 覆盖 scheme 解析、`/k` 命令行引号处理（clink 路径与 profile 目录均含空格）、profile 创建与幂等重写、tab 标题。

## 测试

- Windows 上 `go build ./...`、`go vet`、`go test ./backend/session/ -run Clink`、完整 `wails3 build`（production）全部通过。
- vitest：364 个测试通过；vite build 无告警错误。
- 用安装到 `%LOCALAPPDATA%\clink` 的 clink 1.9.32 在打包应用中端到端实测：两个菜单项正常出现，会话显示 Clink banner，TAB 补全命中调优后的 `color.executable` 配色，首次启动即创建 profile 目录（`<dataDir>\clink\default_settings`、`clink_history`）。