### PR TITLE
fix(window): theme-matched startup background and frameless macOS chrome

### DIFF
--- a/app_darwin.go
+++ b/app_darwin.go
@@ -3,9 +3,11 @@
 package main
 
 import (
+	"context"
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 	"unsafe"
 
 	"github.com/ys-ll/uniterm/backend/log"
@@ -145,3 +147,15 @@ func (a *App) configureMacKeyRepeat() {
 // applyRoundedCorners is a no-op on macOS: window corners are handled by the
 // platform (the Windows build asks DWM for Win11 rounded corners instead).
 func applyRoundedCorners(unsafe.Pointer) {}
+
+// systemPrefersDark reports whether macOS is in dark mode via the same global
+// preference (`AppleInterfaceStyle`) WKWebView consults for the CSS
+// prefers-color-scheme media query. The key only exists when a dark variant
+// is active, so a read error means light mode. Needed because v3's
+// IsDarkMode() is unavailable before Run() (see main.go windowBackgroundColour).
+func systemPrefersDark() bool {
+	ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "defaults", "read", "-g", "AppleInterfaceStyle").Output()
+	return err == nil && len(out) > 0
+}

--- a/app_linux.go
+++ b/app_linux.go
@@ -3,9 +3,11 @@
 package main
 
 import (
+	"context"
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 	"unsafe"
 )
 
@@ -101,3 +103,19 @@ func detectExternalEditors() []ExternalEditorOption {
 // applyRoundedCorners is a no-op on Linux: window corners are handled by the
 // platform (the Windows build asks DWM for Win11 rounded corners instead).
 func applyRoundedCorners(unsafe.Pointer) {}
+
+// systemPrefersDark reports whether the Linux desktop prefers a dark colour
+// scheme, queried from the freedesktop colour-scheme setting — the same value
+// WebKitGTK maps to the CSS prefers-color-scheme media query. Read failures
+// (no gsettings, minimal WMs) default to dark. Needed because v3's
+// IsDarkMode() is unavailable before Run() (see main.go windowBackgroundColour).
+func systemPrefersDark() bool {
+	ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "gsettings", "get",
+		"org.gnome.desktop.interface", "color-scheme").Output()
+	if err != nil {
+		return true
+	}
+	return !strings.Contains(strings.ToLower(string(out)), "light")
+}

--- a/app_windows.go
+++ b/app_windows.go
@@ -528,3 +528,22 @@ func applyRoundedCorners(hwnd unsafe.Pointer) {
 		unsafe.Sizeof(preference),
 	)
 }
+
+// systemPrefersDark reports whether Windows is in app dark mode, reading the
+// same Personalization registry value the WebView2 engine maps to the CSS
+// prefers-color-scheme media query. Needed because v3's IsDarkMode() is
+// unavailable before Run() and the startup background colour must be resolved
+// at window creation. Any failure defaults to dark.
+func systemPrefersDark() bool {
+	k, err := registry.OpenKey(registry.CURRENT_USER,
+		`Software\Microsoft\Windows\CurrentVersion\Themes\Personalize`, registry.QUERY_VALUE)
+	if err != nil {
+		return true
+	}
+	defer k.Close()
+	val, _, err := k.GetIntegerValue("AppsUseLightTheme")
+	if err != nil {
+		return true
+	}
+	return val == 0
+}

--- a/frontend/src/components/AppHeader.vue
+++ b/frontend/src/components/AppHeader.vue
@@ -4,8 +4,15 @@
     :class="`platform-${platform}`"
     @dblclick="onDblClick"
   >
-    <!-- macOS: spacer for native traffic lights -->
-    <div v-if="platform === 'darwin' && !localStateStore.state.systemTitleBar" class="mac-traffic-light-spacer" />
+    <!-- macOS: custom traffic lights (Wails frameless hides the native ones) -->
+    <WindowControls
+      v-if="showWindowControls && platform === 'darwin'"
+      variant="mac"
+      :is-maximised="isMaximised"
+      @minimise="onMinimise"
+      @maximise="onMaximise"
+      @close="onClose"
+    />
 
     <!-- Connections button (icon only, leftmost) -->
     <button class="header-btn" @click="emit('toggle-sidebar')" :title="t('header.connections') + shortcutSuffix('toggleSidebar')">
@@ -86,9 +93,9 @@
       <ExportDialog v-model:visible="showExportDialog" />
     </div>
 
-    <!-- Windows/Linux: window controls right (hidden when using system title bar) -->
+    <!-- Windows/Linux: window controls right -->
     <WindowControls
-      v-if="showWindowControls"
+      v-if="showWindowControls && platform !== 'darwin'"
       :is-maximised="isMaximised"
       @minimise="onMinimise"
       @maximise="onMaximise"
@@ -236,11 +243,10 @@ function detectPlatformSync(): 'windows' | 'darwin' | 'linux' {
 const platform = ref<'windows' | 'darwin' | 'linux'>(detectPlatformSync())
 const isMaximised = ref(false)
 
-// On Windows/Linux the app draws its own window controls — but not when the
-// user opted into the OS native title bar, which already provides them.
-const showWindowControls = computed(
-  () => platform.value !== 'darwin' && !localStateStore.state.systemTitleBar
-)
+// The app draws its own window controls on every platform — but not when the
+// user opted into the OS native title bar, which already provides them. On
+// macOS they render as traffic lights on the left (see template).
+const showWindowControls = computed(() => !localStateStore.state.systemTitleBar)
 
 async function updateMaximisedState() {
   try {
@@ -385,12 +391,6 @@ onUnmounted(() => {
   --wails-draggable: drag;
 }
 
-.app-header.platform-darwin {
-  height: 52px;
-  padding: 0 10px;
-  gap: 8px;
-}
-
 .app-header::after {
   content: '';
   position: absolute;
@@ -472,18 +472,8 @@ onUnmounted(() => {
   );
 }
 
-.mac-traffic-light-spacer {
-  width: 72px;
-  height: 1px;
-  flex-shrink: 0;
-}
-
 .app-header :deep(.window-controls) {
   --wails-draggable: no-drag;
-}
-
-.app-header.platform-darwin :deep(.window-controls) {
-  align-self: center;
 }
 
 /* ── Settings dropdown menu ── */

--- a/frontend/src/components/WindowControls.vue
+++ b/frontend/src/components/WindowControls.vue
@@ -1,5 +1,26 @@
 <template>
-  <div class="window-controls">
+  <!-- macOS: traffic-light style (close/minimise/zoom as coloured dots) -->
+  <div v-if="variant === 'mac'" class="window-controls mac">
+      <button class="wc-btn mac close" @click="$emit('close')" :aria-label="t('window.close')" :title="t('window.close')">
+        <svg viewBox="0 0 8 8"><path d="M1.2 1.2l5.6 5.6M6.8 1.2L1.2 6.8" stroke="currentColor" stroke-width="1.1" stroke-linecap="round"/></svg>
+      </button>
+      <button class="wc-btn mac minimise" @click="$emit('minimise')" :aria-label="t('window.minimize')" :title="t('window.minimize')">
+        <svg viewBox="0 0 8 8"><path d="M1.2 4h5.6" stroke="currentColor" stroke-width="1.1" stroke-linecap="round"/></svg>
+      </button>
+      <button class="wc-btn mac maximise" @click="$emit('maximise')" :aria-label="t('window.maximize')" :title="t('window.maximize')">
+        <svg v-if="isMaximised" viewBox="0 0 8 8">
+          <!-- restore: two small triangles pointing inward -->
+          <path d="M4.9 0.9L7.1 3.1 4.9 3.1zM3.1 7.1L0.9 4.9 3.1 4.9z" fill="currentColor"/>
+        </svg>
+        <svg v-else viewBox="0 0 8 8">
+          <!-- zoom: two triangles pointing outward -->
+          <path d="M3.1 0.9L0.9 3.1 3.1 3.1zM4.9 7.1L7.1 4.9 4.9 4.9z" fill="currentColor"/>
+        </svg>
+      </button>
+  </div>
+
+  <!-- Windows/Linux: match header-btn style -->
+  <div v-else class="window-controls">
       <button class="wc-btn win minimise" @click="$emit('minimise')" :aria-label="t('window.minimize')">
         <svg viewBox="0 0 12 12" width="14" height="14"><path d="M1 5.5h10v1H1z"/></svg>
       </button>
@@ -29,9 +50,13 @@ import { useI18n } from '../i18n'
 
 const { t } = useI18n()
 
-defineProps<{
+withDefaults(defineProps<{
   isMaximised: boolean
-}>()
+  /** 'mac' renders traffic-light dots, 'win' the header-btn-matching icons */
+  variant?: 'win' | 'mac'
+}>(), {
+  variant: 'win'
+})
 
 defineEmits(['minimise', 'maximise', 'close'])
 
@@ -42,16 +67,49 @@ const restoreMaskId = `rm-${Math.random().toString(36).slice(2, 9)}`
 .window-controls {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 2px;
   --wails-draggable: no-drag;
 }
 
-.window-controls {
-  gap: 2px;
+/* ── macOS traffic lights ── */
+.window-controls.mac {
+  gap: 8px;
+  /* nudge right of the header padding so the dots sit clear of the
+     window's rounded corners, matching the native macOS inset */
+  margin-left: 6px;
 }
 
+.wc-btn.mac {
+  width: 12px;
+  height: 12px;
+  padding: 0;
+  border: none;
+  border-radius: 50%;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: inset 0 0 0 0.5px rgba(0, 0, 0, 0.15);
+}
 
-/* Windows/Linux buttons — match header-btn style */
+.wc-btn.mac.close { background: #ff5f57; }
+.wc-btn.mac.minimise { background: #febc2e; }
+.wc-btn.mac.maximise { background: #28c840; }
+
+/* Glyphs appear when hovering anywhere over the group (macOS behaviour) */
+.wc-btn.mac svg {
+  width: 8px;
+  height: 8px;
+  color: rgba(0, 0, 0, 0.55);
+  opacity: 0;
+  transition: opacity 0.1s ease;
+}
+
+.window-controls.mac:hover .wc-btn.mac svg {
+  opacity: 1;
+}
+
+/* ── Windows/Linux buttons — match header-btn style ── */
 .wc-btn.win {
   display: flex;
   align-items: center;

--- a/main.go
+++ b/main.go
@@ -65,23 +65,29 @@ func main() {
 
 	app := NewApp(webviewDataPath)
 
-	// Linux multi-monitor maximize workaround:
-	// Wails sets default max size to primary display, which can clamp
-	// maximize on secondary monitors. Set to large values to disable.
-	// See: https://github.com/wailsapp/wails/issues/2431
-	maxW, maxH := 0, 0
-	if runtime.GOOS == "linux" {
-		maxW, maxH = 9999, 9999
-	}
-
-	// Read persisted window geometry before creating the window — it's fixed at
-	// creation in v3 (services start before the window exists, so ServiceStartup
-	// can't position it). Race the load against a short timeout so a slow disk
-	// doesn't delay first paint.
+	// Read persisted window geometry and theme before creating the window —
+	// both are fixed at creation in v3 (services start before the window
+	// exists, so ServiceStartup can't position it). Race the loads against a
+	// short deadline so a slow disk doesn't delay first paint; on timeout the
+	// defaults (1200x800 centered, dark background) are used instead.
+	//
+	// Geometry comes from localState.json. The theme comes from settings.json,
+	// whose store normally starts later in ServiceStartup, so it is loaded
+	// directly here via the data-dir bootstrap (loadSavedTheme). Both loads
+	// run in parallel against the same deadline.
 	systemTitleBar := false
 	winW, winH := 1200, 800 // fallback before any saved geometry is applied
 	savedX, savedY := 0, 0
 	savedMaxed := false
+	savedTheme := ""
+
+	deadline := time.After(100 * time.Millisecond)
+
+	themeCh := make(chan string, 1)
+	go func() {
+		themeCh <- loadSavedTheme()
+	}()
+
 	if configDir, err := os.UserConfigDir(); err == nil {
 		ls := store.NewLocalStateStore(filepath.Join(configDir, "uniTerm"))
 		done := make(chan store.LocalState, 1)
@@ -100,11 +106,17 @@ func main() {
 			}
 			savedX, savedY = state.WindowX, state.WindowY
 			savedMaxed = state.WindowMaximised
-		case <-time.After(100 * time.Millisecond):
+		case <-deadline:
 			// Slow disk — paint the defaults. The goroutine continues to load
 			// in the background; its result is discarded because the window
 			// geometry options are fixed at startup.
 		}
+	}
+
+	select {
+	case savedTheme = <-themeCh:
+	case <-deadline:
+		// Too slow — windowBackgroundColour falls back to the dark default.
 	}
 
 	// Restore a saved position only when one actually exists; otherwise keep v3's
@@ -116,11 +128,6 @@ func main() {
 	startState := application.WindowStateNormal
 	if savedMaxed {
 		startState = application.WindowStateMaximised
-	}
-
-	macTitleBar := application.MacTitleBarHiddenInset
-	if systemTitleBar {
-		macTitleBar = application.MacTitleBarDefault
 	}
 
 	// Clean external-edit scratch dirs left behind by previous runs that
@@ -182,15 +189,11 @@ func main() {
 		StartState:      startState,
 		MinWidth:        700,
 		MinHeight:       450,
-		MaxWidth:        maxW,
-		MaxHeight:       maxH,
 		// Headless local update e2e runs must not flash a window.
-		Hidden:    os.Getenv("UNITERM_UPDATE_AUTOTEST") == "1",
-		Frameless: runtime.GOOS != "darwin" && !systemTitleBar,
-		BackgroundColour: application.RGBA{
-			Red: 27, Green: 38, Blue: 54, Alpha: 1,
-		},
-		EnableFileDrop: true,
+		Hidden:           os.Getenv("UNITERM_UPDATE_AUTOTEST") == "1",
+		Frameless:        !systemTitleBar,
+		BackgroundColour: windowBackgroundColour(savedTheme),
+		EnableFileDrop:   true,
 		// Open the WebView2 inspector when the window is first shown. Wails
 		// disables browser accelerator keys on Windows (F12 / Ctrl+Shift+I
 		// never reach us), and the app's custom context menus hide the
@@ -200,9 +203,6 @@ func main() {
 		// (Deliberately NOT a window KeyBinding for F12: that would be
 		// window-global and could swallow F12 from TUI apps.)
 		OpenInspectorOnStartup: true,
-		Mac: application.MacWindow{
-			TitleBar: macTitleBar,
-		},
 	})
 
 	// Win11 rounded corners: Wails only extends the DWM frame from its
@@ -270,6 +270,56 @@ func main() {
 	err := w3app.Run()
 	if err != nil {
 		log.Writef("Wails run error: %v", err)
+	}
+}
+
+// loadSavedTheme reads the persisted app theme so the window can be created
+// with a background colour matching it (see windowBackgroundColour). The
+// settings store normally initializes later in ServiceStartup, so this goes
+// through the data-dir bootstrap directly. Returns "" when unavailable
+// (first run / read error) — the caller maps that to the dark default.
+func loadSavedTheme() string {
+	dd, err := store.ResolveDataDir()
+	if err != nil || dd.FirstRun || dd.Path == "" {
+		return ""
+	}
+	// ResolveDataDir only returns paths that exist (bootstrap paths are
+	// validated, the upgrade path is checked for config files), so
+	// NewSettingsStore's MkdirAll is a no-op here.
+	ss, err := store.NewSettingsStore(dd.Path)
+	if err != nil {
+		return ""
+	}
+	settings, err := ss.Load()
+	if err != nil {
+		return ""
+	}
+	return settings.Theme
+}
+
+// windowBackgroundColour maps the persisted app theme to the native window
+// background colour. That colour is only visible before the webview's first
+// paint, so it is matched to the TOP colour of each theme's body gradient in
+// frontend/src/style.css — the seam that would otherwise flash in the wrong
+// colour on startup. 'system' is resolved from the OS the same way the
+// webview engine does (systemtheme_*.go); v3's IsDarkMode() can't be used
+// because it reports false before Run().
+func windowBackgroundColour(theme string) application.RGBA {
+	resolved := theme
+	if theme == "" || theme == "system" {
+		if systemPrefersDark() {
+			resolved = "dark"
+		} else {
+			resolved = "light"
+		}
+	}
+	switch resolved {
+	case "deep-blue":
+		return application.RGBA{Red: 16, Green: 23, Blue: 40, Alpha: 255} // #101728
+	case "light":
+		return application.RGBA{Red: 255, Green: 255, Blue: 255, Alpha: 255} // #ffffff
+	default:
+		return application.RGBA{Red: 27, Green: 31, Blue: 39, Alpha: 255} // #1b1f27
 	}
 }
 


### PR DESCRIPTION
## Summary

- Match the native window background colour to the persisted app theme at startup, so the window no longer flashes a mismatched dark blue before the webview's first paint (most visible on light themes and maximized restores). The colour is aligned with the top of each theme's body gradient; the `system` theme is resolved from the OS via the same setting the webview engine consults for `prefers-color-scheme` (registry on Windows, `defaults` on macOS, `gsettings` on Linux).
- Make macOS frameless like Windows/Linux already were: Wails v3 preserves the AppKit rounded corners and hides the native traffic lights, so the frontend now draws macOS-style traffic light buttons on the left of the header, vertically centered with the tab bar buttons. Dragging and double-click-to-zoom keep working through the existing draggable header region.
- Remove the Linux multi-monitor maximize workaround (max size clamped to 9999): v3 no longer clamps maximize to the primary display.

Closes #626

## Test plan

- [ ] Windows: launch with dark / deep-blue / light / system themes — no colour flash at startup, including restored-maximized launch
- [ ] macOS: rounded corners intact, traffic light buttons work (close / minimise / zoom), header drag and double-click still work
- [ ] Linux: maximize on a secondary monitor still fills that monitor

---

## 概要

- 启动时原生窗口背景色按已保存的应用主题匹配，webview 首帧绘制前不再闪一块不匹配的深蓝色（浅色主题和最大化恢复时最明显）。背景色对齐各主题 body 渐变的顶部色；`system` 主题通过 webview 引擎同款的系统设置解析 `prefers-color-scheme`（Windows 读注册表、macOS 用 `defaults`、Linux 用 `gsettings`）。
- macOS 改为与 Windows/Linux 一致的 frameless：v3 保留 AppKit 原生圆角并自动隐藏原生红绿灯，前端在 header 左侧自绘 macOS 风格红绿灯按钮，与标签栏按钮垂直居中。拖拽和双击最大化通过现有 draggable header 区域继续生效。
- 移除 Linux 多显示器最大化 workaround（max size 钳到 9999）：v3 不再把最大化钳制到主显示器尺寸。

Close #626

## 测试计划

- [ ] Windows：dark / deep-blue / light / system 四种主题下启动均无闪色，最大化恢复启动同样正常
- [ ] macOS：圆角完好，红绿灯按钮（关闭/最小化/最大化）可用，header 拖拽与双击正常
- [ ] Linux：副显示器上最大化仍铺满所在显示器
