### PR TITLE
fix(ai): escape quotes in markdown rendering, close slash-separator XSS

### DIFF
--- a/frontend/src/components/AIMessage.sanitize.test.ts
+++ b/frontend/src/components/AIMessage.sanitize.test.ts
@@ -1,27 +1,11 @@
-// Regression test for FE-01 — XSS via markdown-produced HTML in
-// AIMessage.vue v-html binding. Mirrors the sanitizeRenderedHtml helper
-// implementation; if the helper changes, this test must be updated.
+// Regression tests for FE-01 (XSS via markdown-produced HTML in the
+// AIMessage.vue v-html binding) and the FE-01 follow-up: attribute breakout
+// via slash-separated on* handlers (<a href="x"/onclick="...">), which the
+// whitespace-only strip missed. The real helpers are imported directly (an
+// earlier revision mirrored the implementation, which drifted silently).
 
 import { describe, expect, it } from 'vitest'
-
-function sanitizeRenderedHtml(html: string): string {
-  const dangerousTags = [
-    'script', 'iframe', 'object', 'embed', 'style', 'form',
-    'link', 'meta', 'base', 'svg', 'math',
-  ]
-  for (const tag of dangerousTags) {
-    const re = new RegExp(`<${tag}\\b[\\s\\S]*?<\\/${tag}>`, 'gi')
-    html = html.replace(re, '')
-    const reSelf = new RegExp(`<${tag}\\b[^>]*\\/?>`, 'gi')
-    html = html.replace(reSelf, '')
-  }
-  html = html.replace(/\s+on[a-z]+\s*=\s*("[^"]*"|'[^']*'|[^\s>]+)/gi, '')
-  html = html.replace(
-    /\s+(href|src|action|formaction|xlink:href)\s*=\s*("\s*(?:javascript|data|vbscript):[^"]*"|'\s*(?:javascript|data|vbscript):[^']*'|(?:javascript|data|vbscript):[^\s>]+)/gi,
-    '',
-  )
-  return html
-}
+import { sanitizeRenderedHtml, escapeHtml, renderMarkdownHtml } from '../utils/markdown'
 
 describe('sanitizeRenderedHtml (FE-01 XSS)', () => {
   it('strips javascript: URLs from link href', () => {
@@ -39,6 +23,18 @@ describe('sanitizeRenderedHtml (FE-01 XSS)', () => {
     expect(out).not.toMatch(/onerror/i)
     expect(out).not.toMatch(/alert\(/i)
     expect(out).toMatch(/<img/) // tag still present
+  })
+
+  it('strips slash-separated on* handlers with quoted values', () => {
+    const out = sanitizeRenderedHtml('<a href="x"/onclick="alert(1)">x</a>')
+    expect(out).not.toMatch(/onclick/i)
+    expect(out).not.toMatch(/alert\(/i)
+    expect(out).toMatch(/<a/) // tag still present
+  })
+
+  it('keeps slash URLs containing on…= segments intact (no false positive)', () => {
+    const url = '<a href="https://example.com/online=1">x</a>'
+    expect(sanitizeRenderedHtml(url)).toBe(url)
   })
 
   it('strips <script> tags and their content', () => {
@@ -61,5 +57,28 @@ describe('sanitizeRenderedHtml (FE-01 XSS)', () => {
   it('preserves safe content unchanged', () => {
     const safe = '<p>hello <strong>world</strong></p>'
     expect(sanitizeRenderedHtml(safe)).toBe(safe)
+  })
+})
+
+describe('markdown pipeline attribute-breakout hardening (FE-01 follow-up)', () => {
+  it('escapeHtml escapes double quotes', () => {
+    const out = escapeHtml('[x](x"/onerror="alert(1))')
+    expect(out).not.toMatch(/"/)
+    expect(out).toContain('&quot;')
+  })
+
+  it('renderMarkdownHtml output has no raw quotes from model content', () => {
+    // With quotes escaped at the source, the link-syntax payload
+    // [x](x"/onclick="alert(1)) lands inside the quoted href value with its
+    // quotes entity-encoded — inert URL text that can never split into a
+    // separate attribute.
+    const out = sanitizeRenderedHtml(renderMarkdownHtml('[x](x"/onclick="alert(1))'))
+    expect(out).toContain('href="x&quot;/onclick=&quot;alert(1"')
+    expect(out).not.toMatch(/[\s/]"?onclick="\s*alert/)
+  })
+
+  it('renderMarkdownHtml keeps ordinary links working', () => {
+    const out = renderMarkdownHtml('[docs](https://example.com/a?b=1)')
+    expect(out).toContain('href="https://example.com/a?b=1"')
   })
 })

--- a/frontend/src/components/AIMessage.vue
+++ b/frontend/src/components/AIMessage.vue
@@ -134,7 +134,7 @@ import { ref, computed } from 'vue'
 import { Copy, Check, BookOpen, Terminal } from '@lucide/vue'
 import { useAIStore } from '../stores/aiStore'
 import { useI18n } from '../i18n'
-import { sanitizeRenderedHtml } from '../utils/markdown'
+import { sanitizeRenderedHtml, escapeHtml as escapeHtmlBase } from '../utils/markdown'
 import type { AIMessage } from '../types/ai'
 
 const props = defineProps<{ message: AIMessage; searchText?: string }>()
@@ -343,10 +343,11 @@ function getToolResult(toolCallId: string): AIMessage | undefined {
 }
 
 function renderMarkdown(text: string): string {
-  let html = text
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
+  // escapeHtmlBase escapes & < > and quotes — the quote escape matters here:
+  // without it a markdown link like [x](x"/onerror="alert(1)) breaks out of
+  // href="..." via the slash attribute separator, and sanitizeRenderedHtml
+  // only strips on*= handlers preceded by whitespace (FE-01 follow-up).
+  let html = escapeHtmlBase(text)
 
   // Protect fenced code blocks and inline code from further markdown processing
   const protectedBlocks: string[] = []
@@ -633,11 +634,7 @@ const renderedContent = computed(() => {
 })
 
 function escapeHtml(text: string): string {
-  return text
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/\n/g, '<br>')
+  return escapeHtmlBase(text).replace(/\n/g, '<br>')
 }
 
 // sanitizeRenderedHtml lives in utils/markdown.ts so other v-html surfaces

--- a/frontend/src/utils/markdown.ts
+++ b/frontend/src/utils/markdown.ts
@@ -3,7 +3,10 @@
 // AIMessage.sanitize.test.ts, which mirrors sanitizeRenderedHtml.
 
 // Sanitize markdown-produced HTML before it's assigned to v-html.
-// Conservative strip-list: anything outside this allowlist is removed.
+// This is defense in depth: every caller escapes its input first (see
+// escapeHtml), so no raw tag/quote from model or user content can reach
+// here. The strip-list below catches what the markdown renderer itself
+// could synthesize (javascript: links, quote-less attribute breakouts).
 export function sanitizeRenderedHtml(html: string): string {
   // Drop dangerous tags entirely (including their content).
   const dangerousTags = [
@@ -16,8 +19,12 @@ export function sanitizeRenderedHtml(html: string): string {
     const reSelf = new RegExp(`<${tag}\\b[^>]*\\/?>`, 'gi')
     html = html.replace(reSelf, '')
   }
-  // Strip on*="..." event-handler attributes (any attribute starting with on).
+  // Strip on*="..." event-handler attributes (any attribute starting with on),
+  // whether separated from the previous attribute by whitespace or by the
+  // tag-internal slash (<a href="x"/onclick="...">). The slash variant only
+  // matches a quoted value so URLs like href="/online=1" stay intact.
   html = html.replace(/\s+on[a-z]+\s*=\s*("[^"]*"|'[^']*'|[^\s>]+)/gi, '')
+  html = html.replace(/\/on[a-z]+\s*=\s*("[^"]*"|'[^']*')/gi, '')
   // Strip javascript:/data:/vbscript: URL schemes in href/src.
   html = html.replace(
     /\s+(href|src|action|formaction|xlink:href)\s*=\s*("\s*(?:javascript|data|vbscript):[^"]*"|'\s*(?:javascript|data|vbscript):[^']*'|(?:javascript|data|vbscript):[^\s>]+)/gi,
@@ -26,7 +33,11 @@ export function sanitizeRenderedHtml(html: string): string {
   return html
 }
 
-function escapeHtml(text: string): string {
+// Escape HTML-significant characters (including quotes — a raw double quote
+// in renderer-synthesized attributes would let `on*=` handlers break out).
+// Shared by the markdown pipeline and surfaces that escape model/user text
+// before v-html (AIMessage.vue).
+export function escapeHtml(text: string): string {
   return text
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')


### PR DESCRIPTION
## Summary

Follow-up to FE-01. AIMessage.vue's local markdown renderer escaped `& < >` but **not double quotes**, so a model response containing

```
[x](x"/onclick="alert(1))
```

broke out of the synthesized `href="..."` via the tag-internal slash attribute separator (`<a href="x"/onclick="alert(1)">` — `/` acts as an attribute boundary in the HTML parser). `sanitizeRenderedHtml` strips `on*=` handlers only when preceded by whitespace, so the `/onclick=` attribute survived; clicking the poisoned link executed script in the webview, where the Wails bridge exposes the full app API (terminal sessions, credentials, file transfer).

Found during a supply-chain/code audit of the repo (model output is remote-controlled content: anything piped through the AI from an SSH'd host is a prompt-injection vector, so renderer hardening here is security-relevant, not cosmetic).

## Changes

- **Root fix**: escape `"` in both AIMessage escape paths. The breakout payload now lands entity-encoded (`&quot;`) *inside* the quoted href value — inert URL text that can never split into a separate attribute.
- The escape helper is now exported from `utils/markdown.ts` and imported by AIMessage.vue, replacing two local copies that could (and did) drift from the shared pipeline.
- `sanitizeRenderedHtml` additionally strips **slash-separated** `on*` handlers with quoted values (`<a href="x"/onclick="...">`). Only the quoted form is matched, so legitimate URLs like `href="/online=1"` are untouched (regression-tested).
- `AIMessage.sanitize.test.ts` now imports the real helpers instead of mirroring the implementation inline (the mirror could drift silently) and adds regression cases for the slash payload, the entity-encoded inert output, and the no-false-positive guard.

## Testing

- `vitest`: 392 tests pass, including 3 new regression cases (slash-separator strip, quote escaping, inert-output shape).
- `vite build` clean.

---

## 变更摘要

FE-01 的后续修复。AIMessage.vue 的本地 markdown 渲染转义了 `& < >` 但**没有转义双引号**，模型回复中的

```
[x](x"/onclick="alert(1))
```

会借助标签内 `/` 属性分隔符突破合成出的 `href="..."`（HTML 解析中 `/` 等价于属性边界）。`sanitizeRenderedHtml` 只剥离空白前缀的 `on*=`，`/onclick=` 属性因此存活；点击被投毒的链接即在 webview 内执行脚本，而 Wails 桥在 webview 中暴露了完整应用 API（终端会话、凭据、文件传输）。发现自对仓库的一次供应链/代码审计（模型输出属于远程可控内容：通过 SSH 粘贴到 AI 的远端内容即是提示注入向量，渲染器加固是安全需求而非锦上添花）。

## 变更内容

- **根因修复**：AIMessage 的两条转义路径均转义 `"`。突破载荷现在以实体编码形式（`&quot;`）落在 href 值内部——惰性 URL 文本，永远无法分裂为独立属性。
- 转义助手从 `utils/markdown.ts` 导出供 AIMessage 复用，替换两份会与共享管线漂移的本地副本。
- `sanitizeRenderedHtml` 额外剥离**斜杠分隔**、带引号值的 `on*` 处理器（`<a href="x"/onclick="...">`）；仅匹配带引号形式，`href="/online=1"` 这类合法 URL 不受影响（有回归测试保证）。
- `AIMessage.sanitize.test.ts` 改为直接导入真实实现而非内联镜像（镜像会静默漂移），新增斜杠载荷、实体编码惰性输出、无误伤三个回归用例。

## 测试

- `vitest`：392 个测试通过，含 3 个新增回归用例（斜杠分隔剥离、引号转义、惰性输出形态）。
- `vite build` 通过。