### PR TITLE
refactor(sidebar): reuse the shared shell label helper

### DIFF
--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -477,6 +477,7 @@ import { ref, onMounted, onUnmounted, computed, watch, nextTick, provide } from 
 import { X, ChevronRight, ChevronDown, Filter, Check, Network, Zap, Clock, Plus, Palette, SquareTerminal, Terminal, FolderUp, Folders, FileUp, HardDrive, Cloud, Globe, Monitor, MonitorCloud, MonitorSmartphone, Database, DatabaseZap, Layers, DatabaseSearch, Activity, Laptop, LaptopMinimal, Cable, Pencil, MoreHorizontal, FolderTree, ShipWheel, Boxes, AppWindow, ArrowLeftRight, ArrowRightLeft } from '@lucide/vue'
 import { ElMessageBox } from 'element-plus'
 import { msg } from '../services/message'
+import { getShellLabel as getShellLabelBase } from '../utils/shellLabel'
 import { useConnectionStore } from '../stores/connectionStore'
 import type { GroupTreeNode } from '../stores/connectionStore'
 import { usePanelStore } from '../stores/panelStore'
@@ -1876,24 +1877,10 @@ function onNewConnCommand(cmd: string) {
 
 
 function getShellLabel(path: string): string {
-  if (!path) return 'Local'
-  const lower = path.toLowerCase()
-  if (lower.startsWith('admin://')) {
-    const inner = getShellLabel(path.slice(8))
-    return inner.endsWith(' (Admin)') ? inner : `${inner} (Admin)`
-  }
-  if (lower.startsWith('clink://')) {
-    return 'Command Prompt (Clink)'
-  }
-  if (lower.startsWith('wsl://')) {
-    const distro = path.slice(6)
-    return distro ? `WSL - ${distro}` : 'WSL'
-  }
-  if (lower.includes('pwsh')) return 'PowerShell'
-  if (lower.includes('powershell')) return 'Windows PowerShell'
-  if (lower.includes('bash')) return 'Git Bash'
-  if (lower.includes('cmd')) return 'Command Prompt'
-  return path.split(/[\\/]/).pop() || path
+  // Shared helper (utils/shellLabel.ts): same labels as the start-page
+  // dropdown, connection form and settings, including the Cygwin/MSYS2
+  // bash.exe disambiguation the inline copy here was missing.
+  return getShellLabelBase(path, 'Local')
 }
 
 function getSubtitle(conn: ConnectionConfig): string {


### PR DESCRIPTION
## Summary

One-line cleanup found during a code audit: `Sidebar.vue` kept its own inline copy of `getShellLabel` after #875 moved the other four surfaces (start page, connection form, settings, tab titles) onto `utils/shellLabel.ts`.

Delegating to the shared helper keeps every surface labeling shells identically — and fixes a real inconsistency while at it: the sidebar's inline copy predates the Cygwin/MSYS2 bash.exe disambiguation, so a connection to an MSYS2 bash showed as "Git Bash" in the sidebar but "MSYS2" everywhere else.

## Changes

- `Sidebar.vue`: inline `getShellLabel` body replaced with `getShellLabelBase(path, 'Local')` (same fallback the start page and settings use), plus the import. Behavior for `admin://`, `wsl://`, `clink://` and all stock shells is unchanged — the shared helper covers all of them.

## Testing

- vitest: 387 tests pass; `vite build` clean; vue-tsc error set identical to the pristine base.

---

## 变更摘要

审计时发现的一行清理：#875 把其余四处（起始页、连接表单、设置、tab 标题）的 `getShellLabel` 收敛到 `utils/shellLabel.ts` 后，`Sidebar.vue` 仍留有一份内联副本。本次改为与其他界面一致的共享助手委托。

顺带修复一个真实的不一致：Sidebar 的内联副本早于 Cygwin/MSYS2 的 bash.exe 区分逻辑，同一条 MSYS2 bash 连接在侧栏显示为 "Git Bash"、其他位置显示为 "MSYS2"。

## 变更内容

- `Sidebar.vue`：内联 `getShellLabel` 改为 `getShellLabelBase(path, 'Local')`（与起始页/设置相同的回退值）并补 import。`admin://`、`wsl://`、`clink://` 及所有内置 shell 的行为不变——共享助手已全部覆盖。

## 测试

- vitest：387 个测试通过；`vite build` 通过；vue-tsc 错误集合与基线一致。